### PR TITLE
fix tooltip bugs

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
@@ -511,8 +511,8 @@ nav.q-navbar-home {
 .navbar-tooltip-trigger {
   cursor: pointer;
   position: relative;
-  margin-bottom: -40px;
-  padding-bottom: 40px;
+  margin-bottom: -20px;
+  padding-bottom: 20px;
   span {
     color: #fff;
   }

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -12,9 +12,13 @@ interface TooltipProps {
   tooltipTriggerStyle?: { [key:string]: any }
 }
 
+const VISIBLE = 'visible'
+const RIGHT_JUSTIFY = 'right-justify'
+
 class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean, tooltipVisible: boolean }> {
   private tooltip: any // eslint-disable-line react/sort-comp
   private tooltipTrigger: any // eslint-disable-line react/sort-comp
+  private tooltipWrapper: any // eslint-disable-line react/sort-comp
 
   constructor(props) {
     super(props)
@@ -36,11 +40,15 @@ class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean
     const activeTooltips = document.getElementsByClassName('visible quill-tooltip')
     Array.from(activeTooltips).forEach(tooltip => tooltip.classList.remove('visible'))
     this.tooltip.innerHTML = tooltipText
-    this.tooltip.classList.add('visible')
+    this.tooltip.classList.add(VISIBLE)
+    if (this.tooltip.getBoundingClientRect().right >= window.innerWidth) {
+      this.tooltipWrapper.classList.add(RIGHT_JUSTIFY)
+    }
   }
 
   hideTooltip() {
-    this.tooltip.classList.remove('visible')
+    this.tooltip.classList.remove(VISIBLE)
+    this.tooltipWrapper.classList.remove(RIGHT_JUSTIFY)
     this.tooltip.innerHTML = ''
     this.setState({ tooltipVisible: false });
   }
@@ -109,7 +117,7 @@ class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean
         >
           {tooltipTriggerText}
         </span>
-        <span className="quill-tooltip-wrapper">
+        <span className="quill-tooltip-wrapper" ref={node => this.tooltipWrapper = node}>
           <span
             aria-live="polite"
             className="quill-tooltip"

--- a/services/QuillLMS/client/app/bundles/Shared/styles/tooltip.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/tooltip.scss
@@ -23,9 +23,14 @@
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  left: 50%;
-  transform: translateX(-50%);
   z-index: 2;
+  &:not(.right-justify) {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  &.right-justify {
+    right: 0%;
+  }
 }
 
 .quill-tooltip {


### PR DESCRIPTION
## WHAT
Fix bug where a) tooltip trigger zone in navigation interacted with navigation buttons and b) tooltips on student dashboards were getting cut off on narrow screens 

## WHY
We want our interfaces to be as smooth and bug free as possible!

## HOW
Just CSS adjustments.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-interaction-of-navigation-menu-with-navigation-buttons-754fa041d0bc4ae2a458aeb9c3fedb7d
https://www.notion.so/quill/Fix-tooltips-getting-cut-off-in-narrow-view-on-student-dashboards-1242f589260f446abd6e6e38c2f8e879

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No - no tests for CSS changes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
