### PR TITLE
update scorebook query and view to handle locked activities

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/scorebook_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/scorebook_page.scss
@@ -64,14 +64,14 @@
 		}
 	}
 
-	.in-progress-symbol, .attempt-symbol, .scheduled-symbol {
+	.in-progress-symbol, .attempt-symbol, .scheduled-symbol, .locked-symbol {
 		vertical-align: middle;
 		position: absolute;
 		top: -8px;
 		right: -8px;
 	}
 
-  .scheduled-symbol {
+  .scheduled-symbol, .locked-symbol {
     height: 16px;
     background-color: #f7f5f5;
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
@@ -6,7 +6,7 @@ import ScorebookTooltip from '../modules/componentGenerators/tooltip_title/score
 import gradeColor from '../modules/grade_color.js';
 import { nonRelevantActivityClassificationIds, } from '../../../../modules/activity_classifications'
 import activityFromClassificationId from '../modules/activity_from_classification_id.js';
-import { scheduledIcon, } from '../../../Shared/index'
+import { scheduledIcon, closedLockIcon, } from '../../../Shared/index'
 import { requestGet, } from '../../../../modules/request/index'
 
 export default class ActivityIconWithTooltip extends React.Component {
@@ -107,8 +107,10 @@ export default class ActivityIconWithTooltip extends React.Component {
 
   statusIndicator() {
     const { data, } = this.props
-    const { started, completed_attempts, scheduled, } = data
-    if (scheduled && completed_attempts < 1) {
+    const { started, completed_attempts, scheduled, locked, } = data
+    if (locked) {
+      return <img alt="" className="locked-symbol" src={closedLockIcon.src} />
+    } else if (scheduled && completed_attempts < 1) {
       return <img alt="" className="scheduled-symbol" src={scheduledIcon.src} />
     } else if (started) {
       return <img alt="" className="in-progress-symbol" src="https://assets.quill.org/images/scorebook/blue-circle-sliced.svg" />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/componentGenerators/tooltip_title/scorebook_tooltip_title.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/componentGenerators/tooltip_title/scorebook_tooltip_title.jsx
@@ -40,6 +40,8 @@ export default class ScorebookTooltip extends React.Component {
       return <span>This student has missed this lesson. To make up this material, you can assign this lesson again to the students who missed it.</span>
     } else if (data.scheduled && !data.completed_attempts) {
       return <span>This scheduled activity has not been published.</span>;
+    } else if (data.locked) {
+      return <span>This activity is set for staggered release and has not been unlocked by this student.</span>;
     } else if (!data.completed_attempts) {
       return <span>This activity has not been completed.</span>;
     } else if (data.concept_results && data.concept_results.length) {

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/Scorebook.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/Scorebook.jsx
@@ -232,7 +232,8 @@ export default createReactClass({
         dueDate: s.due_date,
         publishDate: s.publish_date,
         unitActivityCreatedAt: s.unit_activity_created_at,
-        scheduled: s.scheduled
+        scheduled: s.scheduled,
+        locked: s.locked
       });
     });
     this.setState({ loading: false, scores: newScores, missing: this.checkMissing(newScores), });

--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -58,6 +58,27 @@ describe 'ScorebookQuery' do
     expect(results[0]['scheduled']).to eq(false)
   end
 
+  describe 'pack sequence status' do
+    it 'returns activities with locked pack sequence statuses as locked: true' do
+      psi = create(:pack_sequence_item, classroom_unit: classroom_unit)
+      create(:user_pack_sequence_item, pack_sequence_item: psi, user: student, status: UserPackSequenceItem::LOCKED)
+      results = Scorebook::Query.run(classroom.id)
+      expect(results[0]['locked']).to eq(true)
+    end
+
+    it 'returns activities with unlocked pack sequence statuses as locked: false' do
+      psi = create(:pack_sequence_item, classroom_unit: classroom_unit)
+      create(:user_pack_sequence_item, pack_sequence_item: psi, user: student, status: UserPackSequenceItem::UNLOCKED)
+      results = Scorebook::Query.run(classroom.id)
+      expect(results[0]['locked']).to eq(false)
+    end
+
+    it 'returns activities with no pack sequence as locked: false' do
+      results = Scorebook::Query.run(classroom.id)
+      expect(results[0]['locked']).to eq(false)
+    end
+  end
+
   describe 'support date constraints' do
     it 'returns activities completed between the specified dates' do
       begin_date = activity_session1.completed_at - 1.day
@@ -80,7 +101,7 @@ describe 'ScorebookQuery' do
       expect(results.map{|res| res['id']}).not_to include(activity_session1.id)
     end
 
-    context 'time zones' do
+    describe 'time zones' do
       def activity_session_completed_at_to_time_midnight_minus_offset(activity_session, offset)
         original_completed_at = activity_session.completed_at.to_date.to_s
         new_completed_at = Scorebook::Query.to_offset_datetime(original_completed_at, offset)


### PR DESCRIPTION
## WHAT
Update the scorebook query and view to handle locked activities.

## WHY
So teachers have additional context for activities that have not been completed. 

## HOW
Just update the query to use the new tables and send the data to the frontend to render the appropriate icon.

### Screenshots
<img width="1007" alt="Screen Shot 2022-12-20 at 11 11 22 AM" src="https://user-images.githubusercontent.com/18669014/208713280-4bb69eea-ab4d-4c91-ae7d-988aec22ed8d.png">

### Notion Card Links
https://www.notion.so/quill/Changes-to-the-activity-summary-report-to-represent-locked-activities-1b6ddaad6539442b87d0483ad7c771f0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
