### PR TITLE
open archived recommendations when assigning them

### DIFF
--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -23,7 +23,7 @@ class AssignRecommendationsWorker
 
     if units.present?
       unit = find_unit(units)
-      unit.update(visible: true) if unit && !unit.visible
+      unit.update(visible: true, open: true) if unit && !unit.visible
     end
 
     classroom_data = {


### PR DESCRIPTION
## WHAT
Set "open" to true for archived recommendations when they are being re-assigned.

## WHY
Teachers are confused when they archive recommendations, then re-assign them, but they don't appear on their student dashboards (because they are still closed).

## HOW
Just update the logic to set `open` to true when `visible` is set to true in this worker.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Glitch-with-closed-activity-packs-72cf4e4d8f014e20b3288f58689b730c?d=b02d26b0873d44319f7fcdf187335470

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
