### PR TITLE
Bug fix/ activity name reference in Diagnostic assignment warning modal

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/Stage2.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/Stage2.jsx
@@ -95,13 +95,13 @@ export class Stage2 extends React.Component {
 
   renderOverrideWarningModal() {
     const { showOverrideWarningModal, } = this.state
-    const { alreadyCompletedDiagnosticStudentNames, unitTemplateName, } = this.props
+    const { alreadyCompletedDiagnosticStudentNames, unitTemplateName, unitName } = this.props
 
     if (!showOverrideWarningModal) { return }
 
     return (
       <OverrideWarningModal
-        activityName={unitTemplateName}
+        activityName={unitTemplateName || unitName}
         handleClickAssign={this.onAssignDespiteWarning}
         handleCloseModal={this.closeOverrideWarningModal}
         studentNames={alreadyCompletedDiagnosticStudentNames}


### PR DESCRIPTION
## WHAT
fix issue with missing activity name in the Diagnostic assignment warning modal

## WHY
we want to display this name in the modal

## HOW
add backup check for `unitName` in instances when `unitTemplateName` returns undefined

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Fix-missing-reference-to-activity-pack-name-in-the-Are-you-sure-you-want-to-assign-this-diagnostic--63de0e9c76514099980f842a595b49ca

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
