### PR TITLE
migration for closed activity packs view

### DIFF
--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -47,6 +47,8 @@ class Unit < ApplicationRecord
 
   default_scope { where(visible: true)}
 
+  before_save :set_active_to_false
+
   after_save :save_user_pack_sequence_items, if: :visible
   after_save :hide_classroom_units_and_unit_activities
   after_save :create_any_new_classroom_unit_activity_states
@@ -54,6 +56,12 @@ class Unit < ApplicationRecord
   # Using an after_commit hook here because we want to trigger the callback
   # on save or touch, and touch explicitly bypasses after_save hooks
   after_commit :touch_all_classrooms_and_classroom_units
+
+  def set_active_to_false
+    return if visible
+
+    self.active = false
+  end
 
   def hide_if_no_visible_unit_activities
     return if unit_activities.exists?(visible: true)

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -5,6 +5,7 @@
 # Table name: units
 #
 #  id               :integer          not null, primary key
+#  active           :boolean          default(TRUE), not null
 #  name             :string
 #  visible          :boolean          default(TRUE), not null
 #  created_at       :datetime

--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -5,8 +5,8 @@
 # Table name: units
 #
 #  id               :integer          not null, primary key
-#  active           :boolean          default(TRUE), not null
 #  name             :string
+#  open             :boolean          default(TRUE), not null
 #  visible          :boolean          default(TRUE), not null
 #  created_at       :datetime
 #  updated_at       :datetime
@@ -48,7 +48,7 @@ class Unit < ApplicationRecord
 
   default_scope { where(visible: true)}
 
-  before_save :set_active_to_false
+  before_save :set_open_to_false
 
   after_save :save_user_pack_sequence_items, if: :visible
   after_save :hide_classroom_units_and_unit_activities
@@ -58,10 +58,10 @@ class Unit < ApplicationRecord
   # on save or touch, and touch explicitly bypasses after_save hooks
   after_commit :touch_all_classrooms_and_classroom_units
 
-  def set_active_to_false
+  def set_open_to_false
     return if visible
 
-    self.active = false
+    self.open = false
   end
 
   def hide_if_no_visible_unit_activities

--- a/services/QuillLMS/db/migrate/20230104183416_add_active_column_to_units_table.rb
+++ b/services/QuillLMS/db/migrate/20230104183416_add_active_column_to_units_table.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddActiveColumnToUnitsTable < ActiveRecord::Migration[6.1]
-  def change
-    add_column :units, :active, :boolean, null: false, default: true
-  end
-end

--- a/services/QuillLMS/db/migrate/20230104183416_add_active_column_to_units_table.rb
+++ b/services/QuillLMS/db/migrate/20230104183416_add_active_column_to_units_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddActiveColumnToUnitsTable < ActiveRecord::Migration[6.1]
   def change
     add_column :units, :active, :boolean, null: false, default: true

--- a/services/QuillLMS/db/migrate/20230104183416_add_active_column_to_units_table.rb
+++ b/services/QuillLMS/db/migrate/20230104183416_add_active_column_to_units_table.rb
@@ -1,0 +1,5 @@
+class AddActiveColumnToUnitsTable < ActiveRecord::Migration[6.1]
+  def change
+    add_column :units, :active, :boolean, null: false, default: true
+  end
+end

--- a/services/QuillLMS/db/migrate/20230104183416_add_open_column_to_units_table.rb
+++ b/services/QuillLMS/db/migrate/20230104183416_add_open_column_to_units_table.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOpenColumnToUnitsTable < ActiveRecord::Migration[6.1]
+  def change
+    add_column :units, :open, :boolean, null: false, default: true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -4447,7 +4447,7 @@ CREATE TABLE public.units (
     visible boolean DEFAULT true NOT NULL,
     user_id integer,
     unit_template_id integer,
-    active boolean DEFAULT true NOT NULL
+    open boolean DEFAULT true NOT NULL
 );
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -4446,7 +4446,8 @@ CREATE TABLE public.units (
     updated_at timestamp without time zone,
     visible boolean DEFAULT true NOT NULL,
     user_id integer,
-    unit_template_id integer
+    unit_template_id integer,
+    active boolean DEFAULT true NOT NULL
 );
 
 
@@ -9158,6 +9159,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221209134742'),
 ('20221209141047'),
 ('20221209151611'),
-('20221209151957');
+('20221209151957'),
+('20230104183416');
 
 

--- a/services/QuillLMS/spec/factories/units.rb
+++ b/services/QuillLMS/spec/factories/units.rb
@@ -5,8 +5,8 @@
 # Table name: units
 #
 #  id               :integer          not null, primary key
-#  active           :boolean          default(TRUE), not null
 #  name             :string
+#  open             :boolean          default(TRUE), not null
 #  visible          :boolean          default(TRUE), not null
 #  created_at       :datetime
 #  updated_at       :datetime

--- a/services/QuillLMS/spec/factories/units.rb
+++ b/services/QuillLMS/spec/factories/units.rb
@@ -5,6 +5,7 @@
 # Table name: units
 #
 #  id               :integer          not null, primary key
+#  active           :boolean          default(TRUE), not null
 #  name             :string
 #  visible          :boolean          default(TRUE), not null
 #  created_at       :datetime

--- a/services/QuillLMS/spec/models/unit_spec.rb
+++ b/services/QuillLMS/spec/models/unit_spec.rb
@@ -5,8 +5,8 @@
 # Table name: units
 #
 #  id               :integer          not null, primary key
-#  active           :boolean          default(TRUE), not null
 #  name             :string
+#  open             :boolean          default(TRUE), not null
 #  visible          :boolean          default(TRUE), not null
 #  created_at       :datetime
 #  updated_at       :datetime
@@ -33,7 +33,7 @@ describe Unit, type: :model do
   it { should have_many(:standards).through(:activities) }
   it { should belong_to(:unit_template) }
 
-  it { is_expected.to callback(:set_active_to_false).before(:save) }
+  it { is_expected.to callback(:set_open_to_false).before(:save) }
   it { is_expected.to callback(:save_user_pack_sequence_items).after(:save) }
   it { is_expected.to callback(:hide_classroom_units_and_unit_activities).after(:save) }
 
@@ -135,20 +135,20 @@ describe Unit, type: :model do
     end
   end
 
-  describe '#set_active_to_false' do
+  describe '#set_open_to_false' do
     it 'is called when the unit is saved' do
-      expect(unit).to receive(:set_active_to_false)
+      expect(unit).to receive(:set_open_to_false)
       unit.update(name: 'new name')
     end
 
-    it 'is sets active to false if the unit is not visible' do
+    it 'is sets open to false if the unit is not visible' do
       unit.update(visible: false)
-      expect(unit.active).to eq(false)
+      expect(unit.open).to eq(false)
     end
 
-    it 'leaves active value alone if the unit is visible' do
+    it 'leaves open value alone if the unit is visible' do
       unit.update(visible: true)
-      expect(unit.active).to eq(true)
+      expect(unit.open).to eq(true)
     end
   end
 

--- a/services/QuillLMS/spec/models/unit_spec.rb
+++ b/services/QuillLMS/spec/models/unit_spec.rb
@@ -32,6 +32,7 @@ describe Unit, type: :model do
   it { should have_many(:standards).through(:activities) }
   it { should belong_to(:unit_template) }
 
+  it { is_expected.to callback(:set_active_to_false).before(:save) }
   it { is_expected.to callback(:save_user_pack_sequence_items).after(:save) }
   it { is_expected.to callback(:hide_classroom_units_and_unit_activities).after(:save) }
 
@@ -130,6 +131,23 @@ describe Unit, type: :model do
     it 'is called when the unit is saved' do
       expect(unit).to receive(:hide_classroom_units_and_unit_activities)
       unit.update(name: 'new name')
+    end
+  end
+
+  describe '#set_active_to_false' do
+    it 'is called when the unit is saved' do
+      expect(unit).to receive(:set_active_to_false)
+      unit.update(name: 'new name')
+    end
+
+    it 'is sets active to false if the unit is not visible' do
+      unit.update(visible: false)
+      expect(unit.active).to eq(false)
+    end
+
+    it 'leaves active value alone if the unit is visible' do
+      unit.update(visible: true)
+      expect(unit.active).to eq(true)
     end
   end
 

--- a/services/QuillLMS/spec/models/unit_spec.rb
+++ b/services/QuillLMS/spec/models/unit_spec.rb
@@ -5,6 +5,7 @@
 # Table name: units
 #
 #  id               :integer          not null, primary key
+#  active           :boolean          default(TRUE), not null
 #  name             :string
 #  visible          :boolean          default(TRUE), not null
 #  created_at       :datetime


### PR DESCRIPTION
## WHAT
Add a migration file, callback, and tests for the new `units` attribute, `active`.

## WHY
We need this column in place in order to build out the new hidden activity packs page (active is the inverse of hidden; see discussion in the comments in the Notion card).

## HOW
Just add the migration, a necessary callback (since units should never be `{ visible: false, active: true }`), and tests. After deploy and before the feature itself is added, we'll want to run the following in the console: `Unit.unscoped.where(visible: false).update(active: false)` to make sure the data is consistent for previously-archived units.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/V2-RFC-Introduce-activity-pack-hiding-4b39cd1fa869429fbbdd48cc74cbac39?d=ab13888667b34193bca1767facaa85cc)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? |  NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
