### PR TITLE
Add Canonical links to clean up google indexing.

### DIFF
--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -20,6 +20,7 @@
   <meta name="description" content="<%= @description || @content %>">
   <meta name="og:description" content="<%= @description || @content %>">
   <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
+  <link rel="canonical" href="https://www.quill.org<%= request.path %>">
 
   <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
   <!-- Inspectlet tracking -->

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -20,6 +20,7 @@
     <meta property="og:description" content="<%= @description %>" />
     <meta property="og:image"       content=<%= image_url('share/facebook.png') %> />
     <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
+    <link rel="canonical" href="https://www.quill.org<%= request.path %>">
 
     <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
     <%= render partial: 'typekit' unless Rails.env.test? %>


### PR DESCRIPTION
## WHAT
Add links to our page headers to specify that `https://www.quill.org/` is the canonical base path
## WHY
Since we have a wildcard subdomain, any subdomain that we haven't set specific routing for will point to our site. This has caused Google to index some of these random subdomains as urls on our site. We want to be explicit that the `https` and `www` are the links that should be used by the index.
## HOW
Simple `<link rel='canonical'>`
### Screenshots
![Screenshot 2023-01-13 at 1 15 20 PM](https://user-images.githubusercontent.com/1304933/212392541-c6e92bfc-df0c-4232-a6f7-ffcf346e9b7d.png)


### Notion Card Links
https://www.notion.so/quill/SEO-Improvements-30df3beefab44c4ba691786fe84dce57

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'NO', tiny header change
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
