### PR TITLE
Fix stripe bug with nil credit card

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -31,7 +31,7 @@ module StripeIntegration
     end
 
     private def customer
-      User.find_by_stripe_customer_id_or_email!(stripe_customer_id, customer_email)
+      ::User.find_by_stripe_customer_id_or_email!(stripe_customer_id, customer_email)
     rescue ActiveRecord::RecordNotFound
       raise CustomerNotFoundError
     end

--- a/services/QuillLMS/app/models/stripe_integration/user.rb
+++ b/services/QuillLMS/app/models/stripe_integration/user.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module StripeIntegration
+  class User < SimpleDelegator
+    def last_four
+      return nil unless stripe_customer_id
+
+      stripe_default_payment_method&.card&.last4 || stripe_customer_source&.last4
+    end
+
+    private def stripe_customer
+      Stripe::Customer.retrieve(id: stripe_customer_id, expand: ['sources'])
+    rescue Stripe::InvalidRequestError
+      nil
+    end
+
+    private def stripe_customer_source
+      stripe_customer&.sources&.data&.first
+    end
+
+    private def stripe_default_payment_method
+      Stripe::PaymentMethod.retrieve(stripe_default_payment_method_id)
+    rescue Stripe::InvalidRequestError
+      nil
+    end
+
+    private def stripe_default_payment_method_id
+      stripe_customer&.invoice_settings&.default_payment_method
+    end
+  end
+end

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -60,7 +60,7 @@ module StripeIntegration
       end
 
       private def purchaser
-        @purchaser ||= User.find_by_stripe_customer_id_or_email!(stripe_customer_id, purchaser_email)
+        @purchaser ||= ::User.find_by_stripe_customer_id_or_email!(stripe_customer_id, purchaser_email)
       rescue ActiveRecord::RecordNotFound
         raise PurchaserNotFoundError
       end

--- a/services/QuillLMS/spec/models/stripe_integration/user_spec.rb
+++ b/services/QuillLMS/spec/models/stripe_integration/user_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StripeIntegration::User do
+  include_context 'Stripe Payment Method'
+
+  let(:user) { create(:user, stripe_customer_id: stripe_customer_id) }
+  let(:stripe_user) { described_class.new(user) }
+
+  describe '#last_four' do
+    subject { stripe_user.last_four }
+
+    context 'no stripe_customer_id' do
+      let(:stripe_customer_id) { nil }
+
+      it { expect(subject).to eq nil }
+    end
+
+    context 'stripe_customer_id exists' do
+      let(:stripe_customer_id) { "cus_#{SecureRandom.hex}"}
+      let(:stripe_customer) { double(:stripe_customer, customer_attrs) }
+      let(:customer_attrs) { {invoice_settings: invoice_settings, sources: sources} }
+      let(:invoice_settings) { double(:invoice_settings, default_payment_method: default_payment_method) }
+
+      before do
+        allow(Stripe::Customer)
+          .to receive(:retrieve)
+          .with(id: stripe_customer_id, expand: ['sources'])
+          .and_return(stripe_customer)
+      end
+
+      context 'stripe_default_payment method exists' do
+        let(:default_payment_method) { stripe_payment_method_id }
+        let(:sources) { nil }
+
+        before do
+          allow(Stripe::PaymentMethod)
+            .to receive(:retrieve)
+            .with(stripe_payment_method_id)
+            .and_return(stripe_payment_method)
+        end
+
+        it { expect(subject).to eq stripe_last_four }
+      end
+
+      context 'stripe_default_payment_method does not exist' do
+        let(:default_payment_method) { nil }
+        let(:sources) { double(:sources, data: data) }
+
+        context 'stripe_customer_source does not exist' do
+          let(:data) { nil }
+
+          it { expect(subject).to eq nil }
+        end
+
+        context 'stripe_customer_source exists' do
+          let(:data) { double(:data, first: card) }
+          let(:card) { double(:card, last4: stripe_last_four) }
+
+          it { expect(subject).to eq stripe_last_four }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1456,7 +1456,7 @@ describe User, type: :model do
   end
 
   describe '.find_by_stripe_customer_id_or_email!' do
-    subject { User.find_by_stripe_customer_id_or_email!(stripe_customer_id, email) }
+    subject { described_class.find_by_stripe_customer_id_or_email!(stripe_customer_id, email) }
 
     let(:email) { 'text@example.com' }
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -147,30 +147,6 @@ describe User, type: :model do
     end
   end
 
-  describe '#last_four' do
-    it 'returns nil if a user does not have a stripe_customer_id' do
-      expect(user.last_four).to eq(nil)
-    end
-
-    context 'user has a stripe customer_id' do
-      let(:user) { create(:user, stripe_customer_id: stripe_customer_id)}
-      let(:stripe_customer_id) { 'cus_abcdefg' }
-      let(:last4) { 1000 }
-      let(:customer) { double('customer') }
-      let(:customer_with_sources) { double('customer', sources: double(data: double(first: double(last4: last4)))) }
-      let(:retrieve_sources_args) { { id: stripe_customer_id, expand: ['sources'] } }
-
-      before do
-        allow(Stripe::Customer).to receive(:retrieve).with(stripe_customer_id).and_return(customer)
-        allow(Stripe::Customer).to receive(:retrieve).with(retrieve_sources_args).and_return(customer_with_sources)
-      end
-
-      it "calls Stripe::Customer.retrieve with the current user's stripe_customer_id" do
-        expect(user.last_four).to eq last4
-      end
-    end
-  end
-
   describe '#stripe_customer?' do
     let(:user) { create(:teacher, :has_a_stripe_customer_id) }
     let(:stripe_customer_id) { user.stripe_customer_id }


### PR DESCRIPTION
## WHAT
Stripe stores credit card information in different places for various reasons:

1) For new subscriptions, stripe attaches the credit card info on the stripe subscription object.
2) For legacy subscriptions (i.e. subscriptions not purchased through stripe), the credit card is stored on a sources object on the stripe customer object.
3) When a user with a legacy subscription in the past changes their credit card on file _before_ the newer subscription type has been purchased.  stripe stores the credit card information on the stripe customer invoice settings.

This PR fixes a [bug](https://www.notion.so/quill/Credit-card-listed-as-null-on-My-Subscriptions-page-87900b0c36b943aeaf82e6f623100b41) with case 3 where the user's credit card listed is null

## WHY
Users should be able to see what credit card is on file.

## HOW
Add a check for invoice settings on the last_four method.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Credit-card-listed-as-null-on-My-Subscriptions-page-87900b0c36b943aeaf82e6f623100b41

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
