### PR TITLE
Add grade levels and subject areas to Segment Payloads

### DIFF
--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -162,6 +162,10 @@ class School < ApplicationRecord
     subscription&.subscription_status || last_expired_subscription&.subscription_status
   end
 
+  def district_name
+    district&.name
+  end
+
   private def generate_leap_csv_row(student, teacher, classroom, activity_session)
     [
       student.id,

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -21,6 +21,7 @@ module SegmentIntegration
       }
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def common_params
       {
         district: school&.district_name,
@@ -34,6 +35,7 @@ module SegmentIntegration
         subject_areas: teacher_info&.subject_areas_string
       }.reject {|_,v| v.nil? }
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def premium_params
       {

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -15,7 +15,7 @@ module SegmentIntegration
           flagset: flagset,
           minimum_grade_level: teacher_info&.minimum_grade_level,
           maximum_grade_level: teacher_info&.maximum_grade_level,
-          subject_areas: teacher_info&.subject_areas&.map(&:name)&.join(", ")
+          subject_areas: teacher_info&.subject_areas_string
         }.reject {|_,v| v.nil? },
         integrations: integration_rules
       }
@@ -31,7 +31,7 @@ module SegmentIntegration
         is_admin: admin?,
         minimum_grade_level: teacher_info&.minimum_grade_level,
         maximum_grade_level: teacher_info&.maximum_grade_level,
-        subject_areas: teacher_info&.subject_areas&.map(&:name)&.join(", ")
+        subject_areas: teacher_info&.subject_areas_string
       }.reject {|_,v| v.nil? }
     end
 

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -23,7 +23,7 @@ module SegmentIntegration
 
     def common_params
       {
-        district: school&.district&.name,
+        district: school&.district_name,
         school_id: school&.id,
         school_name: school&.name,
         premium_state: premium_state,

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -12,7 +12,10 @@ module SegmentIntegration
           last_name: last_name,
           email: email,
           flags: flags&.join(", "),
-          flagset: flagset
+          flagset: flagset,
+          minimum_grade_level: teacher_info&.minimum_grade_level,
+          maximum_grade_level: teacher_info&.maximum_grade_level,
+          subject_areas: teacher_info&.subject_areas&.map(&:name)&.join(", ")
         }.reject {|_,v| v.nil? },
         integrations: integration_rules
       }
@@ -25,7 +28,10 @@ module SegmentIntegration
         school_name: school&.name,
         premium_state: premium_state,
         premium_type: subscription&.account_type,
-        is_admin: admin?
+        is_admin: admin?,
+        minimum_grade_level: teacher_info&.minimum_grade_level,
+        maximum_grade_level: teacher_info&.maximum_grade_level,
+        subject_areas: teacher_info&.subject_areas&.map(&:name)&.join(", ")
       }.reject {|_,v| v.nil? }
     end
 

--- a/services/QuillLMS/app/models/teacher_info.rb
+++ b/services/QuillLMS/app/models/teacher_info.rb
@@ -86,6 +86,8 @@ class TeacherInfo < ApplicationRecord
   end
 
   def subject_areas_string
+    return nil if subject_areas.empty?
+
     subject_areas&.map(&:name)&.join(", ")
   end
 

--- a/services/QuillLMS/app/models/teacher_info.rb
+++ b/services/QuillLMS/app/models/teacher_info.rb
@@ -85,6 +85,10 @@ class TeacherInfo < ApplicationRecord
     grade_levels.intersection(EIGHT_TO_TWELVE).present?
   end
 
+  def subject_areas_string
+    subject_areas&.map(&:name)&.join(", ")
+  end
+
   private def no_grade_levels?
     minimum_grade_level.nil? && maximum_grade_level.nil?
   end

--- a/services/QuillLMS/spec/models/segment_integration/user_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/user_spec.rb
@@ -4,8 +4,17 @@ require 'rails_helper'
 
 RSpec.describe SegmentIntegration::User do
   let(:teacher) { create(:teacher, flags: ["private", "beta"]) }
+  let(:subject1) { create(:subject_area, name: "subject 1")}
+  let(:subject2) { create(:subject_area, name: "subject 2")}
+  let(:subject3) { create(:subject_area, name: "subject 3")}
+  let(:teacher_info) { create(:teacher_info, user: teacher) }
 
-  before { create(:user_subscription, user: teacher) }
+  before {
+    create(:user_subscription, user: teacher)
+    create(:teacher_info_subject_area, teacher_info: teacher_info, subject_area: subject1)
+    create(:teacher_info_subject_area, teacher_info: teacher_info, subject_area: subject2)
+    create(:teacher_info_subject_area, teacher_info: teacher_info, subject_area: subject3)
+  }
 
   context '#identify_params' do
 
@@ -19,7 +28,10 @@ RSpec.describe SegmentIntegration::User do
           last_name: teacher.last_name,
           email: teacher.email,
           flags: teacher.flags&.join(", "),
-          flagset: teacher.flagset
+          flagset: teacher.flagset,
+          minimum_grade_level: teacher_info.minimum_grade_level,
+          maximum_grade_level: teacher_info.maximum_grade_level,
+          subject_areas: teacher_info.subject_areas.map(&:name).join(", ")
         }.reject {|_,v| v.nil? },
         integrations: teacher.segment_user.integration_rules
       }
@@ -36,7 +48,10 @@ RSpec.describe SegmentIntegration::User do
         school_name: teacher.school&.name,
         premium_state: teacher.premium_state,
         premium_type: teacher.subscription&.account_type,
-        is_admin: teacher.admin?
+        is_admin: teacher.admin?,
+        minimum_grade_level: teacher_info.minimum_grade_level,
+        maximum_grade_level: teacher_info.maximum_grade_level,
+        subject_areas: teacher_info.subject_areas.map(&:name).join(", ")
       }.reject {|_,v| v.nil? }
       expect(teacher.segment_user.common_params).to eq params
     end

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -129,9 +129,9 @@ describe TeacherInfo, type: :model, redis: true do
     end
 
     context 'when no subject areas are attached' do
-      it 'should return empty string' do
+      it 'should return nil' do
         teacher_info2 = create(:teacher_info)
-        expect(teacher_info2.subject_areas_string).to eq("")
+        expect(teacher_info2.subject_areas_string).to eq(nil)
       end
     end
   end

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -110,4 +110,29 @@ describe TeacherInfo, type: :model, redis: true do
     it { expect(build(:teacher_info, minimum_grade_level: nil, maximum_grade_level: 9).in_eighth_through_twelfth?).to eq true }
     it { expect(build(:teacher_info, minimum_grade_level: 5, maximum_grade_level: nil).in_eighth_through_twelfth?).to eq false}
   end
+
+  describe '#subject_areas_string' do
+    let(:subject1) { create(:subject_area, name: "subject 1")}
+    let(:subject2) { create(:subject_area, name: "subject 2")}
+    let(:subject3) { create(:subject_area, name: "subject 3")}
+
+    before do
+      create(:teacher_info_subject_area, teacher_info: teacher_info, subject_area: subject1)
+      create(:teacher_info_subject_area, teacher_info: teacher_info, subject_area: subject2)
+      create(:teacher_info_subject_area, teacher_info: teacher_info, subject_area: subject3)
+    end
+
+    context 'when multiple subject areas are attached' do
+      it 'should return a list of attached subject areas in a comma-separated string' do
+        expect(teacher_info.subject_areas_string).to eq("#{subject1.name}, #{subject2.name}, #{subject3.name}")
+      end
+    end
+
+    context 'when no subject areas are attached' do
+      it 'should return empty string' do
+        teacher_info2 = create(:teacher_info)
+        expect(teacher_info2.subject_areas_string).to eq("")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Add the following fields to the payload we send to segment User Identify and Track calls: `minimum_grade_level`, `maximum_grade_level`, `subject_areas`

## WHY
Now that we collect this data, we want to use it in Segment tracking and analytics.

## HOW
Send these fields in the payload when the data exists.

### Screenshots

### Notion Card Links
https://www.notion.so/quill/PS-Add-new-properties-to-the-Segment-Identify-call-and-the-Teacher-signed-in-Segment-track-call-e9d0192f716848c493186e6d1e64e52e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
