### PR TITLE
strip sr-only text for toggle highlight function

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -53,6 +53,11 @@ const ONBOARDING = 'onboarding'
 const ALL_STEPS = [READ_PASSAGE_STEP_NUMBER, 2, 3, 4]
 const MINIMUM_STUDENT_HIGHLIGHT_COUNT = 2
 
+const STUDENT_HIGHLIGHT_STARTS_TEXT = "(highlighted text begins here)"
+const STUDENT_HIGHLIGHT_ENDS_TEXT = "(highlighted text ends here)"
+const PASSAGE_HIGHLIGHT_STARTS_TEXT = "(yellow underlined text begins here)"
+const PASSAGE_HIGHLIGHT_ENDS_TEXT = "(yellow underlined text ends here)"
+
 export const StudentViewContainer = ({ dispatch, session, isTurk, location, activities, handleFinishActivity, user }: StudentViewContainerProps) => {
   const skipToSpecificStep = window.location.href.includes('skipToStep')
   const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts') || skipToSpecificStep
@@ -446,10 +451,11 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   }
 
   function toggleStudentHighlight(text, callback=null) {
+    const textWithHighlightContentRemoved = text.replace(STUDENT_HIGHLIGHT_STARTS_TEXT, '').replace(STUDENT_HIGHLIGHT_ENDS_TEXT, '')
     let newHighlights = []
 
-    if (studentHighlights.includes(text)) {
-      newHighlights = studentHighlights.filter(hl => hl !== text)
+    if (studentHighlights.includes(textWithHighlightContentRemoved)) {
+      newHighlights = studentHighlights.filter(hl => hl !== textWithHighlightContentRemoved)
     } else {
       newHighlights = studentHighlights.concat(text)
     }
@@ -489,16 +495,16 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
         return (
           <p>
             <span className="passage-highlight">
-              <span className="sr-only">(yellow underlined text begins here)</span>
+              <span className="sr-only">{PASSAGE_HIGHLIGHT_STARTS_TEXT}</span>
               {stringifiedInnerElements}
-              <span className="sr-only">(yellow underlined text ends here)</span>
+              <span className="sr-only">{PASSAGE_HIGHLIGHT_ENDS_TEXT}</span>
             </span>
           </p>
         )
       }
       if (elementIncludesHighlight) {
         let newStringifiedInnerElements = stringifiedInnerElements
-        strippedPassageHighlights.forEach(ph => newStringifiedInnerElements = newStringifiedInnerElements.replace(ph, `<span class="passage-highlight"><span class="sr-only">(yellow underlined text begins here)</span>${ph}<span class="sr-only">(yellow underlined text ends here)</span></span>`))
+        strippedPassageHighlights.forEach(ph => newStringifiedInnerElements = newStringifiedInnerElements.replace(ph, `<span class="passage-highlight"><span class="sr-only">${PASSAGE_HIGHLIGHT_STARTS_TEXT}</span>${ph}<span class="sr-only">${PASSAGE_HIGHLIGHT_ENDS_TEXT}</span></span>`))
         return <p dangerouslySetInnerHTML={{ __html: newStringifiedInnerElements }} />
       }
     }
@@ -511,8 +517,8 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
       const highlighted = studentHighlights.includes(stringifiedInnerElements)
       if(activeStep === 1 && highlighted) {
         className += ' highlighted'
-        const firstElement = <span className="sr-only">(highlighted text begins here)</span>
-        const lastElement = <span className="sr-only">(highlighted text ends here)</span>
+        const firstElement = <span className="sr-only">{STUDENT_HIGHLIGHT_STARTS_TEXT}</span>
+        const lastElement = <span className="sr-only">{STUDENT_HIGHLIGHT_ENDS_TEXT}</span>
         innerElements = [firstElement, ...innerElements, lastElement]
       }
       className += shouldBeHighlightable  ? ' highlightable' : ''


### PR DESCRIPTION
## WHAT
Strip screenreader text from function that determines highlight toggle.

## WHY
We were having a weird bug where clicking on the highlight twice was adding the screenreader-only text the second time, instead of removing it.

## HOW
Just constantize the highlight text and strip it before determining whether to add or remove the new highlight.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Highlighting-the-same-sentence-twice-leads-to-unnecessary-text-displaying-7759a0aa9e7e4b9eaddc0972cfca005b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | Tested locally
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
