### PR TITLE
Save Feedback History with correct activity_version number

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/feedback_controller.rb
@@ -27,7 +27,7 @@ module Evidence
       @session_id = params[:session_id]
       @previous_feedback = params[:previous_feedback]
       @feedback_types = params[:feedback_types]
-      @activity_version = params[:activity_version] || Evidence.feedback_history_class::DEFAULT_VERSION
+      @activity_version = params[:activity_version] || @prompt.activity.version || Evidence.feedback_history_class::DEFAULT_VERSION
     end
 
     private def save_feedback_history(feedback)

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
@@ -15,8 +15,10 @@ module Evidence
       create(:evidence_plagiarism_text, :text => (plagiarized_text2), :rule => (rule))
     end
 
+    let(:activity_version) { 2 }
     let(:entry) {'hello you'}
-    let!(:prompt) { create(:evidence_prompt) }
+    let(:activity) { create(:evidence_activity, version: activity_version)}
+    let!(:prompt) { create(:evidence_prompt, activity: activity) }
     let!(:hint) { create(:evidence_hint) }
     let!(:rule) { create(:evidence_rule, :rule_type => "plagiarism", :hint => hint) }
     let!(:rule_regex) { create(:evidence_rule, :rule_type => "rules-based-1") }
@@ -42,7 +44,7 @@ module Evidence
           prompt_id: prompt.id,
           activity_session_uid: session_id,
           attempt: attempt,
-          activity_version: Evidence.feedback_history_class::DEFAULT_VERSION,
+          activity_version: activity_version,
           api_metadata: feedback.response[:api]
         )
 


### PR DESCRIPTION
## WHAT
We have a bug in our workflow for saving feedback history. Instead of saving the record with the correct activity version, we're simply defaulting to the `DEFAULT_VERSION` (1) each time. This is causing bugs for our data analysis of activity performance.

## WHY
We're not accurately recording the activity version of a feedback history response. So afterwards, we're unable to perform data analysis on activity version correlation to response patterns. This PR will fix this so that going forwards, we're saving the correct activity version.

## HOW
When saving a feedback_history record, try to fetch that prompt's activity's version number and send it as the parameter for `activity_version`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-bug-where-feedbackHistory-is-not-saving-with-right-activity_version-df0bdd990fa14037a9f4abd9a5a7ffe8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
