### PR TITLE
Fix Staggered Release invalid foreign key

### DIFF
--- a/services/QuillLMS/app/models/pack_sequence.rb
+++ b/services/QuillLMS/app/models/pack_sequence.rb
@@ -41,6 +41,6 @@ class PackSequence < ApplicationRecord
   validates :release_method, inclusion: { in: RELEASE_METHODS }
 
   def save_user_pack_sequence_items
-    students.pluck(:id).each { |user_id| SaveUserPackSequenceItemsWorker.perform_async(classroom.id, user_id) }
+    classroom.students.each { |student| SaveUserPackSequenceItemsWorker.perform_async(classroom.id, student.id) }
   end
 end

--- a/services/QuillLMS/app/models/pack_sequence.rb
+++ b/services/QuillLMS/app/models/pack_sequence.rb
@@ -41,6 +41,6 @@ class PackSequence < ApplicationRecord
   validates :release_method, inclusion: { in: RELEASE_METHODS }
 
   def save_user_pack_sequence_items
-    students.pluck(:id).each { |user_id| SaveUserPackSequenceItemsWorker.perform_async(classroom&.id, user_id) }
+    students.pluck(:id).each { |user_id| SaveUserPackSequenceItemsWorker.perform_async(classroom.id, user_id) }
   end
 end

--- a/services/QuillLMS/app/models/pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/pack_sequence_item.rb
@@ -34,8 +34,5 @@ class PackSequenceItem < ApplicationRecord
   after_destroy :save_user_pack_sequence_items
 
   delegate :classroom_id, :unit_id, to: :classroom_unit
-
-  def save_user_pack_sequence_items
-    pack_sequence.users.each { |user| SaveUserPackSequenceItemsWorker.perform_async(classroom_id, user.id) }
-  end
+  delegate :save_user_pack_sequence_items, to: :pack_sequence
 end

--- a/services/QuillLMS/app/models/pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/pack_sequence_item.rb
@@ -29,10 +29,6 @@ class PackSequenceItem < ApplicationRecord
   has_many :user_pack_sequence_items, dependent: :destroy
   has_many :users, through: :user_pack_sequence_items
 
-  after_save :save_user_pack_sequence_items, if: :saved_change_to_order?
-
-  after_destroy :save_user_pack_sequence_items
-
   delegate :classroom_id, :unit_id, to: :classroom_unit
   delegate :save_user_pack_sequence_items, to: :pack_sequence
 end

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -37,6 +37,7 @@ class Unit < ApplicationRecord
 
   belongs_to :user
   belongs_to :unit_template
+
   has_many :unit_activities, dependent: :destroy
   has_many :classroom_units, dependent: :destroy
   has_many :activity_sessions, through: :classroom_units

--- a/services/QuillLMS/app/models/user_pack_sequence_item.rb
+++ b/services/QuillLMS/app/models/user_pack_sequence_item.rb
@@ -35,15 +35,8 @@ class UserPackSequenceItem < ApplicationRecord
   validates :pack_sequence_item, presence: true
   validates :user, presence: true
 
-  after_save :save_user_pack_sequence_items
-  after_destroy :save_user_pack_sequence_items
-
   delegate :classroom_id, to: :pack_sequence_item
 
   scope :locked, -> { where(status: LOCKED) }
   scope :unlocked, -> { where(status: UNLOCKED) }
-
-  def save_user_pack_sequence_items
-    SaveUserPackSequenceItemsWorker.perform_async(classroom_id, user_id)
-  end
 end

--- a/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
+++ b/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
@@ -3,6 +3,8 @@
 class UserPackSequenceItemSaver < ApplicationService
   attr_reader :classroom_id, :user_id, :user_pack_sequence_item_statuses
 
+  class UserPackSequenceItemSaverError < StandardError; end
+
   LOCKED = UserPackSequenceItem::LOCKED
   UNLOCKED = UserPackSequenceItem::UNLOCKED
   COMPLETED_KEY = UserPackSequenceItemQuery::COMPLETED_KEY
@@ -28,22 +30,22 @@ class UserPackSequenceItemSaver < ApplicationService
     previous_packs_unfinished = false
     status = UNLOCKED
 
-    user_pack_sequence_item_results.each do |user_pack_sequence_item_result|
-      current_pack_sequence_id = user_pack_sequence_item_result[PACK_SEQUENCE_ID_KEY]
+    UserPackSequenceItemQuery.call(classroom_id, user_id).each do |result|
+      current_pack_sequence_id = result[PACK_SEQUENCE_ID_KEY]
 
       unless previous_pack_sequence_id == current_pack_sequence_id
         status = UNLOCKED
         previous_packs_unfinished = false
       end
 
-      current_pack_sequence_item_id = user_pack_sequence_item_result[PACK_SEQUENCE_ITEM_ID_KEY]
+      current_pack_sequence_item_id = result[PACK_SEQUENCE_ITEM_ID_KEY]
       pack_sequence_item_changed = previous_pack_sequence_item_id != current_pack_sequence_item_id
 
       status = LOCKED if previous_packs_unfinished && pack_sequence_item_changed
 
       user_pack_sequence_item_statuses[current_pack_sequence_item_id] = status
 
-      previous_packs_unfinished ||= !user_pack_sequence_item_result[COMPLETED_KEY]
+      previous_packs_unfinished ||= !result[COMPLETED_KEY]
 
       previous_pack_sequence_id = current_pack_sequence_id
       previous_pack_sequence_item_id = current_pack_sequence_item_id
@@ -52,13 +54,15 @@ class UserPackSequenceItemSaver < ApplicationService
 
   private def save_statuses
     user_pack_sequence_item_statuses.each_pair do |pack_sequence_item_id, status|
-      UserPackSequenceItem
-        .find_or_create_by!(pack_sequence_item_id: pack_sequence_item_id, user_id: user_id)
-        .tap { |upsi| upsi.update!(status: status) unless status == upsi.status }
-    end
-  end
+      begin
+        UserPackSequenceItem
+          .find_or_create_by!(pack_sequence_item_id: pack_sequence_item_id, user_id: user_id)
+          .tap { |upsi| upsi.update!(status: status) unless status == upsi.status }
+      rescue ActiveRecord::RecordInvalid => e
+        next if e.message == "Validation failed: Pack sequence item can't be blank"
 
-  private def user_pack_sequence_item_results
-    @user_pack_sequence_item_results ||= UserPackSequenceItemQuery.call(classroom_id, user_id)
+        raise UserPackSequenceItemSaverError, e.message
+      end
+    end
   end
 end

--- a/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
+++ b/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
@@ -52,11 +52,9 @@ class UserPackSequenceItemSaver < ApplicationService
 
   private def save_statuses
     user_pack_sequence_item_statuses.each_pair do |pack_sequence_item_id, status|
-      PackSequenceItem
-        .find_by(id: pack_sequence_item_id)
-        &.user_pack_sequence_items
-        &.find_or_create_by!(user_id: user_id)
-        &.tap { |upsi| upsi.update!(status: status) unless status == upsi.status }
+      UserPackSequenceItem
+        .find_or_create_by!(pack_sequence_item_id: pack_sequence_item_id, user_id: user_id)
+        .tap { |upsi| upsi.update!(status: status) unless status == upsi.status }
     end
   end
 

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -67,7 +67,6 @@ class AssignRecommendationsWorker
   def save_pack_sequence_item(classroom_unit, pack_sequence_id, order)
     return if pack_sequence_id.nil? || classroom_unit.nil?
 
-
     PackSequenceItem.find_or_create_by!(
       classroom_unit: classroom_unit,
       pack_sequence_id: pack_sequence_id,

--- a/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
@@ -32,7 +32,7 @@ class BatchAssignRecommendationsWorker
 
   def on_success(_status, options)
     PackSequence
-      .find(options['pack_sequence_id'])
+      .find_by(id: options['pack_sequence_id'])
       &.save_user_pack_sequence_items
   end
 

--- a/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
+++ b/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe PackSequenceItem, type: :model do
 
   it { should belong_to(:pack_sequence) }
   it { should belong_to(:classroom_unit) }
+  it { is_expected.to callback(:save_user_pack_sequence_items).after(:save).if(:saved_change_to_order?) }
+  it { is_expected.to callback(:save_user_pack_sequence_items).after(:destroy) }
 
   it { expect(subject).to be_valid }
 
@@ -44,28 +46,6 @@ RSpec.describe PackSequenceItem, type: :model do
       end
 
       it { expect { duplicate_pack_sequence_item }.to raise_error ActiveRecord::RecordNotUnique }
-    end
-  end
-
-  describe 'save_user_pack_sequence_items' do
-    let(:pack_sequence_item) { create(:pack_sequence_item) }
-    let(:num_user_pack_sequence_items) { 2 }
-    let(:num_jobs) { num_user_pack_sequence_items }
-
-    before { create_list(:user_pack_sequence_item, num_user_pack_sequence_items, pack_sequence_item: pack_sequence_item) }
-
-    context 'after_save' do
-      context 'order has changed' do
-        subject { pack_sequence_item.reload.update(order: pack_sequence_item.order + 1) }
-
-        it { expect { subject }.to change { SaveUserPackSequenceItemsWorker.jobs.size }.by(num_jobs) }
-      end
-    end
-
-    context 'after_destroy' do
-      subject { pack_sequence_item.destroy }
-
-      it { expect { subject }.to change { SaveUserPackSequenceItemsWorker.jobs.size }.by(num_jobs) }
     end
   end
 end

--- a/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
+++ b/services/QuillLMS/spec/models/pack_sequence_item_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe PackSequenceItem, type: :model do
 
   it { should belong_to(:pack_sequence) }
   it { should belong_to(:classroom_unit) }
-  it { is_expected.to callback(:save_user_pack_sequence_items).after(:save).if(:saved_change_to_order?) }
-  it { is_expected.to callback(:save_user_pack_sequence_items).after(:destroy) }
 
   it { expect(subject).to be_valid }
 

--- a/services/QuillLMS/spec/models/pack_sequence_spec.rb
+++ b/services/QuillLMS/spec/models/pack_sequence_spec.rb
@@ -62,4 +62,13 @@ RSpec.describe PackSequence, type: :model do
     # We need sidekiq here so that workers can create new user_pack_sequence_items
     it { Sidekiq::Testing.inline! { expect { subject }.not_to raise_error } }
   end
+
+  context 'save_user_pack_sequence_items' do
+    subject { pack_sequence.save_user_pack_sequence_items }
+
+    let!(:classroom) { create(:classroom_with_a_couple_students) }
+    let!(:pack_sequence) { create(:pack_sequence, classroom: classroom) }
+
+    it { expect { subject }.to change { SaveUserPackSequenceItemsWorker.jobs.size }.by(classroom.students.count) }
+  end
 end

--- a/services/QuillLMS/spec/models/unit_spec.rb
+++ b/services/QuillLMS/spec/models/unit_spec.rb
@@ -211,13 +211,5 @@ describe Unit, type: :model do
         end
       end
     end
-
-    context 'after_destroy' do
-      subject { unit.reload.destroy }
-
-      let(:visible) { true }
-
-      it { expect { subject }.to change { SaveUserPackSequenceItemsWorker.jobs.size }.by(num_jobs) }
-    end
   end
 end

--- a/services/QuillLMS/spec/models/user_pack_sequence_item_spec.rb
+++ b/services/QuillLMS/spec/models/user_pack_sequence_item_spec.rb
@@ -48,14 +48,4 @@ RSpec.describe UserPackSequenceItem, type: :model do
       it { expect { duplicate_user_pack_sequence_item }.to raise_error ActiveRecord::RecordNotUnique }
     end
   end
-
-  describe 'save_user_pack_sequence_items' do
-    let!(:user_pack_sequence_item) { create(:user_pack_sequence_item) }
-
-    context 'after_destroy' do
-      subject { user_pack_sequence_item.destroy }
-
-      it { expect { subject }.to change { SaveUserPackSequenceItemsWorker.jobs.size }.by(1) }
-    end
-  end
 end

--- a/services/QuillLMS/spec/queries/user_pack_sequence_item_query_spec.rb
+++ b/services/QuillLMS/spec/queries/user_pack_sequence_item_query_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe UserPackSequenceItemQuery do
 
       it do
         expect(subject).to eq [
-          result(true, pack_sequence1, pack_sequence_item1),
-          result(true, pack_sequence1, pack_sequence_item2),
-          result(true, pack_sequence2, pack_sequence_item4)
+          result(true, pack_sequence_item1),
+          result(true, pack_sequence_item2),
+          result(true, pack_sequence_item4)
         ]
       end
     end
@@ -50,9 +50,9 @@ RSpec.describe UserPackSequenceItemQuery do
 
       it do
         expect(subject).to eq [
-          result(true, pack_sequence1, pack_sequence_item1),
-          result(false, pack_sequence1, pack_sequence_item2),
-          result(true, pack_sequence2, pack_sequence_item4)
+          result(true, pack_sequence_item1),
+          result(false, pack_sequence_item2),
+          result(true, pack_sequence_item4)
         ]
       end
     end
@@ -66,9 +66,9 @@ RSpec.describe UserPackSequenceItemQuery do
 
       it do
         expect(subject).to eq [
-          result(false, pack_sequence1, pack_sequence_item1),
-          result(true, pack_sequence1, pack_sequence_item2),
-          result(true, pack_sequence2, pack_sequence_item4)
+          result(false, pack_sequence_item1),
+          result(true, pack_sequence_item2),
+          result(true, pack_sequence_item4)
         ]
       end
     end
@@ -78,18 +78,18 @@ RSpec.describe UserPackSequenceItemQuery do
 
       it do
         expect(subject).to eq [
-          result(false, pack_sequence1, pack_sequence_item1),
-          result(false, pack_sequence1, pack_sequence_item2),
-          result(true, pack_sequence2, pack_sequence_item4)
+          result(false, pack_sequence_item1),
+          result(false, pack_sequence_item2),
+          result(true, pack_sequence_item4)
         ]
       end
     end
   end
 
-  def result(completed, pack_sequence, pack_sequence_item)
+  def result(completed, pack_sequence_item)
     {
       described_class::COMPLETED_KEY => completed,
-      described_class::PACK_SEQUENCE_ID_KEY => pack_sequence.id,
+      described_class::PACK_SEQUENCE_ID_KEY => pack_sequence_item.pack_sequence.id,
       described_class::PACK_SEQUENCE_ITEM_ID_KEY => pack_sequence_item.id
     }
   end

--- a/services/QuillLMS/spec/services/user_pack_sequence_item_saver_spec.rb
+++ b/services/QuillLMS/spec/services/user_pack_sequence_item_saver_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UserPackSequenceItemSaver do
   end
 
   context 'one pack_sequence_item with one result' do
-    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
+    let(:result1) { result(completed1, pack_sequence_item1) }
     let(:results) { [result1] }
 
     context 'result is completed' do
@@ -43,8 +43,8 @@ RSpec.describe UserPackSequenceItemSaver do
   end
 
   context 'one pack_sequence_item with two results' do
-    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
-    let(:result2) { result(completed2, pack_sequence1, pack_sequence_item1) }
+    let(:result1) { result(completed1, pack_sequence_item1) }
+    let(:result2) { result(completed2, pack_sequence_item1) }
     let(:results) { [result1, result2] }
 
     context 'results are completed, uncompleted' do
@@ -65,8 +65,8 @@ RSpec.describe UserPackSequenceItemSaver do
   end
 
   context 'two pack_sequences_items with one result each' do
-    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
-    let(:result2) { result(completed2, pack_sequence1, pack_sequence_item2) }
+    let(:result1) { result(completed1, pack_sequence_item1) }
+    let(:result2) { result(completed2, pack_sequence_item2) }
     let(:results) { [result1, result2] }
 
     context 'results are uncompleted, completed' do
@@ -89,9 +89,9 @@ RSpec.describe UserPackSequenceItemSaver do
   end
 
   context 'two pack_sequence_items, one with two results and the other with one result' do
-    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
-    let(:result2) { result(completed2, pack_sequence1, pack_sequence_item1) }
-    let(:result3) { result(completed3, pack_sequence1, pack_sequence_item2) }
+    let(:result1) { result(completed1, pack_sequence_item1) }
+    let(:result2) { result(completed2, pack_sequence_item1) }
+    let(:result3) { result(completed3, pack_sequence_item2) }
     let(:results) { [result1, result2, result3] }
 
     context 'results are uncompleted, completed, completed' do
@@ -110,10 +110,10 @@ RSpec.describe UserPackSequenceItemSaver do
     let(:pack_sequence_item3) { create(:pack_sequence_item, pack_sequence: pack_sequence2) }
     let(:pack_sequence_item4) { create(:pack_sequence_item, pack_sequence: pack_sequence2) }
 
-    let(:result1) { result(completed1, pack_sequence1, pack_sequence_item1) }
-    let(:result2) { result(completed2, pack_sequence1, pack_sequence_item2) }
-    let(:result3) { result(completed3, pack_sequence2, pack_sequence_item3) }
-    let(:result4) { result(completed3, pack_sequence2, pack_sequence_item4) }
+    let(:result1) { result(completed1, pack_sequence_item1) }
+    let(:result2) { result(completed2, pack_sequence_item2) }
+    let(:result3) { result(completed3, pack_sequence_item3) }
+    let(:result4) { result(completed3, pack_sequence_item4) }
     let(:results) { [result1, result2, result3, result4] }
 
     context 'results are uncompleted, completed, completed, uncompleted' do
@@ -143,11 +143,10 @@ RSpec.describe UserPackSequenceItemSaver do
     end
   end
 
-
-  def result(completed, pack_sequence, pack_sequence_item)
+  def result(completed, pack_sequence_item)
     {
       described_class::COMPLETED_KEY => completed,
-      described_class::PACK_SEQUENCE_ID_KEY => pack_sequence.id,
+      described_class::PACK_SEQUENCE_ID_KEY => pack_sequence_item.pack_sequence.id,
       described_class::PACK_SEQUENCE_ITEM_ID_KEY => pack_sequence_item.id
     }
   end


### PR DESCRIPTION
## WHAT
Fix a staggered release [bug](https://sentry.io/organizations/quillorg-5s/issues/3810073844/?project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d) involving an invalid foreign key with Staggered release.

## WHY
When a user switches from staggered release to immediate, the underlying `pack_sequence` is destroyed.  This also destroys associated `pack_sequence_items` which in turn destroy associated `user_pack_sequence_items`.  `UserPackSequenceItem` has an after_destroy callback that is circular in that after_destroying the object, it calls a worker that effectively recreates the same object by calling SaveUserPackSequenceItemWorker.  Instead we should only be recalculating these objects through updates to ActivitySession, ClassroomUnit, etc that have actual effects on UserPackSequenceItem.  

The `after_save` callback on `UserPackSequenceItem` should also be removed since it triggered unnecessary calls to `SaveUserPackSequenceItemWorker`, namely when `after_save` is called, status is [updated](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb#L59) which will in turn trigger the `after_save` callback again.

### Addendum
After removing the callbacks on `UserPackSequenceItem` a race condition involving `PackSequenceItem` still remained:

1.  PackSequence [destroy](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/services/independent_practice_packs_assigner.rb#L62) is called
2.  Associated PackSequenceItems destroy is [called](https://github.com/empirical-org/Empirical-Core/blob/9edff3e8fcf88cf23192b1ddc261a27ed38acedc/services/QuillLMS/app/models/pack_sequence.rb#L35) due to dependent: :destroy
3.  Associated UserPackSequenceItems destroy is [called](https://github.com/empirical-org/Empirical-Core/blob/9edff3e8fcf88cf23192b1ddc261a27ed38acedc/services/QuillLMS/app/models/pack_sequence_item.rb#L29) due dependent: :destroy
 4.  PackSequenceItem after_destroy callback is called
 5.  Triggers SaveUserPackSequenceItemWorkers
 6.  This has two parts, a query and then the update of status
 7.  Since these are asynchronous, the underlying PackSequenceItem might initially exist but after the workers have been queued, will actually be destroyed.
 8.  This causes the race condition in the update of status in 6.

However, this led me to the solution which is that we don't currently need the 
`after_destroy` callback on PackSequenceItems as these objects are only destroyed via the assigner flow.

## HOW
Remove callbacks on `UserPackSequenceItem` and `PackSequenceItem`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
