### PR TITLE
Remove topic data from segment payload on activity change

### DIFF
--- a/services/QuillLMS/app/models/segment_integration/activity.rb
+++ b/services/QuillLMS/app/models/segment_integration/activity.rb
@@ -13,10 +13,7 @@ module SegmentIntegration
       {
         **common_params,
         concepts: activity_categories.pluck(:name).join(", "),
-        content_partners: content_partners.pluck(:name).join(", "),
-        first_topic: topics.first&.name,
-        second_topic: topics.second&.name,
-        third_topic: topics.third&.name
+        content_partners: content_partners.pluck(:name).join(", ")
       }.reject {|_,v| v.nil? }
     end
 

--- a/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/activity_spec.rb
@@ -5,9 +5,6 @@ require 'rails_helper'
 RSpec.describe SegmentIntegration::Activity do
   let(:activity_category) { create(:activity_category) }
   let(:activity_classification) { create(:activity_classification) }
-  let(:first_topic) { create(:topic, level: 1) }
-  let(:second_topic) { create(:topic, level: 1) }
-  let(:third_topic) { create(:topic, level: 1) }
   let(:activity) { create(:activity, activity_classification_id: activity_classification.id, activity_categories: [activity_category]) }
   let(:activity_category_activity) { create(:activity_category_activity, activity: activity, activity_category: activity_category) }
 
@@ -25,15 +22,10 @@ RSpec.describe SegmentIntegration::Activity do
   context '#content_params' do
 
     it 'returns the expected params hash' do
-      activity.topics = [first_topic, second_topic, third_topic]
-      activity.save
       params = {
         **activity.segment_activity.common_params,
         concepts: activity.activity_categories.pluck(:name).join(", "),
-        content_partners: activity.content_partners.pluck(:name).join(", "),
-        first_topic: activity.topics.first&.name,
-        second_topic: activity.topics.second&.name,
-        third_topic: activity.topics.third&.name
+        content_partners: activity.content_partners.pluck(:name).join(", ")
       }.reject {|_,v| v.nil? }
       expect(activity.segment_activity.content_params).to eq params
     end


### PR DESCRIPTION
## WHAT
Stop sending data about an activity's topics through to segment. 

## WHY
We want to start analyzing this data through other means like Metabase. Segment is no longer a useful way to capture this data meaningfully, since we now attach many topics to the same activity.

## HOW
Remove these fields from the payload, and adjust the spec accordingly.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=809f94849bee48c0a0ab3ff26688a30d&pm=c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  Yes
