### PR TITLE
Staggered Release Endpoints Part 9

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -56,7 +56,7 @@ class Activity < ApplicationRecord
   has_many :units, through: :unit_activities
   has_many :classroom_units, through: :units
   has_many :classrooms, through: :classroom_units
-  has_many :pack_sequence_items, through: :units
+  has_many :pack_sequence_items, through: :classroom_units
   has_many :user_pack_sequence_items, through: :pack_sequence_items
   has_many :recommendations, dependent: :destroy
   has_many :activity_category_activities, dependent: :destroy

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -33,6 +33,8 @@ class ClassroomUnit < ApplicationRecord
 
   has_many :activity_sessions
   has_many :unit_activities, through: :unit
+  has_many :pack_sequence_items, through: :unit
+  has_many :user_pack_sequence_items, through: :pack_sequence_items
   has_many :completed_activity_sessions, -> {completed}, class_name: 'ActivitySession'
   has_many :classroom_unit_activity_states
 
@@ -41,6 +43,7 @@ class ClassroomUnit < ApplicationRecord
   validates :unit, uniqueness: { scope: :classroom }
 
   before_save :check_for_assign_on_join_and_update_students_array_if_true
+  after_save :manage_user_pack_sequence_items, if: :saved_change_to_assigned_student_ids?
   after_save :hide_appropriate_activity_sessions, :save_user_pack_sequence_items
 
   # Using an after_commit hook here because we want to trigger the callback
@@ -78,6 +81,8 @@ class ClassroomUnit < ApplicationRecord
     # if assign on join should still be true the aforementioned method will set it.
     update(assigned_student_ids: new_assigned_student_ids, assign_on_join: false)
   end
+
+  def manage_user_pack_sequence_items; end
 
   def save_user_pack_sequence_items
     unit&.save_user_pack_sequence_items

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -85,7 +85,7 @@ class ClassroomUnit < ApplicationRecord
   def manage_user_pack_sequence_items; end
 
   def save_user_pack_sequence_items
-    unit&.save_user_pack_sequence_items
+    nil
   end
 
   private def hide_unassigned_activity_sessions

--- a/services/QuillLMS/app/models/pack_sequence.rb
+++ b/services/QuillLMS/app/models/pack_sequence.rb
@@ -5,11 +5,11 @@
 # Table name: pack_sequences
 #
 #  id                     :bigint           not null, primary key
-#  release_method         :string
+#  release_method         :string           default("staggered")
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  classroom_id           :bigint
-#  diagnostic_activity_id :bigint
+#  classroom_id           :bigint           not null
+#  diagnostic_activity_id :bigint           not null
 #
 # Indexes
 #

--- a/services/QuillLMS/app/models/pack_sequence.rb
+++ b/services/QuillLMS/app/models/pack_sequence.rb
@@ -34,6 +34,7 @@ class PackSequence < ApplicationRecord
 
   has_many :pack_sequence_items, dependent: :destroy
   has_many :user_pack_sequence_items, through: :pack_sequence_items
+  has_many :users, through: :user_pack_sequence_items
 
   scope :staggered, -> { where(release_method: STAGGERED_RELEASE) }
 

--- a/services/QuillLMS/app/models/pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/pack_sequence_item.rb
@@ -5,11 +5,11 @@
 # Table name: pack_sequence_items
 #
 #  id                :bigint           not null, primary key
-#  order             :integer
+#  order             :integer          not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  classroom_unit_id :bigint           not null
-#  pack_sequence_id  :bigint
+#  pack_sequence_id  :bigint           not null
 #
 # Indexes
 #

--- a/services/QuillLMS/app/models/pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/pack_sequence_item.rb
@@ -27,6 +27,7 @@ class PackSequenceItem < ApplicationRecord
   belongs_to :classroom_unit
 
   has_many :user_pack_sequence_items, dependent: :destroy
+  has_many :users, through: :user_pack_sequence_items
 
   after_save :save_user_pack_sequence_items, if: :saved_change_to_order?
 

--- a/services/QuillLMS/app/models/pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/pack_sequence_item.rb
@@ -30,11 +30,11 @@ class PackSequenceItem < ApplicationRecord
 
   after_save :save_user_pack_sequence_items, if: :saved_change_to_order?
 
+  after_destroy :save_user_pack_sequence_items
+
   delegate :classroom_id, :unit_id, to: :classroom_unit
 
   def save_user_pack_sequence_items
-    user_pack_sequence_items
-      .pluck(:user_id)
-      .each { |user_id| SaveUserPackSequenceItemsWorker.perform_async(classroom_id, user_id) }
+    pack_sequence.users.each { |user| SaveUserPackSequenceItemsWorker.perform_async(classroom_id, user.id) }
   end
 end

--- a/services/QuillLMS/app/models/pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/pack_sequence_item.rb
@@ -4,18 +4,22 @@
 #
 # Table name: pack_sequence_items
 #
-#  id               :bigint           not null, primary key
-#  order            :integer
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  pack_sequence_id :bigint
+#  id                :bigint           not null, primary key
+#  order             :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  classroom_unit_id :bigint           not null
+#  pack_sequence_id  :bigint
 #
 # Indexes
 #
-#  index_pack_sequence_items_on_pack_sequence_id  (pack_sequence_id)
+#  index_pack_sequence_items__classroom_unit_id__pack_sequence_id  (classroom_unit_id,pack_sequence_id) UNIQUE
+#  index_pack_sequence_items_on_classroom_unit_id                  (classroom_unit_id)
+#  index_pack_sequence_items_on_pack_sequence_id                   (pack_sequence_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (classroom_unit_id => classroom_units.id)
 #  fk_rails_...  (pack_sequence_id => pack_sequences.id)
 #
 class PackSequenceItem < ApplicationRecord
@@ -29,10 +33,8 @@ class PackSequenceItem < ApplicationRecord
   delegate :classroom_id, :unit_id, to: :classroom_unit
 
   def save_user_pack_sequence_items
-    user_ids.each { |user_id| SaveUserPackSequenceItemsWorker.perform_async(classroom_id, user_id) }
-  end
-
-  private def user_ids
-    classroom_unit.assigned_student_ids
+    user_pack_sequence_items
+      .pluck(:user_id)
+      .each { |user_id| SaveUserPackSequenceItemsWorker.perform_async(classroom_id, user_id) }
   end
 end

--- a/services/QuillLMS/app/models/subject_area.rb
+++ b/services/QuillLMS/app/models/subject_area.rb
@@ -5,7 +5,7 @@
 # Table name: subject_areas
 #
 #  id         :bigint           not null, primary key
-#  name       :string
+#  name       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/services/QuillLMS/app/models/teacher_info.rb
+++ b/services/QuillLMS/app/models/teacher_info.rb
@@ -5,11 +5,19 @@
 # Table name: teacher_infos
 #
 #  id                  :bigint           not null, primary key
-#  minimum_grade_level :integer
 #  maximum_grade_level :integer
-#  teacher_id          :bigint
+#  minimum_grade_level :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  user_id             :bigint           not null
+#
+# Indexes
+#
+#  index_teacher_infos_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 class TeacherInfo < ApplicationRecord
   belongs_to :user

--- a/services/QuillLMS/app/models/teacher_info_subject_area.rb
+++ b/services/QuillLMS/app/models/teacher_info_subject_area.rb
@@ -5,10 +5,20 @@
 # Table name: teacher_info_subject_areas
 #
 #  id              :bigint           not null, primary key
-#  teacher_info_id :bigint
-#  subject_area_id :bigint
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  subject_area_id :bigint           not null
+#  teacher_info_id :bigint           not null
+#
+# Indexes
+#
+#  index_teacher_info_subject_areas_on_subject_area_id  (subject_area_id)
+#  index_teacher_info_subject_areas_on_teacher_info_id  (teacher_info_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (subject_area_id => subject_areas.id)
+#  fk_rails_...  (teacher_info_id => teacher_infos.id)
 #
 class TeacherInfoSubjectArea < ApplicationRecord
   belongs_to :teacher_info

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -43,8 +43,6 @@ class Unit < ApplicationRecord
   has_many :classrooms, through: :classroom_units
   has_many :activities, through: :unit_activities
   has_many :standards, through: :activities
-  has_many :pack_sequence_items, dependent: :destroy
-  has_many :user_pack_sequence_items, through: :pack_sequence_items
 
   default_scope { where(visible: true)}
 
@@ -88,7 +86,7 @@ class Unit < ApplicationRecord
   end
 
   def save_user_pack_sequence_items
-    pack_sequence_items.each(&:save_user_pack_sequence_items)
+    classroom_units.each(&:save_user_pack_sequence_items)
   end
 
   def self.create_with_incremented_name(user_id:, name: )

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -49,8 +49,6 @@ class Unit < ApplicationRecord
   after_save :hide_classroom_units_and_unit_activities
   after_save :create_any_new_classroom_unit_activity_states
 
-  after_update :save_user_pack_sequence_items, if: :saved_change_to_visible?
-
   # Using an after_commit hook here because we want to trigger the callback
   # on save or touch, and touch explicitly bypasses after_save hooks
   after_commit :touch_all_classrooms_and_classroom_units
@@ -62,10 +60,12 @@ class Unit < ApplicationRecord
   end
 
   def hide_classroom_units_and_unit_activities
-    return if visible
-
-    unit_activities.where(visible: true).update(visible: false)
-    classroom_units.where(visible: true).update(visible: false)
+    if visible
+      save_user_pack_sequence_items
+    else
+      unit_activities.where(visible: true).update(visible: false)
+      classroom_units.where(visible: true).update(visible: false)
+    end
   end
 
   def email_lesson_plan

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -88,11 +88,7 @@ class Unit < ApplicationRecord
   end
 
   def save_user_pack_sequence_items
-    pack_sequence_items.each do |pack_sequence_item|
-      pack_sequence_item.users.pluck(:id).each do |user_id|
-        SaveUserPackSequenceItemsWorker.perform_async(pack_sequence_item.classroom&.id, user_id)
-      end
-    end
+    pack_sequence_items.each(&:save_user_pack_sequence_items)
   end
 
   def self.create_with_incremented_name(user_id:, name: )

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -46,6 +46,7 @@ class Unit < ApplicationRecord
 
   default_scope { where(visible: true)}
 
+  after_save :save_user_pack_sequence_items, if: :visible
   after_save :hide_classroom_units_and_unit_activities
   after_save :create_any_new_classroom_unit_activity_states
 
@@ -60,12 +61,10 @@ class Unit < ApplicationRecord
   end
 
   def hide_classroom_units_and_unit_activities
-    if visible
-      save_user_pack_sequence_items
-    else
-      unit_activities.where(visible: true).update(visible: false)
-      classroom_units.where(visible: true).update(visible: false)
-    end
+    return if visible
+
+    unit_activities.where(visible: true).update(visible: false)
+    classroom_units.where(visible: true).update(visible: false)
   end
 
   def email_lesson_plan

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -188,7 +188,7 @@ class UnitActivity < ApplicationRecord
           AND cu.id = cuas.classroom_unit_id
         JOIN users AS teachers ON unit.user_id = teachers.id
         LEFT JOIN pack_sequence_items AS psi
-          ON psi.unit_id = unit.id
+          ON psi.classroom_unit_id = cu.id
         LEFT JOIN user_pack_sequence_items AS upsi
           ON upsi.pack_sequence_item_id = psi.id
           AND upsi.user_id = #{user_id.to_i}

--- a/services/QuillLMS/app/models/user_pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/user_pack_sequence_item.rb
@@ -35,6 +35,7 @@ class UserPackSequenceItem < ApplicationRecord
   validates :pack_sequence_item, presence: true
   validates :user, presence: true
 
+  after_save :save_user_pack_sequence_items
   after_destroy :save_user_pack_sequence_items
 
   delegate :classroom_id, to: :pack_sequence_item

--- a/services/QuillLMS/app/models/user_pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/user_pack_sequence_item.rb
@@ -37,12 +37,12 @@ class UserPackSequenceItem < ApplicationRecord
 
   after_destroy :save_user_pack_sequence_items
 
-  delegate :classroom, to: :pack_sequence_item
+  delegate :classroom_id, to: :pack_sequence_item
 
   scope :locked, -> { where(status: LOCKED) }
   scope :unlocked, -> { where(status: UNLOCKED) }
 
   def save_user_pack_sequence_items
-    SaveUserPackSequenceItemsWorker.perform_async(classroom&.id, user_id)
+    SaveUserPackSequenceItemsWorker.perform_async(classroom_id, user_id)
   end
 end

--- a/services/QuillLMS/app/models/user_pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/user_pack_sequence_item.rb
@@ -13,9 +13,9 @@
 #
 # Indexes
 #
-#  index_user_pack_sequence_items_on_pack_sequence_item_id     (pack_sequence_item_id)
-#  index_user_pack_sequence_items_on_user_id                   (user_id)
-#  on_user_pack_sequence_items_on_user_and_pack_sequence_item  (user_id,pack_sequence_item_id) UNIQUE
+#  index_user_pack_sequence_items__user_id__pack_sequence_item_id  (user_id,pack_sequence_item_id) UNIQUE
+#  index_user_pack_sequence_items_on_pack_sequence_item_id         (pack_sequence_item_id)
+#  index_user_pack_sequence_items_on_user_id                       (user_id)
 #
 # Foreign Keys
 #

--- a/services/QuillLMS/app/queries/user_pack_sequence_item_query.rb
+++ b/services/QuillLMS/app/queries/user_pack_sequence_item_query.rb
@@ -10,8 +10,7 @@ class UserPackSequenceItemQuery
       .staggered
       .select("SUM(CASE WHEN activity_sessions.state = '#{FINISHED}' THEN 1 ELSE 0 END) > 0 AS #{COMPLETED_KEY}")
       .select("pack_sequence_items.id AS #{PACK_SEQUENCE_ITEM_ID_KEY}")
-      .joins(pack_sequence_items: { unit: :classroom_units })
-      .joins(pack_sequence_items: { unit: { unit_activities: :activity } } )
+      .joins(pack_sequence_items: { classroom_unit: { unit: { unit_activities: :activity } } })
       .joins(
         <<-SQL
           LEFT JOIN activity_sessions

--- a/services/QuillLMS/app/services/unit_activities_saver.rb
+++ b/services/QuillLMS/app/services/unit_activities_saver.rb
@@ -22,7 +22,8 @@ class UnitActivitiesSaver < ApplicationService
       activity_id = activity_data[:id].to_i
       due_date = activity_data[:due_date]
       publish_date = activity_data[:publish_date]
-      unit_activity = unit_activities.find { |ua| ua.activity_id == activity_id }
+
+      unit_activity = UnitActivity.find_by(unit_id: unit_id, activity_id: activity_id)
 
       if unit_activity
         unit_activity.save_new_attributes_and_adjust_dates!(
@@ -32,7 +33,7 @@ class UnitActivitiesSaver < ApplicationService
           visible: true
         )
       else
-        UnitActivity.create!(
+        UnitActivity.create(
           activity_id: activity_id,
           due_date: due_date,
           publish_date: publish_date,
@@ -41,9 +42,5 @@ class UnitActivitiesSaver < ApplicationService
         )
       end
     end
-  end
-
-  private def unit_activities
-    @unit_activities ||= UnitActivity.where(unit_id: unit_id)
   end
 end

--- a/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
+++ b/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
@@ -40,9 +40,11 @@ class UserPackSequenceItemSaver < ApplicationService
 
   private def save_statuses
     user_pack_sequence_item_statuses.each_pair do |pack_sequence_item_id, status|
-      UserPackSequenceItem
-        .find_or_create_by!(user_id: user_id, pack_sequence_item_id: pack_sequence_item_id)
-        .tap { |upsi| upsi.update!(status: status) unless status == upsi.status }
+      PackSequenceItem
+        .find_by(id: pack_sequence_item_id)
+        &.user_pack_sequence_items
+        &.find_or_create_by!(user_id: user_id)
+        &.tap { |upsi| upsi.update!(status: status) unless status == upsi.status }
     end
   end
 

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -37,7 +37,7 @@ class AssignRecommendationsWorker
     unit = find_unit(find_units(unit_template_id, teacher.id)) if unit.nil?
     classroom_unit = ClassroomUnit.find_by(unit: unit, classroom_id: classroom_id)
 
-    save_pack_sequence_item(classroom_unit, pack_sequence_id, order, classroom_unit)
+    save_pack_sequence_item(classroom_unit, pack_sequence_id, order)
 
     track_recommendation_assignment(teacher)
     return unless is_last_recommendation

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -35,7 +35,9 @@ class AssignRecommendationsWorker
     assign_unit_to_one_class(unit, classroom_id, classroom_data, unit_template_id, teacher.id)
 
     unit = find_unit(find_units(unit_template_id, teacher.id)) if unit.nil?
-    save_pack_sequence_item(pack_sequence_id, order, unit)
+    classroom_unit = ClassroomUnit.find_by(unit: unit, classroom_id: classroom_id)
+
+    save_pack_sequence_item(classroom_unit, pack_sequence_id, order, classroom_unit)
 
     track_recommendation_assignment(teacher)
     return unless is_last_recommendation
@@ -62,11 +64,12 @@ class AssignRecommendationsWorker
     end
   end
 
-  def save_pack_sequence_item(pack_sequence_id, order, unit)
-    return if pack_sequence_id.nil? || unit.nil?
+  def save_pack_sequence_item(classroom_unit, pack_sequence_id, order)
+    return if pack_sequence_id.nil? || classroom_unit.nil?
+
 
     PackSequenceItem.find_or_create_by!(
-      unit: unit,
+      classroom_unit: classroom_unit,
       pack_sequence_id: pack_sequence_id,
       order: order
     )

--- a/services/QuillLMS/db/migrate/20221103152535_add_uniqueness_constraint_to_user_pack_sequence_items.rb
+++ b/services/QuillLMS/db/migrate/20221103152535_add_uniqueness_constraint_to_user_pack_sequence_items.rb
@@ -4,7 +4,7 @@ class AddUniquenessConstraintToUserPackSequenceItems < ActiveRecord::Migration[6
   def change
     add_index :user_pack_sequence_items,
       [:user_id, :pack_sequence_item_id],
-      name: 'on_user_pack_sequence_items_on_user_and_pack_sequence_item',
+      name: :index_user_pack_sequence_items__user_id__pack_sequence_item_id,
       unique: true
   end
 end

--- a/services/QuillLMS/db/migrate/20221209134742_remove_unit_from_pack_sequence_items.rb
+++ b/services/QuillLMS/db/migrate/20221209134742_remove_unit_from_pack_sequence_items.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveUnitFromPackSequenceItems < ActiveRecord::Migration[6.1]
+  def change
+    remove_foreign_key :pack_sequence_items, to_table: :units
+    remove_index :pack_sequence_items, column: [:unit_id], name: 'index_pack_sequence_items_on_pack_sequence_id_and_unit_id'
+    remove_column :pack_sequence_items, :unit_id, :integer
+  end
+end

--- a/services/QuillLMS/db/migrate/20221209134742_remove_unit_from_pack_sequence_items.rb
+++ b/services/QuillLMS/db/migrate/20221209134742_remove_unit_from_pack_sequence_items.rb
@@ -3,7 +3,9 @@
 class RemoveUnitFromPackSequenceItems < ActiveRecord::Migration[6.1]
   def change
     remove_foreign_key :pack_sequence_items, to_table: :units
-    remove_index :pack_sequence_items, column: [:unit_id], name: 'index_pack_sequence_items_on_pack_sequence_id_and_unit_id'
+
+    remove_index :pack_sequence_items, column: [:pack_sequence_id, :unit_id], unique: true
+
     remove_column :pack_sequence_items, :unit_id, :integer
   end
 end

--- a/services/QuillLMS/db/migrate/20221209141047_add_classroom_unit_to_pack_sequence_items.rb
+++ b/services/QuillLMS/db/migrate/20221209141047_add_classroom_unit_to_pack_sequence_items.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddClassroomUnitToPackSequenceItems < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :pack_sequence_items, :classroom_unit, foreign_key: true, null: false
+
+    add_index :pack_sequence_items,
+      [:classroom_unit_id, :pack_sequence_id],
+      name: :index_pack_sequence_items__classroom_unit_id__pack_sequence_id,
+      unique: true
+  end
+end

--- a/services/QuillLMS/db/migrate/20221209151611_add_null_constraints_to_pack_sequence.rb
+++ b/services/QuillLMS/db/migrate/20221209151611_add_null_constraints_to_pack_sequence.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddNullConstraintsToPackSequence < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :pack_sequences, :classroom_id, false
+    change_column_null :pack_sequences, :diagnostic_activity_id, false
+    change_column_default :pack_sequences, :release_method, from: nil, to: :staggered
+  end
+end

--- a/services/QuillLMS/db/migrate/20221209151957_add_null_constraints_to_pack_sequence_item.rb
+++ b/services/QuillLMS/db/migrate/20221209151957_add_null_constraints_to_pack_sequence_item.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddNullConstraintsToPackSequenceItem < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :pack_sequence_items, :order, false
+    change_column_null :pack_sequence_items, :pack_sequence_id, false
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -7934,6 +7934,13 @@ CREATE UNIQUE INDEX index_user_milestones_on_user_id_and_milestone_id ON public.
 
 
 --
+-- Name: index_user_pack_sequence_items__user_id__pack_sequence_item_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_user_pack_sequence_items__user_id__pack_sequence_item_id ON public.user_pack_sequence_items USING btree (user_id, pack_sequence_item_id);
+
+
+--
 -- Name: index_user_pack_sequence_items_on_pack_sequence_item_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8043,13 +8050,6 @@ CREATE UNIQUE INDEX index_zipcode_infos_on_zipcode ON public.zipcode_infos USING
 --
 
 CREATE INDEX name_idx ON public.users USING gin (name public.gin_trgm_ops);
-
-
---
--- Name: on_user_pack_sequence_items_on_user_and_pack_sequence_item; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX on_user_pack_sequence_items_on_user_and_pack_sequence_item ON public.user_pack_sequence_items USING btree (user_id, pack_sequence_item_id);
 
 
 --

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -10,13 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
-
---
 -- Name: hstore; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -2273,6 +2266,47 @@ CREATE TABLE public.districts_users (
 
 
 --
+-- Name: evidence_activity_healths; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_activity_healths (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    flag character varying NOT NULL,
+    activity_id integer NOT NULL,
+    version integer NOT NULL,
+    version_plays integer NOT NULL,
+    total_plays integer NOT NULL,
+    completion_rate integer,
+    because_final_optimal integer,
+    but_final_optimal integer,
+    so_final_optimal integer,
+    avg_completion_time integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_activity_healths_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_activity_healths_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_activity_healths_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_activity_healths_id_seq OWNED BY public.evidence_activity_healths.id;
+
+
+--
 -- Name: evidence_hints; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2304,6 +2338,53 @@ CREATE SEQUENCE public.evidence_hints_id_seq
 --
 
 ALTER SEQUENCE public.evidence_hints_id_seq OWNED BY public.evidence_hints.id;
+
+
+--
+-- Name: evidence_prompt_healths; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_prompt_healths (
+    id bigint NOT NULL,
+    prompt_id integer NOT NULL,
+    activity_short_name character varying NOT NULL,
+    text character varying NOT NULL,
+    current_version integer NOT NULL,
+    version_responses integer NOT NULL,
+    first_attempt_optimal integer,
+    final_attempt_optimal integer,
+    avg_attempts double precision,
+    confidence double precision,
+    percent_automl_consecutive_repeated integer,
+    percent_automl integer,
+    percent_plagiarism integer,
+    percent_opinion integer,
+    percent_grammar integer,
+    percent_spelling integer,
+    avg_time_spent_per_prompt integer,
+    evidence_activity_health_id bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_prompt_healths_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_prompt_healths_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_prompt_healths_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_prompt_healths_id_seq OWNED BY public.evidence_prompt_healths.id;
 
 
 --
@@ -2850,7 +2931,6 @@ ALTER SEQUENCE public.objectives_id_seq OWNED BY public.objectives.id;
 
 CREATE TABLE public.pack_sequence_items (
     id bigint NOT NULL,
-    unit_id bigint,
     pack_sequence_id bigint,
     "order" integer,
     created_at timestamp(6) without time zone NOT NULL,
@@ -5010,10 +5090,24 @@ ALTER TABLE ONLY public.districts ALTER COLUMN id SET DEFAULT nextval('public.di
 
 
 --
+-- Name: evidence_activity_healths id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_activity_healths ALTER COLUMN id SET DEFAULT nextval('public.evidence_activity_healths_id_seq'::regclass);
+
+
+--
 -- Name: evidence_hints id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.evidence_hints ALTER COLUMN id SET DEFAULT nextval('public.evidence_hints_id_seq'::regclass);
+
+
+--
+-- Name: evidence_prompt_healths id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_healths ALTER COLUMN id SET DEFAULT nextval('public.evidence_prompt_healths_id_seq'::regclass);
 
 
 --
@@ -5936,11 +6030,27 @@ ALTER TABLE ONLY public.districts
 
 
 --
+-- Name: evidence_activity_healths evidence_activity_healths_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_activity_healths
+    ADD CONSTRAINT evidence_activity_healths_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: evidence_hints evidence_hints_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.evidence_hints
     ADD CONSTRAINT evidence_hints_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_prompt_healths evidence_prompt_healths_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_healths
+    ADD CONSTRAINT evidence_prompt_healths_pkey PRIMARY KEY (id);
 
 
 --
@@ -7151,6 +7261,13 @@ CREATE INDEX index_evidence_hints_on_rule_id ON public.evidence_hints USING btre
 
 
 --
+-- Name: index_evidence_prompt_healths_on_evidence_activity_health_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_evidence_prompt_healths_on_evidence_activity_health_id ON public.evidence_prompt_healths USING btree (evidence_activity_health_id);
+
+
+--
 -- Name: index_feedback_histories_on_concept_uid; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7274,20 +7391,6 @@ CREATE UNIQUE INDEX index_oauth_applications_on_uid ON public.oauth_applications
 --
 
 CREATE INDEX index_pack_sequence_items_on_pack_sequence_id ON public.pack_sequence_items USING btree (pack_sequence_id);
-
-
---
--- Name: index_pack_sequence_items_on_pack_sequence_id_and_unit_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_pack_sequence_items_on_pack_sequence_id_and_unit_id ON public.pack_sequence_items USING btree (pack_sequence_id, unit_id);
-
-
---
--- Name: index_pack_sequence_items_on_unit_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pack_sequence_items_on_unit_id ON public.pack_sequence_items USING btree (unit_id);
 
 
 --
@@ -8124,6 +8227,14 @@ ALTER TABLE ONLY public.activities
 
 
 --
+-- Name: evidence_prompt_healths fk_rails_2126b1922f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_healths
+    ADD CONSTRAINT fk_rails_2126b1922f FOREIGN KEY (evidence_activity_health_id) REFERENCES public.evidence_activity_healths(id) ON DELETE CASCADE;
+
+
+--
 -- Name: comprehension_automl_models fk_rails_35c32f80fc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8329,14 +8440,6 @@ ALTER TABLE ONLY public.activity_topics
 
 ALTER TABLE ONLY public.comprehension_highlights
     ADD CONSTRAINT fk_rails_9d58aa0a3c FOREIGN KEY (feedback_id) REFERENCES public.comprehension_feedbacks(id) ON DELETE CASCADE;
-
-
---
--- Name: pack_sequence_items fk_rails_a1e39dcd4a; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pack_sequence_items
-    ADD CONSTRAINT fk_rails_a1e39dcd4a FOREIGN KEY (unit_id) REFERENCES public.units(id);
 
 
 --
@@ -9016,6 +9119,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221103152559'),
 ('20221109181742'),
 ('20221109182042'),
-('20221109182145');
+('20221109182145'),
+('20221110072938'),
+('20221110072939'),
+('20221209134742');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2934,7 +2934,8 @@ CREATE TABLE public.pack_sequence_items (
     pack_sequence_id bigint,
     "order" integer,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    classroom_unit_id bigint NOT NULL
 );
 
 
@@ -7387,6 +7388,20 @@ CREATE UNIQUE INDEX index_oauth_applications_on_uid ON public.oauth_applications
 
 
 --
+-- Name: index_pack_sequence_items__classroom_unit_id__pack_sequence_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_pack_sequence_items__classroom_unit_id__pack_sequence_id ON public.pack_sequence_items USING btree (classroom_unit_id, pack_sequence_id);
+
+
+--
+-- Name: index_pack_sequence_items_on_classroom_unit_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pack_sequence_items_on_classroom_unit_id ON public.pack_sequence_items USING btree (classroom_unit_id);
+
+
+--
 -- Name: index_pack_sequence_items_on_pack_sequence_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8443,6 +8458,14 @@ ALTER TABLE ONLY public.comprehension_highlights
 
 
 --
+-- Name: pack_sequence_items fk_rails_a1d2cd07cb; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pack_sequence_items
+    ADD CONSTRAINT fk_rails_a1d2cd07cb FOREIGN KEY (classroom_unit_id) REFERENCES public.classroom_units(id);
+
+
+--
 -- Name: classroom_units fk_rails_a3c514fc6d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9122,6 +9145,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221109182145'),
 ('20221110072938'),
 ('20221110072939'),
-('20221209134742');
+('20221209134742'),
+('20221209141047');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2931,8 +2931,8 @@ ALTER SEQUENCE public.objectives_id_seq OWNED BY public.objectives.id;
 
 CREATE TABLE public.pack_sequence_items (
     id bigint NOT NULL,
-    pack_sequence_id bigint,
-    "order" integer,
+    pack_sequence_id bigint NOT NULL,
+    "order" integer NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     classroom_unit_id bigint NOT NULL
@@ -9147,6 +9147,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221110072939'),
 ('20221209134742'),
 ('20221209141047'),
-('20221209151611');
+('20221209151611'),
+('20221209151957');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2964,9 +2964,9 @@ ALTER SEQUENCE public.pack_sequence_items_id_seq OWNED BY public.pack_sequence_i
 
 CREATE TABLE public.pack_sequences (
     id bigint NOT NULL,
-    classroom_id bigint,
-    diagnostic_activity_id bigint,
-    release_method character varying,
+    classroom_id bigint NOT NULL,
+    diagnostic_activity_id bigint NOT NULL,
+    release_method character varying DEFAULT 'staggered'::character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
@@ -9146,6 +9146,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221110072938'),
 ('20221110072939'),
 ('20221209134742'),
-('20221209141047');
+('20221209141047'),
+('20221209151611');
 
 

--- a/services/QuillLMS/spec/factories/pack_sequence_items.rb
+++ b/services/QuillLMS/spec/factories/pack_sequence_items.rb
@@ -5,11 +5,11 @@
 # Table name: pack_sequence_items
 #
 #  id                :bigint           not null, primary key
-#  order             :integer
+#  order             :integer          not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  classroom_unit_id :bigint           not null
-#  pack_sequence_id  :bigint
+#  pack_sequence_id  :bigint           not null
 #
 # Indexes
 #

--- a/services/QuillLMS/spec/factories/pack_sequence_items.rb
+++ b/services/QuillLMS/spec/factories/pack_sequence_items.rb
@@ -9,23 +9,19 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  pack_sequence_id :bigint
-#  unit_id          :bigint
 #
 # Indexes
 #
-#  index_pack_sequence_items_on_pack_sequence_id              (pack_sequence_id)
-#  index_pack_sequence_items_on_pack_sequence_id_and_unit_id  (pack_sequence_id,unit_id) UNIQUE
-#  index_pack_sequence_items_on_unit_id                       (unit_id)
+#  index_pack_sequence_items_on_pack_sequence_id  (pack_sequence_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (pack_sequence_id => pack_sequences.id)
-#  fk_rails_...  (unit_id => units.id)
 #
 FactoryBot.define do
   factory :pack_sequence_item do
     sequence(:order) { |n| n }
     pack_sequence
-    unit
+    classroom_unit
   end
 end

--- a/services/QuillLMS/spec/factories/pack_sequence_items.rb
+++ b/services/QuillLMS/spec/factories/pack_sequence_items.rb
@@ -4,18 +4,22 @@
 #
 # Table name: pack_sequence_items
 #
-#  id               :bigint           not null, primary key
-#  order            :integer
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  pack_sequence_id :bigint
+#  id                :bigint           not null, primary key
+#  order             :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  classroom_unit_id :bigint           not null
+#  pack_sequence_id  :bigint
 #
 # Indexes
 #
-#  index_pack_sequence_items_on_pack_sequence_id  (pack_sequence_id)
+#  index_pack_sequence_items__classroom_unit_id__pack_sequence_id  (classroom_unit_id,pack_sequence_id) UNIQUE
+#  index_pack_sequence_items_on_classroom_unit_id                  (classroom_unit_id)
+#  index_pack_sequence_items_on_pack_sequence_id                   (pack_sequence_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (classroom_unit_id => classroom_units.id)
 #  fk_rails_...  (pack_sequence_id => pack_sequences.id)
 #
 FactoryBot.define do

--- a/services/QuillLMS/spec/factories/pack_sequences.rb
+++ b/services/QuillLMS/spec/factories/pack_sequences.rb
@@ -5,11 +5,11 @@
 # Table name: pack_sequences
 #
 #  id                     :bigint           not null, primary key
-#  release_method         :string
+#  release_method         :string           default("staggered")
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  classroom_id           :bigint
-#  diagnostic_activity_id :bigint
+#  classroom_id           :bigint           not null
+#  diagnostic_activity_id :bigint           not null
 #
 # Indexes
 #

--- a/services/QuillLMS/spec/factories/subject_areas.rb
+++ b/services/QuillLMS/spec/factories/subject_areas.rb
@@ -5,7 +5,7 @@
 # Table name: subject_areas
 #
 #  id         :bigint           not null, primary key
-#  name       :string
+#  name       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/services/QuillLMS/spec/factories/teacher_info_subject_areas.rb
+++ b/services/QuillLMS/spec/factories/teacher_info_subject_areas.rb
@@ -5,10 +5,20 @@
 # Table name: teacher_info_subject_areas
 #
 #  id              :bigint           not null, primary key
-#  teacher_info_id :bigint
-#  subject_area_id :bigint
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  subject_area_id :bigint           not null
+#  teacher_info_id :bigint           not null
+#
+# Indexes
+#
+#  index_teacher_info_subject_areas_on_subject_area_id  (subject_area_id)
+#  index_teacher_info_subject_areas_on_teacher_info_id  (teacher_info_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (subject_area_id => subject_areas.id)
+#  fk_rails_...  (teacher_info_id => teacher_infos.id)
 #
 FactoryBot.define do
   factory :teacher_info_subject_area do

--- a/services/QuillLMS/spec/factories/teacher_infos.rb
+++ b/services/QuillLMS/spec/factories/teacher_infos.rb
@@ -5,11 +5,19 @@
 # Table name: teacher_infos
 #
 #  id                  :bigint           not null, primary key
-#  minimum_grade_level :integer
 #  maximum_grade_level :integer
-#  teacher_id          :bigint
+#  minimum_grade_level :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  user_id             :bigint           not null
+#
+# Indexes
+#
+#  index_teacher_infos_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
   factory :teacher_info do

--- a/services/QuillLMS/spec/factories/user_pack_sequence_items.rb
+++ b/services/QuillLMS/spec/factories/user_pack_sequence_items.rb
@@ -13,9 +13,9 @@
 #
 # Indexes
 #
-#  index_user_pack_sequence_items_on_pack_sequence_item_id     (pack_sequence_item_id)
-#  index_user_pack_sequence_items_on_user_id                   (user_id)
-#  on_user_pack_sequence_items_on_user_and_pack_sequence_item  (user_id,pack_sequence_item_id) UNIQUE
+#  index_user_pack_sequence_items__user_id__pack_sequence_item_id  (user_id,pack_sequence_item_id) UNIQUE
+#  index_user_pack_sequence_items_on_pack_sequence_item_id         (pack_sequence_item_id)
+#  index_user_pack_sequence_items_on_user_id                       (user_id)
 #
 # Foreign Keys
 #

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -714,7 +714,8 @@ describe Activity, type: :model, redis: true do
 
     context 'user_pack_sequence_item exists' do
       let(:unit) { create(:unit_activity, activity: activity).unit }
-      let(:pack_sequence_item) { create(:pack_sequence_item, unit: unit) }
+      let(:classroom_unit) { create(:classroom_unit, unit: unit) }
+      let(:pack_sequence_item) { create(:pack_sequence_item, classroom_unit: classroom_unit) }
 
       before { create(:user_pack_sequence_item, status, user: user, pack_sequence_item: pack_sequence_item) }
 

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -35,6 +35,7 @@ describe ClassroomUnit, type: :model, redis: true do
 
   it { is_expected.to callback(:check_for_assign_on_join_and_update_students_array_if_true).before(:save) }
   it { is_expected.to callback(:hide_appropriate_activity_sessions).after(:save) }
+  it { is_expected.to callback(:manage_user_pack_sequence_items).after(:save) }
   it { is_expected.to callback(:save_user_pack_sequence_items).after(:save) }
 
   let!(:activity) { create(:activity) }
@@ -191,4 +192,5 @@ describe ClassroomUnit, type: :model, redis: true do
       end
     end
   end
+
 end

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -193,4 +193,46 @@ describe ClassroomUnit, type: :model, redis: true do
     end
   end
 
+  describe 'manage_user_pack_sequence_items' do
+    context 'after_save' do
+      context 'assigned_student_ids has changed' do
+        subject { classroom_unit.reload.update(assigned_student_ids: new_assigned_student_ids, assign_on_join: false) }
+
+        let(:another_student) { create(:student) }
+
+        context 'no user_pack_sequence_items exist' do
+          context 'student was removed' do
+            let(:new_assigned_student_ids) { [] }
+
+            it { expect { subject }.not_to change(UserPackSequenceItem, :count) }
+          end
+
+          context 'new student was added' do
+            let(:new_assigned_student_ids) { [student.id, another_student.id]}
+
+            it { expect { subject }.not_to change(UserPackSequenceItem, :count) }
+          end
+        end
+
+        context 'user_pack_sequence_items exist' do
+          let!(:pack_sequence_item) { create(:pack_sequence_item, classroom_unit: classroom_unit) }
+
+          before { create(:user_pack_sequence_item, user: student, pack_sequence_item: pack_sequence_item) }
+
+          context 'student was removed' do
+            let(:new_assigned_student_ids) { [] }
+
+            it { expect { subject }.to change(UserPackSequenceItem, :count).from(1).to(0) }
+          end
+
+          context 'new student was added' do
+            let(:new_assigned_student_ids) { [student.id, another_student.id]}
+
+            it { expect { subject }.to change(UserPackSequenceItem, :count).from(1).to(2) }
+          end
+        end
+      end
+    end
+  end
+
 end

--- a/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
+++ b/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
@@ -5,11 +5,11 @@
 # Table name: pack_sequence_items
 #
 #  id                :bigint           not null, primary key
-#  order             :integer
+#  order             :integer          not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  classroom_unit_id :bigint           not null
-#  pack_sequence_id  :bigint
+#  pack_sequence_id  :bigint           not null
 #
 # Indexes
 #

--- a/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
+++ b/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
@@ -9,18 +9,14 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  pack_sequence_id :bigint
-#  unit_id          :bigint
 #
 # Indexes
 #
-#  index_pack_sequence_items_on_pack_sequence_id              (pack_sequence_id)
-#  index_pack_sequence_items_on_pack_sequence_id_and_unit_id  (pack_sequence_id,unit_id) UNIQUE
-#  index_pack_sequence_items_on_unit_id                       (unit_id)
+#  index_pack_sequence_items_on_pack_sequence_id  (pack_sequence_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (pack_sequence_id => pack_sequences.id)
-#  fk_rails_...  (unit_id => units.id)
 #
 require 'rails_helper'
 
@@ -28,7 +24,7 @@ RSpec.describe PackSequenceItem, type: :model do
   subject { create(:pack_sequence_item) }
 
   it { should belong_to(:pack_sequence) }
-  it { should belong_to(:unit) }
+  it { should belong_to(:classroom_unit) }
 
   it { expect(subject).to be_valid }
 
@@ -39,7 +35,7 @@ RSpec.describe PackSequenceItem, type: :model do
       let(:duplicate_pack_sequence_item) do
         create(:pack_sequence_item,
           pack_sequence: pack_sequence_item.pack_sequence,
-          unit: pack_sequence_item.unit
+          classroom_unit: pack_sequence_item.classroom_unit
         )
       end
 

--- a/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
+++ b/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
@@ -4,18 +4,22 @@
 #
 # Table name: pack_sequence_items
 #
-#  id               :bigint           not null, primary key
-#  order            :integer
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  pack_sequence_id :bigint
+#  id                :bigint           not null, primary key
+#  order             :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  classroom_unit_id :bigint           not null
+#  pack_sequence_id  :bigint
 #
 # Indexes
 #
-#  index_pack_sequence_items_on_pack_sequence_id  (pack_sequence_id)
+#  index_pack_sequence_items__classroom_unit_id__pack_sequence_id  (classroom_unit_id,pack_sequence_id) UNIQUE
+#  index_pack_sequence_items_on_classroom_unit_id                  (classroom_unit_id)
+#  index_pack_sequence_items_on_pack_sequence_id                   (pack_sequence_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (classroom_unit_id => classroom_units.id)
 #  fk_rails_...  (pack_sequence_id => pack_sequences.id)
 #
 require 'rails_helper'

--- a/services/QuillLMS/spec/models/pack_sequence_spec.rb
+++ b/services/QuillLMS/spec/models/pack_sequence_spec.rb
@@ -5,11 +5,11 @@
 # Table name: pack_sequences
 #
 #  id                     :bigint           not null, primary key
-#  release_method         :string
+#  release_method         :string           default("staggered")
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  classroom_id           :bigint
-#  diagnostic_activity_id :bigint
+#  classroom_id           :bigint           not null
+#  diagnostic_activity_id :bigint           not null
 #
 # Indexes
 #

--- a/services/QuillLMS/spec/models/subject_area_spec.rb
+++ b/services/QuillLMS/spec/models/subject_area_spec.rb
@@ -5,7 +5,7 @@
 # Table name: subject_areas
 #
 #  id         :bigint           not null, primary key
-#  name       :string
+#  name       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -5,11 +5,19 @@
 # Table name: teacher_infos
 #
 #  id                  :bigint           not null, primary key
-#  minimum_grade_level :integer
 #  maximum_grade_level :integer
-#  teacher_id          :bigint
+#  minimum_grade_level :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  user_id             :bigint           not null
+#
+# Indexes
+#
+#  index_teacher_infos_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/teacher_info_subject_area_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_subject_area_spec.rb
@@ -5,10 +5,20 @@
 # Table name: teacher_info_subject_areas
 #
 #  id              :bigint           not null, primary key
-#  teacher_info_id :bigint
-#  subject_area_id :bigint
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  subject_area_id :bigint           not null
+#  teacher_info_id :bigint           not null
+#
+# Indexes
+#
+#  index_teacher_info_subject_areas_on_subject_area_id  (subject_area_id)
+#  index_teacher_info_subject_areas_on_teacher_info_id  (teacher_info_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (subject_area_id => subject_areas.id)
+#  fk_rails_...  (teacher_info_id => teacher_infos.id)
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/unit_spec.rb
+++ b/services/QuillLMS/spec/models/unit_spec.rb
@@ -32,6 +32,7 @@ describe Unit, type: :model do
   it { should have_many(:standards).through(:activities) }
   it { should belong_to(:unit_template) }
 
+  it { is_expected.to callback(:save_user_pack_sequence_items).after(:save) }
   it { is_expected.to callback(:hide_classroom_units_and_unit_activities).after(:save) }
 
   let!(:classroom) { create(:classroom) }

--- a/services/QuillLMS/spec/models/unit_spec.rb
+++ b/services/QuillLMS/spec/models/unit_spec.rb
@@ -184,8 +184,10 @@ describe Unit, type: :model do
   describe 'save_user_pack_sequence_items' do
     let!(:unit) { create(:unit, user: teacher, visible: visible) }
     let!(:num_students) { 2 }
+    let!(:student_ids) { create_list(:student, num_students).pluck(:id) }
+    let!(:classroom_unit) { create(:classroom_unit, unit: unit, assigned_student_ids: student_ids) }
     let!(:num_jobs) { num_students }
-    let!(:pack_sequence_item) { create(:pack_sequence_item, unit: unit) }
+    let!(:pack_sequence_item) { create(:pack_sequence_item, classroom_unit: classroom_unit) }
 
     before { create_list(:user_pack_sequence_item, num_students, pack_sequence_item: pack_sequence_item) }
 

--- a/services/QuillLMS/spec/models/user_pack_sequence_item_spec.rb
+++ b/services/QuillLMS/spec/models/user_pack_sequence_item_spec.rb
@@ -13,9 +13,9 @@
 #
 # Indexes
 #
-#  index_user_pack_sequence_items_on_pack_sequence_item_id     (pack_sequence_item_id)
-#  index_user_pack_sequence_items_on_user_id                   (user_id)
-#  on_user_pack_sequence_items_on_user_and_pack_sequence_item  (user_id,pack_sequence_item_id) UNIQUE
+#  index_user_pack_sequence_items__user_id__pack_sequence_item_id  (user_id,pack_sequence_item_id) UNIQUE
+#  index_user_pack_sequence_items_on_pack_sequence_item_id         (pack_sequence_item_id)
+#  index_user_pack_sequence_items_on_user_id                       (user_id)
 #
 # Foreign Keys
 #

--- a/services/QuillLMS/spec/queries/user_pack_sequence_item_query_spec.rb
+++ b/services/QuillLMS/spec/queries/user_pack_sequence_item_query_spec.rb
@@ -12,19 +12,16 @@ RSpec.describe UserPackSequenceItemQuery do
   let!(:classroom) { create(:classroom) }
   let!(:pack_sequence) { create(:pack_sequence, classroom: classroom) }
 
-  let!(:unit1) { create(:unit) }
-  let!(:pack_sequence_item1) { create(:pack_sequence_item, pack_sequence: pack_sequence, unit: unit1, order: 1) }
-  let!(:classroom_unit1) { create(:classroom_unit, unit: unit1, classroom: classroom) }
+  let!(:classroom_unit1) { create(:classroom_unit, classroom: classroom) }
+  let!(:pack_sequence_item1) { create(:pack_sequence_item, pack_sequence: pack_sequence, classroom_unit: classroom_unit1, order: 1) }
   let!(:activity_session1) { create(:activity_session, state1.to_sym, classroom_unit: classroom_unit1, user: student) }
 
-  let!(:unit2) { create(:unit) }
-  let!(:pack_sequence_item2) { create(:pack_sequence_item, pack_sequence: pack_sequence, unit: unit2, order: 2) }
-  let!(:classroom_unit2) { create(:classroom_unit, unit: unit2, classroom: classroom) }
+  let!(:classroom_unit2) { create(:classroom_unit, classroom: classroom) }
+  let!(:pack_sequence_item2) { create(:pack_sequence_item, pack_sequence: pack_sequence, classroom_unit: classroom_unit2, order: 2) }
   let!(:activity_session2) { create(:activity_session, state2.to_sym, classroom_unit: classroom_unit2, user: student) }
 
-  let!(:unit3) { create(:unit) }
-  let!(:pack_sequence_item3) { create(:pack_sequence_item, pack_sequence: pack_sequence, unit: unit3, order: 3) }
-  let!(:classroom_unit3) { create(:classroom_unit, unit: unit3, classroom: classroom) }
+  let!(:classroom_unit3) { create(:classroom_unit, classroom: classroom) }
+  let!(:pack_sequence_item3) { create(:pack_sequence_item, pack_sequence: pack_sequence, classroom_unit: classroom_unit3, order: 3) }
   let!(:activity_session3) { create(:activity_session, classroom_unit: classroom_unit3) }
 
   let(:finished) { ActivitySession::STATE_FINISHED }

--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -104,8 +104,9 @@ describe AssignRecommendationsWorker do
 
     context 'when pack_sequence_item already exists' do
       let(:unit) { create(:unit, unit_template: unit_template, user: teacher) }
+      let(:classroom_unit) { create(:classroom_unit, classroom: classroom, unit: unit) }
 
-      before { create(:pack_sequence_item, unit: unit, pack_sequence_id: pack_sequence_id, order: 0) }
+      before { create(:pack_sequence_item, classroom_unit: classroom_unit, pack_sequence_id: pack_sequence_id, order: 0) }
 
       it { expect { subject }.not_to change(PackSequenceItem, :count).from(1) }
     end


### PR DESCRIPTION
## WHAT
1) Change schema for `PackSequenceItem` so that it belongs to `:classroom_unit` instead of `:unit`
2) Add some null constraints to `PackSequence` and `PackSequenceItem`

## WHY
ClassroomUnit has an attribute `assigned_student_ids` is a vital piece of information in monitoring the PackSequenceItem lifecycle.  When students are added/removed to a classroom unit, we need to add/remove corresponding `UserPackSequenceItem`.  Currently, the PackSequenceItem has to go through Unit to get to the ClassroomUnit object, which is kind of clunky and begs the question if it's actually the correct object for the relationship. 

## HOW
Write some migrations that change this relationship from :unit to :classroom_unit

Add a new method `manage_user_pack_sequence_items` that monitors changes to assigned_student_ids.  When these are altered, create/destroy the necessary UserPackSequenceItems

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet, deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
