### PR TITLE
Evidence Activity Health Dashboard front end

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/reactTable/reactTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/reactTable/reactTable.tsx
@@ -19,6 +19,7 @@ function columnClassName(isSorted, isSortedDesc) {
 export const TextFilter = ({ column, setFilter, }) => {
   return (
     <input
+      aria-label="text-filter"
       onChange={event => setFilter(column.id, event.target.value)}
       style={{ width: "100%" }}
       value={column.filterValue}
@@ -31,11 +32,11 @@ export const NumberFilterInput = ({ handleChange, label, column }: NumberFilterI
     <div style={{ display: 'flex' }}>
       <input
         aria-label={label}
-        defaultValue={column.filterValue || ''}
         onChange={e => handleChange(column.id, e.target.value)}
         placeholder={`0-5, >1, <1`}
         style={{width: '100px', marginRight: '0.5rem'}}
         type="text"
+        value={column.filterValue || ''}
       />
     </div>
   );
@@ -71,7 +72,9 @@ interface ReactTableProps {
   defaultSorted?: string,
   onSortedChange?: (sortBy: string) => void,
   onPageChange?: (pageIndex: number) => void,
+  onFiltersChange?: (filters: []) => void,
   showPaginationBottom?: boolean,
+  manualFilters?: boolean,
   manualSortBy?: boolean,
   manualPagination?: boolean,
   manualPageCount?: boolean,
@@ -89,10 +92,12 @@ export const ReactTable = ({
   defaultSorted,
   onSortedChange,
   onPageChange,
+  onFiltersChange,
   showPaginationBottom,
   manualSortBy,
   manualPagination,
   manualPageCount,
+  manualFilters,
   defaultGroupBy,
   SubComponent,
 }: ReactTableProps) => {
@@ -110,13 +115,14 @@ export const ReactTable = ({
     canNextPage,
     pageCount,
     gotoPage,
-    state: { pageIndex, sortBy, }
+    state: { pageIndex, sortBy, filters }
   } = useTable(
     {
       data,
       defaultColumn,
       manualSortBy,
       manualPagination,
+      manualFilters: manualFilters,
       SubComponent,
       columns,
       autoResetSortBy: false,
@@ -126,6 +132,7 @@ export const ReactTable = ({
         pageSize: defaultPageSize || data.length || DEFAULT_PAGE_SIZE,
         sortBy: defaultSorted || [],
         groupBy: defaultGroupBy || [],
+        filters: [],
       }
     },
     useFilters,
@@ -146,6 +153,13 @@ export const ReactTable = ({
       onPageChange(pageIndex);
     }
   }, [pageIndex]);
+
+  React.useEffect(() => {
+    if (manualFilters && onFiltersChange) {
+      onFiltersChange(filters);
+    }
+
+  }, [filters]);
 
   return (
     <div className={`${className} ReactTable`}>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/EvidenceLanding.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/EvidenceLanding.tsx
@@ -4,6 +4,7 @@ import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
 import Activities from './activities';
 import Activity from './activity';
 import Hints from './hints';
+import HealthDashboard from "./healthDashboards/healthDashboard";
 import UniversalRulesIndex from './universalRules/universalRules';
 import UniversalRule from './universalRules/universalRule';
 
@@ -12,6 +13,7 @@ const EvidenceLanding = () => (
     <Switch>
       <Redirect exact from='/' to='/activities' />
       <Route component={Activity} path='/activities/:activityId' />
+      <Route component={HealthDashboard} path='/health-dashboard' />
       <Route component={UniversalRule} path='/universal-rules/:ruleId' />
       <Route component={UniversalRulesIndex} path='/universal-rules' />
       <Route component={Activities} path='/activities' />

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/healthDashboard.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/healthDashboard.test.tsx.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HealthDashboard component should render HealthDashboard 1`] = `
+<ContextProvider
+  value={true}
+>
+  <ContextProvider
+    value={
+      DefaultReactQueryClient {
+        "defaultOptions": Object {
+          "queries": Object {
+            "cacheTime": Infinity,
+            "staleTime": Infinity,
+          },
+        },
+        "mutationCache": MutationCache {
+          "config": Object {},
+          "listeners": Array [],
+          "mutationId": 0,
+          "mutations": Array [],
+        },
+        "mutationDefaults": Array [],
+        "queryCache": QueryCache {
+          "config": Object {},
+          "listeners": Array [],
+          "queries": Array [],
+          "queriesMap": Object {},
+        },
+        "queryDefaults": Array [],
+      }
+    }
+  >
+    <HealthDashboard
+      history={
+        Object {
+          "createHref": [Function],
+          "createKey": [Function],
+          "createLocation": [Function],
+          "createPath": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "listen": [Function],
+          "listenBefore": [Function],
+          "push": [Function],
+          "pushState": [Function],
+          "registerTransitionHook": [Function],
+          "replace": [Function],
+          "replaceState": [Function],
+          "setState": [Function],
+          "transitionTo": [Function],
+          "unregisterTransitionHook": [Function],
+        }
+      }
+      location={
+        Object {
+          "action": "POP",
+          "hash": "",
+          "key": null,
+          "pathname": "/",
+          "search": "",
+          "state": null,
+        }
+      }
+      match={
+        Object {
+          "isExact": true,
+          "params": Object {
+            "activityId": "1",
+          },
+          "path": "",
+          "url": "",
+        }
+      }
+    />
+  </ContextProvider>
+</ContextProvider>
+`;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activity.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activity.test.tsx
@@ -12,7 +12,7 @@ describe('Activity component', () => {
     </MemoryRouter>
   );
 
-  it('should render 4 NavLinks', () => {
-    expect(container.find(NavLink).length).toEqual(4);
+  it('should render 5 NavLinks', () => {
+    expect(container.find(NavLink).length).toEqual(5);
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/healthDashboard.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/healthDashboard.test.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import 'whatwg-fetch';
+import { shallow } from 'enzyme';
+import { createMemoryHistory, createLocation } from 'history';
+import { QueryClientProvider } from 'react-query'
+
+import { DefaultReactQueryClient } from '../../../../Shared/index';
+import HealthDashboard from '../healthDashboards/healthDashboard';
+
+const queryClient = new DefaultReactQueryClient();
+
+const mockProps = {
+  match: {
+    params: {
+      activityId: '1'
+    },
+    isExact: true,
+    path: '',
+    url:''
+  },
+  history: createMemoryHistory(),
+  location: createLocation('')
+}
+
+describe('HealthDashboard component', () => {
+  const container = shallow(
+    <QueryClientProvider client={queryClient} contextSharing={true}>
+      <HealthDashboard {...mockProps} />
+    </QueryClientProvider>
+  );
+
+  it('should render HealthDashboard', () => {
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/healthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/healthDashboard.tsx
@@ -1,0 +1,289 @@
+import * as React from "react";
+import { useRef } from 'react';
+import { useQuery } from 'react-query';
+import { matchSorter } from 'match-sorter';
+import { CSVLink } from 'react-csv';
+import { firstBy } from 'thenby';
+
+
+import Navigation from '../navigation'
+import { FlagDropdown, ReactTable, TextFilter, filterNumbers } from '../../../../Shared/index'
+import { fetchAggregatedActivityHealths } from '../../../utils/evidence/ruleFeedbackHistoryAPIs';
+import { getLinkToActivity, secondsToHumanReadableTime, addCommasToThousands } from "../../../helpers/evidence/miscHelpers";
+
+const ALL_FLAGS = "All Flags"
+
+export const HealthDashboard = ({ location, match }) => {
+  const [flag, setFlag] = React.useState<string>(ALL_FLAGS)
+  const [promptSearchInput, setPromptSearchInput] = React.useState<string>("")
+  const [dataToDownload, setDataToDownload] = React.useState<Array<{}>>([])
+  const [rows, setRows] = React.useState<Array<{}>>(null)
+  const [poorHealthFlag, setPoorHealthFlag] = React.useState<boolean>(false)
+  let csvLink = useRef(null);
+
+  // get cached activity data to pass to rule
+  const { data: activityHealthsData } = useQuery({
+    queryKey: [`evidence-activity-healths`],
+    queryFn: fetchAggregatedActivityHealths
+  });
+
+  React.useEffect(() => {
+    if (dataToDownload.length > 0) {
+      csvLink.link.click();
+    }
+  }, [dataToDownload]);
+
+  React.useEffect(() => {
+    if (activityHealthsData && activityHealthsData.activityHealths) {
+      setRows(getFilteredData(activityHealthsData.activityHealths))
+    }
+  }, [activityHealthsData])
+
+  const dataTableFields = [
+    {
+      Header: 'Name',
+      accessor: "name",
+      key: "name",
+      filter: (rows, idArray, filterValue) => {
+        return matchSorter(rows, filterValue, { keys: ['original.name']})
+      },
+      Filter: TextFilter,
+      filterAll: true,
+      Cell: ({row}) => <span className="name"><a href={getLinkToActivity(row.original.activity_id)} rel="noopener noreferrer" target="_blank">{row.original.name}</a></span>, // eslint-disable-line react/display-name
+      minWidth: 330,
+    },
+    {
+      Header: 'Version #',
+      accessor: "version",
+      key: "version",
+      filter: filterNumbers,
+      Filter: TextFilter,
+      minWidth: 70,
+    },
+    {
+      Header: 'Version Plays',
+      accessor: "version_plays",
+      key: "versionPlays",
+      filter: filterNumbers,
+      Filter: TextFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.version_plays && <span className="versionPlays">{addCommasToThousands(row.original.version_plays)}</span>
+    },
+    {
+      Header: 'Total Plays',
+      accessor: "total_plays",
+      key: "totalPlays",
+      filter: filterNumbers,
+      Filter: TextFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.total_plays && <span className="versionPlays">{addCommasToThousands(row.original.total_plays)}</span>
+    },
+    {
+      Header: 'Completion Rate',
+      accessor: "completion_rate",
+      key: "completionRate",
+      filter: filterNumbers,
+      Filter: TextFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.completion_rate && <span className="name">{row.original.completion_rate}%</span>
+    },
+    {
+      Header: 'Because Final Optimal',
+      accessor: "because_final_optimal",
+      key: "becauseFinalOptimal",
+      filter: filterNumbers,
+      Filter: TextFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.because_final_optimal && <span className={row.original.because_final_optimal <= 75 ? "poor-health" : "" + " name"}>{row.original.because_final_optimal}%</span>
+    },
+    {
+      Header: 'But Final Optimal',
+      accessor: "but_final_optimal",
+      key: "butFinalOptimal",
+      filter: filterNumbers,
+      Filter: TextFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.but_final_optimal && <span className={row.original.but_final_optimal <= 75 ? "poor-health" : "" + " name"}>{row.original.but_final_optimal}%</span>
+    },
+    {
+      Header: 'So Final Optimal',
+      accessor: "so_final_optimal",
+      key: "soFinalOptimal",
+      filter: filterNumbers,
+      Filter: TextFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.so_final_optimal && <span className={row.original.so_final_optimal <= 75 ? "poor-health" : "" + " name"}>{row.original.so_final_optimal}%</span>
+    },
+    {
+      Header: 'Avg Time Spent - Activity',
+      accessor: "avg_completion_time",
+      key: "avgCompletionTime",
+      filter: filterNumbers,
+      Filter: TextFilter,
+      minWidth: 70,
+      Cell: ({row}) => secondsToHumanReadableTime(row.original.avg_completion_time)
+    },
+    {
+      Header: 'Poor Health Flag',
+      accessor: "poor_health_flag",
+      key: "poorHealthFlag",
+      filter: filterNumbers,
+      Filter: TextFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.poor_health_flag === true && <span className="poor-health-flag">X</span>
+    }
+  ];
+
+  const handleFlagChange = (e) => {setFlag(e.target.value)}
+  const handleSearchByPrompt = (e) => {setPromptSearchInput(e.target.value)}
+  const handlePoorHealthFlagToggle = () => {setPoorHealthFlag(!poorHealthFlag)}
+
+  const getFilteredData = (data) => {
+    if (!data) return []
+
+    let filteredData = flag === ALL_FLAGS ? data : data.filter(data => data.flag === flag)
+
+    if (!filteredData) return []
+    filteredData = filteredData.filter(value => {
+      return (
+        value.name && value.name.toLowerCase().includes(promptSearchInput.toLowerCase())
+      );
+    })
+
+    if (poorHealthFlag) {
+      filteredData = filteredData.filter(value => value.poor_health_flag)
+    }
+
+    return filteredData
+  }
+
+
+  const getSortedRows = (rows, sortInfo) => {
+    if(sortInfo) {
+      const { id, desc } = sortInfo;
+      // we have this reversed so that the first click will sort from highest to lowest by default
+      const directionOfSort = desc ? `asc` : 'desc';
+      return rows.sort(firstBy(id, { direction: directionOfSort }));
+    } else {
+      return rows;
+    }
+  }
+
+  const filterRowsByColumnValue = (rows, column, value) => {
+    if (column === 'name') {
+      return matchSorter(rows, value, { keys: [column]})
+    } else {
+      return filterNumbers(rows.map(r => {return {original: r}}), [column], value).map(r => r.original)
+    }
+  }
+
+  const handleFiltersChange = (filters) => {
+    if (!rows) return;
+    let newRows = activityHealthsData.activityHealths
+    filters.forEach((filter) => {
+      const column = filter.id
+      const value = filter.value
+
+      newRows = filterRowsByColumnValue(newRows, column, value)
+    })
+    setRows(getFilteredData(newRows))
+  }
+
+  const handleDataUpdate = (sorted) => {
+    const sortInfo = sorted[0];
+    if (!sortInfo) return
+
+    const sortedRows = getSortedRows(rows, sortInfo)
+    const newIdSortedRows = sortedRows.map((r, i) => {
+      r.id = i
+      return r
+    })
+    setRows(getFilteredData(newIdSortedRows))
+  }
+
+
+  const formatTableForCSV = (e) => {
+    if (!rows) return;
+
+    const columns = dataTableFields
+    let dataToDownload = []
+    for (let index = 0; index < rows.length; index++) {
+      let recordToDownload = {}
+      for(let colIndex = 0; colIndex < columns.length ; colIndex ++) {
+        recordToDownload[columns[colIndex].Header] = rows[index][columns[colIndex].accessor]
+      }
+      dataToDownload.push(recordToDownload)
+    }
+
+    // Convert seconds to human readable time
+    let clonedDataToDownload = JSON.parse(JSON.stringify(dataToDownload));
+    clonedDataToDownload.forEach(item=> {
+      item["Avg Time Spent - Activity"] = item["Avg Time Spent - Activity"] ? secondsToHumanReadableTime(item["Avg Time Spent - Activity"]) : ''
+    });
+
+    setDataToDownload(clonedDataToDownload)
+  }
+
+
+  return(
+    <React.Fragment>
+      <Navigation location={location} match={match} />
+      <div className="health-dashboards-index-container">
+        <section className="header-section">
+          <h2>Activities Health Dashboard</h2>
+          <div className="first-input-row">
+            <FlagDropdown flag={flag} handleFlagChange={handleFlagChange} isLessons={true} />
+            <div className="csv-download-button">
+              <button onClick={formatTableForCSV} style={{cursor: 'pointer'}} type="button">
+                Download CSV
+              </button>
+            </div>
+          </div>
+
+          <div className="second-input-row">
+            <input
+              aria-label="Search by prompt"
+              className="search-box"
+              name="searchInput"
+              onChange={handleSearchByPrompt}
+              placeholder="Search by prompt or activity name"
+              value={promptSearchInput || ""}
+            />
+          </div>
+
+          <div className="poor-health-filter">
+            <input aria-label="poor-health-check" checked={poorHealthFlag} onChange={handlePoorHealthFlagToggle} type="checkbox" />
+            <label className="poor-health-label" htmlFor="poor-health-check">Poor Health Flag</label>
+          </div>
+
+          <div>
+            <CSVLink
+              data={dataToDownload}
+              filename="activity_health_report"
+              ref={(c) => (csvLink = c)}
+              rel="noopener noreferrer"
+              target="_blank"
+            />
+          </div>
+        </section>
+
+        <section className="table-section">
+          <ReactTable
+            className="activity-healths-table"
+            columns={dataTableFields}
+            data={(rows && getFilteredData(rows)) || []}
+            defaultPageSize={(rows && rows.length) || 0}
+            filterable
+            manualFilters
+            manualSortBy
+            onFiltersChange={handleFiltersChange}
+            onSortedChange={handleDataUpdate}
+          />
+        </section>
+      </div>
+    </React.Fragment>
+  );
+
+}
+
+export default HealthDashboard

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/healthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/healthDashboard.tsx
@@ -51,6 +51,8 @@ export const HealthDashboard = ({ location, match }) => {
       filterAll: true,
       Cell: ({row}) => <span className="name"><a href={getLinkToActivity(row.original.activity_id)} rel="noopener noreferrer" target="_blank">{row.original.name}</a></span>, // eslint-disable-line react/display-name
       minWidth: 330,
+      width: 330,
+      maxWidth: 330
     },
     {
       Header: 'Version #',
@@ -223,7 +225,6 @@ export const HealthDashboard = ({ location, match }) => {
 
     setDataToDownload(clonedDataToDownload)
   }
-
 
   return(
     <React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/navigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/navigation.tsx
@@ -158,6 +158,9 @@ const Navigation = ({ location, match }) => {
           <NavLink activeClassName='is-active' to="/hints">
             View Hints
           </NavLink>
+          <NavLink activeClassName='is-active' to="/health-dashboard">
+            Health Dashboard
+          </NavLink>
         </ul>
         {activityEditorAndResults}
       </section>

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
@@ -477,3 +477,29 @@ export function renderCSVDownloadButton(csvDataLoadInitiated, handleLoadCSVDataC
   }
   return <button className="quill-button fun primary contained csv-download-button" onClick={handleLoadCSVDataClick}>Load CSV Data</button>
 }
+
+
+export function addCommasToThousands(num)
+{
+  if (!num) return ""
+  let num_parts = num.toString().split(".");
+  num_parts[0] = num_parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return num_parts.join(".");
+}
+
+export function getLinkToActivity(id) {
+  return `${process.env.DEFAULT_URL}/cms/evidence#/activities/${id}/settings`
+}
+
+export function secondsToHumanReadableTime(seconds) {
+
+  let numhours = Math.floor(((seconds % 31536000) % 86400) / 3600).toString();
+  let numminutes = Math.floor((((seconds % 31536000) % 86400) % 3600) / 60).toString();
+  let numseconds = Math.floor((((seconds % 31536000) % 86400) % 3600) % 60).toString();
+
+  if (numhours.length === 1) numhours = "0" + numhours
+  if (numminutes.length === 1) numminutes = "0" + numminutes
+  if (numseconds.length === 1) numseconds = "0" + numseconds
+
+  return numhours + ":" + numminutes + ":" + numseconds;
+}

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
@@ -482,9 +482,9 @@ export function renderCSVDownloadButton(csvDataLoadInitiated, handleLoadCSVDataC
 export function addCommasToThousands(num)
 {
   if (!num) return ""
-  let num_parts = num.toString().split(".");
-  num_parts[0] = num_parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-  return num_parts.join(".");
+  let numParts = num.toString().split(".");
+  numParts[0] = numParts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return numParts.join(".");
 }
 
 export function getLinkToActivity(id) {

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/routingHelpers.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/routingHelpers.ts
@@ -70,6 +70,10 @@ export const getActivityHealthUrl = ({ activityId }) => {
   return `activity_health?activity_id=${activityId}`;
 }
 
+export const getAggregatedActivityHealthsUrl = () => {
+  return `evidence/activity_healths.json`;
+}
+
 // not a 2xx status
 export const requestFailed = (status: number ) => Math.round(status / 100) !== 2;
 

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/routingHelpers.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/routingHelpers.ts
@@ -70,9 +70,8 @@ export const getActivityHealthUrl = ({ activityId }) => {
   return `activity_health?activity_id=${activityId}`;
 }
 
-export const getAggregatedActivityHealthsUrl = () => {
-  return `evidence/activity_healths.json`;
-}
+export const aggregatedActivityHealthsUrl = `evidence/activity_healths.json`;
+
 
 // not a 2xx status
 export const requestFailed = (status: number ) => Math.round(status / 100) !== 2;

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
@@ -1,0 +1,55 @@
+.health-dashboards-index-container {
+  padding: 20px;
+  .header-section {
+    .search-box {
+      width: 600px;
+    }
+    .control {
+      float: left;
+    }
+    .csv-download-button {
+      float: right;
+    }
+    .second-input-row {
+      width: 700px;
+    }
+    .poor-health-filter {
+      padding-top: 5px;
+    }
+    .poor-health-label {
+      padding-left: 5px;
+      font-weight: normal;
+    }
+    padding-bottom: 30px;
+  }
+
+  .table-section {
+    .rt-th {
+      min-width: 100px;
+      width: 100px;
+      max-width: 9.0072e15px;
+      .sortable-header {
+        height: 80px;
+        display: block;
+      }
+      input {
+        width: 60px !important;
+      }
+    }
+
+    .poor-health {
+      background-color: lightpink;
+      color: red;
+      font-weight: bold;
+      width: 70px;
+      padding: 3px;
+      display: block;
+    }
+    .poor-health-flag {
+      color: red;
+      font-weight: bold;
+    }
+  }
+
+
+}

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
@@ -24,6 +24,9 @@
   }
 
   .table-section {
+    td {
+      white-space: normal;
+    }
     .rt-th {
       min-width: 100px;
       width: 100px;

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
@@ -30,7 +30,7 @@
     .rt-th {
       min-width: 100px;
       width: 100px;
-      max-width: 9.0072e15px;
+      max-width: 100px;
       .sortable-header {
         height: 80px;
         display: block;

--- a/services/QuillLMS/client/app/bundles/Staff/styles/styles.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/styles.scss
@@ -26,6 +26,7 @@
 @import './evidence_manager/activity_form.scss';
 @import './evidence_manager/change_log.scss';
 @import './evidence_manager/hint.scss';
+@import './evidence_manager/health_dashboard.scss';
 @import './evidence_manager/model.scss';
 @import './evidence_manager/rule_form.scss';
 @import './evidence_manager/rules.scss';

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/ruleFeedbackHistoryAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/ruleFeedbackHistoryAPIs.ts
@@ -1,4 +1,4 @@
-import { handleApiError, mainApiFetch, getRuleFeedbackHistoriesUrl, getRuleFeedbackHistoryUrl, getActivityStatsUrl, getActivityHealthUrl, getAggregatedActivityHealthsUrl } from '../../helpers/evidence/routingHelpers';
+import { handleApiError, mainApiFetch, getRuleFeedbackHistoriesUrl, getRuleFeedbackHistoryUrl, getActivityStatsUrl, getActivityHealthUrl, aggregatedActivityHealthsUrl } from '../../helpers/evidence/routingHelpers';
 
 export const fetchRuleFeedbackHistories = async ({ queryKey, }) => {
   const [key, activityId, selectedConjunction, startDate, endDate]: [string, string, string, string?, string?, string?] = queryKey
@@ -52,7 +52,7 @@ export const fetchActivityHealth = async({queryKey, }) => {
 export const fetchAggregatedActivityHealths = async({queryKey, }) => {
   const [key]: [string] = queryKey
 
-  const url = getAggregatedActivityHealthsUrl();
+  const url = aggregatedActivityHealthsUrl;
   const response = await mainApiFetch(url);
   const activityHealths = await response.json();
   return {

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/ruleFeedbackHistoryAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/ruleFeedbackHistoryAPIs.ts
@@ -1,4 +1,4 @@
-import { handleApiError, mainApiFetch, getRuleFeedbackHistoriesUrl, getRuleFeedbackHistoryUrl, getActivityStatsUrl, getActivityHealthUrl } from '../../helpers/evidence/routingHelpers';
+import { handleApiError, mainApiFetch, getRuleFeedbackHistoriesUrl, getRuleFeedbackHistoryUrl, getActivityStatsUrl, getActivityHealthUrl, getAggregatedActivityHealthsUrl } from '../../helpers/evidence/routingHelpers';
 
 export const fetchRuleFeedbackHistories = async ({ queryKey, }) => {
   const [key, activityId, selectedConjunction, startDate, endDate]: [string, string, string, string?, string?, string?] = queryKey
@@ -48,3 +48,16 @@ export const fetchActivityHealth = async({queryKey, }) => {
     activity: activityHealth
   };
 }
+
+export const fetchAggregatedActivityHealths = async({queryKey, }) => {
+  const [key]: [string] = queryKey
+
+  const url = getAggregatedActivityHealthsUrl();
+  const response = await mainApiFetch(url);
+  const activityHealths = await response.json();
+  return {
+    error: handleApiError('Failed to fetch aggregated activity healths, please refresh the page.', response),
+    activityHealths: activityHealths
+  };
+}
+

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activity_healths_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activity_healths_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_dependency 'evidence/application_controller'
+
+module Evidence
+  class ActivityHealthsController < ApiController
+
+    def index
+      render json: ActivityHealth.all.includes(:prompt_healths).as_json
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity_health.rb
@@ -3,6 +3,8 @@
 module Evidence
   class ActivityHealth < ApplicationRecord
 
+    POOR_HEALTH_CUTOFF = 75
+
     has_many :prompt_healths, foreign_key: "evidence_activity_health_id", dependent: :destroy
 
     validates :flag, inclusion: { in: Evidence.flags_class::FLAGS, allow_nil: true}
@@ -30,7 +32,7 @@ module Evidence
     end
 
     def poor_health_flag
-      return ((because_final_optimal && because_final_optimal < 75) || (but_final_optimal && but_final_optimal < 75) || (so_final_optimal && so_final_optimal < 75))
+      (because_final_optimal && because_final_optimal < POOR_HEALTH_CUTOFF) || (but_final_optimal && but_final_optimal < POOR_HEALTH_CUTOFF) || (so_final_optimal && so_final_optimal < POOR_HEALTH_CUTOFF)
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity_health.rb
@@ -24,8 +24,13 @@ module Evidence
           :because_final_optimal, :but_final_optimal, :so_final_optimal,
           :avg_completion_time
         ],
-        include: [:prompt_healths]
+        include: [:prompt_healths],
+        methods: [:poor_health_flag]
       ))
+    end
+
+    private def poor_health_flag
+      return ((because_final_optimal && because_final_optimal < 75) || (but_final_optimal && but_final_optimal < 75) || (so_final_optimal && so_final_optimal < 75))
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity_health.rb
@@ -29,7 +29,7 @@ module Evidence
       ))
     end
 
-    private def poor_health_flag
+    def poor_health_flag
       return ((because_final_optimal && because_final_optimal < 75) || (but_final_optimal && but_final_optimal < 75) || (so_final_optimal && so_final_optimal < 75))
     end
   end

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -20,7 +20,6 @@ Evidence::Engine.routes.draw do
   resource :feedback, only: [:create], controller: :feedback
 
   resources :hints, only: [:index, :show, :create, :update, :destroy]
-
   put 'rules/update_rule_order' => 'rules#update_rule_order'
 
   resources :rules, only: [:index, :show, :create, :update, :destroy] do
@@ -33,4 +32,6 @@ Evidence::Engine.routes.draw do
     end
   end
   resources :turking_rounds, only: [:index, :show, :create, :update, :destroy]
+
+  resources :activity_healths, only: [:index]
 end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activity_healths_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activity_healths_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  RSpec.describe(ActivityHealthsController, :type => :controller) do
+    before { @routes = Engine.routes }
+
+    context 'should index' do
+      it 'should return successfully - no activity healths' do
+        get(:index)
+        parsed_response = JSON.parse(response.body)
+        expect(response.status).to eq(200)
+        expect(parsed_response.class).to(eq(Array))
+        expect(parsed_response.empty?).to(eq(true))
+      end
+
+      context 'should return activity healths' do
+        let!(:activity_health) { create(:evidence_activity_health) }
+
+        it 'should return successfully' do
+          get(:index)
+          parsed_response = JSON.parse(response.body)
+          expect(response.status).to eq(200)
+          expect(parsed_response.class).to(eq(Array))
+          expect(parsed_response.empty?).to(eq(false))
+          expect(parsed_response.first["name"]).to(eq(activity_health.name))
+          expect(parsed_response.first["version"]).to(eq(activity_health.version))
+          expect(parsed_response.first["completion_rate"]).to(eq(activity_health.completion_rate))
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/activity_healths.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/activity_healths.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :evidence_activity_health, class: 'Evidence::ActivityHealth' do
+    name { "test name" }
+    flag { "production" }
+    activity_id { 1 }
+    version { 1 }
+    version_plays { 10 }
+    total_plays { 10 }
+    completion_rate { 91 }
+    because_final_optimal { 66 }
+    but_final_optimal { 77 }
+    so_final_optimal { 88 }
+    avg_completion_time { 303 }
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_health_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_health_spec.rb
@@ -29,5 +29,27 @@ module Evidence
 
       it { should validate_inclusion_of(:so_final_optimal).in?(0..100)}
     end
+
+    context 'methods' do
+      describe 'poor_health_flag' do
+        it 'should return true if one of the final_optimal values is less than 75' do
+          activity_health = create(:evidence_activity_health, but_final_optimal: 6)
+
+          expect(activity_health.poor_health_flag).to eq(true)
+        end
+
+        it 'should return false if all of the final_optimal values is greater than 75' do
+          activity_health = create(:evidence_activity_health, but_final_optimal: 100, because_final_optimal: 100, so_final_optimal: 100)
+
+          expect(activity_health.poor_health_flag).to eq(false)
+        end
+
+        it 'should return false if there are nil values in the final_optimal columns' do
+          activity_health = create(:evidence_activity_health, but_final_optimal: nil, because_final_optimal: 100, so_final_optimal: 100)
+
+          expect(activity_health.poor_health_flag).to eq(false)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## WHAT
Add the front end React components for the Evidence Activity Health table.

## WHY
This will help Curriculum team make judgments about Evidence activities to work on.

## HOW
The bulk of the work is in the new React component HealthDashboard, which will display a table of all the evidence activity health data. 
The new HealthDashboard table also has filtering and download as CSV functionalities. I edited the shared component `ReactTable` a bit to enable manual filtering (similar to the existent manual sorting), because we need to control all filters and sorts manually in order to download the data as a CSV.

### Screenshots
![Screen Shot 2022-12-16 at 7 50 54 PM](https://user-images.githubusercontent.com/57366100/208092317-fab67fb9-401a-420d-8d17-43cf2d9e417e.png)

### Notion Card Links
https://www.notion.so/quill/2-Activity-Health-Dashboard-Front-End-5d802fcb4c144c7985e1f4f67a0f5fe1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
