### PR TITLE
Add segment tracking for staggered release

### DIFF
--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -82,7 +82,7 @@ class AssignRecommendationsWorker
   end
 
   def track_recommendation_assignment(teacher, release_method)
-    Analyzer.new.track(
+    Analyzer.new.track_with_attributes(
       teacher,
       SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS,
       properties: { release_method: release_method }

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -39,7 +39,8 @@ class AssignRecommendationsWorker
 
     save_pack_sequence_item(classroom_unit, pack_sequence_id, order)
 
-    track_recommendation_assignment(teacher)
+    release_method = pack_sequence_id.nil? ? :Immediate : :Staggered
+    track_recommendation_assignment(teacher, release_method)
     return unless is_last_recommendation
 
     handle_error_tracking_for_diagnostic_recommendation_assignment_time(teacher.id, lesson)
@@ -80,9 +81,12 @@ class AssignRecommendationsWorker
     end
   end
 
-  def track_recommendation_assignment(teacher)
-    analytics = Analyzer.new
-    analytics.track(teacher, SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS)
+  def track_recommendation_assignment(teacher, release_method)
+    Analyzer.new.track(
+      teacher,
+      SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS,
+      properties: { release_method: release_method }
+    )
   end
 
   def track_assign_all_recommendations(teacher)

--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -15,6 +15,8 @@ describe AssignRecommendationsWorker do
   let(:assigning_all_recommended_packs) { false }
   let(:pack_sequence_id) { nil }
   let(:order) { 0 }
+  let(:properties) { { properties: { release_method: release_method } } }
+  let(:release_method) { pack_sequence_id.nil? ? :Immediate : :Staggered }
 
   let(:args) do
     {
@@ -100,6 +102,7 @@ describe AssignRecommendationsWorker do
   context 'when pack_sequence_id exists' do
     let(:pack_sequence_id) { create(:pack_sequence).id }
 
+    it { should_track_that_all_recommendations_are_being_assigned }
     it { expect { subject }.to change(PackSequenceItem, :count).from(0).to(1) }
 
     context 'when pack_sequence_item already exists' do
@@ -113,7 +116,7 @@ describe AssignRecommendationsWorker do
   end
 
   def should_track_that_all_recommendations_are_being_assigned
-    expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS)
+    expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS, properties)
     subject
   end
 

--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -9,7 +9,7 @@ describe AssignRecommendationsWorker do
   let(:classroom) { create(:classroom) }
   let(:teacher) { classroom.owner }
   let(:student) { create(:student) }
-  let(:analyzer) { double(:analyzer, track: true) }
+  let(:analyzer) { double(:analyzer, track: true, track_with_attributes: true) }
   let(:is_last_recommendation) { true }
   let(:lesson) { 'lesson' }
   let(:assigning_all_recommended_packs) { false }
@@ -116,7 +116,10 @@ describe AssignRecommendationsWorker do
   end
 
   def should_track_that_all_recommendations_are_being_assigned
-    expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS, properties)
+    expect(analyzer)
+      .to receive(:track_with_attributes)
+      .with(teacher, SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS, properties)
+
     subject
   end
 


### PR DESCRIPTION
## WHAT
Add tracking of Staggered Release usage for Segment Analytics

## WHY
It's useful to see how much usage this feature is getting.

## HOW
Update the track call to include properties based on release method.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/PS-Add-a-new-property-to-the-Teacher-assigned-a-recommended-activity-pack-Segment-event-to-track-s-0ff5338ccf3f4e699326909c06425b9a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
