### PR TITLE
Fix staggered release locks with multiple pack sequences

### DIFF
--- a/services/QuillLMS/app/queries/user_pack_sequence_item_query.rb
+++ b/services/QuillLMS/app/queries/user_pack_sequence_item_query.rb
@@ -3,6 +3,7 @@
 class UserPackSequenceItemQuery
   FINISHED = ActivitySession::STATE_FINISHED
   COMPLETED_KEY = 'completed'
+  PACK_SEQUENCE_ID_KEY = 'pack_sequence_id'
   PACK_SEQUENCE_ITEM_ID_KEY = 'pack_sequence_item_id'
 
   def self.call(classroom_id, user_id)
@@ -10,6 +11,7 @@ class UserPackSequenceItemQuery
       .staggered
       .select("SUM(CASE WHEN activity_sessions.state = '#{FINISHED}' THEN 1 ELSE 0 END) > 0 AS #{COMPLETED_KEY}")
       .select("pack_sequence_items.id AS #{PACK_SEQUENCE_ITEM_ID_KEY}")
+      .select("pack_sequences.id AS #{PACK_SEQUENCE_ID_KEY}")
       .joins(pack_sequence_items: { classroom_unit: { unit: { unit_activities: :activity } } })
       .joins(
         <<-SQL
@@ -33,7 +35,7 @@ class UserPackSequenceItemQuery
         'units.id',
         'unit_activities.id'
       )
-      .order('pack_sequence_items.order')
+      .order('pack_sequences.id, pack_sequence_items.order')
   end
 end
 

--- a/services/QuillLMS/spec/queries/user_pack_sequence_item_query_spec.rb
+++ b/services/QuillLMS/spec/queries/user_pack_sequence_item_query_spec.rb
@@ -5,24 +5,27 @@ require 'rails_helper'
 RSpec.describe UserPackSequenceItemQuery do
   subject { described_class.call(classroom.id, student.id).as_json(except: :id) }
 
-  let(:completed) { described_class::COMPLETED_KEY }
-  let(:pack_sequence_item_id) { described_class::PACK_SEQUENCE_ITEM_ID_KEY }
-
   let!(:student) { create(:student) }
   let!(:classroom) { create(:classroom) }
-  let!(:pack_sequence) { create(:pack_sequence, classroom: classroom) }
+  let!(:pack_sequence1) { create(:pack_sequence, classroom: classroom) }
 
   let!(:classroom_unit1) { create(:classroom_unit, classroom: classroom) }
-  let!(:pack_sequence_item1) { create(:pack_sequence_item, pack_sequence: pack_sequence, classroom_unit: classroom_unit1, order: 1) }
+  let!(:pack_sequence_item1) { create(:pack_sequence_item, pack_sequence: pack_sequence1, classroom_unit: classroom_unit1, order: 1) }
   let!(:activity_session1) { create(:activity_session, state1.to_sym, classroom_unit: classroom_unit1, user: student) }
 
   let!(:classroom_unit2) { create(:classroom_unit, classroom: classroom) }
-  let!(:pack_sequence_item2) { create(:pack_sequence_item, pack_sequence: pack_sequence, classroom_unit: classroom_unit2, order: 2) }
+  let!(:pack_sequence_item2) { create(:pack_sequence_item, pack_sequence: pack_sequence1, classroom_unit: classroom_unit2, order: 2) }
   let!(:activity_session2) { create(:activity_session, state2.to_sym, classroom_unit: classroom_unit2, user: student) }
 
   let!(:classroom_unit3) { create(:classroom_unit, classroom: classroom) }
-  let!(:pack_sequence_item3) { create(:pack_sequence_item, pack_sequence: pack_sequence, classroom_unit: classroom_unit3, order: 3) }
+  let!(:pack_sequence_item3) { create(:pack_sequence_item, pack_sequence: pack_sequence1, classroom_unit: classroom_unit3, order: 3) }
   let!(:activity_session3) { create(:activity_session, classroom_unit: classroom_unit3) }
+
+  let!(:pack_sequence2) { create(:pack_sequence, classroom: classroom) }
+
+  let!(:classroom_unit4) { create(:classroom_unit, classroom: classroom) }
+  let!(:pack_sequence_item4) { create(:pack_sequence_item, pack_sequence: pack_sequence2, classroom_unit: classroom_unit4, order: 1) }
+  let!(:activity_session4) { create(:activity_session, classroom_unit: classroom_unit4, user: student) }
 
   let(:finished) { ActivitySession::STATE_FINISHED }
   let(:unfinished) { ActivitySession::STATE_UNSTARTED }
@@ -35,8 +38,9 @@ RSpec.describe UserPackSequenceItemQuery do
 
       it do
         expect(subject).to eq [
-          { completed => true, pack_sequence_item_id => pack_sequence_item1.id },
-          { completed => true, pack_sequence_item_id => pack_sequence_item2.id }
+          result(true, pack_sequence1, pack_sequence_item1),
+          result(true, pack_sequence1, pack_sequence_item2),
+          result(true, pack_sequence2, pack_sequence_item4)
         ]
       end
     end
@@ -46,8 +50,9 @@ RSpec.describe UserPackSequenceItemQuery do
 
       it do
         expect(subject).to eq [
-          { completed => true, pack_sequence_item_id => pack_sequence_item1.id },
-          { completed => false, pack_sequence_item_id => pack_sequence_item2.id }
+          result(true, pack_sequence1, pack_sequence_item1),
+          result(false, pack_sequence1, pack_sequence_item2),
+          result(true, pack_sequence2, pack_sequence_item4)
         ]
       end
     end
@@ -61,8 +66,9 @@ RSpec.describe UserPackSequenceItemQuery do
 
       it do
         expect(subject).to eq [
-          { completed => false, pack_sequence_item_id => pack_sequence_item1.id },
-          { completed => true, pack_sequence_item_id => pack_sequence_item2.id }
+          result(false, pack_sequence1, pack_sequence_item1),
+          result(true, pack_sequence1, pack_sequence_item2),
+          result(true, pack_sequence2, pack_sequence_item4)
         ]
       end
     end
@@ -72,11 +78,20 @@ RSpec.describe UserPackSequenceItemQuery do
 
       it do
         expect(subject).to eq [
-          { completed => false, pack_sequence_item_id => pack_sequence_item1.id },
-          { completed => false, pack_sequence_item_id => pack_sequence_item2.id }
+          result(false, pack_sequence1, pack_sequence_item1),
+          result(false, pack_sequence1, pack_sequence_item2),
+          result(true, pack_sequence2, pack_sequence_item4)
         ]
       end
     end
+  end
+
+  def result(completed, pack_sequence, pack_sequence_item)
+    {
+      described_class::COMPLETED_KEY => completed,
+      described_class::PACK_SEQUENCE_ID_KEY => pack_sequence.id,
+      described_class::PACK_SEQUENCE_ITEM_ID_KEY => pack_sequence_item.id
+    }
   end
 end
 

--- a/services/QuillLMS/spec/services/user_pack_sequence_item_saver_spec.rb
+++ b/services/QuillLMS/spec/services/user_pack_sequence_item_saver_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe UserPackSequenceItemSaver do
   let(:classroom) { create(:classroom) }
   let(:user) { create(:student) }
 
-  let(:pack_sequence_item1) { create(:pack_sequence_item) }
-  let(:pack_sequence_item2) { create(:pack_sequence_item) }
+  let(:pack_sequence1) { create(:pack_sequence) }
+  let(:pack_sequence_item1) { create(:pack_sequence_item, pack_sequence: pack_sequence1) }
+  let(:pack_sequence_item2) { create(:pack_sequence_item, pack_sequence: pack_sequence1) }
 
   let(:locked) { described_class::LOCKED }
   let(:unlocked) { described_class::UNLOCKED }
@@ -23,7 +24,7 @@ RSpec.describe UserPackSequenceItemSaver do
   end
 
   context 'one pack_sequence_item with one result' do
-    let(:result1) { result(completed1, pack_sequence_item1.id) }
+    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
     let(:results) { [result1] }
 
     context 'result is completed' do
@@ -42,8 +43,8 @@ RSpec.describe UserPackSequenceItemSaver do
   end
 
   context 'one pack_sequence_item with two results' do
-    let(:result1) { result(completed1, pack_sequence_item1.id) }
-    let(:result2) { result(completed2, pack_sequence_item1.id) }
+    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
+    let(:result2) { result(completed2, pack_sequence1, pack_sequence_item1) }
     let(:results) { [result1, result2] }
 
     context 'results are completed, uncompleted' do
@@ -64,8 +65,8 @@ RSpec.describe UserPackSequenceItemSaver do
   end
 
   context 'two pack_sequences_items with one result each' do
-    let(:result1) { result(completed1, pack_sequence_item1.id) }
-    let(:result2) { result(completed2, pack_sequence_item2.id) }
+    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
+    let(:result2) { result(completed2, pack_sequence1, pack_sequence_item2) }
     let(:results) { [result1, result2] }
 
     context 'results are uncompleted, completed' do
@@ -88,9 +89,9 @@ RSpec.describe UserPackSequenceItemSaver do
   end
 
   context 'two pack_sequence_items, one with two results and the other with one result' do
-    let(:result1) { result(completed1, pack_sequence_item1.id) }
-    let(:result2) { result(completed2, pack_sequence_item1.id) }
-    let(:result3) { result(completed3, pack_sequence_item2.id) }
+    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
+    let(:result2) { result(completed2, pack_sequence1, pack_sequence_item1) }
+    let(:result3) { result(completed3, pack_sequence1, pack_sequence_item2) }
     let(:results) { [result1, result2, result3] }
 
     context 'results are uncompleted, completed, completed' do
@@ -104,10 +105,50 @@ RSpec.describe UserPackSequenceItemSaver do
     end
   end
 
-  def result(completed, pack_sequence_item_id)
+  context 'two pack_sequences' do
+    let(:pack_sequence2) { create(:pack_sequence) }
+    let(:pack_sequence_item3) { create(:pack_sequence_item, pack_sequence: pack_sequence2) }
+    let(:pack_sequence_item4) { create(:pack_sequence_item, pack_sequence: pack_sequence2) }
+
+    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
+    let(:result2) { result(completed2, pack_sequence1, pack_sequence_item2) }
+    let(:result3) { result(completed3, pack_sequence2, pack_sequence_item3) }
+    let(:result4) { result(completed3, pack_sequence2, pack_sequence_item4) }
+    let(:results) { [result1, result2, result3, result4] }
+
+    context 'results are uncompleted, completed, completed, uncompleted' do
+      let(:completed1) { false }
+      let(:completed2) { true }
+      let(:completed3) { true }
+      let(:completed4) { false }
+
+      it { expect { subject }.to change(UserPackSequenceItem, :count).from(0).to(4) }
+      it { should_save_user_pack_sequence_item(pack_sequence_item1, unlocked) }
+      it { should_save_user_pack_sequence_item(pack_sequence_item2, locked) }
+      it { should_save_user_pack_sequence_item(pack_sequence_item3, unlocked) }
+      it { should_save_user_pack_sequence_item(pack_sequence_item4, unlocked) }
+    end
+
+    context 'results are uncompleted, completed, uncompleted, completed' do
+      let(:completed1) { false }
+      let(:completed2) { true }
+      let(:completed3) { false }
+      let(:completed4) { true }
+
+      it { expect { subject }.to change(UserPackSequenceItem, :count).from(0).to(4) }
+      it { should_save_user_pack_sequence_item(pack_sequence_item1, unlocked) }
+      it { should_save_user_pack_sequence_item(pack_sequence_item2, locked) }
+      it { should_save_user_pack_sequence_item(pack_sequence_item3, unlocked) }
+      it { should_save_user_pack_sequence_item(pack_sequence_item4, locked) }
+    end
+  end
+
+
+  def result(completed, pack_sequence, pack_sequence_item)
     {
       described_class::COMPLETED_KEY => completed,
-      described_class::PACK_SEQUENCE_ITEM_ID_KEY => pack_sequence_item_id
+      described_class::PACK_SEQUENCE_ID_KEY => pack_sequence.id,
+      described_class::PACK_SEQUENCE_ITEM_ID_KEY => pack_sequence_item.id
     }
   end
 


### PR DESCRIPTION
## WHAT
Fix a bug with locks involving multiple pack sequences.

## WHY
If a user selects multiple pack sequences for staggered release (e.g. a pre-diagnostic and then a post-diagnostic) the locks are not calculated properly

## HOW
When iterating through the `user_pack_sequence_item_results` in `UserPackSequenceItemSaver#compute_statuses` a new variable `pack_sequence_id` is needed to determine if the status should be reset to `UNLOCKED`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
