### PR TITLE
Add HTTP Basic Authentication to staging environments.

### DIFF
--- a/services/QuillLMS/config/environments/staging.rb
+++ b/services/QuillLMS/config/environments/staging.rb
@@ -116,6 +116,12 @@ EmpiricalGrammar::Application.configure do
     'staging.quill.org.' => 'staging.quill.org'
   }
 
+  if ENV['STAGING_AUTH']
+    config.middleware.use Rack::Auth::Basic do |username, password|
+      ENV['STAGING_AUTH'].split(':') == [username, password]
+    end
+  end
+
   config.active_record.database_selector = { delay: 2.seconds }
   config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session


### PR DESCRIPTION
## WHAT
Add a http basic auth to our staging environments
## WHY
Adds a little more security to our staging environments and prevents google (and other search engines) from crawling and listing our staging environment pages.
## HOW
Add a rack middleware to the staging environment config if an ENV var is present.
### Screenshots
![Screenshot 2023-01-13 at 11 21 37 AM](https://user-images.githubusercontent.com/1304933/212369192-2d5ce93e-1203-47c6-84a8-d79ad5a0e2bd.png)


How our results appear in google rn
![Screenshot 2023-01-12 at 4 10 34 PM](https://user-images.githubusercontent.com/1304933/212369446-4f28af7f-4b6d-42e2-a9ed-daf8c4dd1872.png)



### Notion Card Links
https://www.notion.so/quill/SEO-Improvements-30df3beefab44c4ba691786fe84dce57

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO', tiny change to staging config
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
