### PR TITLE
Home Page speed and accessibility updates

### DIFF
--- a/services/QuillLMS/app/views/application/_footer.html.erb
+++ b/services/QuillLMS/app/views/application/_footer.html.erb
@@ -37,9 +37,9 @@
 				</ul>
 
 				<ul class="footer-social">
-					<li><a class="focus-on-light" href="https://twitter.com/Quill_org"><img alt="Twitter icon" data-src="https://assets.quill.org/images/icons/social-twitter.svg" class='lazyload'/></a></li>
-					<li><a class="focus-on-light" href="https://www.instagram.com/quill_org"><img alt="Instagram icon" data-src="https://assets.quill.org/images/icons/social-instagram.svg" class='lazyload' /></a></li>
-					<li><a class="focus-on-light" href="https://facebook.com/quill.org"><img alt="Facebook icon" data-src="https://assets.quill.org/images/icons/social-facebook.svg" class='lazyload'/></a></li>
+					<li><a class="focus-on-light" href="https://twitter.com/Quill_org" aria-label="Visit Quill on Twitter"><img alt="Twitter icon" data-src="https://assets.quill.org/images/icons/social-twitter.svg" class='lazyload'/></a></li>
+					<li><a class="focus-on-light" href="https://www.instagram.com/quill_org" aria-label="Visit Quill on Instagram"><img alt="Instagram icon" data-src="https://assets.quill.org/images/icons/social-instagram.svg" class='lazyload' /></a></li>
+					<li><a class="focus-on-light" href="https://facebook.com/quill.org" aria-label="Visit Quill on Facebook"><img alt="Facebook icon" data-src="https://assets.quill.org/images/icons/social-facebook.svg" class='lazyload'/></a></li>
 				</ul>
 
 			</div>

--- a/services/QuillLMS/app/views/application/_footer.html.erb
+++ b/services/QuillLMS/app/views/application/_footer.html.erb
@@ -8,7 +8,7 @@
 			<% if !is_student %>
 				<div class="top-half">
 					<div class="logo-and-text">
-						<a href="/"><img src="https://assets.quill.org/images/logos/quill-gray-logo-footer.svg"></img></a>
+						<a href="/"><img data-src="https://assets.quill.org/images/logos/quill-gray-logo-footer.svg" class='lazyload'></img></a>
 						<%= link_to "Quill is a free literacy tool powered by an open source, non-profit community of educators and developers.","#{root_path}mission", class: 'footer-copy' %>
 					</div>
 
@@ -37,9 +37,9 @@
 				</ul>
 
 				<ul class="footer-social">
-					<li><a class="focus-on-light" href="https://twitter.com/Quill_org"><img alt="Twitter icon" src="https://assets.quill.org/images/icons/social-twitter.svg" /></a></li>
-					<li><a class="focus-on-light" href="https://www.instagram.com/quill_org"><img alt="Instagram icon" src="https://assets.quill.org/images/icons/social-instagram.svg" /></a></li>
-					<li><a class="focus-on-light" href="https://facebook.com/quill.org"><img alt="Facebook icon" src="https://assets.quill.org/images/icons/social-facebook.svg" /></a></li>
+					<li><a class="focus-on-light" href="https://twitter.com/Quill_org"><img alt="Twitter icon" data-src="https://assets.quill.org/images/icons/social-twitter.svg" class='lazyload'/></a></li>
+					<li><a class="focus-on-light" href="https://www.instagram.com/quill_org"><img alt="Instagram icon" data-src="https://assets.quill.org/images/icons/social-instagram.svg" class='lazyload' /></a></li>
+					<li><a class="focus-on-light" href="https://facebook.com/quill.org"><img alt="Facebook icon" data-src="https://assets.quill.org/images/icons/social-facebook.svg" class='lazyload'/></a></li>
 				</ul>
 
 			</div>

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -22,7 +22,7 @@
   <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
   <link rel="canonical" href="https://www.quill.org<%= request.path %>">
 
-  <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
+  <script defer src="<%= ENV['FONT_AWESOME_KIT_LINK'] %>" crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
   <!-- Inspectlet tracking -->
   <% if ENV.fetch('SHOW_INSPECTLET', 'true') == 'true' %>
     <% if current_user&.teacher? %>

--- a/services/QuillLMS/app/views/application/_sub_header.html.erb
+++ b/services/QuillLMS/app/views/application/_sub_header.html.erb
@@ -31,13 +31,13 @@
   <% if on_sign_up_or_log_in %>
     <div class="logo-only">
       <a aria-label="Quill" class="focus-on-dark" href=<%= root_path %>>
-        <img data-src="/images/quill_header_logo.svg" alt="Quill logo" class='lazyload'>
+        <img src="/images/quill_header_logo.svg" alt="Quill logo" />
       </a>
     </div>
   <% else %>
 	  <div>
 			<a aria-label="Quill" class="focus-on-dark" href=<%= root_path %> >
-  			<img data-src="https://assets.quill.org/images/logos/quill-logo-white-2022.svg" alt="Quill.org logo" class='lazyload'>
+  			<img src="https://assets.quill.org/images/logos/quill-logo-white-2022.svg" alt="Quill.org logo" />
   		</a>
   	</div>
 

--- a/services/QuillLMS/app/views/application/_sub_header.html.erb
+++ b/services/QuillLMS/app/views/application/_sub_header.html.erb
@@ -31,13 +31,13 @@
   <% if on_sign_up_or_log_in %>
     <div class="logo-only">
       <a aria-label="Quill" class="focus-on-dark" href=<%= root_path %>>
-        <img src="/images/quill_header_logo.svg" alt="Quill logo">
+        <img data-src="/images/quill_header_logo.svg" alt="Quill logo" class='lazyload'>
       </a>
     </div>
   <% else %>
 	  <div>
 			<a aria-label="Quill" class="focus-on-dark" href=<%= root_path %> >
-  			<img src="https://assets.quill.org/images/logos/quill-logo-white-2022.svg" alt="Quill.org logo">
+  			<img data-src="https://assets.quill.org/images/logos/quill-logo-white-2022.svg" alt="Quill.org logo" class='lazyload'>
   		</a>
   	</div>
 

--- a/services/QuillLMS/app/views/evidence/_first_topic.html.erb
+++ b/services/QuillLMS/app/views/evidence/_first_topic.html.erb
@@ -1,6 +1,6 @@
 <div class="topic-section">
   <p class="topic">Culture & Society Topics</p>
-  <img alt="photograph of a football" src="https://assets.quill.org/images/evidence/home_page/EvidenceLandingPage_Image_Football.png"/>
+  <img class="lazyload" alt="photograph of a football" data-src="https://assets.quill.org/images/evidence/home_page/EvidenceLandingPage_Image_Football.png"/>
   <p class="activity-title">"Should Schools Have Grade Requirements for Student Athletes?"</p>
   <a href='https://www.quill.org/evidence/#/play?uid=180&skipToPrompts=true' target="_blank" class="q-button text-quillteal bg-white">View a sample activity</a>
 </div>

--- a/services/QuillLMS/app/views/evidence/_second_topic.html.erb
+++ b/services/QuillLMS/app/views/evidence/_second_topic.html.erb
@@ -1,6 +1,6 @@
 <div class="topic-section">
   <p class="topic">Science Topics</p>
-  <img alt="photograph of a cow" src="https://assets.quill.org/images/evidence/home_page/EvidenceLandingPage_Image_Cow.png"/>
+  <img class="lazyload" alt="photograph of a cow" data-src="https://assets.quill.org/images/evidence/home_page/EvidenceLandingPage_Image_Cow.png"/>
   <p class="activity-title">"How Does Eating Meat Impact Global Warming?"</p>
   <a href='https://www.quill.org/evidence/#/play?uid=176&skipToPrompts=true' target="_blank" class="q-button text-quillteal bg-white">View a sample activity</a>
 </div>

--- a/services/QuillLMS/app/views/evidence/_third_topic.html.erb
+++ b/services/QuillLMS/app/views/evidence/_third_topic.html.erb
@@ -1,6 +1,6 @@
 <div class="topic-section">
   <p class="topic">Social Studies Topics</p>
-  <img alt="photograph of the Statue of Liberty" src="https://assets.quill.org/images/evidence/home_page/EvidenceLandingPage_Image_StatueOfLiberty.png"/>
+  <img class="lazyload" alt="photograph of the Statue of Liberty" data-src="https://assets.quill.org/images/evidence/home_page/EvidenceLandingPage_Image_StatueOfLiberty.png"/>
   <p class="activity-title" id="first-title-topic">U.S. History</p>
   <p class="activity-title" id="second-title-topic">World History</p>
   <p id="under-development">Under Development, Coming 2023</p>

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -24,7 +24,7 @@
 
     <script defer src="<%= ENV['FONT_AWESOME_KIT_LINK'] %>" crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
     <%= render partial: 'typekit' unless Rails.env.test? %>
-    <%= javascript_pack_tag((@js_file || 'home'), 'crossorigin': 'anonymous') %>
+    <%= javascript_pack_tag((@js_file || 'home'), defer: true, 'crossorigin': 'anonymous') %>
     <%= stylesheet_pack_tag('home') %>
     <%= stylesheet_pack_tag('shared') %>
     <%= csrf_meta_tags %>

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -22,7 +22,7 @@
     <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
     <link rel="canonical" href="https://www.quill.org<%= request.path %>">
 
-    <script defer src=<%= ENV['FONT_AWESOME_KIT_LINK'] %> crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
+    <script defer src="<%= ENV['FONT_AWESOME_KIT_LINK'] %>" crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
     <%= render partial: 'typekit' unless Rails.env.test? %>
     <%= javascript_pack_tag((@js_file || 'home'), 'crossorigin': 'anonymous') %>
     <%= stylesheet_pack_tag('home') %>

--- a/services/QuillLMS/app/views/pages/connect_tool.erb
+++ b/services/QuillLMS/app/views/pages/connect_tool.erb
@@ -22,7 +22,7 @@
     </section>
 
     <section class="tool-animation-section " id="overview">
-          <video class='tool-animation' src=<%= "#{ENV['CDN_URL']}/videos/tools/connect.mp4" %> autoplay loop/>
+          <video class='tool-animation lazyload' data-src=<%= "#{ENV['CDN_URL']}/videos/tools/connect.mp4" %> autoplay loop/>
     </section>
 
     <section class="walk-thru-wrapper desktop" id="how-it-works">
@@ -118,7 +118,7 @@
       </div>
         <div class="walk-thru-step">
             <div class="content-wrapper">
-              <img src=<%= "#{ENV['CDN_URL']}/images/tools/connect/attempt_1.png" %> alt="connect image">
+              <img data-src=<%= "#{ENV['CDN_URL']}/images/tools/connect/attempt_1.png" %> alt="connect image lazyload">
               <div class="blurb">
                   <h2><span>1st Attempt:</span> Write Concisely</h2>
                   <p>
@@ -129,7 +129,7 @@
         </div>
         <div class="walk-thru-step">
             <div class="content-wrapper">
-              <img src=<%= "#{ENV['CDN_URL']}/images/tools/connect/attempt_2.png" %> alt="connect image">
+              <img data-src=<%= "#{ENV['CDN_URL']}/images/tools/connect/attempt_2.png" %> alt="connect image lazyload">
                 <div class="blurb">
                     <h2><span>2nd Attempt:</span> Show Relationships</h2>
                     <p>
@@ -177,21 +177,21 @@
           <div class="carousel-inner" role="listbox">
               <div class="item active">
                 <div class="wrapper">
-                  <img src=<%= "#{ENV['CDN_URL']}/images/tools/connect/visual_overview_screenshot.png" %> alt="Chania">
+                  <img data-src=<%= "#{ENV['CDN_URL']}/images/tools/connect/visual_overview_screenshot.png" %> alt="Chania" class="lazyload">
                 </div>
                 <p>Teachers can use their activity summary report to see which concepts the student has mastered and which ones they need to practice.</p>
               </div>
 
               <div class="item">
                 <div class="wrapper">
-                  <img src=<%= "#{ENV['CDN_URL']}/images/tools/connect/analysis_screenshot.png" %> alt="Chania">
+                  <img data-src=<%= "#{ENV['CDN_URL']}/images/tools/connect/analysis_screenshot.png" %> alt="Chania" class="lazyload">
                 </div>
                 <p>Teachers see reports that state exactly which errors the student made and which concepts the student mastered.</p>
               </div>
 
               <div class="item">
                 <div class="wrapper">
-                  <img src=<%= "#{ENV['CDN_URL']}/images/tools/connect/activities_screenshot.png" %> alt="Chania">
+                  <img data-src=<%= "#{ENV['CDN_URL']}/images/tools/connect/activities_screenshot.png" %> alt="Chania" class='lazyload'>
                 </div>
                 <p>Teachers have access to over 200 exercises aligned with the Common Core language standards.</p>
               </div>
@@ -221,7 +221,7 @@
 
   <section>
     <div class="boy-playing-quill">
-      <img src=<%= "#{ENV['CDN_URL']}/images/tools/connect/laura_marshall_student.png" %> alt="boy playing quill">
+      <img data-src=<%= "#{ENV['CDN_URL']}/images/tools/connect/laura_marshall_student.png" %> alt="boy playing quill" class='lazyload'>
     </div>
   </section>
 

--- a/services/QuillLMS/app/views/pages/home_new.html.erb
+++ b/services/QuillLMS/app/views/pages/home_new.html.erb
@@ -118,73 +118,73 @@
         <div class="flags">
           <span class="flags-row">
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/spain.png"/>
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/spain.png" alt="Flag of Spain"/>
               <p class="flag-label">Spanish</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/china.png"/>
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/china.png" alt="Flag of China"/>
               <p class="flag-label">Mandarin</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/france.png"/>
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/france.png" alt="Flag of Flance"/>
               <p class="flag-label">French</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/vietnam.png"/>
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/vietnam.png" alt="Flag of Vietnam"/>
               <p class="flag-label">Vietnamese</p>
             </span>
           </span>
           <span class="flags-row">
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/egypt.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/egypt.png" alt="Flag of Egypt">
               <p class="flag-label">Arabic</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/india.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/india.png" alt="Flag of India">
               <p class="flag-label">Hindi</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/russia.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/russia.png" alt="Flag of Russia">
               <p class="flag-label">Russian</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/ukraine.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/ukraine.png" alt="Flag of Ukraine">
               <p class="flag-label">Ukrainian</p>
             </span>
           </span>
           <span class="flags-row">
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/pakistan.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/pakistan.png" alt="Flag of Pakistan">
               <p class="flag-label">Urdu</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/germany.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/germany.png" alt="Flag of Pakistan">
               <p class="flag-label">German</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/philippines.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/philippines.png" alt="Flag of Philippines">
               <p class="flag-label">Tagalog</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/brazil.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/brazil.png" alt="Flag of Brazil">
               <p class="flag-label">Portuguese</p>
             </span>
           </span>
           <span class="flags-row">
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/thailand.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/thailand.png" alt="Flag of Thailand">
               <p class="flag-label">Thai</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/afghanistan.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/afghanistan.png" alt="Flag of Afghanistan">
               <p class="flag-label">Dari</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/japan.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/japan.png" alt="Flag of Japan">
               <p class="flag-label">Japanese</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/south_korea.png">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/south_korea.png" alt="Flag of South Korea">
               <p class="flag-label">Korean</p>
             </span>
           </span>
@@ -281,42 +281,42 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
   <div class="features">
     <div class="feature">
       <div class="feature-img-container">
-        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/feedback_icon.svg" alt=""/>
+        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/feedback_icon.svg" alt="Paper with incorrect and correct marks"/>
       </div>
       <p class="feature-heading">Get immediate feedback for your students</p>
       <p class="feature-sub-heading">Save time grading and watch your students correct their mistakes instantly.</p>
     </div>
     <div class="feature">
       <div class="feature-img-container">
-        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/intervene_icon.svg" alt=""/>
+        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/intervene_icon.svg" alt="line graph"/>
       </div>
       <p class="feature-heading">Intervene where students struggle</p>
       <p class="feature-sub-heading">See exactly where your students need intervention with our comprehensive reports.</p>
     </div>
     <div class="feature">
       <div class="feature-img-container">
-        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/differentiate_icon.svg" alt=""/>
+        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/differentiate_icon.svg" alt="Globe"/>
       </div>
       <p class="feature-heading">Differentiate learning to meet the <br/>needs of all students</p>
       <p class="feature-sub-heading">Assign specific activities for ELLs and students with learning differences.</p>
     </div>
     <div class="feature">
       <div class="feature-img-container">
-        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/adaptive_icon.svg" alt=""/>
+        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/adaptive_icon.svg" alt="Criss-crossed lines"/>
       </div>
       <p class="feature-heading">Engage students with adaptive activities</p>
       <p class="feature-sub-heading">Challenge students with questions that automatically adapt based on their previous responses.</p>
     </div>
     <div class="feature">
       <div class="feature-img-container">
-        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/common_core_icon.svg" alt=""/>
+        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/common_core_icon.svg" alt="Common Core logo"/>
       </div>
       <p class="feature-heading">Align with the Common Core Standards</p>
       <p class="feature-sub-heading">Easily meet Common Core language standards with our aligned activities.</p>
     </div>
     <div class="feature">
       <div class="feature-img-container">
-        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/classroom_icon.svg" alt=""/>
+        <img class="lazyload" data-src="https://assets.quill.org/images/homepage/classroom_icon.svg" alt="Online classroom"/>
       </div>
       <p class="feature-heading">Easily sign up with Google Classroom</p>
       <p class="feature-sub-heading">With one click all of your students and classes will be imported.</p>

--- a/services/QuillLMS/app/views/pages/home_new.html.erb
+++ b/services/QuillLMS/app/views/pages/home_new.html.erb
@@ -329,12 +329,12 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
   <div class="concepts">
     <a class="concept-link" target="_blank" href="/activity_sessions/anonymous?activity_id=299">Parallel Structure</a>
     <a class="concept-link" target="_blank" href="/activity_sessions/anonymous?activity_id=178">Capitalization</a>
-    <a class="concept-link" target="_blank" href="http://quill.org/connect/#/play/lesson/-KQX-YEGiFW71KKpep2X">Subordinating Conjunctions</a>
-    <a class="concept-link" target="_blank" href="http://quill.org/connect/#/play/lesson/-KS7QDRfWsPhAZF27hfL">Coordinating Conjunctions</a>
-    <a class="concept-link" target="_blank" href="http://quill.org/connect/#/play/lesson/-KRizUHvbl3hLJH6eey3">Commas</a>
+    <a class="concept-link" target="_blank" href="/connect/#/play/lesson/-KQX-YEGiFW71KKpep2X">Subordinating Conjunctions</a>
+    <a class="concept-link" target="_blank" href="/connect/#/play/lesson/-KS7QDRfWsPhAZF27hfL">Coordinating Conjunctions</a>
+    <a class="concept-link" target="_blank" href="/connect/#/play/lesson/-KRizUHvbl3hLJH6eey3">Commas</a>
     <a class="concept-link" target="_blank" href="/activity_sessions/anonymous?activity_id=291">Prepositions</a>
     <a class="concept-link" target="_blank" href="/activity_sessions/anonymous?activity_id=298">Pronoun Reference</a>
-    <a class="concept-link" target="_blank" href="http://quill.org/connect/#/play/lesson/-KXHxOiPXAMZmQOGGer9">Run-ons</a>
+    <a class="concept-link" target="_blank" href="/connect/#/play/lesson/-KXHxOiPXAMZmQOGGer9">Run-ons</a>
     <a class="concept-link" target="_blank" href="/activity_sessions/anonymous?activity_id=297">Subject-Verb Agreement</a>
     <a class="concept-link" target="_blank" href="/activity_sessions/anonymous?activity_id=154">Verb Tense</a>
     <a class="concept-link" target="_blank" href="/activity_sessions/anonymous?activity_id=111">Commonly Confused Words</a>
@@ -453,8 +453,8 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
       <a class="quill-button medium secondary outlined" href=<%= premium_path %> target="_blank">Learn more</a>
     </div>
   </div>
-  <img src=<%="#{ENV['CDN_URL']}/images/homepage/quill-premium-user-interfaces.svg"%>
-  class="quill-premium-user-interfaces">
+  <img data-src=<%="#{ENV['CDN_URL']}/images/homepage/quill-premium-user-interfaces.svg"%>
+  class="quill-premium-user-interfaces lazyload">
 </section>
 
 <section class="press-section">

--- a/services/QuillLMS/app/views/pages/home_new.html.erb
+++ b/services/QuillLMS/app/views/pages/home_new.html.erb
@@ -62,7 +62,7 @@
 <section class='tool-section bg-tool-orange'>
   <div class="tool connect-tool">
     <div class='info-section'>
-      <a href="/tools/connect/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_connect_white.svg' alt="Quill Connect Icon">Quill Connect</h2></a>
+      <a href="/tools/connect/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_connect_white.svg' alt=''>Quill Connect</h2></a>
       <p class='blurb'>Help your students advance from fragmented and run-on sentences to complex and well structured ones.</p>
       <%= render_dash(@is_mobile) %>
       <%= render_video_content(@device, 'mobile','https://assets.quill.org/videos/tools/connect.mp4') %>
@@ -82,7 +82,7 @@
   <div class="tool lessons-tool">
     <%= render_video_content(@device, 'desktop', 'https://assets.quill.org/videos/tools/lessons.mp4') %>
     <div class='info-section right'>
-      <a href="/tools/lessons/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/icon_lessons_white.svg' alt="Quill Lessons Icon">Quill Lessons</h2></a>
+      <a href="/tools/lessons/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/icon_lessons_white.svg' alt=''>Quill Lessons</h2></a>
       <p class='blurb'>Quill Lessons enables teachers to lead whole-class and small group writing instruction.</p>
       <%= render_dash(@is_mobile) %>
       <%= render_video_content(@device, 'mobile', 'https://assets.quill.org/videos/tools/lessons.mp4') %>
@@ -100,7 +100,7 @@
 <section class='tool-section bg-tool-red'>
   <div class="tool diagnostic-tool">
     <div class='info-section'>
-      <a href="/tools/diagnostic/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_diagnostic_white.svg' alt='Quill Diagnostic Icon'>Quill Diagnostic</h2></a>
+      <a href="/tools/diagnostic/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_diagnostic_white.svg' alt=''>Quill Diagnostic</h2></a>
       <p class='blurb'>
         Quickly determine which skills your students need to work on with our diagnostics.
       </p>
@@ -126,7 +126,7 @@
               <p class="flag-label">Mandarin</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/france.png" alt="Flag of Flance"/>
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/france.png" alt="Flag of France"/>
               <p class="flag-label">French</p>
             </span>
             <span class="flag-container">
@@ -158,11 +158,11 @@
               <p class="flag-label">Urdu</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/germany.png" alt="Flag of Pakistan">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/germany.png" alt="Flag of Germany">
               <p class="flag-label">German</p>
             </span>
             <span class="flag-container">
-              <img class="lazyload" data-src="https://assets.quill.org/images/flags/philippines.png" alt="Flag of Philippines">
+              <img class="lazyload" data-src="https://assets.quill.org/images/flags/philippines.png" alt="Flag of the Philippines">
               <p class="flag-label">Tagalog</p>
             </span>
             <span class="flag-container">
@@ -200,7 +200,7 @@
   <div class="tool proofreader-tool">
     <%= render_video_content(@device, 'desktop', 'https://assets.quill.org/videos/tools/proofreader.mp4') %>
     <div class='info-section right'>
-      <a href="/tools/proofreader/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_proofreader_white.svg' alt='Quill Proofreader Icon'>Quill Proofreader</h2></a>
+      <a href="/tools/proofreader/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_proofreader_white.svg' alt=''>Quill Proofreader</h2></a>
       <p class='blurb'>Proofreader teaches your students editing skills by having them proofread passages.</p>
       <%= render_dash(@is_mobile) %>
       <%= render_video_content(@device, 'mobile', 'https://assets.quill.org/videos/tools/proofreader.mp4') %>
@@ -220,7 +220,7 @@
 <section class='tool-section bg-tool-purple'>
   <div class="tool grammar-tool">
     <div class='info-section'>
-      <a href="/tools/grammar/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_grammar_white.svg' alt='Quill Grammar Icon'>Quill Grammar</h2></a>
+      <a href="/tools/grammar/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_grammar_white.svg' alt=''>Quill Grammar</h2></a>
       <p class='blurb'>Students practice basic grammar skills, from comma placement to parallel structure.</p>
       <%= render_dash(@is_mobile) %>
       <%= render_video_content(@device, 'mobile', 'https://assets.quill.org/videos/tools/grammar.mp4') %>
@@ -241,7 +241,7 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
   <div class="how-setup">
     <div class="how-img-container">
       <img class="setup-img lazyload" data-src="https://assets.quill.org/images/homepage/setup_icon.svg" alt="Open book"/>
-      <img class="line lazyload" data-src="https://assets.quill.org/images/homepage/line_1.svg"alt="line connecting images"/>
+      <img class="line lazyload" data-src="https://assets.quill.org/images/homepage/line_1.svg" alt=''/>
     </div>
     <div class="how-text-container">
       <h5>Set up your classroom, without IT</h5>
@@ -264,7 +264,7 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
     </div>
     <div class="how-reporting">
       <div class="how-img-container">
-        <img class="line-2 lazyload" data-src="https://assets.quill.org/images/homepage/line_2.svg" alt="line connecting images"/>
+        <img class="line-2 lazyload" data-src="https://assets.quill.org/images/homepage/line_2.svg" alt=''/>
         <img class="setup-img lazyload" data-src="https://assets.quill.org/images/homepage/reporting_icon.svg" alt="graph on a computer screen"/>
       </div>
       <div class="how-text-container">
@@ -427,13 +427,13 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
   <p>Join over 2,000 schools using Quill to advance student writing.</p>
   <div class="schools">
     <div class="schools-img-container">
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/boston_logo.png"alt='Boston Public Schools Logo'/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/boston_logo.png" alt='Boston Public Schools Logo'/>
     </div>
     <div class="schools-img-container">
       <img class="lazyload" data-src="https://assets.quill.org/images/homepage/kipp_logo.png" alt='KIPP: Bay Area Schools Logo'/>
     </div>
     <div class="schools-img-container">
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/houston_logo.png"alt='Houston Independent School District Logo'/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/houston_logo.png" alt='Houston Independent School District Logo'/>
     </div>
     <div class="schools-img-container">
       <img class="lazyload" data-src="https://assets.quill.org/images/homepage/orange_county_logo.png" alt='Orange County Public Schools Logo'/>

--- a/services/QuillLMS/app/views/pages/home_new.html.erb
+++ b/services/QuillLMS/app/views/pages/home_new.html.erb
@@ -62,7 +62,7 @@
 <section class='tool-section bg-tool-orange'>
   <div class="tool connect-tool">
     <div class='info-section'>
-      <a href="/tools/connect/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_connect_white.svg'>Quill Connect</h2></a>
+      <a href="/tools/connect/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_connect_white.svg' alt="Quill Connect Icon">Quill Connect</h2></a>
       <p class='blurb'>Help your students advance from fragmented and run-on sentences to complex and well structured ones.</p>
       <%= render_dash(@is_mobile) %>
       <%= render_video_content(@device, 'mobile','https://assets.quill.org/videos/tools/connect.mp4') %>
@@ -82,7 +82,7 @@
   <div class="tool lessons-tool">
     <%= render_video_content(@device, 'desktop', 'https://assets.quill.org/videos/tools/lessons.mp4') %>
     <div class='info-section right'>
-      <a href="/tools/lessons/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/icon_lessons_white.svg'>Quill Lessons</h2></a>
+      <a href="/tools/lessons/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/icon_lessons_white.svg' alt="Quill Lessons Icon">Quill Lessons</h2></a>
       <p class='blurb'>Quill Lessons enables teachers to lead whole-class and small group writing instruction.</p>
       <%= render_dash(@is_mobile) %>
       <%= render_video_content(@device, 'mobile', 'https://assets.quill.org/videos/tools/lessons.mp4') %>
@@ -100,7 +100,7 @@
 <section class='tool-section bg-tool-red'>
   <div class="tool diagnostic-tool">
     <div class='info-section'>
-      <a href="/tools/diagnostic/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_diagnostic_white.svg'>Quill Diagnostic</h2></a>
+      <a href="/tools/diagnostic/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_diagnostic_white.svg' alt='Quill Diagnostic Icon'>Quill Diagnostic</h2></a>
       <p class='blurb'>
         Quickly determine which skills your students need to work on with our diagnostics.
       </p>
@@ -200,7 +200,7 @@
   <div class="tool proofreader-tool">
     <%= render_video_content(@device, 'desktop', 'https://assets.quill.org/videos/tools/proofreader.mp4') %>
     <div class='info-section right'>
-      <a href="/tools/proofreader/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_proofreader_white.svg'>Quill Proofreader</h2></a>
+      <a href="/tools/proofreader/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_proofreader_white.svg' alt='Quill Proofreader Icon'>Quill Proofreader</h2></a>
       <p class='blurb'>Proofreader teaches your students editing skills by having them proofread passages.</p>
       <%= render_dash(@is_mobile) %>
       <%= render_video_content(@device, 'mobile', 'https://assets.quill.org/videos/tools/proofreader.mp4') %>
@@ -220,7 +220,7 @@
 <section class='tool-section bg-tool-purple'>
   <div class="tool grammar-tool">
     <div class='info-section'>
-      <a href="/tools/grammar/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_grammar_white.svg'>Quill Grammar</h2></a>
+      <a href="/tools/grammar/"><h2 class='q-h2'><img class="icon-white lazyload" data-src='https://assets.quill.org/images/shared/quill_grammar_white.svg' alt='Quill Grammar Icon'>Quill Grammar</h2></a>
       <p class='blurb'>Students practice basic grammar skills, from comma placement to parallel structure.</p>
       <%= render_dash(@is_mobile) %>
       <%= render_video_content(@device, 'mobile', 'https://assets.quill.org/videos/tools/grammar.mp4') %>
@@ -240,8 +240,8 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
   <h3>How Quill Works</h3>
   <div class="how-setup">
     <div class="how-img-container">
-      <img class="setup-img lazyload" data-src="https://assets.quill.org/images/homepage/setup_icon.svg"/>
-      <img class="line lazyload" data-src="https://assets.quill.org/images/homepage/line_1.svg"/>
+      <img class="setup-img lazyload" data-src="https://assets.quill.org/images/homepage/setup_icon.svg" alt="Open book"/>
+      <img class="line lazyload" data-src="https://assets.quill.org/images/homepage/line_1.svg"alt="line connecting images"/>
     </div>
     <div class="how-text-container">
       <h5>Set up your classroom, without IT</h5>
@@ -253,7 +253,7 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
   <div class="how-step-2-3">
     <div class="how-choose">
       <div class="how-img-container">
-        <img class="setup-img lazyload" data-src="https://assets.quill.org/images/homepage/activities_icon.svg"/>
+        <img class="setup-img lazyload" data-src="https://assets.quill.org/images/homepage/activities_icon.svg" alt="Paper in an inbox"/>
       </div>
       <div class="how-text-container">
       <h5>Choose activities</h5>
@@ -264,8 +264,8 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
     </div>
     <div class="how-reporting">
       <div class="how-img-container">
-        <img class="line-2 lazyload" data-src="https://assets.quill.org/images/homepage/line_2.svg"/>
-        <img class="setup-img lazyload" data-src="https://assets.quill.org/images/homepage/reporting_icon.svg"/>
+        <img class="line-2 lazyload" data-src="https://assets.quill.org/images/homepage/line_2.svg" alt="line connecting images"/>
+        <img class="setup-img lazyload" data-src="https://assets.quill.org/images/homepage/reporting_icon.svg" alt="graph on a computer screen"/>
       </div>
       <div class="how-text-container">
       <h5>Use easy-to-consume reporting</h5>
@@ -387,7 +387,7 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
 
       <ul class='inline teacher-list'>
         <li>
-          <a href="#tab-1"><img class="lazyload" data-src=<%="#{ENV['CDN_URL']}/images/shared/Roxanna_Butkus_90.png"%>></img><br>
+          <a href="#tab-1"><img class="lazyload" data-src=<%="#{ENV['CDN_URL']}/images/shared/Roxanna_Butkus_90.png"%> alt="Picture of a teacher"></img><br>
             <p class="teacher-description">
               3rd Grade<br>
               ELA
@@ -395,7 +395,7 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
           </a>
         </li>
         <li>
-          <a href="#tab-2"><img class="lazyload" data-src=<%="#{ENV['CDN_URL']}/images/shared/Sara_Angel_90.png"%>></img><br>
+          <a href="#tab-2"><img class="lazyload" data-src=<%="#{ENV['CDN_URL']}/images/shared/Sara_Angel_90.png"%> alt="Picture of a teacher"></img><br>
             <p class="teacher-description">
               5th Grade<br>
               ELA
@@ -403,7 +403,7 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
           </a>
         </li>
         <li>
-          <a href="#tab-3"><img class="lazyload" data-src=<%="#{ENV['CDN_URL']}/images/shared/Colette_Kang_90.png"%>><br>
+          <a href="#tab-3"><img class="lazyload" data-src=<%="#{ENV['CDN_URL']}/images/shared/Colette_Kang_90.png"%> alt="Picture of a teacher"><br>
             <p class="teacher-description">
               6th Grade<br>
               ELA
@@ -411,7 +411,7 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
           </a>
         </li>
         <li>
-          <a href="#tab-4"><img class="lazyload" data-src=<%="#{ENV['CDN_URL']}/images/shared/daniel_90.png"%>></img><br>
+          <a href="#tab-4"><img class="lazyload" data-src=<%="#{ENV['CDN_URL']}/images/shared/daniel_90.png"%> alt="Picture of a teacher"></img><br>
             <p class="teacher-description">
               8th Grade<br>
               ELA & ELL
@@ -427,19 +427,19 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
   <p>Join over 2,000 schools using Quill to advance student writing.</p>
   <div class="schools">
     <div class="schools-img-container">
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/boston_logo.png"/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/boston_logo.png"alt='Boston Public Schools Logo'/>
     </div>
     <div class="schools-img-container">
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/kipp_logo.png"/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/kipp_logo.png" alt='KIPP: Bay Area Schools Logo'/>
     </div>
     <div class="schools-img-container">
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/houston_logo.png"/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/houston_logo.png"alt='Houston Independent School District Logo'/>
     </div>
     <div class="schools-img-container">
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/orange_county_logo.png"/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/orange_county_logo.png" alt='Orange County Public Schools Logo'/>
     </div>
     <div class="schools-img-container">
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/rocketship_logo.png"/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/rocketship_logo.png" alt='Rocketship Schools Logo' />
     </div>
   </div>
 </section>
@@ -454,18 +454,18 @@ Quill Grammar has over 150 sentence writing activities to help your students. Ou
     </div>
   </div>
   <img data-src=<%="#{ENV['CDN_URL']}/images/homepage/quill-premium-user-interfaces.svg"%>
-  class="quill-premium-user-interfaces lazyload">
+  class="quill-premium-user-interfaces lazyload" alt="Screenshot of Premium Report">
 </section>
 
 <section class="press-section">
-  <img class="lazyload background-img" data-src="https://assets.quill.org/images/homepage/quill_laptop.jpg"/>
+  <img class="lazyload background-img" data-src="https://assets.quill.org/images/homepage/quill_laptop.jpg" alt='student viewing Quill.org on a laptop'/>
   <a class="press-link-container" href="/press">
     <div class="press-links">
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/nyt_logo.svg"/>
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/edsurge_logo.svg"/>
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/iste_logo.svg"/>
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/freetech_logo.svg"/>
-      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/fast_company_logo.svg"/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/nyt_logo.svg" alt='New York Times logo'/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/edsurge_logo.svg" alt='EdSurge logo'/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/iste_logo.svg" alt='ISTE logo'/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/freetech_logo.svg" alt='Free Technology for Teachers'/>
+      <img class="lazyload" data-src="https://assets.quill.org/images/homepage/fast_company_logo.svg" alt='Fast Company Logo'/>
     </div>
   </a>
   <div class="press-cta">

--- a/services/QuillLMS/app/views/pages/shared/_footer.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_footer.html.erb
@@ -95,12 +95,12 @@
       <p>We’re helping every student succeed thanks to our partners:</p>
       <a href="/about">
         <div class="partner-links">
-          <img class="lazyload" src="https://assets.quill.org/images/homepage/gates_logo.svg" />
-          <img class="lazyload" src="https://assets.quill.org/images/homepage/google_logo.svg"/>
-          <img class="lazyload" src="https://assets.quill.org/images/homepage/footer-att.svg"/>
-          <img class="lazyload" src="https://assets.quill.org/images/homepage/footer-fast-forward.svg"/>
-          <img class="lazyload" src="https://assets.quill.org/images/homepage/footer-nbc.svg"/>
-          <img class="lazyload" src="https://assets.quill.org/images/homepage/footer-robin-hood.svg"/>
+          <img class="lazyload" src="https://assets.quill.org/images/homepage/gates_logo.svg" alt='Gates Foundation Logo'/>
+          <img class="lazyload" src="https://assets.quill.org/images/homepage/google_logo.svg" alt='Google.org Logo'/>
+          <img class="lazyload" src="https://assets.quill.org/images/homepage/footer-att.svg" alt='AT&T Logo'/>
+          <img class="lazyload" src="https://assets.quill.org/images/homepage/footer-fast-forward.svg" alt='Fast Forward Logo'/>
+          <img class="lazyload" src="https://assets.quill.org/images/homepage/footer-nbc.svg" alt='NBC Logo'/>
+          <img class="lazyload" src="https://assets.quill.org/images/homepage/footer-robin-hood.svg" alt='Robinhood Logo'/>
         </div>
       </a>
     </div>

--- a/services/QuillLMS/client/app/bundles/Tools/components/evidenceWidget.tsx
+++ b/services/QuillLMS/client/app/bundles/Tools/components/evidenceWidget.tsx
@@ -41,7 +41,7 @@ export const EvidenceWidget = () => {
   return(
     <div className="image-container">
       {reversedUrls.map(url => (
-        <img alt="" className={`evidence-image ${evidenceImageUrl === url ? '' : INACTIVE}`} src={url} />
+        <img alt="Example Evidence Activity" className={`evidence-image lazyload ${evidenceImageUrl === url ? '' : INACTIVE}`} data-src={url} />
       ))}
     </div>
   )

--- a/services/QuillLMS/client/app/bundles/Tools/tests/component/__snapshots__/evidenceHomeHeader.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Tools/tests/component/__snapshots__/evidenceHomeHeader.test.tsx.snap
@@ -57,64 +57,64 @@ exports[`EvidenceHomeSection Component should match snapshot 1`] = `
           className="image-container"
         >
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_12.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_12.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_11.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_11.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_10.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_10.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_9.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_9.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_8.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_8.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_7.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_7.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_6.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_6.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_5.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_5.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_4.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_4.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_3.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_3.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_2.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_2.png"
           />
           <img
-            alt=""
-            className="evidence-image "
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_1.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload "
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_1.png"
           />
         </div>
       </EvidenceWidget>

--- a/services/QuillLMS/client/app/bundles/Tools/tests/component/__snapshots__/evidenceTool.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Tools/tests/component/__snapshots__/evidenceTool.test.tsx.snap
@@ -139,64 +139,64 @@ exports[`EvidenceTool Component should match snapshot 1`] = `
           className="image-container"
         >
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_12.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_12.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_11.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_11.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_10.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_10.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_9.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_9.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_8.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_8.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_7.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_7.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_6.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_6.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_5.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_5.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_4.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_4.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_3.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_3.png"
           />
           <img
-            alt=""
-            className="evidence-image inactive"
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_2.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload inactive"
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_2.png"
           />
           <img
-            alt=""
-            className="evidence-image "
-            src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_1.png"
+            alt="Example Evidence Activity"
+            className="evidence-image lazyload "
+            data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_1.png"
           />
         </div>
       </EvidenceWidget>

--- a/services/QuillLMS/client/app/bundles/Tools/tests/component/__snapshots__/evidenceWidget.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Tools/tests/component/__snapshots__/evidenceWidget.test.tsx.snap
@@ -6,64 +6,64 @@ exports[`EvidenceWidget Component should match snapshot 1`] = `
     className="image-container"
   >
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_12.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_12.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_11.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_11.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_10.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_10.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_9.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_9.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_8.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_8.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_7.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_7.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_6.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_6.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_5.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_5.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_4.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_4.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_3.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_3.png"
     />
     <img
-      alt=""
-      className="evidence-image inactive"
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_2.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload inactive"
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_2.png"
     />
     <img
-      alt=""
-      className="evidence-image "
-      src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_1.png"
+      alt="Example Evidence Activity"
+      className="evidence-image lazyload "
+      data-src="https://assets.quill.org/images/evidence/home_page/widget_images/2x/HeroEvidenceWidget_1.png"
     />
   </div>
 </EvidenceWidget>


### PR DESCRIPTION
## WHAT
Performance and accessibility updates to the home page and tool landing pages
## WHY
Better performance for visitors and this should help our search rankings (Google punishes slow sites).
## HOW
The main 2 things are:
1. Deferring loading of javascript for this layout which used by the home page and the tool landing pages. 
2. Lazy-loading images

Other items:
1. Alt tags to images
2. Other accessibility tags added where flagged
### Screenshots
Tested here:
https://pagespeed.web.dev/

Focusing on Desktop:
#### On Prod
![Screenshot 2023-01-18 at 5 16 39 PM](https://user-images.githubusercontent.com/1304933/213307503-1d7bed5c-2ec8-4443-9a3c-f8d1f8107d0d.png)


#### On Staging with these changes:
![Screenshot 2023-01-18 at 5 17 24 PM](https://user-images.githubusercontent.com/1304933/213307486-91b18d26-6043-41a4-bd70-2c66ea5f43e0.png)


### Notion Card Links
https://www.notion.so/quill/Improve-the-speed-of-the-homepage-a9e73a7477ed42aa8ae4b055607c7641

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
