### PR TITLE
Bug fix/ Activity Analysis questions view score

### DIFF
--- a/services/QuillLMS/app/models/concept_result.rb
+++ b/services/QuillLMS/app/models/concept_result.rb
@@ -131,6 +131,12 @@ class ConceptResult < ApplicationRecord
     self.extra_metadata = extra_metadata
   end
 
+  def question_score_for_correct_count
+    return question_score unless question_score.nil?
+
+    correct ? 1 : 0
+  end
+
   private def legacy_format_metadata
     legacy_format_base_metadata
       .merge(extra_metadata || {})

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -53,7 +53,7 @@ module PublicProgressReports
       curr_quest = questions[answer.question_number]
       curr_quest[:correct] ||= 0
       curr_quest[:total] ||= 0
-      curr_quest[:correct] += answer.question_score || answer.correct ? 1 : 0
+      curr_quest[:correct] += answer.question_score_for_correct_count
       curr_quest[:total] += 1
       curr_quest[:prompt] ||= answer.concept_result_prompt&.text
       curr_quest[:question_number] ||= answer.question_number

--- a/services/QuillLMS/spec/models/concept_result_spec.rb
+++ b/services/QuillLMS/spec/models/concept_result_spec.rb
@@ -225,5 +225,55 @@ RSpec.describe ConceptResult, type: :model do
         })
       end
     end
+
+    context 'question_score_for_correct_count' do
+      let(:question) { create(:question) }
+      let(:activity) { create(:activity, data: {questions: [{key: question.uid}]}) }
+      let(:activity_session) { create(:activity_session, activity: activity) }
+      let(:concept) { create(:concept) }
+      let(:metadata1) do
+        {
+          "correct": 1,
+          "directions": "Combine the sentences. (And)",
+          "lastFeedback": "Proofread your work. Check your spelling.",
+          "prompt": "Deserts are very dry. Years go by without rain.",
+          "attemptNumber": 2,
+          "answer": "Deserts are very dry, and years go by without rain.",
+          "questionNumber": 1,
+          "questionScore": 0.8
+        }
+      end
+      let(:metadata2) do
+        {
+          "correct": 1,
+          "directions": "Combine the sentences. (And)",
+          "lastFeedback": "Proofread your work. Check your spelling.",
+          "prompt": "Deserts are very dry. Years go by without rain.",
+          "attemptNumber": 2,
+          "answer": "Deserts are very dry, and years go by without rain.",
+          "questionNumber": 1,
+        }
+      end
+      let(:metadata3) do
+        {
+          "correct": 0,
+          "directions": "Combine the sentences. (And)",
+          "lastFeedback": "Proofread your work. Check your spelling.",
+          "prompt": "Deserts are very dry. Years go by without rain.",
+          "attemptNumber": 2,
+          "answer": "Deserts are very dry, and years go by without rain.",
+          "questionNumber": 1,
+        }
+      end
+      let(:concept_result1) { ConceptResult.create_from_json({concept_id: concept.id, activity_session_id: activity_session.id, metadata: metadata1, activity_classification_id: activity.activity_classification_id, question_type: 'sentence-combining'}) }
+      let(:concept_result2) { ConceptResult.create_from_json({concept_id: concept.id, activity_session_id: activity_session.id, metadata: metadata2, activity_classification_id: activity.activity_classification_id, question_type: 'sentence-combining'}) }
+      let(:concept_result3) { ConceptResult.create_from_json({concept_id: concept.id, activity_session_id: activity_session.id, metadata: metadata3, activity_classification_id: activity.activity_classification_id, question_type: 'sentence-combining'}) }
+
+      it 'should return the expected value' do
+        expect(concept_result1.question_score_for_correct_count).to eq(0.8)
+        expect(concept_result2.question_score_for_correct_count).to eq(1)
+        expect(concept_result3.question_score_for_correct_count).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
## WHAT
fix score calculation for Activity Analysis questions view

## WHY
all of the questions were being defaulted to 100% rather than averaged across all students

## HOW
pull out logic into `question_score_for_correct_count` to correctly calculate score

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Activity-Analysis-Questions-View-Score-Are-Defaulting-to-100-40142cbab5a34e65bfa7ef508246ea68

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
