### PR TITLE
Throttle account creation by IP address

### DIFF
--- a/services/QuillLMS/config/initializers/rack_attack.rb
+++ b/services/QuillLMS/config/initializers/rack_attack.rb
@@ -14,6 +14,12 @@ class Rack::Attack
     end
   end
 
+  Rack::Attack.throttle('account creation per IP', limit: 5, period: 60.minutes) do |req|
+    if req.path == '/account' && req.post?
+      req.ip
+    end
+  end
+
   Rack::Attack.throttled_response = lambda do |request|
     # NB: you have access to the name and other data about the matched throttle
     #  request.env['rack.attack.matched'],
@@ -23,7 +29,7 @@ class Rack::Attack
 
     # Using 503 because it may make attacker think that they have successfully
     # DOSed the site. Rack::Attack returns 429 for throttling by default
-    [503, {}, [{ message: 'Too many login attempts. Please try again later.', type: 'password' }.to_json]]
+    [503, {}, [{ message: 'Too many attempts. Please try again later.', type: 'password' }.to_json]]
   end
 
 end

--- a/services/QuillLMS/config/initializers/rack_attack.rb
+++ b/services/QuillLMS/config/initializers/rack_attack.rb
@@ -14,7 +14,7 @@ class Rack::Attack
     end
   end
 
-  Rack::Attack.throttle('account creation per IP', limit: 5, period: 60.minutes) do |req|
+  Rack::Attack.throttle('account creation per IP', limit: 10, period: 30.minutes) do |req|
     if req.path == '/account' && req.post?
       req.ip
     end

--- a/services/QuillLMS/config/initializers/rack_attack.rb
+++ b/services/QuillLMS/config/initializers/rack_attack.rb
@@ -14,7 +14,7 @@ class Rack::Attack
     end
   end
 
-  Rack::Attack.throttle('account creation per IP', limit: 10, period: 30.minutes) do |req|
+  Rack::Attack.throttle('account creation per IP', limit: 10, period: 20.minutes) do |req|
     if req.path == '/account' && req.post?
       req.ip
     end


### PR DESCRIPTION
## WHAT
Add a throttle for account creation to limit bots creating accounts.

Note, the git history of the [original PR ](https://github.com/empirical-org/Empirical-Core/pull/10077) got messed up in a merge, so I reopened this. 
## WHY
We had a few fake accounts created today.
## HOW
Use standard rack attack setup.

Confirmed this locally using this script:
```ruby
6.times.map do
  HTTParty.post('http://localhost:3000/account', 
    { user: { name: 'Testing', email: "test#{SecureRandom.uuid}@test.com", password: '12345', role: User::TEACHER } }
  )
end
```
### Screenshots


### Notion Card Links
https://www.notion.so/quill/ea241f31a84c4b79ad56e83e99f7ee93?v=9f7aead86cc749d8a6f963070cef4f5e&p=1da7d6b727374e4fbd4a9fe2af055923&pm=c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, this is sorta outside of our test suite.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
