### PR TITLE
Evidence/add more second layer feedback

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/opinion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/opinion.rb
@@ -5,7 +5,7 @@ module Evidence
 
     def run
       opinion_client = ::Evidence::Opinion::Client.new(entry: entry, prompt_text: prompt.text)
-      @response = ::Evidence::Opinion::FeedbackAssembler.run(opinion_client.post, feedback_history)
+      @response = ::Evidence::Opinion::FeedbackAssembler.run(opinion_client.post, previous_feedback)
     end
 
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/opinion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/opinion.rb
@@ -5,7 +5,7 @@ module Evidence
 
     def run
       opinion_client = ::Evidence::Opinion::Client.new(entry: entry, prompt_text: prompt.text)
-      @response = ::Evidence::Opinion::FeedbackAssembler.run(opinion_client.post)
+      @response = ::Evidence::Opinion::FeedbackAssembler.run(opinion_client.post, feedback_history)
     end
 
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/prefilter.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/prefilter.rb
@@ -4,7 +4,7 @@ module Evidence
   class Check::Prefilter < Check::Base
 
     def run
-      prefilter_check = Evidence::PrefilterCheck.new(entry)
+      prefilter_check = Evidence::PrefilterCheck.new(entry, previous_feedback)
       @response = prefilter_check.feedback_object
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/spelling.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/check/spelling.rb
@@ -6,7 +6,7 @@ module Evidence
     class BingException < StandardError; end
 
     def run
-      spelling_check = Evidence::SpellingCheck.new(entry)
+      spelling_check = Evidence::SpellingCheck.new(entry, previous_feedback)
 
       if spelling_check.error
         raise BingException, spelling_check.error

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/feedback_assembler.rb
@@ -6,13 +6,13 @@ module Evidence
       raise NotImplementedError, 'Cannot call #error_to_rule_uid on abstract class FeedbackAssembler'
     end
 
-    def self.run(client_response)
+    def self.run(client_response, feedback_history = [])
       error = client_response[error_name]
       return default_payload if error.empty?
 
       rule_uid = error_to_rule_uid.fetch(error)
-      rule = Evidence::Rule.where(uid: rule_uid).includes(:feedbacks).first
-      top_feedback = rule&.feedbacks&.min_by(&:order)
+      rule = Evidence::Rule.includes(:feedbacks).find_by(uid: rule_uid)
+      top_feedback = rule&.determine_feedback_from_history(feedback_history)
 
       default_payload.merge({
         'concept_uid': rule&.concept_uid,

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -35,8 +35,9 @@ module Evidence
 
     attr_reader :entry
 
-    def initialize(entry)
+    def initialize(entry, feedback_history = [])
       @entry = entry
+      @feedback_history = feedback_history
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
@@ -57,7 +58,7 @@ module Evidence
     # rubocop:enable Metrics/CyclomaticComplexity
 
     def non_optimal_feedback_string
-      spelling_rule&.feedbacks&.first&.text || FALLBACK_INCORRECT_FEEDBACK
+      spelling_rule&.determine_feedback_from_history(@feedback_history)&.text || FALLBACK_INCORRECT_FEEDBACK
     end
 
     def error

--- a/services/QuillLMS/engines/evidence/spec/lib/feedback_assembler_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/feedback_assembler_spec.rb
@@ -40,13 +40,15 @@ module Evidence
         let!(:rule) do
           create(:evidence_rule, uid: example_rule_uid, optimal: false, concept_uid: 'xyz')
         end
+        let!(:feedback) { create(:evidence_feedback, rule: rule, text: 'First feedback', order: 1) }
+        let!(:feedback2) { create(:evidence_feedback, rule: rule, text: 'Second feedback', order: 2) }
 
         it 'should lookup a rule and format it' do
           expect(
             FeedbackAssembler.run(client_response)
           ).to eq({
             concept_uid: 'xyz',
-            feedback: nil,
+            feedback: feedback.text,
             feedback_type: '',
             optimal: false,
             highlight: [
@@ -56,6 +58,29 @@ module Evidence
             labels: '',
             rule_uid: example_rule_uid.to_s
           })
+        end
+
+        it 'should use the higher order feedback when lower order feedback is in history' do
+          feedback_history = [{
+            'feedback_type' => feedback.rule.rule_type,
+            'feedback' => feedback.text
+          }]
+          expect(
+            FeedbackAssembler.run(client_response, feedback_history)[:feedback]
+          ).to eq(feedback2.text)
+        end
+
+        it 'should use the highest order feedback when all feedback is in history' do
+          feedback_history = [{
+            'feedback_type' => feedback.rule.rule_type,
+            'feedback' => feedback.text
+          },{
+            'feedback_type' => feedback2.rule.rule_type,
+            'feedback' => feedback2.text
+          }]
+          expect(
+            FeedbackAssembler.run(client_response, feedback_history)[:feedback]
+          ).to eq(feedback2.text)
         end
       end
 

--- a/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
@@ -104,6 +104,33 @@ module Evidence
         spelling_check = Evidence::SpellingCheck.new("")
         expect(feedback.text).to(eq(spelling_check.non_optimal_feedback_string))
       end
+
+      it 'should use the higher ordered feedback if lower ordered feedback is in feedback_history' do
+        rule = create(:evidence_rule, :rule_type => (Evidence::Rule::TYPE_SPELLING))
+        feedback = create(:evidence_feedback, :text => 'First feedback', :rule => rule, :order => 1)
+        feedback2 = create(:evidence_feedback, :text => 'Second feedback', :rule => rule, :order => 2)
+        feedback_history = [{
+          'feedback_type' => feedback.rule.rule_type,
+          'feedback' => feedback.text
+        }]
+        spelling_check = Evidence::SpellingCheck.new("", feedback_history)
+        expect(feedback2.text).to(eq(spelling_check.non_optimal_feedback_string))
+      end
+
+      it 'should use the highest ordered feedback if all feedback options are in feedback_history' do
+        rule = create(:evidence_rule, :rule_type => (Evidence::Rule::TYPE_SPELLING))
+        feedback = create(:evidence_feedback, :text => 'First feedback', :rule => rule, :order => 1)
+        feedback2 = create(:evidence_feedback, :text => 'Second feedback', :rule => rule, :order => 2)
+        feedback_history = [{
+          'feedback_type' => feedback.rule.rule_type,
+          'feedback' => feedback.text
+        },{
+          'feedback_type' => feedback2.rule.rule_type,
+          'feedback' => feedback2.text
+        }]
+        spelling_check = Evidence::SpellingCheck.new("", feedback_history)
+        expect(feedback2.text).to(eq(spelling_check.non_optimal_feedback_string))
+      end
     end
 
     context 'should handle appropriate Bing API errors' do


### PR DESCRIPTION
## WHAT
Allow Prefilter, Spelling, and Opinion rules to return multiple "layers" of feedback in Evidence
## WHY
We want to be able to provide more complex experiences and more detailed feedback to students who are struggling with the same concept even after they receive feedback.
## HOW
Pass `previous_feedback` from through to additional Check classes, and refactor them to use that information to call `determine_feedback_from_history` in order to determine which "layer" of Feedback attached to a Rule to show to the end user.

### Notion Card Links
https://www.notion.so/quill/Prefilter-API-Secondary-Feedback-41405bbba97d4339a0bd6d2788123a0a
https://www.notion.so/quill/Spelling-API-Secondary-Feedback-2776c4ab70544d63a039e0108b7cbe02
https://www.notion.so/quill/Opinion-API-Secondary-Feedback-e44faee131dd4ae98ff70260ee676b48

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A