### PR TITLE
Evidence Prompt Health Dashboard front end 

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/EvidenceLanding.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/EvidenceLanding.tsx
@@ -4,7 +4,7 @@ import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
 import Activities from './activities';
 import Activity from './activity';
 import Hints from './hints';
-import HealthDashboard from "./healthDashboards/healthDashboard";
+import HealthDashboards from "./healthDashboards/healthDashboards";
 import UniversalRulesIndex from './universalRules/universalRules';
 import UniversalRule from './universalRules/universalRule';
 
@@ -13,7 +13,7 @@ const EvidenceLanding = () => (
     <Switch>
       <Redirect exact from='/' to='/activities' />
       <Route component={Activity} path='/activities/:activityId' />
-      <Route component={HealthDashboard} path='/health-dashboard' />
+      <Route component={HealthDashboards} path='/health-dashboards' />
       <Route component={UniversalRule} path='/universal-rules/:ruleId' />
       <Route component={UniversalRulesIndex} path='/universal-rules' />
       <Route component={Activities} path='/activities' />

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/healthDashboard.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/healthDashboard.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`HealthDashboard component should render HealthDashboard 1`] = `
       }
     }
   >
-    <HealthDashboard
+    <ActivityHealthDashboard
       history={
         Object {
           "createHref": [Function],

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/healthDashboard.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/healthDashboard.test.tsx
@@ -5,7 +5,7 @@ import { createMemoryHistory, createLocation } from 'history';
 import { QueryClientProvider } from 'react-query'
 
 import { DefaultReactQueryClient } from '../../../../Shared/index';
-import HealthDashboard from '../healthDashboards/healthDashboard';
+import HealthDashboard from '../healthDashboards/activityHealthDashboard';
 
 const queryClient = new DefaultReactQueryClient();
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
@@ -89,8 +89,8 @@ export const ActivityHealthDashboard = ({ handleDashboardToggle }) => {
     },
     {
       Header: 'Version #',
-      accessor: "current_version",
-      key: "current_version",
+      accessor: "version",
+      key: "version",
       Filter: NumberFilter,
       minWidth: 70,
     },
@@ -259,62 +259,62 @@ export const ActivityHealthDashboard = ({ handleDashboardToggle }) => {
   }
 
   return(
-      <div>
-        <section className="header-section">
-          <h2>Activities Health Dashboard</h2>
-          <div className="first-input-row">
-            <FlagDropdown flag={flag} handleFlagChange={handleFlagChange} isLessons={true} />
-            <div className="right-side-div">
-              <a onClick={handleDashboardToggle}>Switch to Prompt View</a>
-              <div className="csv-download-button">
-                <button onClick={formatTableForCSV} type="button">
-                  Download CSV
-                </button>
-              </div>
+    <div>
+      <section className="header-section">
+        <h2>Activities Health Dashboard</h2>
+        <div className="first-input-row">
+          <FlagDropdown flag={flag} handleFlagChange={handleFlagChange} isLessons={true} />
+          <div className="right-side-div">
+            <button className="switch-view" onClick={handleDashboardToggle} type="button">Switch to Prompt View</button>
+            <div className="csv-download-button">
+              <button onClick={formatTableForCSV} type="button">
+                Download CSV
+              </button>
             </div>
           </div>
+        </div>
 
-          <div className="second-input-row">
-            <input
-              aria-label="Search by prompt"
-              className="search-box"
-              name="searchInput"
-              onChange={handleSearchByPrompt}
-              placeholder="Search by prompt or activity name"
-              value={promptSearchInput || ""}
-            />
-          </div>
-
-          <div className="poor-health-filter">
-            <input aria-label="poor-health-check" checked={poorHealthFlag} onChange={handlePoorHealthFlagToggle} type="checkbox" />
-            <label className="poor-health-label" htmlFor="poor-health-check">Poor Health Flag</label>
-          </div>
-
-          <div>
-            <CSVLink
-              data={dataToDownload}
-              filename="activity_health_report"
-              ref={(c) => (csvLink = c)}
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </div>
-        </section>
-
-        <section className="table-section">
-          <ReactTable
-            className="activity-healths-table"
-            columns={dataTableFields}
-            data={(rows && getFilteredData(rows)) || []}
-            defaultPageSize={(rows && rows.length) || 0}
-            filterable
-            manualFilters
-            manualSortBy
-            onFiltersChange={handleFiltersChange}
-            onSortedChange={handleDataUpdate}
+        <div className="second-input-row">
+          <input
+            aria-label="Search by prompt"
+            className="search-box"
+            name="searchInput"
+            onChange={handleSearchByPrompt}
+            placeholder="Search by prompt or activity name"
+            value={promptSearchInput || ""}
           />
-        </section>
-      </div>
+        </div>
+
+        <div className="poor-health-filter">
+          <input aria-label="poor-health-check" checked={poorHealthFlag} onChange={handlePoorHealthFlagToggle} type="checkbox" />
+          <label className="poor-health-label" htmlFor="poor-health-check">Poor Health Flag</label>
+        </div>
+
+        <div>
+          <CSVLink
+            data={dataToDownload}
+            filename="activity_health_report"
+            ref={(c) => (csvLink = c)}
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </section>
+
+      <section className="table-section">
+        <ReactTable
+          className="activity-healths-table"
+          columns={dataTableFields}
+          data={(rows && getFilteredData(rows)) || []}
+          defaultPageSize={(rows && rows.length) || 0}
+          filterable
+          manualFilters
+          manualSortBy
+          onFiltersChange={handleFiltersChange}
+          onSortedChange={handleDataUpdate}
+        />
+      </section>
+    </div>
   );
 
 }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
@@ -1,0 +1,322 @@
+import * as React from "react";
+import { useRef } from 'react';
+import { useQuery } from 'react-query';
+import { CSVLink } from 'react-csv';
+import { firstBy } from 'thenby';
+
+
+import { FlagDropdown, ReactTable, filterNumbers } from '../../../../Shared/index'
+import { fetchAggregatedActivityHealths } from '../../../utils/evidence/ruleFeedbackHistoryAPIs';
+import { getLinkToActivity, secondsToHumanReadableTime, addCommasToThousands } from "../../../helpers/evidence/miscHelpers";
+
+const ALL_FLAGS = "All Flags"
+const NAME_COLUMN = "name"
+const POOR_HEALTH_FLAG_COLUMN = "poor_health_flag"
+
+const CustomTextFilter = ({ column, setFilter, placeholder }) => {
+  return (
+    <input
+      aria-label="text-filter"
+      onChange={event => setFilter(column.id, event.target.value)}
+      placeholder={placeholder}
+      style={{ width: "100%" }}
+      value={column.filterValue}
+    />
+  )
+}
+
+const NumberFilter = ({ column, setFilter }) => (
+  <CustomTextFilter
+    column={column}
+    placeholder="1-2, <1, >1"
+    setFilter={setFilter}
+  />
+)
+
+const TimeFilter = ({ column, setFilter }) => (
+  <CustomTextFilter
+    column={column}
+    placeholder="in seconds: 1-2, <1, >1"
+    setFilter={setFilter}
+  />
+)
+
+const TrueFalseFilter = ({ column, setFilter }) => (
+  <CustomTextFilter
+    column={column}
+    placeholder="1 / 0"
+    setFilter={setFilter}
+  />
+)
+
+export const ActivityHealthDashboard = ({ handleDashboardToggle }) => {
+  const [flag, setFlag] = React.useState<string>(ALL_FLAGS)
+  const [promptSearchInput, setPromptSearchInput] = React.useState<string>("")
+  const [dataToDownload, setDataToDownload] = React.useState<Array<{}>>([])
+  const [rows, setRows] = React.useState<Array<{}>>(null)
+  const [poorHealthFlag, setPoorHealthFlag] = React.useState<boolean>(false)
+  let csvLink = useRef(null);
+
+  // get cached activity data to pass to rule
+  const { data: activityHealthsData } = useQuery({
+    queryKey: [`evidence-activity-healths`],
+    queryFn: fetchAggregatedActivityHealths
+  });
+
+  React.useEffect(() => {
+    if (dataToDownload.length > 0) {
+      csvLink.link.click();
+    }
+  }, [dataToDownload]);
+
+  React.useEffect(() => {
+    if (activityHealthsData && activityHealthsData.activityHealths) {
+      setRows(getFilteredData(activityHealthsData.activityHealths))
+    }
+  }, [activityHealthsData])
+
+  const dataTableFields = [
+    {
+      Header: 'Name',
+      accessor: "name",
+      key: "name",
+      Filter: CustomTextFilter,
+      filterAll: true,
+      Cell: ({row}) => <span className="name"><a href={getLinkToActivity(row.original.activity_id)} rel="noopener noreferrer" target="_blank">{row.original.name}</a></span>, // eslint-disable-line react/display-name
+      minWidth: 330,
+      width: 330,
+      maxWidth: 330
+    },
+    {
+      Header: 'Version #',
+      accessor: "current_version",
+      key: "current_version",
+      Filter: NumberFilter,
+      minWidth: 70,
+    },
+    {
+      Header: 'Version Plays',
+      accessor: "version_plays",
+      key: "versionPlays",
+      Filter: NumberFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.version_plays && <span className="versionPlays">{addCommasToThousands(row.original.version_plays)}</span>
+    },
+    {
+      Header: 'Total Plays',
+      accessor: "total_plays",
+      key: "totalPlays",
+      Filter: NumberFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.total_plays && <span className="versionPlays">{addCommasToThousands(row.original.total_plays)}</span>
+    },
+    {
+      Header: 'Completed Rate',
+      accessor: "completion_rate",
+      key: "completionRate",
+      Filter: NumberFilter,
+      minWidth: 80,
+      Cell: ({row}) => row.original.completion_rate && <span className="name">{row.original.completion_rate}%</span>
+    },
+    {
+      Header: 'Because Final Optimal',
+      accessor: "because_final_optimal",
+      key: "becauseFinalOptimal",
+      Filter: NumberFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.because_final_optimal && <span className={row.original.because_final_optimal <= 75 ? "poor-health" : "" + " name"}>{row.original.because_final_optimal}%</span>
+    },
+    {
+      Header: 'But Final Optimal',
+      accessor: "but_final_optimal",
+      key: "butFinalOptimal",
+      Filter: NumberFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.but_final_optimal && <span className={row.original.but_final_optimal <= 75 ? "poor-health" : "" + " name"}>{row.original.but_final_optimal}%</span>
+    },
+    {
+      Header: 'So Final Optimal',
+      accessor: "so_final_optimal",
+      key: "soFinalOptimal",
+      Filter: NumberFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.so_final_optimal && <span className={row.original.so_final_optimal <= 75 ? "poor-health" : "" + " name"}>{row.original.so_final_optimal}%</span>
+    },
+    {
+      Header: 'Avg Time Spent - Activity',
+      accessor: "avg_completion_time",
+      key: "avgCompletionTime",
+      Filter: TimeFilter,
+      minWidth: 70,
+      Cell: ({row}) => secondsToHumanReadableTime(row.original.avg_completion_time)
+    },
+    {
+      Header: 'Poor Health Flag',
+      accessor: "poor_health_flag",
+      key: "poorHealthFlag",
+      Filter: TrueFalseFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.poor_health_flag === true && <span className="poor-health-flag">X</span>
+    }
+  ];
+
+  const handleFlagChange = (e) => {setFlag(e.target.value)}
+  const handleSearchByPrompt = (e) => {setPromptSearchInput(e.target.value)}
+  const handlePoorHealthFlagToggle = () => {setPoorHealthFlag(!poorHealthFlag)}
+
+  const getFilteredData = (data) => {
+    if (!data) return []
+
+    let filteredData = flag === ALL_FLAGS ? data : data.filter(data => data.flag === flag)
+
+    if (!filteredData) return []
+    filteredData = filteredData.filter(value => {
+      return (
+        value.name && value.name.toLowerCase().includes(promptSearchInput.toLowerCase())
+      );
+    })
+
+    if (poorHealthFlag) {
+      filteredData = filteredData.filter(value => value.poor_health_flag)
+    }
+
+    return filteredData
+  }
+
+
+  const getSortedRows = (rows, sortInfo) => {
+    if (!sortInfo) return rows;
+
+    const { id, desc } = sortInfo;
+    // we have this reversed so that the first click will sort from highest to lowest by default
+    const directionOfSort = desc ? 'asc' : 'desc';
+    return rows.sort(firstBy(id, { direction: directionOfSort }));
+  }
+
+  const filterPoorHealthRows = (value, rows) => {
+    if (value === '1') return rows.filter(r => r.poor_health_flag === true)
+    else if (value === '0') return rows.filter(r => !r.poor_health_flag)
+    else return rows
+  }
+
+  const filterRowsByColumnValue = (rows, column, value) => {
+    if (value === '' || !value) return rows
+
+    if (column === NAME_COLUMN) {
+      return rows.filter(r => r.name.toLowerCase().includes(value.toLowerCase()))
+    } else if (column === POOR_HEALTH_FLAG_COLUMN) {
+      return filterPoorHealthRows(value, rows)
+    } else {
+      return filterNumbers(rows.map(r => {return {original: r}}), [column], value.replaceAll(',','')).map(r => r.original)
+    }
+  }
+
+  const handleFiltersChange = (filters) => {
+    if (!rows) return;
+    let newRows = activityHealthsData.activityHealths
+    filters.forEach((filter) => {
+      const column = filter.id
+      const value = filter.value
+
+      newRows = filterRowsByColumnValue(activityHealthsData.activityHealths, column, value)
+    })
+    setRows(getFilteredData(newRows))
+  }
+
+  const handleDataUpdate = (sorted) => {
+    const sortInfo = sorted[0];
+    if (!sortInfo) return
+
+    const sortedRows = getSortedRows(rows, sortInfo)
+    const newIdSortedRows = sortedRows.map((r, i) => {
+      r.id = i
+      return r
+    })
+    setRows(getFilteredData(newIdSortedRows))
+  }
+
+
+  const formatTableForCSV = (e) => {
+    if (!rows) return;
+
+    const columns = dataTableFields
+    let dataToDownload = []
+    for (let index = 0; index < rows.length; index++) {
+      let recordToDownload = {}
+      for(let colIndex = 0; colIndex < columns.length ; colIndex ++) {
+        recordToDownload[columns[colIndex].Header] = rows[index][columns[colIndex].accessor]
+      }
+      dataToDownload.push(recordToDownload)
+    }
+
+    // Convert seconds to human readable time
+    let clonedDataToDownload = JSON.parse(JSON.stringify(dataToDownload));
+    clonedDataToDownload.forEach(item=> {
+      item["Avg Time Spent - Activity"] = item["Avg Time Spent - Activity"] ? secondsToHumanReadableTime(item["Avg Time Spent - Activity"]) : ''
+    });
+
+    setDataToDownload(clonedDataToDownload)
+  }
+
+  return(
+      <div>
+        <section className="header-section">
+          <h2>Activities Health Dashboard</h2>
+          <div className="first-input-row">
+            <FlagDropdown flag={flag} handleFlagChange={handleFlagChange} isLessons={true} />
+            <div className="right-side-div">
+              <a onClick={handleDashboardToggle}>Switch to Prompt View</a>
+              <div className="csv-download-button">
+                <button onClick={formatTableForCSV} type="button">
+                  Download CSV
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="second-input-row">
+            <input
+              aria-label="Search by prompt"
+              className="search-box"
+              name="searchInput"
+              onChange={handleSearchByPrompt}
+              placeholder="Search by prompt or activity name"
+              value={promptSearchInput || ""}
+            />
+          </div>
+
+          <div className="poor-health-filter">
+            <input aria-label="poor-health-check" checked={poorHealthFlag} onChange={handlePoorHealthFlagToggle} type="checkbox" />
+            <label className="poor-health-label" htmlFor="poor-health-check">Poor Health Flag</label>
+          </div>
+
+          <div>
+            <CSVLink
+              data={dataToDownload}
+              filename="activity_health_report"
+              ref={(c) => (csvLink = c)}
+              rel="noopener noreferrer"
+              target="_blank"
+            />
+          </div>
+        </section>
+
+        <section className="table-section">
+          <ReactTable
+            className="activity-healths-table"
+            columns={dataTableFields}
+            data={(rows && getFilteredData(rows)) || []}
+            defaultPageSize={(rows && rows.length) || 0}
+            filterable
+            manualFilters
+            manualSortBy
+            onFiltersChange={handleFiltersChange}
+            onSortedChange={handleDataUpdate}
+          />
+        </section>
+      </div>
+  );
+
+}
+
+export default ActivityHealthDashboard

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/healthDashboards.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/healthDashboards.tsx
@@ -1,11 +1,19 @@
 import * as React from "react";
 
-import Navigation from '../navigation'
 import ActivityHealthDashboard from "./activityHealthDashboard";
 import PromptHealthDashboard from "./promptHealthDashboard";
 
+import Navigation from '../navigation'
+
 const HealthDashboards = ({ location, match }) => {
   const [showActivities, setShowActivities] = React.useState<boolean>(true);
+
+  function renderDashboard() {
+    if(showActivities) {
+      return <ActivityHealthDashboard handleDashboardToggle={handleDashboardToggle} />
+    }
+    return <PromptHealthDashboard handleDashboardToggle={handleDashboardToggle} />
+  }
 
   const handleDashboardToggle = () => {
     setShowActivities(!showActivities)
@@ -15,7 +23,7 @@ const HealthDashboards = ({ location, match }) => {
     <React.Fragment>
       <Navigation location={location} match={match} />
       <div className="health-dashboards-index-container">
-        {showActivities ? <ActivityHealthDashboard handleDashboardToggle={handleDashboardToggle} /> : <PromptHealthDashboard handleDashboardToggle={handleDashboardToggle} />}
+        {renderDashboard()}
       </div>
     </React.Fragment>
   );

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/healthDashboards.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/healthDashboards.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import Navigation from '../navigation'
+import ActivityHealthDashboard from "./activityHealthDashboard";
+import PromptHealthDashboard from "./promptHealthDashboard";
+
+const HealthDashboards = ({ location, match }) => {
+  const [showActivities, setShowActivities] = React.useState<boolean>(true);
+
+  const handleDashboardToggle = () => {
+    setShowActivities(!showActivities)
+  }
+
+  return(
+    <React.Fragment>
+      <Navigation location={location} match={match} />
+      <div className="health-dashboards-index-container">
+        {showActivities ? <ActivityHealthDashboard handleDashboardToggle={handleDashboardToggle} /> : <PromptHealthDashboard handleDashboardToggle={handleDashboardToggle} />}
+      </div>
+    </React.Fragment>
+  );
+}
+
+export default HealthDashboards

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthDashboard.tsx
@@ -5,13 +5,13 @@ import { CSVLink } from 'react-csv';
 import { firstBy } from 'thenby';
 
 
-import Navigation from '../navigation'
 import { FlagDropdown, ReactTable, filterNumbers } from '../../../../Shared/index'
-import { fetchAggregatedActivityHealths } from '../../../utils/evidence/ruleFeedbackHistoryAPIs';
-import { getLinkToActivity, secondsToHumanReadableTime, addCommasToThousands } from "../../../helpers/evidence/miscHelpers";
+import { fetchAggregatedPromptHealths } from '../../../utils/evidence/ruleFeedbackHistoryAPIs';
+import { getLinkToPrompt, secondsToHumanReadableTime, addCommasToThousands } from "../../../helpers/evidence/miscHelpers";
 
 const ALL_FLAGS = "All Flags"
-const NAME_COLUMN = "name"
+const SHORT_NAME_COLUMN = "activity_short_name"
+const TEXT_COLUMN = "text"
 const POOR_HEALTH_FLAG_COLUMN = "poor_health_flag"
 
 const CustomTextFilter = ({ column, setFilter, placeholder }) => {
@@ -50,7 +50,7 @@ const TrueFalseFilter = ({ column, setFilter }) => (
   />
 )
 
-export const HealthDashboard = ({ location, match }) => {
+export const PromptHealthDashboard = ({ handleDashboardToggle }) => {
   const [flag, setFlag] = React.useState<string>(ALL_FLAGS)
   const [promptSearchInput, setPromptSearchInput] = React.useState<string>("")
   const [dataToDownload, setDataToDownload] = React.useState<Array<{}>>([])
@@ -59,9 +59,9 @@ export const HealthDashboard = ({ location, match }) => {
   let csvLink = useRef(null);
 
   // get cached activity data to pass to rule
-  const { data: activityHealthsData } = useQuery({
-    queryKey: [`evidence-activity-healths`],
-    queryFn: fetchAggregatedActivityHealths
+  const { data: promptHealthsData } = useQuery({
+    queryKey: [`evidence-prompt-healths`],
+    queryFn: fetchAggregatedPromptHealths
   });
 
   React.useEffect(() => {
@@ -71,93 +71,125 @@ export const HealthDashboard = ({ location, match }) => {
   }, [dataToDownload]);
 
   React.useEffect(() => {
-    if (activityHealthsData && activityHealthsData.activityHealths) {
-      setRows(getFilteredData(activityHealthsData.activityHealths))
+    if (promptHealthsData && promptHealthsData.promptHealths) {
+      setRows(getFilteredData(promptHealthsData.promptHealths))
     }
-  }, [activityHealthsData])
+  }, [promptHealthsData])
 
   const dataTableFields = [
     {
-      Header: 'Name',
-      accessor: "name",
-      key: "name",
+      Header: 'Activity Short Name',
+      accessor: "activity_short_name",
+      key: "activity_short_name",
       Filter: CustomTextFilter,
       filterAll: true,
-      Cell: ({row}) => <span className="name"><a href={getLinkToActivity(row.original.activity_id)} rel="noopener noreferrer" target="_blank">{row.original.name}</a></span>, // eslint-disable-line react/display-name
+      Cell: ({row}) => <span>{row.original.activity_short_name}</span>, // eslint-disable-line react/display-name
+      minWidth: 100,
+      width: 100,
+      maxWidth: 100
+    },
+    {
+      Header: 'Prompt',
+      accessor: "text",
+      key: "text",
+      Filter: CustomTextFilter,
+      filterAll: true,
+      Cell: ({row}) => <span className="name"><a href={getLinkToPrompt(row.original.activity_id, row.original.conjunction)} rel="noopener noreferrer" target="_blank">{row.original.text}</a></span>, // eslint-disable-line react/display-name
       minWidth: 330,
       width: 330,
       maxWidth: 330
     },
     {
       Header: 'Version #',
-      accessor: "version",
-      key: "version",
+      accessor: "current_version",
+      key: "current_version",
       Filter: NumberFilter,
       minWidth: 70,
     },
     {
-      Header: 'Version Plays',
-      accessor: "version_plays",
-      key: "versionPlays",
+      Header: 'Version responses',
+      accessor: "version_responses",
+      key: "version_responses",
       Filter: NumberFilter,
       minWidth: 70,
-      Cell: ({row}) => row.original.version_plays && <span className="versionPlays">{addCommasToThousands(row.original.version_plays)}</span>
     },
     {
-      Header: 'Total Plays',
-      accessor: "total_plays",
-      key: "totalPlays",
+      Header: 'First Attempt Optimal',
+      accessor: "first_attempt_optimal",
+      key: "first_attempt_optimal",
       Filter: NumberFilter,
       minWidth: 70,
-      Cell: ({row}) => row.original.total_plays && <span className="versionPlays">{addCommasToThousands(row.original.total_plays)}</span>
     },
     {
-      Header: 'Completed Rate',
-      accessor: "completion_rate",
-      key: "completionRate",
-      Filter: NumberFilter,
-      minWidth: 80,
-      Cell: ({row}) => row.original.completion_rate && <span className="name">{row.original.completion_rate}%</span>
-    },
-    {
-      Header: 'Because Final Optimal',
-      accessor: "because_final_optimal",
-      key: "becauseFinalOptimal",
+      Header: 'Final Attempt Optimal',
+      accessor: "final_attempt_optimal",
+      key: "final_attempt_optimal",
       Filter: NumberFilter,
       minWidth: 70,
-      Cell: ({row}) => row.original.because_final_optimal && <span className={row.original.because_final_optimal <= 75 ? "poor-health" : "" + " name"}>{row.original.because_final_optimal}%</span>
     },
     {
-      Header: 'But Final Optimal',
-      accessor: "but_final_optimal",
-      key: "butFinalOptimal",
+      Header: 'Average Attempts',
+      accessor: "avg_attempts",
+      key: "avg_attempts",
       Filter: NumberFilter,
       minWidth: 70,
-      Cell: ({row}) => row.original.but_final_optimal && <span className={row.original.but_final_optimal <= 75 ? "poor-health" : "" + " name"}>{row.original.but_final_optimal}%</span>
     },
     {
-      Header: 'So Final Optimal',
-      accessor: "so_final_optimal",
-      key: "soFinalOptimal",
+      Header: 'Confid- ence',
+      accessor: "confidence",
+      key: "confidence",
       Filter: NumberFilter,
       minWidth: 70,
-      Cell: ({row}) => row.original.so_final_optimal && <span className={row.original.so_final_optimal <= 75 ? "poor-health" : "" + " name"}>{row.original.so_final_optimal}%</span>
     },
     {
-      Header: 'Avg Time Spent - Activity',
-      accessor: "avg_completion_time",
-      key: "avgCompletionTime",
+      Header: '% AutoML Consecut- ive Repeated',
+      accessor: "percent_automl_consecutive_repeated",
+      key: "percent_automl_consecutive_repeated",
+      Filter: NumberFilter,
+      minWidth: 70,
+    },
+    {
+      Header: '% AutoML',
+      accessor: "percent_automl",
+      key: "percent_automl",
+      Filter: NumberFilter,
+      minWidth: 70,
+    },
+    {
+      Header: '% Plagiar- ism',
+      accessor: "percent_plagiarism",
+      key: "percent_plagiarism",
+      Filter: NumberFilter,
+      minWidth: 70,
+    },
+    {
+      Header: '% Opinion',
+      accessor: "percent_opinion",
+      key: "percent_opinion",
+      Filter: NumberFilter,
+      minWidth: 70,
+    },
+    {
+      Header: '% Grammar',
+      accessor: "percent_grammar",
+      key: "percent_grammar",
+      Filter: NumberFilter,
+      minWidth: 70,
+    },
+    {
+      Header: '% Spelling',
+      accessor: "percent_spelling",
+      key: "percent_spelling",
+      Filter: NumberFilter,
+      minWidth: 70,
+    },
+    {
+      Header: 'Avg Time Spent - Prompt',
+      accessor: "avg_time_spent_per_prompt",
+      key: "avg_time_spent_per_prompt",
       Filter: TimeFilter,
       minWidth: 70,
-      Cell: ({row}) => secondsToHumanReadableTime(row.original.avg_completion_time)
-    },
-    {
-      Header: 'Poor Health Flag',
-      accessor: "poor_health_flag",
-      key: "poorHealthFlag",
-      Filter: TrueFalseFilter,
-      minWidth: 70,
-      Cell: ({row}) => row.original.poor_health_flag === true && <span className="poor-health-flag">X</span>
+      Cell: ({row}) => secondsToHumanReadableTime(row.original.avg_time_spent_per_prompt)
     }
   ];
 
@@ -173,7 +205,8 @@ export const HealthDashboard = ({ location, match }) => {
     if (!filteredData) return []
     filteredData = filteredData.filter(value => {
       return (
-        value.name && value.name.toLowerCase().includes(promptSearchInput.toLowerCase())
+        ((value.text && value.text.toLowerCase().includes(promptSearchInput.toLowerCase())) ||
+        (value.activity_short_name && value.activity_short_name.toLowerCase().includes(promptSearchInput.toLowerCase())))
       );
     })
 
@@ -203,8 +236,10 @@ export const HealthDashboard = ({ location, match }) => {
   const filterRowsByColumnValue = (rows, column, value) => {
     if (value === '' || !value) return rows
 
-    if (column === NAME_COLUMN) {
-      return rows.filter(r => r.name.toLowerCase().includes(value.toLowerCase()))
+    if (column === TEXT_COLUMN) {
+      return rows.filter(r => r.text.toLowerCase().includes(value.toLowerCase()))
+    } else if (column === SHORT_NAME_COLUMN) {
+      return rows.filter(r => r.activity_short_name.toLowerCase().includes(value.toLowerCase()))
     } else if (column === POOR_HEALTH_FLAG_COLUMN) {
       return filterPoorHealthRows(value, rows)
     } else {
@@ -214,12 +249,12 @@ export const HealthDashboard = ({ location, match }) => {
 
   const handleFiltersChange = (filters) => {
     if (!rows) return;
-    let newRows = activityHealthsData.activityHealths
+    let newRows = promptHealthsData.promptHealths
     filters.forEach((filter) => {
       const column = filter.id
       const value = filter.value
 
-      newRows = filterRowsByColumnValue(activityHealthsData.activityHealths, column, value)
+      newRows = filterRowsByColumnValue(promptHealthsData.promptHealths, column, value)
     })
     setRows(getFilteredData(newRows))
   }
@@ -260,64 +295,64 @@ export const HealthDashboard = ({ location, match }) => {
   }
 
   return(
-    <React.Fragment>
-      <Navigation location={location} match={match} />
-      <div className="health-dashboards-index-container">
-        <section className="header-section">
-          <h2>Activities Health Dashboard</h2>
-          <div className="first-input-row">
-            <FlagDropdown flag={flag} handleFlagChange={handleFlagChange} isLessons={true} />
+    <div>
+      <section className="header-section">
+        <h2>Prompt Health Dashboard</h2>
+        <div className="first-input-row">
+          <FlagDropdown flag={flag} handleFlagChange={handleFlagChange} isLessons={true} />
+          <div className="right-side-div">
+            <a onClick={handleDashboardToggle}>Switch to Activity View</a>
             <div className="csv-download-button">
               <button onClick={formatTableForCSV} type="button">
                 Download CSV
               </button>
             </div>
           </div>
+        </div>
 
-          <div className="second-input-row">
-            <input
-              aria-label="Search by prompt"
-              className="search-box"
-              name="searchInput"
-              onChange={handleSearchByPrompt}
-              placeholder="Search by prompt or activity name"
-              value={promptSearchInput || ""}
-            />
-          </div>
-
-          <div className="poor-health-filter">
-            <input aria-label="poor-health-check" checked={poorHealthFlag} onChange={handlePoorHealthFlagToggle} type="checkbox" />
-            <label className="poor-health-label" htmlFor="poor-health-check">Poor Health Flag</label>
-          </div>
-
-          <div>
-            <CSVLink
-              data={dataToDownload}
-              filename="activity_health_report"
-              ref={(c) => (csvLink = c)}
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          </div>
-        </section>
-
-        <section className="table-section">
-          <ReactTable
-            className="activity-healths-table"
-            columns={dataTableFields}
-            data={(rows && getFilteredData(rows)) || []}
-            defaultPageSize={(rows && rows.length) || 0}
-            filterable
-            manualFilters
-            manualSortBy
-            onFiltersChange={handleFiltersChange}
-            onSortedChange={handleDataUpdate}
+        <div className="second-input-row">
+          <input
+            aria-label="Search by prompt"
+            className="search-box"
+            name="searchInput"
+            onChange={handleSearchByPrompt}
+            placeholder="Search by prompt or activity name"
+            value={promptSearchInput || ""}
           />
-        </section>
-      </div>
-    </React.Fragment>
+        </div>
+
+        <div className="poor-health-filter">
+          <input aria-label="poor-health-check" checked={poorHealthFlag} onChange={handlePoorHealthFlagToggle} type="checkbox" />
+          <label className="poor-health-label" htmlFor="poor-health-check">Poor Health Flag</label>
+        </div>
+
+        <div>
+          <CSVLink
+            data={dataToDownload}
+            filename="activity_health_report"
+            ref={(c) => (csvLink = c)}
+            rel="noopener noreferrer"
+            target="_blank"
+          />
+        </div>
+      </section>
+
+      <section className="table-section">
+        <ReactTable
+          className="activity-healths-table"
+          columns={dataTableFields}
+          data={(rows && getFilteredData(rows)) || []}
+          defaultPageSize={(rows && rows.length) || 0}
+          filterable
+          manualFilters
+          manualSortBy
+          onFiltersChange={handleFiltersChange}
+          onSortedChange={handleDataUpdate}
+        />
+      </section>
+    </div>
   );
 
 }
 
-export default HealthDashboard
+export default PromptHealthDashboard

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthDashboard.tsx
@@ -201,7 +201,7 @@ export const PromptHealthDashboard = ({ handleDashboardToggle }) => {
       key: "poorHealthFlag",
       Filter: TrueFalseFilter,
       minWidth: 70,
-      Cell: ({row}) => row.original.poor_health_flag === true && <span className="poor-health-flag">X</span>
+      Cell: ({row}) => row.original.poor_health_flag === true && <span className="poor-health-flag">X</span>,
     }
   ];
 
@@ -313,7 +313,7 @@ export const PromptHealthDashboard = ({ handleDashboardToggle }) => {
         <div className="first-input-row">
           <FlagDropdown flag={flag} handleFlagChange={handleFlagChange} isLessons={true} />
           <div className="right-side-div">
-            <a onClick={handleDashboardToggle}>Switch to Activity View</a>
+            <button className="switch-view" onClick={handleDashboardToggle} type="button">Switch to Activity View</button>
             <div className="csv-download-button">
               <button onClick={formatTableForCSV} type="button">
                 Download CSV

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthDashboard.tsx
@@ -119,6 +119,7 @@ export const PromptHealthDashboard = ({ handleDashboardToggle }) => {
       key: "first_attempt_optimal",
       Filter: NumberFilter,
       minWidth: 70,
+      Cell: ({row}) => row.original.first_attempt_optimal && <span className={row.original.first_attempt_optimal < 25 ? "poor-health" : "" + " name"}>{row.original.first_attempt_optimal}%</span>
     },
     {
       Header: 'Final Attempt Optimal',
@@ -126,6 +127,7 @@ export const PromptHealthDashboard = ({ handleDashboardToggle }) => {
       key: "final_attempt_optimal",
       Filter: NumberFilter,
       minWidth: 70,
+      Cell: ({row}) => row.original.final_attempt_optimal && <span className={row.original.final_attempt_optimal < 75 ? "poor-health" : "" + " name"}>{row.original.final_attempt_optimal}%</span>
     },
     {
       Header: 'Average Attempts',
@@ -140,6 +142,7 @@ export const PromptHealthDashboard = ({ handleDashboardToggle }) => {
       key: "confidence",
       Filter: NumberFilter,
       minWidth: 70,
+      Cell: ({row}) => row.original.confidence && <span className={row.original.confidence < 0.9 ? "poor-health" : "" + " name"}>{row.original.confidence}%</span>
     },
     {
       Header: '% AutoML Consecut- ive Repeated',
@@ -147,6 +150,7 @@ export const PromptHealthDashboard = ({ handleDashboardToggle }) => {
       key: "percent_automl_consecutive_repeated",
       Filter: NumberFilter,
       minWidth: 70,
+      Cell: ({row}) => row.original.percent_automl_consecutive_repeated && <span className={row.original.percent_automl_consecutive_repeated > 30 ? "poor-health" : "" + " name"}>{row.original.percent_automl_consecutive_repeated}%</span>
     },
     {
       Header: '% AutoML',
@@ -190,6 +194,14 @@ export const PromptHealthDashboard = ({ handleDashboardToggle }) => {
       Filter: TimeFilter,
       minWidth: 70,
       Cell: ({row}) => secondsToHumanReadableTime(row.original.avg_time_spent_per_prompt)
+    },
+    {
+      Header: 'Poor Health Flag',
+      accessor: "poor_health_flag",
+      key: "poorHealthFlag",
+      Filter: TrueFalseFilter,
+      minWidth: 70,
+      Cell: ({row}) => row.original.poor_health_flag === true && <span className="poor-health-flag">X</span>
     }
   ];
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/navigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/navigation.tsx
@@ -158,7 +158,7 @@ const Navigation = ({ location, match }) => {
           <NavLink activeClassName='is-active' to="/hints">
             View Hints
           </NavLink>
-          <NavLink activeClassName='is-active' to="/health-dashboard">
+          <NavLink activeClassName='is-active' to="/health-dashboards">
             Health Dashboard
           </NavLink>
         </ul>

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
@@ -491,6 +491,10 @@ export function getLinkToActivity(id) {
   return `${process.env.DEFAULT_URL}/cms/evidence#/activities/${id}/settings`
 }
 
+export function getLinkToPrompt(activity_id, conjunction) {
+  return `${process.env.DEFAULT_URL}/cms/evidence#/activities/${activity_id}/rules-analysis/${conjunction}?selected_rule_type=All%20Rules`
+}
+
 export function secondsToHumanReadableTime(seconds) {
 
   let numhours = Math.floor(((seconds % 31536000) % 86400) / 3600).toString();

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/routingHelpers.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/routingHelpers.ts
@@ -72,6 +72,8 @@ export const getActivityHealthUrl = ({ activityId }) => {
 
 export const aggregatedActivityHealthsUrl = `evidence/activity_healths.json`;
 
+export const aggregatedPromptHealthsUrl = `evidence/prompt_healths.json`;
+
 
 // not a 2xx status
 export const requestFailed = (status: number ) => Math.round(status / 100) !== 2;

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
@@ -20,8 +20,9 @@
     .right-side-div {
       float: right;
       display: flex;
-      a {
-        padding: 5px;
+      .switch-view {
+        border: none;
+        background: none;
       }
     }
     padding-bottom: 30px;

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
@@ -7,9 +7,6 @@
     .control {
       float: left;
     }
-    .csv-download-button {
-      float: right;
-    }
     .second-input-row {
       width: 700px;
     }
@@ -19,6 +16,13 @@
     .poor-health-label {
       padding-left: 5px;
       font-weight: normal;
+    }
+    .right-side-div {
+      float: right;
+      display: flex;
+      a {
+        padding: 5px;
+      }
     }
     padding-bottom: 30px;
   }
@@ -32,7 +36,7 @@
       width: 100px;
       max-width: 100px;
       .sortable-header {
-        height: 80px;
+        height: 100px;
         display: block;
       }
       input {

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/ruleFeedbackHistoryAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/ruleFeedbackHistoryAPIs.ts
@@ -1,4 +1,4 @@
-import { handleApiError, mainApiFetch, getRuleFeedbackHistoriesUrl, getRuleFeedbackHistoryUrl, getActivityStatsUrl, getActivityHealthUrl, aggregatedActivityHealthsUrl } from '../../helpers/evidence/routingHelpers';
+import { handleApiError, mainApiFetch, getRuleFeedbackHistoriesUrl, getRuleFeedbackHistoryUrl, getActivityStatsUrl, getActivityHealthUrl, aggregatedActivityHealthsUrl, aggregatedPromptHealthsUrl } from '../../helpers/evidence/routingHelpers';
 
 export const fetchRuleFeedbackHistories = async ({ queryKey, }) => {
   const [key, activityId, selectedConjunction, startDate, endDate]: [string, string, string, string?, string?, string?] = queryKey
@@ -61,3 +61,14 @@ export const fetchAggregatedActivityHealths = async({queryKey, }) => {
   };
 }
 
+export const fetchAggregatedPromptHealths = async({queryKey, }) => {
+  const [key]: [string] = queryKey
+
+  const url = aggregatedPromptHealthsUrl;
+  const response = await mainApiFetch(url);
+  const promptHealths = await response.json();
+  return {
+    error: handleApiError('Failed to fetch aggregated activity healths, please refresh the page.', response),
+    promptHealths: promptHealths
+  };
+}

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/prompt_healths_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/prompt_healths_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_dependency 'evidence/application_controller'
+
+module Evidence
+  class PromptHealthsController < ApiController
+
+    def index
+      render json: PromptHealth.all.as_json
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
@@ -17,5 +17,35 @@ module Evidence
     validates :percent_opinion, inclusion: { in: 0..100, allow_nil: true }
     validates :percent_grammar, inclusion: { in: 0..100, allow_nil: true }
     validates :percent_spelling, inclusion: { in: 0..100, allow_nil: true }
+
+    def serializable_hash(options = nil)
+      options ||= {}
+
+      super(options.reverse_merge(
+        only: [
+          :id, :current_version, :version_responses, :first_attempt_optimal, :final_attempt_optimal,
+          :avg_attempts, :confidence, :percent_automl_consecutive_repeated, :percent_automl,
+          :percent_plagiarism, :percent_opinion, :percent_grammar, :percent_spelling, :text,
+          :avg_time_spent_per_prompt, :prompt_id, :activity_short_name
+        ],
+        methods: [:conjunction, :activity_id, :flag]
+      ))
+    end
+
+    def conjunction
+      prompt.conjunction
+    end
+
+    def activity_id
+      prompt.activity_id
+    end
+
+    def flag
+      prompt.activity.flag
+    end
+
+    private def prompt
+      @prompt ||= Prompt.find(prompt_id)
+    end
   end
 end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
@@ -26,37 +26,63 @@ module Evidence
       options ||= {}
 
       super(options.reverse_merge(
-        only: [
-          :id, :current_version, :version_responses, :first_attempt_optimal, :final_attempt_optimal,
-          :avg_attempts, :confidence, :percent_automl_consecutive_repeated, :percent_automl,
-          :percent_plagiarism, :percent_opinion, :percent_grammar, :percent_spelling, :text,
-          :avg_time_spent_per_prompt, :prompt_id, :activity_short_name
-        ],
-        methods: [:conjunction, :activity_id, :flag, :poor_health_flag]
+        only:
+          %i(
+            id
+            current_version
+            version_responses
+            first_attempt_optimal
+            final_attempt_optimal
+            avg_attempts
+            confidence
+            percent_automl_consecutive_repeated
+            percent_automl
+            percent_plagiarism
+            percent_opinion
+            percent_grammar
+            percent_spelling
+            text
+            avg_time_spent_per_prompt
+            prompt_id
+            activity_short_name
+          ),
+        methods:
+          %i(
+            conjunction
+            activity_id
+            flag
+            poor_health_flag
+          )
       ))
     end
 
     def poor_health_flag
-      (first_attempt_optimal && first_attempt_optimal < FIRST_ATTEMPT_OPTIMAL_CUTOFF) ||
-      (final_attempt_optimal && final_attempt_optimal < FINAL_ATTEMPT_OPTIMAL_CUTFF) ||
-      (confidence && confidence < CONFIDENCE_CUTOFF) ||
-      (percent_automl_consecutive_repeated && percent_automl_consecutive_repeated > PERCENT_AUTOML_CONSECUTIVE_REPEATED_CUTOFF)
+      (
+        failed_cutoff(first_attempt_optimal, FIRST_ATTEMPT_OPTIMAL_CUTOFF) ||
+        failed_cutoff(final_attempt_optimal, FINAL_ATTEMPT_OPTIMAL_CUTFF) ||
+        failed_cutoff(confidence, CONFIDENCE_CUTOFF) ||
+        (percent_automl_consecutive_repeated && percent_automl_consecutive_repeated > PERCENT_AUTOML_CONSECUTIVE_REPEATED_CUTOFF)
+      )
     end
 
     def conjunction
-      prompt.conjunction
+      prompt && prompt.conjunction
     end
 
     def activity_id
-      prompt.activity_id
+      prompt && prompt.activity_id
     end
 
     def flag
-      prompt.activity.flag
+      prompt && prompt.activity.flag
     end
 
     private def prompt
       @prompt ||= Prompt.find(prompt_id)
+    end
+
+    private def failed_cutoff(number, cutoff)
+      number && number < cutoff
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
@@ -2,6 +2,10 @@
 
 module Evidence
   class PromptHealth < ApplicationRecord
+    FIRST_ATTEMPT_OPTIMAL_CUTOFF = 25
+    FINAL_ATTEMPT_OPTIMAL_CUTFF = 75
+    CONFIDENCE_CUTOFF = 0.9
+    PERCENT_AUTOML_CONSECUTIVE_REPEATED_CUTOFF = 30
 
     belongs_to :activity_health, foreign_key: "evidence_activity_health_id"
 
@@ -28,8 +32,15 @@ module Evidence
           :percent_plagiarism, :percent_opinion, :percent_grammar, :percent_spelling, :text,
           :avg_time_spent_per_prompt, :prompt_id, :activity_short_name
         ],
-        methods: [:conjunction, :activity_id, :flag]
+        methods: [:conjunction, :activity_id, :flag, :poor_health_flag]
       ))
+    end
+
+    def poor_health_flag
+      (first_attempt_optimal && first_attempt_optimal < FIRST_ATTEMPT_OPTIMAL_CUTOFF) ||
+      (final_attempt_optimal && final_attempt_optimal < FINAL_ATTEMPT_OPTIMAL_CUTFF) ||
+      (confidence && confidence < CONFIDENCE_CUTOFF) ||
+      (percent_automl_consecutive_repeated && percent_automl_consecutive_repeated > PERCENT_AUTOML_CONSECUTIVE_REPEATED_CUTOFF)
     end
 
     def conjunction

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -34,4 +34,6 @@ Evidence::Engine.routes.draw do
   resources :turking_rounds, only: [:index, :show, :create, :update, :destroy]
 
   resources :activity_healths, only: [:index]
+
+  resources :prompt_healths, only: [:index]
 end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/prompt_healths_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/prompt_healths_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  RSpec.describe(PromptHealthsController, :type => :controller) do
+    before { @routes = Engine.routes }
+
+    context 'should index' do
+      it 'should return successfully - no prompt healths' do
+        get(:index)
+        parsed_response = JSON.parse(response.body)
+        expect(response.status).to eq(200)
+        expect(parsed_response.class).to eq(Array)
+        expect(parsed_response.empty?).to eq(true)
+      end
+
+      context 'should return activity healths' do
+        let!(:activity) { create(:evidence_activity) }
+        let!(:prompt) { create(:evidence_prompt, activity: activity) }
+        let!(:prompt_health) { create(:evidence_prompt_health, prompt_id: prompt.id) }
+
+        it 'should return successfully' do
+          get(:index)
+          parsed_response = JSON.parse(response.body)
+          expect(response.status).to eq(200)
+          expect(parsed_response.class).to eq(Array)
+          expect(parsed_response.empty?).to(eq(false))
+          expect(parsed_response.first["text"]).to(eq(prompt_health.text))
+          expect(parsed_response.first["current_version"]).to(eq(prompt_health.current_version))
+          expect(parsed_response.first["confidence"]).to(eq(prompt_health.confidence))
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_healths.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_healths.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :evidence_prompt_health, class: 'Evidence::PromptHealth' do
+    prompt_id { 1 }
+    activity_short_name { "test activity" }
+    text { "some prompt text here" }
+    current_version { 1 }
+    version_responses { 10 }
+    first_attempt_optimal { 90 }
+    avg_attempts { 3 }
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_health_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_health_spec.rb
@@ -37,5 +37,36 @@ module Evidence
 
       it { should validate_inclusion_of(:percent_spelling).in?(0..100)}
     end
+
+    context 'methods' do
+      describe 'flag' do
+        it 'should return the flag of the associated activity' do
+          activity = create(:evidence_activity)
+          prompt = create(:evidence_prompt, activity: activity)
+          prompt_health = create(:evidence_prompt_health, prompt_id: prompt.id)
+
+          expect(prompt_health.flag).to eq(activity.flag)
+        end
+      end
+
+      describe 'conjunction' do
+        it 'should return the conjunction of the associated prompt' do
+          prompt = create(:evidence_prompt)
+          prompt_health = create(:evidence_prompt_health, prompt_id: prompt.id)
+
+          expect(prompt_health.conjunction).to eq(prompt.conjunction)
+        end
+      end
+
+      describe 'conjunction' do
+        it 'should return the id of the associated activity' do
+          activity = create(:evidence_activity)
+          prompt = create(:evidence_prompt, activity: activity)
+          prompt_health = create(:evidence_prompt_health, prompt_id: prompt.id)
+
+          expect(prompt_health.activity_id).to eq(activity.id)
+        end
+      end
+    end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_health_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_health_spec.rb
@@ -58,7 +58,7 @@ module Evidence
         end
       end
 
-      describe 'conjunction' do
+      describe 'activity_id' do
         it 'should return the id of the associated activity' do
           activity = create(:evidence_activity)
           prompt = create(:evidence_prompt, activity: activity)


### PR DESCRIPTION
## WHAT
This is the front end work for the new Evidence Prompt Health dashboard, which will display all the Evidence Prompts and their current state of health (as evidenced by various data points pre-calculated and cached).

## WHY
So Curriculum team can see information about all evidence prompts at a glance, and determine which prompts to focus their work on.

## HOW
This uses the same skeleton and format as my previous [Evidence Activity Health dashboard](https://github.com/empirical-org/Empirical-Core/pull/10078). It's essentially one React component that contains a table displaying all data columns, with manual filtering and sorting methods.

I also added some back end code to pull all the Prompt Health objects from our database and serialize them with some useful additional data to send to the front end.

### Screenshots
<img width="1302" alt="Screen Shot 2023-01-04 at 4 48 49 PM" src="https://user-images.githubusercontent.com/57366100/210664508-a9a152b6-a5f9-433f-afaf-56c6bf492cd6.png">


### Notion Card Links
https://www.notion.so/quill/4-Prompt-Health-Dashboard-Front-End-9eafe28d1d2247878cc380e2141c80d6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
