### PR TITLE
Update Evidence Banner logic to use new teacher info

### DIFF
--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -323,7 +323,13 @@ module Teacher
   end
 
   def teaches_eighth_through_twelfth?
-    return classrooms_i_teach.map(&:grade).compact.any? { |grade| grade.to_i.between?(8, 12) }
+    return true if teacher_info&.in_eighth_through_twelfth?
+
+    classrooms_i_teach
+      .map(&:grade)
+      .compact
+      .uniq
+      .any? { |grade| grade.to_i.in?(TeacherInfo::EIGHT_TO_TWELVE) }
   end
 
   def google_classrooms

--- a/services/QuillLMS/app/models/teacher_info.rb
+++ b/services/QuillLMS/app/models/teacher_info.rb
@@ -32,6 +32,8 @@ class TeacherInfo < ApplicationRecord
   KINDERGARTEN_DISPLAY_STRING = 'K'
   KINDERGARTEN_DATABASE_INTEGER = 0
 
+  EIGHT_TO_TWELVE = (8..12).to_a
+
   def minimum_grade_level=(value)
     value = KINDERGARTEN_DATABASE_INTEGER if value == KINDERGARTEN_DISPLAY_STRING
     super(value)
@@ -68,5 +70,22 @@ class TeacherInfo < ApplicationRecord
 
   def teacher_id=(value)
     self.user_id = value
+  end
+
+  def grade_levels
+    return [] if no_grade_levels?
+
+    return [maximum_grade_level] if minimum_grade_level.nil?
+    return [minimum_grade_level] if maximum_grade_level.nil?
+
+    (self[:minimum_grade_level]..self[:maximum_grade_level]).to_a
+  end
+
+  def in_eighth_through_twelfth?
+    grade_levels.intersection(EIGHT_TO_TWELVE).present?
+  end
+
+  private def no_grade_levels?
+    minimum_grade_level.nil? && maximum_grade_level.nil?
   end
 end

--- a/services/QuillLMS/config/initializers/rack_attack.rb
+++ b/services/QuillLMS/config/initializers/rack_attack.rb
@@ -14,6 +14,12 @@ class Rack::Attack
     end
   end
 
+  Rack::Attack.throttle('account creation per IP', limit: 5, period: 60.minutes) do |req|
+    if req.path == '/account' && req.post?
+      req.ip
+    end
+  end
+
   Rack::Attack.throttled_response = lambda do |request|
     # NB: you have access to the name and other data about the matched throttle
     #  request.env['rack.attack.matched'],
@@ -23,7 +29,7 @@ class Rack::Attack
 
     # Using 503 because it may make attacker think that they have successfully
     # DOSed the site. Rack::Attack returns 429 for throttling by default
-    [503, {}, [{ message: 'Too many login attempts. Please try again later.', type: 'password' }.to_json]]
+    [503, {}, [{ message: 'Too many attempts. Please try again later.', type: 'password' }.to_json]]
   end
 
 end

--- a/services/QuillLMS/config/initializers/rack_attack.rb
+++ b/services/QuillLMS/config/initializers/rack_attack.rb
@@ -14,12 +14,6 @@ class Rack::Attack
     end
   end
 
-  Rack::Attack.throttle('account creation per IP', limit: 5, period: 60.minutes) do |req|
-    if req.path == '/account' && req.post?
-      req.ip
-    end
-  end
-
   Rack::Attack.throttled_response = lambda do |request|
     # NB: you have access to the name and other data about the matched throttle
     #  request.env['rack.attack.matched'],
@@ -29,7 +23,7 @@ class Rack::Attack
 
     # Using 503 because it may make attacker think that they have successfully
     # DOSed the site. Rack::Attack returns 429 for throttling by default
-    [503, {}, [{ message: 'Too many attempts. Please try again later.', type: 'password' }.to_json]]
+    [503, {}, [{ message: 'Too many login attempts. Please try again later.', type: 'password' }.to_json]]
   end
 
 end

--- a/services/QuillLMS/spec/models/concerns/teacher_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/teacher_spec.rb
@@ -316,6 +316,22 @@ describe User, type: :model do
           expect(one_classroom_teacher.teaches_eighth_through_twelfth?).not_to be
         end
       end
+
+      context 'using teacher_info' do
+        let(:new_teacher) { create(:teacher) }
+
+        it { expect(new_teacher.teaches_eighth_through_twelfth?).to be false }
+
+        context 'teacher info grades in range' do
+          let!(:teacher_info) {create(:teacher_info, user: new_teacher, minimum_grade_level: 6, maximum_grade_level: 10)}
+          it { expect(new_teacher.teaches_eighth_through_twelfth?).to be true }
+        end
+
+        context 'teacher info grades out of range' do
+          let!(:teacher_info) {create(:teacher_info, user: new_teacher, minimum_grade_level: 6, maximum_grade_level: 7)}
+          it { expect(new_teacher.teaches_eighth_through_twelfth?).to be false}
+        end
+      end
     end
 
     describe '#unlink' do

--- a/services/QuillLMS/spec/models/concerns/teacher_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/teacher_spec.rb
@@ -324,11 +324,13 @@ describe User, type: :model do
 
         context 'teacher info grades in range' do
           let!(:teacher_info) {create(:teacher_info, user: new_teacher, minimum_grade_level: 6, maximum_grade_level: 10)}
+
           it { expect(new_teacher.teaches_eighth_through_twelfth?).to be true }
         end
 
         context 'teacher info grades out of range' do
           let!(:teacher_info) {create(:teacher_info, user: new_teacher, minimum_grade_level: 6, maximum_grade_level: 7)}
+
           it { expect(new_teacher.teaches_eighth_through_twelfth?).to be false}
         end
       end

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -33,6 +33,7 @@ describe TeacherInfo, type: :model, redis: true do
 
   context 'uniqueness' do
     let!(:teacher_info) {create(:teacher_info)}
+
     it {should validate_uniqueness_of(:user_id)}
   end
 

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -30,10 +30,14 @@ describe TeacherInfo, type: :model, redis: true do
   it {should validate_numericality_of(:maximum_grade_level)}
 
   it {should validate_presence_of(:user_id)}
-  it {should validate_uniqueness_of(:user_id)}
 
-  let!(:teacher_info) {create(:teacher_info)}
-  let!(:teacher) {create(:teacher)}
+  context 'uniqueness' do
+    let!(:teacher_info) {create(:teacher_info)}
+    it {should validate_uniqueness_of(:user_id)}
+  end
+
+  let(:teacher_info) {create(:teacher_info)}
+  let(:teacher) {create(:teacher)}
 
   describe 'minimum_grade_level=' do
     it 'should set the minimum grade level to 0 if it is passed in as K' do
@@ -89,4 +93,20 @@ describe TeacherInfo, type: :model, redis: true do
     end
   end
 
+  describe '#grade_levels' do
+    it { expect(build(:teacher_info, minimum_grade_level: 0, maximum_grade_level: 12).grade_levels).to eq (0..12).to_a }
+    it { expect(build(:teacher_info, minimum_grade_level: 8, maximum_grade_level: 8).grade_levels).to eq [8] }
+    it { expect(build(:teacher_info, minimum_grade_level: nil, maximum_grade_level: nil).grade_levels).to eq [] }
+    it { expect(build(:teacher_info, minimum_grade_level: nil, maximum_grade_level: 9).grade_levels).to eq [9] }
+    it { expect(build(:teacher_info, minimum_grade_level: 5, maximum_grade_level: nil).grade_levels).to eq [5]}
+  end
+
+  describe '#in_eighth_through_twelfth?' do
+    it { expect(build(:teacher_info, minimum_grade_level: 0, maximum_grade_level: 12).in_eighth_through_twelfth?).to be true }
+    it { expect(build(:teacher_info, minimum_grade_level: 0, maximum_grade_level: 7).in_eighth_through_twelfth?).to be false }
+    it { expect(build(:teacher_info, minimum_grade_level: 8, maximum_grade_level: 8).in_eighth_through_twelfth?).to eq true }
+    it { expect(build(:teacher_info, minimum_grade_level: nil, maximum_grade_level: nil).in_eighth_through_twelfth?).to eq false }
+    it { expect(build(:teacher_info, minimum_grade_level: nil, maximum_grade_level: 9).in_eighth_through_twelfth?).to eq true }
+    it { expect(build(:teacher_info, minimum_grade_level: 5, maximum_grade_level: nil).in_eighth_through_twelfth?).to eq false}
+  end
 end


### PR DESCRIPTION
## WHAT
Update [Evidence Banner logic](https://github.com/empirical-org/Empirical-Core/blob/5adf5a2b0633d659f552b88f16b3c92e487cbe98/services/QuillLMS/app/views/teachers/classroom_manager/dashboard.html.erb#L10) to use new `TeacherInfo` grade level information
## WHY
We don't have classroom grade levels for a lot of teachers, but are collecting grade levels on sign-up now.. This will increase the amount of appropriate teachers that see the Evidence banner.
## HOW
Add a `grade_levels` method to `TeacherInfo`, built the logic off of that.


### Notion Card Links
https://www.notion.so/quill/Use-new-teacher-collected-grade-level-to-Evidence-banner-logic-2051a9ce1afc4f69915559df1cf0c67e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Yes deploying now.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
