### PR TITLE
Fix worker args for whole class instruction assignment

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -217,7 +217,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   def assign_whole_class_instruction_packs
-    return render json: {}, status: 401 unless params[:classroom_id].in?(current_user.classrooms_i_teach.pluck(:id))
+    return render json: {}, status: 401 unless params[:classroom_id].to_i.in?(current_user.classrooms_i_teach.pluck(:id))
 
     set_lesson_diagnostic_recommendations_start_time
     last_recommendation_index = params[:unit_template_ids].length - 1

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -224,12 +224,14 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
 
     params[:unit_template_ids].each_with_index do |unit_template_id, index|
       AssignRecommendationsWorker.perform_async(
-        assign_on_join: true,
-        classroom_id: params[:classroom_id],
-        is_last_recommendation: index == last_recommendation_index,
-        lesson: true,
-        student_ids: [],
-        unit_template_id: unit_template_id
+        {
+          'assign_on_join' => true,
+          'classroom_id' => params[:classroom_id],
+          'is_last_recommendation' => (index == last_recommendation_index),
+          'lesson' => true,
+          'student_ids' => [],
+          'unit_template_id' => unit_template_id
+        }
       )
     end
 


### PR DESCRIPTION
## WHAT
Fix a bug with parameters passed to a worker

## WHY
During staggered release, the worker args were accidentally converted to named parameters.

## HOW
Conver the parameters back into a hash like they were before.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
