### PR TITLE
Bugfix for overnight jobs, fixing a nil error

### DIFF
--- a/services/QuillLMS/app/services/serialize_evidence_prompt_health.rb
+++ b/services/QuillLMS/app/services/serialize_evidence_prompt_health.rb
@@ -10,11 +10,28 @@ class SerializeEvidencePromptHealth
   end
 
   def data
-    {
+    serialized_data = {
       prompt_id: prompt.id,
       activity_short_name: prompt.activity.notes,
       text: prompt.text,
       current_version: prompt.activity.version,
+      version_responses: 0,
+      first_attempt_optimal: nil,
+      final_attempt_optimal: nil,
+      avg_attempts: nil,
+      confidence: nil,
+      percent_automl_consecutive_repeated: nil,
+      percent_automl: nil,
+      percent_plagiarism: nil,
+      percent_opinion: nil,
+      percent_grammar: nil,
+      percent_spelling: nil,
+      avg_time_spent_per_prompt: nil
+    }
+
+    return serialized_data if prompt_feedback_history.empty?
+
+    feedback_history_data = {
       version_responses: prompt_feedback_history[prompt.id]["total_responses"],
       first_attempt_optimal: num_first_attempts > 0 ? ((prompt_feedback_history[prompt.id]["num_first_attempt_optimal"] / num_first_attempts.to_f) * 100).round : nil,
       final_attempt_optimal: num_final_attempts > 0 ? ((prompt_feedback_history[prompt.id]["num_final_attempt_optimal"] / num_final_attempts.to_f) * 100).round : nil,
@@ -28,6 +45,8 @@ class SerializeEvidencePromptHealth
       percent_spelling: percent_responses_for_api(FeedbackHistory::SPELLING),
       avg_time_spent_per_prompt: prompt_feedback_history[prompt.id]["avg_time_spent"] ? Utils::Numeric.human_readable_time_to_seconds(prompt_feedback_history[prompt.id]["avg_time_spent"]) : nil
     }
+
+    serialized_data.merge!(feedback_history_data)
   end
 
   private def rule_feedback_histories

--- a/services/QuillLMS/spec/services/serialize_evidence_prompt_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_evidence_prompt_health_spec.rb
@@ -86,4 +86,29 @@ describe 'SerializeEvidencePromptHealth' do
     data = SerializeEvidencePromptHealth.new(prompt, @prompt_feedback_history).data
     expect(data).to eq expected_results
   end
+
+  it 'will return without errring if prompt_feedback_history object is empty' do
+    nil_data_object = {
+      prompt_id: @because_prompt1.id,
+      activity_short_name: @activity.notes,
+      text: @because_prompt1.text,
+      current_version: @activity.version,
+      version_responses: 0,
+      first_attempt_optimal: nil,
+      final_attempt_optimal: nil,
+      avg_attempts: nil,
+      confidence: nil,
+      percent_automl_consecutive_repeated: nil,
+      percent_automl: nil,
+      percent_plagiarism: nil,
+      percent_opinion: nil,
+      percent_grammar: nil,
+      percent_spelling: nil,
+      avg_time_spent_per_prompt: nil
+    }
+
+    prompt = @because_prompt1
+    data = SerializeEvidencePromptHealth.new(prompt, {}).data
+    expect(data).to eq nil_data_object
+  end
 end


### PR DESCRIPTION
## WHAT
There's an edge case that's causing a nil error on some of our overnight Evidence Activity stats aggregator jobs. This PR handles the edge case so we don't get nil error alerts and failing/retrying jobs.

## WHY
To prevent job failures and wasted time retrying Sidekiq jobs.

## HOW
The error is happening for activities that have no feedback records attached to them yet. To handle it, the code looks for the case where `prompt_feedback_object` is empty and returns a default "nil feedback" object.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes