### PR TITLE
Fix some intermittent spec failures

### DIFF
--- a/services/QuillLMS/spec/models/clever_integration/teacher_classrooms_cache_spec.rb
+++ b/services/QuillLMS/spec/models/clever_integration/teacher_classrooms_cache_spec.rb
@@ -24,14 +24,13 @@ RSpec.describe CleverIntegration::TeacherClassroomsCache do
       expect(cache.read(user_id)).to eq data
     end
 
-    it 'allows for expiration' do
-      cache.write(user_id, data, 0.1)
-      sleep 0.1
-      expect(cache.read(user_id)).to eq nil
-    end
-
     it 'deletes data' do
       expect { cache.delete(user_id) }.to change { cache.read(user_id) }.from(data).to(nil)
     end
+  end
+
+  it 'allows for expiration' do
+    cache.write(user_id, data, 0)
+    expect(cache.read(user_id)).to eq nil
   end
 end

--- a/services/QuillLMS/spec/models/google_integration/teacher_classrooms_cache_spec.rb
+++ b/services/QuillLMS/spec/models/google_integration/teacher_classrooms_cache_spec.rb
@@ -24,14 +24,13 @@ RSpec.describe GoogleIntegration::TeacherClassroomsCache do
       expect(cache.read(user_id)).to eq data
     end
 
-    it 'allows for expiration' do
-      cache.write(user_id, data, 0.1)
-      sleep 0.1
-      expect(cache.read(user_id)).to eq nil
-    end
-
     it 'deletes data' do
       expect { cache.delete(user_id) }.to change { cache.read(user_id) }.from(data).to(nil)
     end
+  end
+
+  it 'allows for expiration' do
+    cache.write(user_id, data, 0)
+    expect(cache.read(user_id)).to eq nil
   end
 end


### PR DESCRIPTION
## WHAT
Fix some intermittent spec [failures](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/19407/workflows/c6b2fa39-f824-4348-b8f8-965021b7d7c8/jobs/253449) involving

1) Google and Clever Integration Caching
2) Ordering with teacher classrooms controller

## WHY
False positives like this slow down development.

## HOW
1) Have cache expire immediately to eliminate race condition
2) Use database order clause on the items in question

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
