### PR TITLE
Fix race condition with missing pack_sequence

### DIFF
--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -66,6 +66,7 @@ class AssignRecommendationsWorker
   end
 
   def save_pack_sequence_item(classroom_unit, pack_sequence_id, order)
+    return unless PackSequence.exists?(id: pack_sequence_id)
     return if pack_sequence_id.nil? || classroom_unit.nil?
 
     PackSequenceItem.find_or_create_by!(

--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -113,6 +113,12 @@ describe AssignRecommendationsWorker do
 
       it { expect { subject }.not_to change(PackSequenceItem, :count).from(1) }
     end
+
+    context 'when pack_sequence does not exist' do
+      before { allow(PackSequence).to receive(:exists?).with(id: pack_sequence_id).and_return(false) }
+
+      it { expect { subject }.not_to change(PackSequenceItem, :count).from(0) }
+    end
   end
 
   def should_track_that_all_recommendations_are_being_assigned


### PR DESCRIPTION
## WHAT
Fix a race condition involving the AssignRecommendationsWorker where a pack_sequence_id no longer exists in the database.

## WHY
It's being retried in the queue with no chance of passing.

I'm able to replicate this failed worker intermittently as follows.  
1.  Opening the same recommendations table in two windows and then selecting staggered release in one modal and immediate in the other modal.
2. Save both as close to in time as possible.

Assigning to ImmediateRelease immediately destroys any associated pack_sequences, therefore a worker attempting to assign to StaggeredRelease is now referring to a non-existent pack_sequence. 

## HOW
Add a guard clause to see if the PackSequence exists.  If it does not, skip creating the pack_sequence_id.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
