### PR TITLE
Fix finder bug with User namespace

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -71,7 +71,7 @@ module StripeIntegration
     end
 
     private def stripe_customer_id
-      User.find_by(email: customer_email).stripe_customer_id
+      ::User.find_by(email: customer_email).stripe_customer_id
     end
 
     private def success_url


### PR DESCRIPTION
## WHAT
Fix a [bug](https://sentry.io/organizations/quillorg-5s/issues/3828246580/?referrer=slack) with the wrong `User` class being called.

## WHY
Users won't be able to do a stripe subscription

## HOW
Add root namespace to `User.find_by`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  N/A
