### PR TITLE
Revert "Fire multiple events for each activity topic on activity completion"

### DIFF
--- a/services/QuillLMS/app/models/segment_integration/activity.rb
+++ b/services/QuillLMS/app/models/segment_integration/activity.rb
@@ -13,7 +13,10 @@ module SegmentIntegration
       {
         **common_params,
         concepts: activity_categories.pluck(:name).join(", "),
-        content_partners: content_partners.pluck(:name).join(", ")
+        content_partners: content_partners.pluck(:name).join(", "),
+        first_topic: topics.first&.name,
+        second_topic: topics.second&.name,
+        third_topic: topics.third&.name
       }.reject {|_,v| v.nil? }
     end
 

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -72,24 +72,11 @@ class SegmentAnalytics
   end
 
   def track_activity_completion(user, student_id, activity, activity_session)
-    activity_topics = activity.topics
-    activity_topics.each do |topic_level_one|
-      topic_level_two = Topic.find(topic_level_one.parent_id)
-      topic_level_three = Topic.find(topic_level_two.parent_id)
-
-      properties = {
-        student_id: student_id,
-        topic_level_one: topic_level_one.name,
-        topic_level_two: topic_level_two.name,
-        topic_level_three: topic_level_three.name,
-      }
-
-      track({
-          user_id: user&.id,
-          event: SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION,
-          properties: activity.segment_activity.content_params.merge(properties)
-      })
-    end
+    track({
+      user_id: user&.id,
+      event: SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION,
+      properties: activity.segment_activity.content_params.merge({student_id: student_id})
+    })
     track_activity_pack_completion(user, student_id, activity_session) if activity_pack_completed?(student_id, activity_session)
   end
 

--- a/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
@@ -5,6 +5,9 @@ require 'rails_helper'
 RSpec.describe SegmentIntegration::Activity do
   let(:activity_category) { create(:activity_category) }
   let(:activity_classification) { create(:activity_classification) }
+  let(:first_topic) { create(:topic, level: 1) }
+  let(:second_topic) { create(:topic, level: 1) }
+  let(:third_topic) { create(:topic, level: 1) }
   let(:activity) { create(:activity, activity_classification_id: activity_classification.id, activity_categories: [activity_category]) }
   let(:activity_category_activity) { create(:activity_category_activity, activity: activity, activity_category: activity_category) }
 
@@ -22,11 +25,15 @@ RSpec.describe SegmentIntegration::Activity do
   context '#content_params' do
 
     it 'returns the expected params hash' do
+      activity.topics = [first_topic, second_topic, third_topic]
       activity.save
       params = {
         **activity.segment_activity.common_params,
         concepts: activity.activity_categories.pluck(:name).join(", "),
-        content_partners: activity.content_partners.pluck(:name).join(", ")
+        content_partners: activity.content_partners.pluck(:name).join(", "),
+        first_topic: activity.topics.first&.name,
+        second_topic: activity.topics.second&.name,
+        third_topic: activity.topics.third&.name
       }.reject {|_,v| v.nil? }
       expect(activity.segment_activity.content_params).to eq params
     end

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -70,31 +70,19 @@ describe 'SegmentAnalytics' do
 
   context 'tracking activity completion' do
     let(:teacher) { create(:teacher) }
-    let(:topic1) { create(:topic, level: 1) }
-    let(:topic2) { create(:topic, level: 1) }
     let(:activity) { create(:diagnostic_activity) }
     let(:student) { create(:student) }
     let(:activity_session) { create(:activity_session) }
 
-    before do
-      create(:activity_topic, topic: topic1, activity: activity)
-      create(:activity_topic, topic: topic2, activity: activity)
-    end
-
     it 'sends an event with information about the activity' do
       analytics.track_activity_completion(teacher, student.id, activity, activity_session)
       expect(identify_calls.size).to eq(0)
-      expect(track_calls.size).to eq(2)
+      expect(track_calls.size).to eq(1)
       expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
       expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
       expect(track_calls[0][:properties][:student_id]).to eq(student.id)
-      expect(track_calls[0][:properties][:topic_level_one]).to eq(topic1.name)
-      expect(track_calls[0][:properties][:topic_level_two]).to eq(Topic.find(topic1.parent_id).name)
-      expect(track_calls[0][:properties][:topic_level_three]).to eq(Topic.find(Topic.find(topic1.parent_id).parent_id).name)
-      expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION)
-      expect(track_calls[1][:properties][:topic_level_one]).to eq(topic2.name)
     end
   end
 
@@ -257,9 +245,6 @@ describe 'SegmentAnalytics' do
     let(:unit_activity2) { create(:unit_activity, unit: unit) }
     let!(:activity_session1) { create(:activity_session, :finished, user: student, classroom_unit: classroom_unit, activity: unit_activity1.activity) }
     let!(:activity_session2) { create(:activity_session, :started, user: student, classroom_unit: classroom_unit, activity: unit_activity2.activity) }
-    let!(:topic) { create(:topic, level: 1) }
-
-    before { create(:activity_topic, topic: topic, activity: unit_activity2.activity) }
 
     it '#activity_pack_completed? returns false if activity pack has not been completed' do
       expect(analytics.activity_pack_completed?(student.id, activity_session1)).to eq false
@@ -277,10 +262,6 @@ describe 'SegmentAnalytics' do
       analytics.track_activity_completion(teacher, student.id, unit_activity2.activity, activity_session2)
       expect(identify_calls.size).to eq(0)
       expect(track_calls.size).to eq(2)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION)
-      expect(track_calls[0][:properties][:topic_level_one]).to eq(topic.name)
-      expect(track_calls[0][:properties][:topic_level_two]).to eq(Topic.find(topic.parent_id).name)
-      expect(track_calls[0][:properties][:topic_level_three]).to eq(Topic.find(Topic.find(topic.parent_id).parent_id).name)
       expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_COMPLETION)
       expect(track_calls[1][:user_id]).to eq(teacher.id)
       expect(track_calls[1][:properties][:activity_pack_name]).to eq(unit.name)


### PR DESCRIPTION
It seems that sending this in multiple events is throwing off our counts. Reverting this for now at the request of Peter Sharkey

See comment here:
https://www.notion.so/quill/PS-Update-how-we-send-topic-data-to-Segment-e7edc7e4a621413cb9c952825612a5ae

Reverts empirical-org/Empirical-Core#10106