### PR TITLE
Premium footer banner added to all pages for un-subscribed teachers

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/banner-with-button.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/banner-with-button.scss
@@ -33,10 +33,28 @@
 .premium-footer {
   background-color: #DF9E3D;
   color: white;
+  .content-container {
+    max-width: 1030px;
+    width: calc(100% - 30px);
+    margin: 0px auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 16px;
+    @media (max-width: 410px) {
+      flex-direction: column;
+      align-items: flex-start;
+      .quill-button {
+        margin-top: 8px;
+      }
+      span {
+        width: 100%;
+      }
+    }
+  }
   .text-section {
     width: 703px;
-    padding-top: 28px;
-    padding-left: 57px;
+    padding-top: 32px;
     padding-bottom: 32px;
 
     h2 {
@@ -60,6 +78,22 @@
     font-weight: 700;
     font-size: 14px;
     line-height: 14px;
+    min-width: min-content;
+  }
+  @media (max-width: 750px) {
+    .text-section {
+      display: inline;
+      width: auto;
+      h2 {
+        font-size: 20px;
+      }
+      p {
+        width: auto;
+      }
+    }
+    .explore-premium-button {
+      margin-bottom: 15px;
+    }
   }
 }
 

--- a/services/QuillLMS/app/assets/stylesheets/shared/banner-with-button.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/banner-with-button.scss
@@ -34,7 +34,7 @@
   background-color: #DF9E3D;
   color: white;
   .content-container {
-    max-width: 1030px;
+    max-width: 1200px;
     width: calc(100% - 30px);
     margin: 0px auto;
     display: flex;

--- a/services/QuillLMS/app/assets/stylesheets/shared/banner-with-button.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/banner-with-button.scss
@@ -30,6 +30,39 @@
   }
 }
 
+.premium-footer {
+  background-color: #DF9E3D;
+  color: white;
+  .text-section {
+    width: 703px;
+    padding-top: 28px;
+    padding-left: 57px;
+    padding-bottom: 32px;
+
+    h2 {
+      font-style: normal;
+      font-weight: 700;
+      font-size: 24px;
+      line-height: 30px;
+    }
+    p {
+      padding-top: 8px;
+      width: 703px;
+      font-style: normal;
+      font-weight: 400;
+      font-size: 15px;
+      line-height: 19px;
+    }
+  }
+  .explore-premium-button {
+    color: #DF9E3D;
+    background-color: white;
+    font-weight: 700;
+    font-size: 14px;
+    line-height: 14px;
+  }
+}
+
 .demo-account-banner {
   background-color: #FFEFC7;
   color: #9B5F05;

--- a/services/QuillLMS/app/assets/stylesheets/shared/footer.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/footer.scss
@@ -1,16 +1,16 @@
 .footer-white {
   background-color: #fff;
-  padding: 78px 0px 172px;
   width: 100%;
-  max-width: 950px;
-  display: flex;
+  display: inherit;
   justify-content: center;
   box-shadow: 0 100vh 0 100vh #fff;
   margin: 300px auto auto auto;
   .footer-content {
     display: flex;
     flex-direction: column;
-    max-width: 1300px;
+    max-width: 950px;
+    margin: auto;
+    padding: 78px 0px 172px;
     width: 100%;
     > * {
       flex-grow: 1;

--- a/services/QuillLMS/app/helpers/navigation_helper.rb
+++ b/services/QuillLMS/app/helpers/navigation_helper.rb
@@ -44,7 +44,7 @@ module NavigationHelper
     when 'locked'
       current_user.last_expired_subscription&.is_trial? ? "<span>Premium</span>#{star_img}<span>Trial Expired</span>" : "<span>Premium</span>#{star_img}<span>Subscription Expired</span>"
     when 'none', nil
-      "<span>Try Premium</span>#{star_img}"
+      "<span>Explore Premium</span>#{star_img}"
     end
   end
 

--- a/services/QuillLMS/app/views/application/_footer.html.erb
+++ b/services/QuillLMS/app/views/application/_footer.html.erb
@@ -2,6 +2,7 @@
 
 	<% is_student = current_user&.role == 'student' %>
 	<% footer_class = is_student ? 'footer-white student-footer' : 'footer-white' %>
+	<%= render partial: 'application/premium_footer' %>
 
 	<footer class="<%=footer_class%>">
 		<div class="footer-content">

--- a/services/QuillLMS/app/views/application/_footer.html.erb
+++ b/services/QuillLMS/app/views/application/_footer.html.erb
@@ -2,9 +2,12 @@
 
 	<% is_student = current_user&.role == 'student' %>
 	<% footer_class = is_student ? 'footer-white student-footer' : 'footer-white' %>
-	<%= render partial: 'application/premium_footer' %>
 
 	<footer class="<%=footer_class%>">
+		<div class="footer-banner">
+			<%= render partial: 'application/premium_footer' %>
+		</div>
+		<br />
 		<div class="footer-content">
 			<% if !is_student %>
 				<div class="top-half">

--- a/services/QuillLMS/app/views/application/_premium_footer.html.erb
+++ b/services/QuillLMS/app/views/application/_premium_footer.html.erb
@@ -1,0 +1,12 @@
+<% if !current_user || (current_user.teacher? && !current_user.is_premium?) %>
+  <div class="banner-with-button premium-footer">
+    <div class="content-container">
+      <div class="text-section">
+        <h2>Learn More About Quill Premium</h2>
+        <p>Premium subscriptions for schools and districts interested in priority technical support, additional reporting, and support from Quill's professional learning team--plus an option for individual teachers</p>
+      </div>
+
+      <a class="quill-button primary medium focus-on-light explore-premium-button" href="/premium">Explore Premium</a>
+    </div>
+  </div>
+<% end %>

--- a/services/QuillLMS/app/views/application/_premium_footer.html.erb
+++ b/services/QuillLMS/app/views/application/_premium_footer.html.erb
@@ -1,5 +1,5 @@
 <% if !current_user || (current_user.teacher? && !current_user.is_premium?) %>
-  <div class="banner-with-button premium-footer">
+  <div class="premium-footer">
     <div class="content-container">
       <div class="text-section">
         <h2>Learn More About Quill Premium</h2>

--- a/services/QuillLMS/app/views/pages/connect_tool.erb
+++ b/services/QuillLMS/app/views/pages/connect_tool.erb
@@ -257,7 +257,6 @@
 
 </div>
 
-
 <% if current_user %>
   <%= render partial: 'footer' %>
 <% else %>

--- a/services/QuillLMS/app/views/pages/connect_tool.erb
+++ b/services/QuillLMS/app/views/pages/connect_tool.erb
@@ -257,6 +257,7 @@
 
 </div>
 
+
 <% if current_user %>
   <%= render partial: 'footer' %>
 <% else %>

--- a/services/QuillLMS/app/views/pages/shared/_footer.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_footer.html.erb
@@ -1,4 +1,5 @@
 <% if show_site_navigation? %>
+  <%= render partial: 'application/premium_footer' %>
   <footer class="home-footer">
     <div class="footer-navigation">
       <ul>

--- a/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
@@ -92,9 +92,9 @@ describe NavigationHelper do
       allow(helper).to receive(:current_user) { double(:user, premium_state: "locked", last_expired_subscription: trial_subscription) }
       expect(helper.premium_tab_copy).to eq "<span>Premium</span><img alt='' src='https://assets.quill.org/images/icons/star.svg'></img><span>Trial Expired</span>"
       allow(helper).to receive(:current_user) { double(:user, premium_state: nil) }
-      expect(helper.premium_tab_copy).to eq "<span>Try Premium</span><img alt='' src='https://assets.quill.org/images/icons/star.svg'></img>"
+      expect(helper.premium_tab_copy).to eq "<span>Explore Premium</span><img alt='' src='https://assets.quill.org/images/icons/star.svg'></img>"
       allow(helper).to receive(:current_user) { double(:user, premium_state: "none") }
-      expect(helper.premium_tab_copy).to eq "<span>Try Premium</span><img alt='' src='https://assets.quill.org/images/icons/star.svg'></img>"
+      expect(helper.premium_tab_copy).to eq "<span>Explore Premium</span><img alt='' src='https://assets.quill.org/images/icons/star.svg'></img>"
     end
   end
 


### PR DESCRIPTION
## WHAT
Add an "Explore Premium" footer banner to all pages in Quill. This displays for all un-signed-in users and all teachers who are not currently subscribed to premium. Also change button text "Try Premium" to "Explore Premium".

## WHY
Promote premium features across all pages so teachers are more aware of the premium feature.

## HOW
Create the footer element and add to all pages (with appropriate styling adjustments to make it look right on all pages and screen sizes).

### Screenshots
<img width="1171" alt="Screen Shot 2023-01-18 at 3 47 58 PM" src="https://user-images.githubusercontent.com/57366100/213117905-84915fb9-f3c8-4470-aad0-df362d34cdbb.png">
<img width="1126" alt="Screen Shot 2023-01-18 at 3 48 09 PM" src="https://user-images.githubusercontent.com/57366100/213117915-dae7d6e9-1a9a-4d03-a7fa-88805c633971.png">
<img width="909" alt="Screen Shot 2023-01-18 at 3 48 28 PM" src="https://user-images.githubusercontent.com/57366100/213117927-b4336df2-86b2-45f0-b0d9-be469032e1a9.png">
<img width="328" alt="Screen Shot 2023-01-18 at 3 48 45 PM" src="https://user-images.githubusercontent.com/57366100/213117939-1f22ffaf-248f-440a-9899-81bbe3074446.png">

### Notion Card Links
https://www.notion.so/quill/Updates-to-Premium-Page-copy-edits-d522e9b7e0a64b5091b77b9bf4fee68e
https://www.notion.so/quill/New-Explore-Premium-Footer-Banner-0a71955d71a142548bead2466903c5bd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
