### PR TITLE
lms/sync-subscription-data-to-vitally

### DIFF
--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -26,6 +26,8 @@
 class District < ApplicationRecord
   include Subscriber
 
+  VITALLY_NOT_APPLICABLE = 'N/A'
+
   validates :name, presence: true
   validates_uniqueness_of :nces_id, allow_blank: true, message: "A district with this NCES ID already exists."
 
@@ -135,23 +137,23 @@ class District < ApplicationRecord
   end
 
   private def premium_start_date
-    subscription&.start_date || 'N/A'
+    subscription&.start_date || VITALLY_NOT_APPLICABLE
   end
 
   private def premium_expiry_date
-    latest_subscription&.expiration || 'N/A'
+    latest_subscription&.expiration || VITALLY_NOT_APPLICABLE
   end
 
   private def district_subscription
-    subscription&.account_type || 'N/A'
+    subscription&.account_type || VITALLY_NOT_APPLICABLE
   end
 
   private def annual_revenue_current_contract
-    subscription&.payment_amount || 'N/A'
+    subscription&.payment_amount || VITALLY_NOT_APPLICABLE
   end
 
   private def stripe_invoice_id_current_contract
-    subscription&.stripe_invoice_id || 'N/A'
+    subscription&.stripe_invoice_id || VITALLY_NOT_APPLICABLE
   end
 
 end

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -91,14 +91,12 @@ class District < ApplicationRecord
   end
 
   def vitally_subscription_rollups
-    latest_subscription = subscriptions.not_expired.not_de_activated.order(expiration: :desc).first
-
     {
-      premium_start_date: subscription&.start_date || 'N/A',
-      premium_expiry_date: latest_subscription&.expiration || 'N/A',
-      district_subscription: subscription&.account_type || 'N/A',
-      annual_revenue_current_contract: subscription&.payment_amount || 'N/A',
-      stripe_invoice_id_current_contract: subscription&.stripe_invoice_id || 'N/A',
+      premium_start_date: premium_start_date,
+      premium_expiry_date: premium_expiry_date,
+      district_subscription: district_subscription,
+      annual_revenue_current_contract: annual_revenue_current_contract,
+      stripe_invoice_id_current_contract: stripe_invoice_id_current_contract
     }
   end
 
@@ -131,4 +129,29 @@ class District < ApplicationRecord
       .distinct
       .count
   end
+
+  private def latest_subscription
+    subscriptions.not_expired.not_de_activated.order(expiration: :desc).first
+  end
+
+  private def premium_start_date
+    subscription&.start_date || 'N/A'
+  end
+
+  private def premium_expiry_date
+    latest_subscription&.expiration || 'N/A'
+  end
+
+  private def district_subscription
+    subscription&.account_type || 'N/A'
+  end
+
+  private def annual_revenue_current_contract
+    subscription&.payment_amount || 'N/A'
+  end
+
+  private def stripe_invoice_id_current_contract
+    subscription&.stripe_invoice_id || 'N/A'
+  end
+
 end

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -64,7 +64,8 @@ class District < ApplicationRecord
         phone: phone,
         total_students: total_students,
         total_schools: total_schools,
-        **vitally_diagnostic_rollups
+        **vitally_diagnostic_rollups,
+        **vitally_subscription_rollups
       }
     }
   end
@@ -86,6 +87,18 @@ class District < ApplicationRecord
       diagnostics_completed_last_year: diagnostics_completed_last_year,
       percent_diagnostics_completed_this_year: percent_completed_this_year,
       percent_diagnostics_completed_last_year: percent_completed_last_year
+    }
+  end
+
+  def vitally_subscription_rollups
+    latest_subscription = subscriptions.not_expired.not_de_activated.order(expiration: :desc).first
+
+    {
+      premium_start_date: subscription&.start_date || 'N/A',
+      premium_expiry_date: latest_subscription&.expiration || 'N/A',
+      district_subscription: subscription&.account_type || 'N/A',
+      annual_revenue_current_contract: subscription&.payment_amount || 'N/A',
+      stripe_invoice_id_current_contract: subscription&.stripe_invoice_id || 'N/A',
     }
   end
 

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -3,6 +3,8 @@
 class SerializeVitallySalesAccount
   include VitallySchoolStats
 
+  NOT_APPLICABLE = 'N/A'
+
   def initialize(school)
     @school = school
   end
@@ -53,8 +55,8 @@ class SerializeVitallySalesAccount
         created_at: @school.created_at,
         premium_expiry_date: subscription_expiration_date,
         premium_start_date: subscription_start_date,
-        annual_revenue_current_contract: @school.subscription&.payment_amount || 'N/A',
-        stripe_invoice_id_current_contract: @school.subscription&.stripe_invoice_id || 'N/A',
+        annual_revenue_current_contract: @school.subscription&.payment_amount || NOT_APPLICABLE,
+        stripe_invoice_id_current_contract: @school.subscription&.stripe_invoice_id || NOT_APPLICABLE,
         last_active: last_active
       }
     }
@@ -76,7 +78,7 @@ class SerializeVitallySalesAccount
     if @school.subscription
       @school.subscription.account_type
     else
-      'N/A'
+      NOT_APPLICABLE
     end
   end
 
@@ -97,12 +99,12 @@ class SerializeVitallySalesAccount
 
   private def subscription_start_date
     subscription = @school&.present_and_future_subscriptions&.first
-    subscription&.start_date || 'N/A'
+    subscription&.start_date || NOT_APPLICABLE
   end
 
   private def subscription_expiration_date
     subscription = @school&.present_and_future_subscriptions&.last
-    subscription&.expiration || 'N/A'
+    subscription&.expiration || NOT_APPLICABLE
   end
 
   private def last_active

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -52,6 +52,9 @@ class SerializeVitallySalesAccount
         school_link: school_link,
         created_at: @school.created_at,
         premium_expiry_date: subscription_expiration_date,
+        premium_start_date: subscription_start_date,
+        annual_revenue_current_contract: @school.subscription&.payment_amount || 'N/A',
+        stripe_invoice_id_current_contract: @school.subscription&.stripe_invoice_id || 'N/A',
         last_active: last_active
       }
     }
@@ -73,7 +76,7 @@ class SerializeVitallySalesAccount
     if @school.subscription
       @school.subscription.account_type
     else
-      'NA'
+      'N/A'
     end
   end
 
@@ -92,9 +95,14 @@ class SerializeVitallySalesAccount
     "https://www.quill.org/cms/schools/#{@school.id}"
   end
 
+  private def subscription_start_date
+    subscription = @school&.present_and_future_subscriptions&.first
+    subscription&.start_date || 'N/A'
+  end
+
   private def subscription_expiration_date
     subscription = @school&.present_and_future_subscriptions&.last
-    subscription&.expiration || 'NA'
+    subscription&.expiration || 'N/A'
   end
 
   private def last_active

--- a/services/QuillLMS/spec/models/district_spec.rb
+++ b/services/QuillLMS/spec/models/district_spec.rb
@@ -88,7 +88,12 @@ describe District, type: :model do
           diagnostics_completed_this_year: 0,
           diagnostics_completed_last_year: 0,
           percent_diagnostics_completed_this_year: 0,
-          percent_diagnostics_completed_last_year: 0
+          percent_diagnostics_completed_last_year: 0,
+          premium_start_date: 'N/A',
+          premium_expiry_date: 'N/A',
+          district_subscription: 'N/A',
+          annual_revenue_current_contract: 'N/A',
+          stripe_invoice_id_current_contract: 'N/A'
         }
       })
     end
@@ -205,6 +210,30 @@ describe District, type: :model do
         expect(district.vitally_data[:traits]).to include(
           percent_diagnostics_completed_this_year: 0.0
         )
+      end
+    end
+
+    context 'subscription rollups' do
+      let!(:subscription) { create(:subscription, districts: [district],
+        payment_amount: 1800,
+        stripe_invoice_id: 'in_12345678'
+      ) }
+
+      it 'pulls current subscription data' do
+        expect(district.vitally_data[:traits]).to include(
+          premium_start_date: subscription.start_date,
+          premium_expiry_date: subscription.expiration,
+          district_subscription: subscription.account_type,
+          annual_revenue_current_contract: subscription.payment_amount,
+          stripe_invoice_id_current_contract: subscription.stripe_invoice_id
+        )
+      end
+
+      it 'pulls the latest expiration date when multiple subscriptions are active' do
+        later_subscription = create(:subscription, districts: [district], start_date: subscription.start_date, expiration: subscription.expiration + 1.year)
+        earlier_subscription = create(:subscription, districts: [district], start_date: subscription.start_date - 1.year, expiration: subscription.expiration + 10.days)
+
+        expect(district.vitally_data[:traits][:premium_expiry_date]).to eq(later_subscription.expiration)
       end
     end
   end

--- a/services/QuillLMS/spec/models/district_spec.rb
+++ b/services/QuillLMS/spec/models/district_spec.rb
@@ -214,10 +214,13 @@ describe District, type: :model do
     end
 
     context 'subscription rollups' do
-      let!(:subscription) { create(:subscription, districts: [district],
-        payment_amount: 1800,
-        stripe_invoice_id: 'in_12345678'
-      ) }
+      let!(:subscription) {
+        create(:subscription,
+          districts: [district],
+          payment_amount: 1800,
+          stripe_invoice_id: 'in_12345678'
+        )
+      }
 
       it 'pulls current subscription data' do
         expect(district.vitally_data[:traits]).to include(

--- a/services/QuillLMS/spec/models/district_spec.rb
+++ b/services/QuillLMS/spec/models/district_spec.rb
@@ -89,11 +89,11 @@ describe District, type: :model do
           diagnostics_completed_last_year: 0,
           percent_diagnostics_completed_this_year: 0,
           percent_diagnostics_completed_last_year: 0,
-          premium_start_date: 'N/A',
-          premium_expiry_date: 'N/A',
-          district_subscription: 'N/A',
-          annual_revenue_current_contract: 'N/A',
-          stripe_invoice_id_current_contract: 'N/A'
+          premium_start_date: District::VITALLY_NOT_APPLICABLE,
+          premium_expiry_date: District::VITALLY_NOT_APPLICABLE,
+          district_subscription: District::VITALLY_NOT_APPLICABLE,
+          annual_revenue_current_contract: District::VITALLY_NOT_APPLICABLE,
+          stripe_invoice_id_current_contract: District::VITALLY_NOT_APPLICABLE
         }
       })
     end

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -84,7 +84,7 @@ describe 'SerializeVitallySalesAccount' do
       frl: 0,
       ppin: nil,
       nces_id: '111111111',
-      school_subscription: 'NA',
+      school_subscription: 'N/A',
       school_type: 'Rural, Fringe',
       employee_count: 0,
       paid_teacher_subscriptions: 0,
@@ -96,14 +96,20 @@ describe 'SerializeVitallySalesAccount' do
       activities_per_student: 0,
       activities_per_student_this_year: 0,
       activities_finished: 0,
-      school_link: "https://www.quill.org/cms/schools/#{school.id}"
+      school_link: "https://www.quill.org/cms/schools/#{school.id}",
+      premium_expiry_date: 'N/A',
+      premium_start_date: 'N/A',
+      annual_revenue_current_contract: 'N/A',
+      stripe_invoice_id_current_contract: 'N/A',
     )
   end
 
   it 'generates school premium status' do
     school_subscription = create(:subscription,
       account_type: 'SUPER SAVER PREMIUM',
-      expiration: Date.tomorrow
+      expiration: Date.tomorrow,
+      payment_amount: '1800',
+      stripe_invoice_id: 'in_12345678'
     )
     create(:school_subscription,
       subscription_id: school_subscription.id,
@@ -113,10 +119,11 @@ describe 'SerializeVitallySalesAccount' do
     school_data = SerializeVitallySalesAccount.new(school).data
 
     expect(school_data[:traits]).to include(
-      school_subscription: 'SUPER SAVER PREMIUM'
-    )
-    expect(school_data[:traits]).to include(
-      premium_expiry_date: Date.tomorrow
+      school_subscription: school_subscription.account_type,
+      premium_expiry_date: school_subscription.expiration,
+      premium_start_date: school_subscription.start_date,
+      annual_revenue_current_contract: school_subscription.payment_amount,
+      stripe_invoice_id_current_contract: school_subscription.stripe_invoice_id,
     )
   end
 

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -84,7 +84,7 @@ describe 'SerializeVitallySalesAccount' do
       frl: 0,
       ppin: nil,
       nces_id: '111111111',
-      school_subscription: 'N/A',
+      school_subscription: SerializeVitallySalesAccount::NOT_APPLICABLE,
       school_type: 'Rural, Fringe',
       employee_count: 0,
       paid_teacher_subscriptions: 0,
@@ -97,10 +97,10 @@ describe 'SerializeVitallySalesAccount' do
       activities_per_student_this_year: 0,
       activities_finished: 0,
       school_link: "https://www.quill.org/cms/schools/#{school.id}",
-      premium_expiry_date: 'N/A',
-      premium_start_date: 'N/A',
-      annual_revenue_current_contract: 'N/A',
-      stripe_invoice_id_current_contract: 'N/A'
+      premium_expiry_date: SerializeVitallySalesAccount::NOT_APPLICABLE,
+      premium_start_date: SerializeVitallySalesAccount::NOT_APPLICABLE,
+      annual_revenue_current_contract: SerializeVitallySalesAccount::NOT_APPLICABLE,
+      stripe_invoice_id_current_contract: SerializeVitallySalesAccount::NOT_APPLICABLE
     )
   end
 

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -100,7 +100,7 @@ describe 'SerializeVitallySalesAccount' do
       premium_expiry_date: 'N/A',
       premium_start_date: 'N/A',
       annual_revenue_current_contract: 'N/A',
-      stripe_invoice_id_current_contract: 'N/A',
+      stripe_invoice_id_current_contract: 'N/A'
     )
   end
 
@@ -123,7 +123,7 @@ describe 'SerializeVitallySalesAccount' do
       premium_expiry_date: school_subscription.expiration,
       premium_start_date: school_subscription.start_date,
       annual_revenue_current_contract: school_subscription.payment_amount,
-      stripe_invoice_id_current_contract: school_subscription.stripe_invoice_id,
+      stripe_invoice_id_current_contract: school_subscription.stripe_invoice_id
     )
   end
 


### PR DESCRIPTION
## WHAT
Add Vitally sync for Schools and Districts with subscription data

NOTE: The spec (see Notion link below) calls for an additional trait “Purchase Order Number” to be synced, but that trait hasn't been added to our code yet.  It's currently blocked in a code branch that's waiting on some coordination with Operations to go live, so we're skipping it for now.
## WHY
We want Partnerships and Operations to be able to use Vitally to understand revenue information for our entire organization, so we need that data to sync to Vitally
## HOW
- Add some additional values to the Account (school) Vitally sync logic
- Add new traits for Organization (district) sync logic to include all the new attributes

### Notion Card Links
https://www.notion.so/quill/Sync-subscription-related-data-to-Vitally-6e4d9efde2db420a9edb1f40790c6e3d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
