### PR TITLE
Teacher Onboarding/ add migration for role_selected_at_signup

### DIFF
--- a/services/QuillLMS/app/models/teacher_info.rb
+++ b/services/QuillLMS/app/models/teacher_info.rb
@@ -4,12 +4,13 @@
 #
 # Table name: teacher_infos
 #
-#  id                  :bigint           not null, primary key
-#  maximum_grade_level :integer
-#  minimum_grade_level :integer
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  user_id             :bigint           not null
+#  id                      :bigint           not null, primary key
+#  maximum_grade_level     :integer
+#  minimum_grade_level     :integer
+#  role_selected_at_signup :string           default("")
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  user_id                 :bigint           not null
 #
 # Indexes
 #

--- a/services/QuillLMS/db/migrate/20230113132638_add_role_selected_at_signup_to_teachersinfo.rb
+++ b/services/QuillLMS/db/migrate/20230113132638_add_role_selected_at_signup_to_teachersinfo.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRoleSelectedAtSignupToTeachersinfo < ActiveRecord::Migration[6.1]
+  def change
+    add_column :teacher_infos, :role_selected_at_signup, :string, default: ''
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -4166,7 +4166,8 @@ CREATE TABLE public.teacher_infos (
     maximum_grade_level integer,
     user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    role_selected_at_signup character varying DEFAULT ''::character varying
 );
 
 
@@ -9160,6 +9161,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221209141047'),
 ('20221209151611'),
 ('20221209151957'),
-('20230104183416');
+('20230104183416'),
+('20230113132638');
 
 

--- a/services/QuillLMS/spec/factories/teacher_infos.rb
+++ b/services/QuillLMS/spec/factories/teacher_infos.rb
@@ -4,12 +4,13 @@
 #
 # Table name: teacher_infos
 #
-#  id                  :bigint           not null, primary key
-#  maximum_grade_level :integer
-#  minimum_grade_level :integer
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  user_id             :bigint           not null
+#  id                      :bigint           not null, primary key
+#  maximum_grade_level     :integer
+#  minimum_grade_level     :integer
+#  role_selected_at_signup :string           default("")
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  user_id                 :bigint           not null
 #
 # Indexes
 #

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -4,12 +4,13 @@
 #
 # Table name: teacher_infos
 #
-#  id                  :bigint           not null, primary key
-#  maximum_grade_level :integer
-#  minimum_grade_level :integer
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  user_id             :bigint           not null
+#  id                      :bigint           not null, primary key
+#  maximum_grade_level     :integer
+#  minimum_grade_level     :integer
+#  role_selected_at_signup :string           default("")
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  user_id                 :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
## WHAT
add a `role_selected_at_signup` column to the `teacher_infos` table

## WHY
we need this to store the role that a user selects in the teacher onboarding updates

## HOW
just add a migration to the table for this column (note: this was discussed with both Dan and Emilia, and we felt like this is the best place to store this piece of data)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Design-of-Collecting-Teacher-Onboarding-Materials-Part-II-04073c66d0d242ee95aea8be6fe34a10

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | no-- migration PR
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
