### PR TITLE
lessons/new-service-provider

### DIFF
--- a/services/QuillLessonsServer/src/config/rethinkdb.js
+++ b/services/QuillLessonsServer/src/config/rethinkdb.js
@@ -5,13 +5,13 @@ export const rethinkdbConfig = (hosts, server, authKey, publicKey, useSSL) => {
   const db = 'quill_lessons';
   const hostWithPort = rethinkDBHost(hosts, server);
   const [host, port] = splitStringOnLast(hostWithPort, ':');
-  const ssl = (useSSL === 'true') ? { ca: Buffer.from(publicKey, 'utf8') } : undefined;
+  const ssl = (useSSL === 'true') ? { ca_certs: Buffer.from(publicKey, 'utf8') } : undefined;
 
   return {
     host,
     port,
     db,
-    authKey,
+    password: authKey,
     ssl,
   }
 }


### PR DESCRIPTION
# WARNING
Do not merge and deploy this code until we're doing the RethinkDB production migration.

## WHAT
Replace `authKey` with `password` in the config for connecting to RethinkDB because, apparently, the updated versions of RethinkDB running in Stackhero don't use `authKey` anymore.

Also `ssl.ca` needs to be `ssl.ca_certs` in the new version.
## WHY
The original config won't connect to Stackhero, but this updated code does.
## HOW
Fortunately we just need to update the names of the values used, nothing else.

### Notion Card Links
https://www.notion.so/quill/RethinkDB-Migration-Process-2439ddad6f1841a1a55c2ba1bc36581f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on configs
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
