### PR TITLE
Limit account creation attempts to 5 an hour.

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_minis/unit_template_minis.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_minis/unit_template_minis.scss
@@ -45,7 +45,7 @@
     }
   }
 
-  .pack-type-header {
+  .pack-type-header, .top-card-margin-top {
     font-weight: 700;
     font-size: 20px;
     margin-left: 4px;
@@ -67,6 +67,20 @@
     }
   }
 
+  .unit-template-minis:has(.all-packs-section) {
+    display: flex;
+    flex-direction: column;
+    .packs-section {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      .unit-template-mini-wrapper {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+      }
+    }
+  }
+
   .unit-template-minis {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -76,9 +90,11 @@
       .packs-section {
         padding: 0;
         border-bottom: none;
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-between;
+      }
+    }
+    .unit-template-mini-wrapper {
+      &.second-card {
+        margin-top: 28px;
       }
     }
     .unit-template-mini-wrapper:nth-child(odd) {
@@ -211,7 +227,7 @@
   }
 }
 
-@media only screen and (max-width: 500px) {
+@media only screen and (max-width: 980px) {
   .small-screen-unit-template-container {
     .author-picture {
       display: none;
@@ -232,6 +248,8 @@
     }
   }
   .unit-template-minis {
+    display: flex;
+    flex-wrap: wrap;
     justify-content: center !important;
     .unit-template-mini {
       width: 350px;

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -323,7 +323,13 @@ module Teacher
   end
 
   def teaches_eighth_through_twelfth?
-    return classrooms_i_teach.map(&:grade).compact.any? { |grade| grade.to_i.between?(8, 12) }
+    return true if teacher_info&.in_eighth_through_twelfth?
+
+    classrooms_i_teach
+      .map(&:grade)
+      .compact
+      .uniq
+      .any? { |grade| grade.to_i.in?(TeacherInfo::EIGHT_TO_TWELVE) }
   end
 
   def google_classrooms

--- a/services/QuillLMS/app/models/teacher_info.rb
+++ b/services/QuillLMS/app/models/teacher_info.rb
@@ -32,6 +32,8 @@ class TeacherInfo < ApplicationRecord
   KINDERGARTEN_DISPLAY_STRING = 'K'
   KINDERGARTEN_DATABASE_INTEGER = 0
 
+  EIGHT_TO_TWELVE = (8..12).to_a
+
   def minimum_grade_level=(value)
     value = KINDERGARTEN_DATABASE_INTEGER if value == KINDERGARTEN_DISPLAY_STRING
     super(value)
@@ -68,5 +70,22 @@ class TeacherInfo < ApplicationRecord
 
   def teacher_id=(value)
     self.user_id = value
+  end
+
+  def grade_levels
+    return [] if no_grade_levels?
+
+    return [maximum_grade_level] if minimum_grade_level.nil?
+    return [minimum_grade_level] if maximum_grade_level.nil?
+
+    (self[:minimum_grade_level]..self[:maximum_grade_level]).to_a
+  end
+
+  def in_eighth_through_twelfth?
+    grade_levels.intersection(EIGHT_TO_TWELVE).present?
+  end
+
+  private def no_grade_levels?
+    minimum_grade_level.nil? && maximum_grade_level.nil?
   end
 end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unit_template_minis.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unit_template_minis.test.jsx.snap
@@ -138,17 +138,17 @@ exports[`UnitTemplateMinis component should render dropdowns when on mobile 1`] 
           <section
             className="all-packs-section"
           >
-            <p
-              className="pack-type-header"
-            >
-              Diagnostic
-            </p>
             <section
               className="packs-section"
             >
               <div
                 className="unit-template-mini-wrapper"
               >
+                <p
+                  className="pack-type-header"
+                >
+                  Diagnostic
+                </p>
                 <UnitTemplateMini
                   data={
                     Object {
@@ -190,17 +190,17 @@ exports[`UnitTemplateMinis component should render dropdowns when on mobile 1`] 
           <section
             className="all-packs-section"
           >
-            <p
-              className="pack-type-header"
-            >
-              Whole Class Lessons
-            </p>
             <section
               className="packs-section"
             >
               <div
                 className="unit-template-mini-wrapper"
               >
+                <p
+                  className="pack-type-header"
+                >
+                  Whole Class Lessons
+                </p>
                 <UnitTemplateMini
                   data={
                     Object {
@@ -356,17 +356,17 @@ exports[`UnitTemplateMinis component should render without createYourOwn mini wh
           <section
             className="all-packs-section"
           >
-            <p
-              className="pack-type-header"
-            >
-              Diagnostic
-            </p>
             <section
               className="packs-section"
             >
               <div
                 className="unit-template-mini-wrapper"
               >
+                <p
+                  className="pack-type-header"
+                >
+                  Diagnostic
+                </p>
                 <UnitTemplateMini
                   data={
                     Object {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_minis.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_minis.jsx
@@ -89,10 +89,11 @@ export default class UnitTemplateMinis extends React.Component {
     }
   }
 
-  generateUnitTemplateView = (model, index) => {
+  generateUnitTemplateView = (model, index, type) => {
     const { actions, signedInTeacher, } = this.props
     return (
       <div className="unit-template-mini-wrapper">
+        {type && index === 0 && <p className="pack-type-header">{type}</p>}
         <UnitTemplateMini
           actions={actions}
           data={model}
@@ -118,7 +119,9 @@ export default class UnitTemplateMinis extends React.Component {
 
       return unit_template_category.name === type
     })
-    return filteredModels.map(this.generateUnitTemplateView);
+    return filteredModels.map((model, index) => {
+      return this.generateUnitTemplateView(model, index, type)
+    });
   }
 
   generateUnitTemplateViews() {
@@ -145,31 +148,26 @@ export default class UnitTemplateMinis extends React.Component {
       return(
         <React.Fragment>
           {!!readingTextModels.length && <section className="all-packs-section">
-            <p className="pack-type-header">{READING_TEXTS}</p>
             <section className="packs-section">
               {readingTextModels}
             </section>
           </section>}
           {!!diagnosticModels.length && <section className="all-packs-section">
-            <p className="pack-type-header">{DIAGNOSTIC}</p>
             <section className="packs-section">
               {diagnosticModels}
             </section>
           </section>}
           {!!languageSkillsModels.length && <section className="all-packs-section">
-            <p className="pack-type-header">{LANGUAGE_SKILLS}</p>
             <section className="packs-section">
               {languageSkillsModels}
             </section>
           </section>}
           {!!dailyProofreadingModels.length && <section className="all-packs-section">
-            <p className="pack-type-header">{DAILY_PROOFREADING}</p>
             <section className="packs-section">
               {dailyProofreadingModels}
             </section>
           </section>}
           {!!wholeClassModels.length && <section className="all-packs-section">
-            <p className="pack-type-header">{WHOLE_CLASS_LESSONS}</p>
             <section className="packs-section">
               {wholeClassModels}
             </section>
@@ -177,7 +175,7 @@ export default class UnitTemplateMinis extends React.Component {
         </React.Fragment>
       )
     }
-    const modelCards = models.map(this.generateUnitTemplateView);
+    const modelCards = models.map((model, index) => this.generateUnitTemplateView(model, index));
     return modelCards;
   }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
@@ -6,7 +6,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
   defaultText="No date selected"
   handleClickCopyToAll={[Function]}
   icon={null}
-  initialValue={"2022-11-10T05:00:00.000Z"}
+  initialValue={"2022-11-10T03:00:00.000Z"}
   rowIndex={0}
 >
   <div
@@ -21,7 +21,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
         closeOnSelect={false}
         closeOnTab={true}
         dateFormat="MMM D"
-        initialValue={"2022-11-10T05:00:00.000Z"}
+        initialValue={"2022-11-10T03:00:00.000Z"}
         initialViewDate={2022-11-10T09:00:00.000Z}
         input={true}
         inputProps={Object {}}
@@ -85,7 +85,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       "onFocus": [Function],
                       "onKeyDown": [Function],
                       "type": "text",
-                      "value": "Nov 10 5:00 am",
+                      "value": "Nov 10 3:00 am",
                     }
                   }
                 >
@@ -102,7 +102,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       onKeyDown={[Function]}
                       placeholder="No date selected"
                       type="text"
-                      value="Nov 10 5:00 am"
+                      value="Nov 10 3:00 am"
                     />
                     <img
                       alt="dropdown indicator"
@@ -120,7 +120,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                   moment={[Function]}
                   navigate={[Function]}
                   renderDay={[Function]}
-                  selectedDate={"2022-11-10T05:00:00.000Z"}
+                  selectedDate={"2022-11-10T03:00:00.000Z"}
                   showView={[Function]}
                   timeFormat="h:mm a"
                   updateDate={[Function]}

--- a/services/QuillLMS/config/initializers/rack_attack.rb
+++ b/services/QuillLMS/config/initializers/rack_attack.rb
@@ -14,6 +14,12 @@ class Rack::Attack
     end
   end
 
+  Rack::Attack.throttle('account creation per IP', limit: 5, period: 60.minutes) do |req|
+    if req.path == '/account' && req.post?
+      req.ip
+    end
+  end
+
   Rack::Attack.throttled_response = lambda do |request|
     # NB: you have access to the name and other data about the matched throttle
     #  request.env['rack.attack.matched'],
@@ -23,7 +29,7 @@ class Rack::Attack
 
     # Using 503 because it may make attacker think that they have successfully
     # DOSed the site. Rack::Attack returns 429 for throttling by default
-    [503, {}, [{ message: 'Too many login attempts. Please try again later.', type: 'password' }.to_json]]
+    [503, {}, [{ message: 'Too many attempts. Please try again later.', type: 'password' }.to_json]]
   end
 
 end

--- a/services/QuillLMS/spec/models/clever_integration/teacher_classrooms_cache_spec.rb
+++ b/services/QuillLMS/spec/models/clever_integration/teacher_classrooms_cache_spec.rb
@@ -24,14 +24,13 @@ RSpec.describe CleverIntegration::TeacherClassroomsCache do
       expect(cache.read(user_id)).to eq data
     end
 
-    it 'allows for expiration' do
-      cache.write(user_id, data, 0.1)
-      sleep 0.1
-      expect(cache.read(user_id)).to eq nil
-    end
-
     it 'deletes data' do
       expect { cache.delete(user_id) }.to change { cache.read(user_id) }.from(data).to(nil)
     end
+  end
+
+  it 'allows for expiration' do
+    cache.write(user_id, data, 0)
+    expect(cache.read(user_id)).to eq nil
   end
 end

--- a/services/QuillLMS/spec/models/concerns/teacher_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/teacher_spec.rb
@@ -316,6 +316,24 @@ describe User, type: :model do
           expect(one_classroom_teacher.teaches_eighth_through_twelfth?).not_to be
         end
       end
+
+      context 'using teacher_info' do
+        let(:new_teacher) { create(:teacher) }
+
+        it { expect(new_teacher.teaches_eighth_through_twelfth?).to be false }
+
+        context 'teacher info grades in range' do
+          let!(:teacher_info) {create(:teacher_info, user: new_teacher, minimum_grade_level: 6, maximum_grade_level: 10)}
+
+          it { expect(new_teacher.teaches_eighth_through_twelfth?).to be true }
+        end
+
+        context 'teacher info grades out of range' do
+          let!(:teacher_info) {create(:teacher_info, user: new_teacher, minimum_grade_level: 6, maximum_grade_level: 7)}
+
+          it { expect(new_teacher.teaches_eighth_through_twelfth?).to be false}
+        end
+      end
     end
 
     describe '#unlink' do

--- a/services/QuillLMS/spec/models/google_integration/teacher_classrooms_cache_spec.rb
+++ b/services/QuillLMS/spec/models/google_integration/teacher_classrooms_cache_spec.rb
@@ -24,14 +24,13 @@ RSpec.describe GoogleIntegration::TeacherClassroomsCache do
       expect(cache.read(user_id)).to eq data
     end
 
-    it 'allows for expiration' do
-      cache.write(user_id, data, 0.1)
-      sleep 0.1
-      expect(cache.read(user_id)).to eq nil
-    end
-
     it 'deletes data' do
       expect { cache.delete(user_id) }.to change { cache.read(user_id) }.from(data).to(nil)
     end
+  end
+
+  it 'allows for expiration' do
+    cache.write(user_id, data, 0)
+    expect(cache.read(user_id)).to eq nil
   end
 end

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -30,10 +30,15 @@ describe TeacherInfo, type: :model, redis: true do
   it {should validate_numericality_of(:maximum_grade_level)}
 
   it {should validate_presence_of(:user_id)}
-  it {should validate_uniqueness_of(:user_id)}
 
-  let!(:teacher_info) {create(:teacher_info)}
-  let!(:teacher) {create(:teacher)}
+  context 'uniqueness' do
+    let!(:teacher_info) {create(:teacher_info)}
+
+    it {should validate_uniqueness_of(:user_id)}
+  end
+
+  let(:teacher_info) {create(:teacher_info)}
+  let(:teacher) {create(:teacher)}
 
   describe 'minimum_grade_level=' do
     it 'should set the minimum grade level to 0 if it is passed in as K' do
@@ -89,4 +94,20 @@ describe TeacherInfo, type: :model, redis: true do
     end
   end
 
+  describe '#grade_levels' do
+    it { expect(build(:teacher_info, minimum_grade_level: 0, maximum_grade_level: 12).grade_levels).to eq (0..12).to_a }
+    it { expect(build(:teacher_info, minimum_grade_level: 8, maximum_grade_level: 8).grade_levels).to eq [8] }
+    it { expect(build(:teacher_info, minimum_grade_level: nil, maximum_grade_level: nil).grade_levels).to eq [] }
+    it { expect(build(:teacher_info, minimum_grade_level: nil, maximum_grade_level: 9).grade_levels).to eq [9] }
+    it { expect(build(:teacher_info, minimum_grade_level: 5, maximum_grade_level: nil).grade_levels).to eq [5]}
+  end
+
+  describe '#in_eighth_through_twelfth?' do
+    it { expect(build(:teacher_info, minimum_grade_level: 0, maximum_grade_level: 12).in_eighth_through_twelfth?).to be true }
+    it { expect(build(:teacher_info, minimum_grade_level: 0, maximum_grade_level: 7).in_eighth_through_twelfth?).to be false }
+    it { expect(build(:teacher_info, minimum_grade_level: 8, maximum_grade_level: 8).in_eighth_through_twelfth?).to eq true }
+    it { expect(build(:teacher_info, minimum_grade_level: nil, maximum_grade_level: nil).in_eighth_through_twelfth?).to eq false }
+    it { expect(build(:teacher_info, minimum_grade_level: nil, maximum_grade_level: 9).in_eighth_through_twelfth?).to eq true }
+    it { expect(build(:teacher_info, minimum_grade_level: 5, maximum_grade_level: nil).in_eighth_through_twelfth?).to eq false}
+  end
 end


### PR DESCRIPTION
## WHAT
Add a throttle for account creation to limit bots creating accounts.
## WHY
We had a few fake accounts created today.
## HOW
Use standard rack attack setup.

Confirmed this locally using this script:
```ruby
6.times.map do
  HTTParty.post('http://localhost:3000/account', 
    { user: { name: 'Testing', email: "test#{SecureRandom.uuid}@test.com", password: '12345', role: User::TEACHER } }
  )
end
```
### Screenshots


### Notion Card Links
https://www.notion.so/quill/ea241f31a84c4b79ad56e83e99f7ee93?v=9f7aead86cc749d8a6f963070cef4f5e&p=1da7d6b727374e4fbd4a9fe2af055923&pm=c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, this is sorta outside of our test suite.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
