### PR TITLE
lms/clear-cache-when-hiding-activities

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
@@ -21,7 +21,7 @@ class Teachers::UnitActivitiesController < ApplicationController
     @activity_sessions.update_all(visible: false)
     @unit_activities.each(&:save_user_pack_sequence_items)
     # touch the parent unit in order to clear our caches
-    @unit_activity.unit.touch
+    @unit_activity&.unit&.touch
     ResetLessonCacheWorker.new.perform(current_user.id)
     render json: {}
   end

--- a/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
@@ -20,6 +20,8 @@ class Teachers::UnitActivitiesController < ApplicationController
     @unit_activity&.unit&.hide_if_no_visible_unit_activities
     @activity_sessions.update_all(visible: false)
     @unit_activities.each(&:save_user_pack_sequence_items)
+    # touch the parent unit in order to clear our caches
+    @unit_activity.unit.touch
     ResetLessonCacheWorker.new.perform(current_user.id)
     render json: {}
   end

--- a/services/QuillLMS/spec/controllers/teachers/unit_activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/unit_activities_controller_spec.rb
@@ -26,6 +26,7 @@ describe Teachers::UnitActivitiesController, type: :controller do
     end
 
     it 'should touch the parent unit in order to bubble up cache clearing' do
+      allow(UnitActivity).to receive(:find).with(unit_activity.id.to_s).and_return(unit_activity)
       expect_any_instance_of(Unit).to receive(:touch)
       put :hide, params: { id: unit_activity.id }
     end

--- a/services/QuillLMS/spec/controllers/teachers/unit_activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/unit_activities_controller_spec.rb
@@ -24,6 +24,11 @@ describe Teachers::UnitActivitiesController, type: :controller do
       put :hide, params: { id: unit_activity.id }
       expect(unit_activity.reload.visible).to eq false
     end
+
+    it 'should touch the parent unit in order to bubble up cache clearing' do
+      expect_any_instance_of(Unit).to receive(:touch)
+      put :hide, params: { id: unit_activity.id }
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION


## WHAT
Touch the parent Unit when hiding UnitActivities
## WHY
So that the cache clears and the fact that these activities have been removed will reflect in reporting
## HOW
Just add a `touch` call to the `hide` controller action

### Notion Card Links
https://www.notion.so/quill/Deleted-activity-showing-in-Activity-Summary-report-7c07237133624cd5bc2cd6436e9586c1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A