### PR TITLE
add max height to release method modal

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_release_method_modal.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_release_method_modal.scss
@@ -6,6 +6,7 @@
     z-index: 5;
     height: min-content;
     max-height: 100vh;
+    overflow: scroll;
     width: 1020px;
     top: 50%;
     bottom: 0px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_release_method_modal.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_release_method_modal.scss
@@ -5,6 +5,7 @@
   .release-method-modal {
     z-index: 5;
     height: min-content;
+    max-height: 100vh;
     width: 1020px;
     top: 50%;
     bottom: 0px;


### PR DESCRIPTION
## WHAT
Add a `max-height` to the release method modal.

## WHY
So that a scroll bar appears if the view height is smaller than the height of the modal (a problem pointed out by Peter Sharkey).

## HOW
Just add the CSS rule.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests for CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
