### PR TITLE
Add expanding/collapsing Prompt Health rows inside Activity Health table

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
@@ -5,7 +5,9 @@ import { CSVLink } from 'react-csv';
 import { firstBy } from 'thenby';
 
 
-import { FlagDropdown, ReactTable, filterNumbers } from '../../../../Shared/index'
+import { PromptHealthRows } from './promptHealthRow'
+
+import { FlagDropdown, ReactTable, filterNumbers, expanderColumn } from '../../../../Shared/index'
 import { fetchAggregatedActivityHealths } from '../../../utils/evidence/ruleFeedbackHistoryAPIs';
 import { getLinkToActivity, secondsToHumanReadableTime, addCommasToThousands } from "../../../helpers/evidence/miscHelpers";
 
@@ -76,6 +78,7 @@ export const ActivityHealthDashboard = ({ handleDashboardToggle }) => {
   }, [activityHealthsData])
 
   const dataTableFields = [
+    expanderColumn,
     {
       Header: 'Name',
       accessor: "name",
@@ -312,6 +315,13 @@ export const ActivityHealthDashboard = ({ handleDashboardToggle }) => {
           manualSortBy
           onFiltersChange={handleFiltersChange}
           onSortedChange={handleDataUpdate}
+          SubComponent={(row) => {
+            return (
+              <PromptHealthRows
+                data={row.original && row.original.prompt_healths || []}
+              />
+            );
+          }}
         />
       </section>
     </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthRow.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthRow.tsx
@@ -125,15 +125,17 @@ export const PromptHealthRows = ({ data }) => {
   const renderTableOrEmptyMessage = () => {
 
     if (data.length) {
-      return (<ReactTable
-        className='prompt-health-dropdown-table'
-        collapseOnDataChange={false}
-        columns={dataTableFields}
-        data={data}
-        defaultPageSize={data.length}
-        loading={false}
-        pages={1}
-      />)
+      return (
+        <ReactTable
+          className='prompt-health-dropdown-table'
+          collapseOnDataChange={false}
+          columns={dataTableFields}
+          data={data}
+          defaultPageSize={data.length}
+          loading={false}
+          pages={1}
+        />
+      )
     }
     return <p>NO_DATA_FOUND_MESSAGE</p>
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthRow.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthRow.tsx
@@ -43,7 +43,11 @@ export const PromptHealthRows = ({ data }) => {
       accessor: "first_attempt_optimal",
       key: "first_attempt_optimal",
       minWidth: 70,
-      Cell: ({row}) => row.original.first_attempt_optimal && <span className={row.original.first_attempt_optimal < 25 ? "poor-health" : "" + " name"}>{row.original.first_attempt_optimal}%</span>
+      Cell: ({row}) => {
+        if (!row.original.first_attempt_optimal) { return }
+        const className = row.original.first_attempt_optimal < 25 ? "poor-health" : "" + " name"
+        return <span className={className}>{row.original.first_attempt_optimal}%</span>
+      }
     },
     {
       Header: 'Final Attempt Optimal',
@@ -118,15 +122,10 @@ export const PromptHealthRows = ({ data }) => {
     }
   ];
 
-  const renderTable = () => {
-    return tableOrEmptyMessage()
-  }
-
-  const tableOrEmptyMessage = () => {
-    let tableOrEmptyMessage
+  const renderTableOrEmptyMessage = () => {
 
     if (data.length) {
-      tableOrEmptyMessage = (<ReactTable
+      return (<ReactTable
         className='prompt-health-dropdown-table'
         collapseOnDataChange={false}
         columns={dataTableFields}
@@ -135,20 +134,14 @@ export const PromptHealthRows = ({ data }) => {
         loading={false}
         pages={1}
       />)
-    } else {
-      tableOrEmptyMessage = NO_DATA_FOUND_MESSAGE
     }
-    return (
-      <div>
-        {tableOrEmptyMessage}
-      </div>
-    )
+    return <p>NO_DATA_FOUND_MESSAGE</p>
   }
 
 
   return (
     <div className="standard-columns">
-      {renderTable()}
+      {renderTableOrEmptyMessage()}
     </div>
   )
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthRow.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/promptHealthRow.tsx
@@ -1,0 +1,157 @@
+import * as React from "react";
+
+import { ReactTable } from '../../../../Shared/index'
+import { getLinkToPrompt, secondsToHumanReadableTime, } from "../../../helpers/evidence/miscHelpers";
+
+const NO_DATA_FOUND_MESSAGE = "No prompt data yet available for this activity."
+
+export const PromptHealthRows = ({ data }) => {
+
+  const dataTableFields = [
+    {
+      Header: 'Activity Short Name',
+      accessor: "activity_short_name",
+      key: "activity_short_name",
+      Cell: ({row}) => <span>{row.original.activity_short_name}</span>, // eslint-disable-line react/display-name
+      minWidth: 100,
+      width: 100,
+      maxWidth: 100
+    },
+    {
+      Header: 'Prompt',
+      accessor: "text",
+      key: "text",
+      Cell: ({row}) => <span className="name"><a href={getLinkToPrompt(row.original.activity_id, row.original.conjunction)} rel="noopener noreferrer" target="_blank">{row.original.text}</a></span>, // eslint-disable-line react/display-name
+      minWidth: 330,
+      width: 330,
+      maxWidth: 330
+    },
+    {
+      Header: 'Version #',
+      accessor: "current_version",
+      key: "current_version",
+      minWidth: 70,
+    },
+    {
+      Header: 'Version responses',
+      accessor: "version_responses",
+      key: "version_responses",
+      minWidth: 70,
+    },
+    {
+      Header: 'First Attempt Optimal',
+      accessor: "first_attempt_optimal",
+      key: "first_attempt_optimal",
+      minWidth: 70,
+      Cell: ({row}) => row.original.first_attempt_optimal && <span className={row.original.first_attempt_optimal < 25 ? "poor-health" : "" + " name"}>{row.original.first_attempt_optimal}%</span>
+    },
+    {
+      Header: 'Final Attempt Optimal',
+      accessor: "final_attempt_optimal",
+      key: "final_attempt_optimal",
+      minWidth: 70,
+      Cell: ({row}) => row.original.final_attempt_optimal && <span className={row.original.final_attempt_optimal < 75 ? "poor-health" : "" + " name"}>{row.original.final_attempt_optimal}%</span>
+    },
+    {
+      Header: 'Average Attempts',
+      accessor: "avg_attempts",
+      key: "avg_attempts",
+      minWidth: 70,
+    },
+    {
+      Header: 'Confid- ence',
+      accessor: "confidence",
+      key: "confidence",
+      minWidth: 70,
+      Cell: ({row}) => row.original.confidence && <span className={row.original.confidence < 0.9 ? "poor-health" : "" + " name"}>{row.original.confidence}%</span>
+    },
+    {
+      Header: '% AutoML Consecut- ive Repeated',
+      accessor: "percent_automl_consecutive_repeated",
+      key: "percent_automl_consecutive_repeated",
+      minWidth: 70,
+      Cell: ({row}) => row.original.percent_automl_consecutive_repeated && <span className={row.original.percent_automl_consecutive_repeated > 30 ? "poor-health" : "" + " name"}>{row.original.percent_automl_consecutive_repeated}%</span>
+    },
+    {
+      Header: '% AutoML',
+      accessor: "percent_automl",
+      key: "percent_automl",
+      minWidth: 70,
+    },
+    {
+      Header: '% Plagiar- ism',
+      accessor: "percent_plagiarism",
+      key: "percent_plagiarism",
+      minWidth: 70,
+    },
+    {
+      Header: '% Opinion',
+      accessor: "percent_opinion",
+      key: "percent_opinion",
+      minWidth: 70,
+    },
+    {
+      Header: '% Grammar',
+      accessor: "percent_grammar",
+      key: "percent_grammar",
+      minWidth: 70,
+    },
+    {
+      Header: '% Spelling',
+      accessor: "percent_spelling",
+      key: "percent_spelling",
+      minWidth: 70,
+    },
+    {
+      Header: 'Avg Time Spent - Prompt',
+      accessor: "avg_time_spent_per_prompt",
+      key: "avg_time_spent_per_prompt",
+      minWidth: 70,
+      Cell: ({row}) => secondsToHumanReadableTime(row.original.avg_time_spent_per_prompt)
+    },
+    {
+      Header: 'Poor Health Flag',
+      accessor: "poor_health_flag",
+      key: "poorHealthFlag",
+      minWidth: 70,
+      Cell: ({row}) => row.original.poor_health_flag === true && <span className="poor-health-flag">X</span>,
+    }
+  ];
+
+  const renderTable = () => {
+    return tableOrEmptyMessage()
+  }
+
+  const tableOrEmptyMessage = () => {
+    let tableOrEmptyMessage
+
+    if (data.length) {
+      tableOrEmptyMessage = (<ReactTable
+        className='prompt-health-dropdown-table'
+        collapseOnDataChange={false}
+        columns={dataTableFields}
+        data={data}
+        defaultPageSize={data.length}
+        loading={false}
+        pages={1}
+      />)
+    } else {
+      tableOrEmptyMessage = NO_DATA_FOUND_MESSAGE
+    }
+    return (
+      <div>
+        {tableOrEmptyMessage}
+      </div>
+    )
+  }
+
+
+  return (
+    <div className="standard-columns">
+      {renderTable()}
+    </div>
+  )
+
+}
+
+export default PromptHealthRows

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/health_dashboard.scss
@@ -59,5 +59,7 @@
     }
   }
 
-
+  .prompt-health-dropdown-table {
+    background: whitesmoke;
+  }
 }

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activity_healths_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activity_healths_controller.rb
@@ -6,7 +6,7 @@ module Evidence
   class ActivityHealthsController < ApiController
 
     def index
-      render json: ActivityHealth.all.includes(:prompt_healths).as_json
+      render json: ActivityHealth.includes([:prompt_healths]).all.to_json(include: :prompt_healths)
     end
   end
 end


### PR DESCRIPTION
## WHAT
The last step in the Evidence Health Dashboards project is to add a subrow to the ActivityHealth table that contains data pertinent to that activity's prompts. 
This SubRow will expand and collapse manually. It contains all the data displayed in the PromptHealth table, but in a static, unsearchable/unsortable format.

## WHY
Having all this data on one table simplifies staff's workflow and makes it easier to visualize everything they need to see. The expand/collapse function prevents the data from getting too visually overwhelming.

## HOW
Use the `SubComponent` ReactTable property to add this `PromptHealthRow` component as a subcomponent inside of the main react table. This component has the same column definitions as the bigger `PromptHealthTable`, but it doesn't have any of the manual sort/filter/search functions for simplicity's sake.

### Screenshots
<img width="1333" alt="Screen Shot 2023-01-09 at 4 47 22 PM" src="https://user-images.githubusercontent.com/57366100/211414989-a35100e8-dbee-40eb-a19f-72b3e480affa.png">

### Notion Card Links
https://www.notion.so/quill/Evidence-Health-Dashboard-17188413c0f54baba169f3fee1b4e7df

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
