### PR TITLE
Fix bug with student merge account not happening properly

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/classroom_students_importer.rb
+++ b/services/QuillLMS/app/services/clever_integration/classroom_students_importer.rb
@@ -2,11 +2,12 @@
 
 module CleverIntegration
   class ClassroomStudentsImporter < ApplicationService
-    attr_reader :classroom, :students_data
+    attr_reader :classroom, :students_data, :teacher_id
 
-    def initialize(classroom, students_data)
+    def initialize(classroom, students_data, teacher_id)
       @classroom = classroom
       @students_data = students_data
+      @teacher_id = teacher_id
     end
 
     def run
@@ -30,7 +31,7 @@ module CleverIntegration
     end
 
     private def students
-      @students ||= students_data.map { |student_data| CleverIntegration::StudentImporter.run(student_data) }
+      @students ||= students_data.map { |student_data| CleverIntegration::StudentImporter.run(student_data, teacher_id) }
     end
   end
 end

--- a/services/QuillLMS/app/services/clever_integration/student_importer.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_importer.rb
@@ -2,12 +2,13 @@
 
 module CleverIntegration
   class StudentImporter < ApplicationService
-    attr_reader :data, :clever_id, :email, :username
+    attr_reader :data, :clever_id, :email, :teacher_id, :username
 
-    def initialize(data)
+    def initialize(data, teacher_id)
       @data = data
       @clever_id = data[:clever_id]
       @email = data[:email]
+      @teacher_id = teacher_id
       @username = data[:username]
     end
 
@@ -16,7 +17,7 @@ module CleverIntegration
     end
 
     private def importer
-      student ? StudentUpdater.new(student, data) : StudentCreator.new(data)
+      student ? StudentUpdater.new(student, data, teacher_id) : StudentCreator.new(data)
     end
 
     private def student

--- a/services/QuillLMS/app/services/clever_integration/student_updater.rb
+++ b/services/QuillLMS/app/services/clever_integration/student_updater.rb
@@ -2,15 +2,16 @@
 
 module CleverIntegration
   class StudentUpdater < ApplicationService
-    attr_reader :clever_id, :data, :student, :username
+    attr_reader :clever_id, :data, :student, :teacher_id, :username
 
     ACCOUNT_TYPE = ::User::CLEVER_ACCOUNT
     ROLE = ::User::STUDENT
 
-    def initialize(student, data)
+    def initialize(student, data, teacher_id)
       @student = student
       @data = data
       @clever_id = data[:clever_id]
+      @teacher_id = teacher_id
       @username = data[:username]
     end
 
@@ -29,7 +30,7 @@ module CleverIntegration
       return unless clever_id_and_email_disjointed?
 
       clever_student = ::User.find_by(clever_id: clever_id)
-      student.merge_student_account(clever_student)
+      student.merge_student_account(clever_student, teacher_id)
       clever_student.update!(clever_id: nil, account_type: 'unknown')
     end
 

--- a/services/QuillLMS/app/services/clever_integration/teacher_classrooms_students_importer.rb
+++ b/services/QuillLMS/app/services/clever_integration/teacher_classrooms_students_importer.rb
@@ -26,7 +26,7 @@ module CleverIntegration
     private def import_classroom_students
       classrooms.each do |classroom|
         students_data = client.get_classroom_students(classroom.clever_id)
-        ClassroomStudentsImporter.run(classroom, students_data)
+        ClassroomStudentsImporter.run(classroom, students_data, teacher.id)
       end
     end
   end

--- a/services/QuillLMS/spec/services/clever_integration/classroom_students_importer_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/classroom_students_importer_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe CleverIntegration::ClassroomStudentsImporter do
   let(:classroom) { create(:classroom, :from_clever) }
+  let(:teacher_id) { create(:teacher).id }
 
-  subject { described_class.run(classroom, students_data) }
+  subject { described_class.run(classroom, students_data, teacher_id) }
 
   context 'students_data is nil' do
     let(:students_data) { nil }

--- a/services/QuillLMS/spec/services/clever_integration/student_importer_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_importer_spec.rb
@@ -10,18 +10,19 @@ describe CleverIntegration::StudentImporter do
   let!(:existing_student1) { create(:student, email: existing_email) }
   let!(:existing_student2) { create(:student, clever_id: existing_clever_id) }
   let!(:existing_student3) { create(:student, username: existing_username) }
+  let(:teacher_id) { create(:teacher).id }
 
-  subject { described_class.run(data) }
+  subject { described_class.run(data, teacher_id) }
 
   context 'student with email exists' do
-    let(:data) {
+    let(:data) do
       {
         clever_id: '1',
         email: existing_email,
         name: 'John Smith',
         username: 'username'
       }
-    }
+    end
 
     it { expect { subject }.not_to change(User.student, :count) }
   end

--- a/services/QuillLMS/spec/services/clever_integration/student_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/student_updater_spec.rb
@@ -16,8 +16,9 @@ describe CleverIntegration::StudentUpdater do
   let(:email) { 'student@gmail.com' }
   let(:name) { 'Student Name' }
   let(:username) { 'student.username' }
+  let(:teacher_id) { create(:teacher).id }
 
-  subject { described_class.run(student, data) }
+  subject { described_class.run(student, data, teacher_id) }
 
   context 'student with email exists' do
     let!(:student) { create(:student, email: email) }

--- a/services/QuillLMS/spec/services/clever_integration/teacher_classrooms_students_importer_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_classrooms_students_importer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CleverIntegration::TeacherClassroomsStudentsImporter do
   it 'runs the importer only on clever classrooms' do
     expect(CleverIntegration::ClientFetcher).to receive(:run).with(teacher).and_return(client)
     expect(client).to receive(:get_classroom_students).with(clever_classroom.clever_id).and_return(students_data)
-    expect(CleverIntegration::ClassroomStudentsImporter).to receive(:run).with(clever_classroom, students_data)
+    expect(CleverIntegration::ClassroomStudentsImporter).to receive(:run).with(clever_classroom, students_data, teacher.id)
     subject
   end
 end


### PR DESCRIPTION
## WHAT
There’s an issue involving schools moving from clever library to secure sync integration where duplicate users aren't being properly merged which results in duplicate users being shown in the classroom.

## WHY
Teachers should not be seeing duplicate users for cases that we can resolve.

## HOW
When attempting to [merge](https://github.com/empirical-org/Empirical-Core/blob/e2559ffb248412995512f24c4ff341e27841ab06/services/QuillLMS/app/services/clever_integration/student_updater.rb#L33) two students, there are some [cases](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/models/concerns/student.rb#L123) where students cannot be merged together without the presence of the teacher_id. 

`teacher_id` is available higher upstream, so we can pass it down the chain and do the merge properly.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
