### PR TITLE
Add check for nil user in CheckboxAnalyticsWorker

### DIFF
--- a/services/QuillLMS/app/workers/checkbox_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/checkbox_analytics_worker.rb
@@ -4,8 +4,10 @@ class CheckboxAnalyticsWorker
   include Sidekiq::Worker
 
   def perform(user_id, activity_id)
-    analytics = SegmentAnalytics.new
-    analytics.track_activity_assignment(user_id, activity_id)
-  end
+    return unless User.exists?(id: user_id)
 
+    SegmentAnalytics
+      .new
+      .track_activity_assignment(user_id, activity_id)
+  end
 end

--- a/services/QuillLMS/spec/workers/checkbox_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/checkbox_analytics_worker_spec.rb
@@ -10,13 +10,20 @@ describe CheckboxAnalyticsWorker do
     let!(:activity) { create(:activity) }
     let(:analyzer) { double(:analyzer) }
 
-    before do
-      allow(SegmentAnalytics).to receive(:new) { analyzer }
-    end
+    before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
 
     it 'should track the event' do
       expect(analyzer).to receive(:track_activity_assignment).with(user.id, activity.id)
       subject.perform(user.id, activity.id)
+    end
+
+    context 'user_id refers to nil user' do
+      before { allow(User).to receive(:exists?).with(id: user.id).and_return(false) }
+
+      it 'does not track the event' do
+        expect(analyzer).not_to receive(:track_activity_assignment).with(user.id, activity.id)
+        subject.perform(user.id, activity.id)
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a bug involving nil User with `CheckboxAnalyticsWorker`

## WHY
When `Demo::ReportDemoCreator.create_demo` is run, many `CheckboxAnalyticsWorker` jobs are enqueued.  If a subsequent `Demo::ReportDemoCreator.create_demo` is run before those  `CheckboxAnalyticsWorker` complete,  `ActiveRecord::RecordNotFound: Couldn't find User with 'id'=...`  errors will result, triggering retries that will never finish.

## HOW
Add a guard clause that checks to see if the user_id actually exists.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
