### PR TITLE
Fix bug with invite students and assign_on_join

### DIFF
--- a/services/QuillLMS/app/models/students_classrooms.rb
+++ b/services/QuillLMS/app/models/students_classrooms.rb
@@ -58,6 +58,12 @@ class StudentsClassrooms < ApplicationRecord
     SaveUserPackSequenceItemsWorker.perform_async(classroom_id, student_id)
   end
 
+  def validate_assigned_student
+    classroom
+      &.classroom_units
+      &.each { |classroom_unit| classroom_unit.validate_assigned_student(student_id) }
+  end
+
   private def run_associator
     return unless student && classroom && visible
 

--- a/services/QuillLMS/app/services/creators/student_creator.rb
+++ b/services/QuillLMS/app/services/creators/student_creator.rb
@@ -33,10 +33,13 @@ module Creators::StudentCreator
   end
 
   def self.build_classroom_relation(classroom_id)
-    sc  = StudentsClassrooms.unscoped.find_or_initialize_by(student_id: @student.id, classroom_id: classroom_id)
+    sc = StudentsClassrooms.unscoped.find_or_initialize_by(student_id: @student.id, classroom_id: classroom_id)
+
     if sc.new_record? && sc.save!
       StudentJoinedClassroomWorker.perform_async(Classroom.find(classroom_id).owner.id, @student.id)
-      end
+      sc.validate_assigned_student
+    end
+
     sc.update(visible: true)
     sc
   end


### PR DESCRIPTION
## WHAT
Fix a [bug](https://www.notion.so/quill/New-students-are-not-added-to-existing-packs-8c558379cef24603886d37a8e7a955fb) where students invited to a classroom are not being added to existing packs

## WHY
An older create_student is missing a call to validate_assigned_student across classroom_units. 

## HOW
Refactor out `update_classroom_units(student_classroom)` method into students_classrooms.rb as `validate_assigned_student`

Call `sc.validate_assigned_student` in student_creator.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manual check.  I've made a note to add some testing later to this legacy code.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
