### PR TITLE
lms/remove-sqreen-from-app

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -157,7 +157,6 @@ group :production, :staging do
   gem 'rails-autoscale-web'
   gem 'rails-autoscale-sidekiq'
   gem 'lograge'
-  gem 'sqreen'
 end
 
 group :development do

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -392,7 +392,6 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    libsqreen (1.0.4.0.0)
     libv8-node (15.14.0.1)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -732,14 +731,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqreen (1.25.1)
-      libsqreen (~> 1.0)
-      mini_racer (>= 0.4.0)
-      sqreen-backport (~> 0.1.0)
-      sqreen-kit (~> 0.2.4)
-    sqreen-backport (0.1.0)
-    sqreen-kit (0.2.4)
-      sqreen-backport (~> 0.1.0)
     ssrf_filter (1.0.7)
     stripe (5.30.0)
     super_diff (0.6.1)
@@ -913,7 +904,6 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   sprockets (~> 3.7.2)
-  sqreen
   stripe (~> 5.30)
   super_diff
   terminal-notifier-guard

--- a/services/QuillLMS/config/sqreen.yml
+++ b/services/QuillLMS/config/sqreen.yml
@@ -1,1 +1,0 @@
-token: <%= ENV['SQREEN_TOKEN'] %>


### PR DESCRIPTION
## WHAT
Remove Sqreen gem from Gemfile and remove related config file
## WHY
We never really used the service much in the first place, and now it's been taken off of the Heroku marketplace so we can't use it at all.  This just cleans up our code-base to reflect reality.
## HOW
- `bundle remove sqreen`
- `git rm config/sqreen.yml`

### Notion Card Links
https://www.notion.so/quill/Remove-Sqreen-from-our-Codebase-87455f6c8e54484f8748470eef43a3f0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests around third-party service usage
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
