### PR TITLE
stop showing data with visible: false on student dashboards

### DIFF
--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -157,10 +157,7 @@ class UnitActivity < ApplicationRecord
           COALESCE(cuas.locked, false) AS locked,
           COALESCE(cuas.pinned, false) AS pinned,
           MAX(acts.percentage) AS max_percentage,
-          CASE WHEN
-            false IN (unit.visible, ua.visible, cu.visible, acts.visible, unit.open)
-            OR NOT #{user_id.to_i} = ANY(cu.assigned_student_ids::int[])
-          THEN true ELSE false END as archived,
+          CASE WHEN unit.open = false THEN true ELSE false END as closed,
           SUM(CASE WHEN pre_activity_sessions_classroom_units.id > 0 AND pre_activity_sessions.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) > 0 AS completed_pre_activity_session,
           SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) > 0 AS #{ActivitySession::STATE_FINISHED_KEY},
           SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_STARTED}' THEN 1 ELSE 0 END) AS resume_link
@@ -180,6 +177,7 @@ class UnitActivity < ApplicationRecord
         LEFT JOIN activity_sessions AS pre_activity_sessions
           ON pre_activity_sessions.activity_id = pre_activity.id
           AND pre_activity_sessions.visible = true
+          AND acts.visible = true
           AND pre_activity_sessions.user_id = #{user_id.to_i}
         LEFT JOIN classroom_units AS pre_activity_sessions_classroom_units
           ON pre_activity_sessions_classroom_units.id = pre_activity_sessions.classroom_unit_id
@@ -195,7 +193,11 @@ class UnitActivity < ApplicationRecord
         LEFT JOIN user_pack_sequence_items AS upsi
           ON upsi.pack_sequence_item_id = psi.id
           AND upsi.user_id = #{user_id.to_i}
-        WHERE cu.classroom_id = #{classroom_id.to_i}
+        WHERE #{user_id.to_i} = ANY (cu.assigned_student_ids::int[])
+          AND cu.classroom_id = #{classroom_id.to_i}
+          AND cu.visible = true
+          AND unit.visible = true
+          AND ua.visible = true
           AND (ua.publish_date IS NULL OR ua.publish_date <= NOW())
         GROUP BY
           unit.id,
@@ -233,6 +235,6 @@ class UnitActivity < ApplicationRecord
     )
 
     # we could also do this with a HAVING clause, but it is pretty difficult to read because the logic for computing those values is complex
-    data.filter { |ua| ua['finished'] || !ua['archived'] }
+    data.filter { |ua| ua['finished'] || !ua['closed'] }
   end
 end

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -169,6 +169,7 @@ class UnitActivity < ApplicationRecord
         LEFT JOIN activity_sessions AS acts
           ON cu.id = acts.classroom_unit_id
           AND acts.activity_id = ua.activity_id
+          AND acts.visible = true
           AND acts.user_id = #{user_id.to_i}
         JOIN activities AS activity
           ON activity.id = ua.activity_id
@@ -177,7 +178,6 @@ class UnitActivity < ApplicationRecord
         LEFT JOIN activity_sessions AS pre_activity_sessions
           ON pre_activity_sessions.activity_id = pre_activity.id
           AND pre_activity_sessions.visible = true
-          AND acts.visible = true
           AND pre_activity_sessions.user_id = #{user_id.to_i}
         LEFT JOIN classroom_units AS pre_activity_sessions_classroom_units
           ON pre_activity_sessions_classroom_units.id = pre_activity_sessions.classroom_unit_id

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -110,7 +110,7 @@ const completeHeaders = [
 export default class StudentProfileUnit extends React.Component {
   actionButton = (act, nextActivitySession) => {
     const { isBeingPreviewed, onShowPreviewModal, } = this.props
-    const { repeatable, locked, marked_complete, resume_link, classroom_unit_id, activity_id, finished, pre_activity_id, completed_pre_activity_session, activity_classification_key, name, archived, } = act
+    const { repeatable, locked, marked_complete, resume_link, classroom_unit_id, activity_id, finished, pre_activity_id, completed_pre_activity_session, activity_classification_key, name, closed, } = act
     let linkText = 'Start'
 
     if (activity_classification_key === DIAGNOSTIC_ACTIVITY_CLASSIFICATION_KEY && pre_activity_id && !completed_pre_activity_session) { return <span className="complete-baseline">Complete Baseline first</span>}
@@ -128,10 +128,10 @@ export default class StudentProfileUnit extends React.Component {
       )
     }
 
-    if (archived) {
+    if (closed) {
       return (
         <Tooltip
-          tooltipText="Sorry, you can't replay this activity. Your teacher closed or deleted this activity pack."
+          tooltipText="Sorry, you can't replay this activity. Your teacher closed this activity pack."
           tooltipTriggerText="Replay"
           tooltipTriggerTextClass="quill-button disabled medium secondary outlined"
         />

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -242,7 +242,7 @@ describe ProfilesController, type: :controller do
                 'completed_pre_activity_session' => pre_test_completed_session.present?,
                 'finished' => activity_session&.percentage ? true : false,
                 'resume_link' => activity_session&.state == 'started' ? 1 : 0,
-                'archived' => false
+                'closed' => false
               }
             end
           end

--- a/services/QuillLMS/spec/models/unit_activity_spec.rb
+++ b/services/QuillLMS/spec/models/unit_activity_spec.rb
@@ -271,10 +271,10 @@ describe UnitActivity, type: :model, redis: true do
 
     describe 'behavior around archived (deleted) and closed data' do
       describe 'when an activity session has been completed' do
-        it 'does not include the unit activity if the activity session has been archived' do
+        it 'include the unit activity, but not as completed, if the activity session has been archived' do
           activity_session.update(visible: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == unit_activity.id}
-          expect(relevant_ua).not_to be
+          expect(relevant_ua[ActivitySession::STATE_FINISHED_KEY]).to eq false
         end
 
         it 'does not include the unit activity if the student has been removed from the list of assigned students' do

--- a/services/QuillLMS/spec/models/unit_activity_spec.rb
+++ b/services/QuillLMS/spec/models/unit_activity_spec.rb
@@ -269,65 +269,73 @@ describe UnitActivity, type: :model, redis: true do
       expect(unit_activities.count).to eq(2)
     end
 
-    describe 'behavior around archived data' do
+    describe 'behavior around archived (deleted) and closed data' do
       describe 'when an activity session has been completed' do
-        it 'includes the unit activity even if the activity session has been archived' do
+        it 'does not include the unit activity if the activity session has been archived' do
           activity_session.update(visible: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == unit_activity.id}
-          expect(relevant_ua['archived']).to eq(true)
-          expect(relevant_ua[ActivitySession::STATE_FINISHED_KEY]).to eq(true)
+          expect(relevant_ua).not_to be
         end
 
-        it 'includes the unit activity even if the student has been removed from the list of assigned students' do
+        it 'does not include the unit activity if the student has been removed from the list of assigned students' do
           classroom_unit.update!(assigned_student_ids: [], assign_on_join: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == unit_activity.id}
-          expect(relevant_ua['archived']).to eq(true)
-          expect(relevant_ua[ActivitySession::STATE_FINISHED_KEY]).to eq(true)
+          expect(relevant_ua).not_to be
         end
 
-        it 'includes the unit activity even if the classroom unit has been archived' do
+        it 'does not include the unit activity if the classroom unit has been archived' do
           classroom_unit.update(visible: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == unit_activity.id}
-          expect(relevant_ua['archived']).to eq(true)
-          expect(relevant_ua[ActivitySession::STATE_FINISHED_KEY]).to eq(true)
+          expect(relevant_ua).not_to be
         end
 
-        it 'includes the unit activity even if the unit activity has been archived' do
+        it 'does not include the unit activity if the unit activity has been archived' do
           unit_activity.update(visible: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == unit_activity.id}
-          expect(relevant_ua['archived']).to eq(true)
-          expect(relevant_ua[ActivitySession::STATE_FINISHED_KEY]).to eq(true)
+          expect(relevant_ua).not_to be
         end
 
-        it 'includes the unit activity even if the unit has been archived' do
+        it 'does not include the unit activity if the unit has been archived' do
           unit.update(visible: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == unit_activity.id}
-          expect(relevant_ua['archived']).to eq(true)
-          expect(relevant_ua[ActivitySession::STATE_FINISHED_KEY]).to eq(true)
+          expect(relevant_ua).not_to be
+        end
+
+        it 'does include the unit activity if the unit has been closed' do
+          unit.update(open: false)
+          relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == unit_activity.id}
+          expect(relevant_ua['closed']).to eq true
+          expect(relevant_ua[ActivitySession::STATE_FINISHED_KEY]).to eq true
         end
       end
 
       describe 'when an activity session has not been completed' do
-        it 'does not include the unit activity even if the student has been removed from the list of assigned students' do
+        it 'does not include the unit activity if the student has been removed from the list of assigned students' do
           classroom_unit.update!(assigned_student_ids: [], assign_on_join: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == lessons_unit_activity.id}
           expect(relevant_ua).not_to be
         end
 
-        it 'does not include the unit activity even if the classroom unit has been archived' do
+        it 'does not include the unit activity if the classroom unit has been archived' do
           classroom_unit.update(visible: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == lessons_unit_activity.id}
           expect(relevant_ua).not_to be
         end
 
-        it 'does not include the unit activity even if the unit activity has been archived' do
+        it 'does not include the unit activity if the unit activity has been archived' do
           lessons_unit_activity.update(visible: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == lessons_unit_activity.id}
           expect(relevant_ua).not_to be
         end
 
-        it 'does not include the unit activity even if the unit has been archived' do
+        it 'does not include the unit activity if the unit has been archived' do
           unit.update(visible: false)
+          relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == lessons_unit_activity.id}
+          expect(relevant_ua).not_to be
+        end
+
+        it 'does not include the unit activity if the unit has been closed' do
+          unit.update(open: false)
           relevant_ua = UnitActivity.get_classroom_user_profile(classroom.id, student.id).find { |ua| ua['ua_id'] == lessons_unit_activity.id}
           expect(relevant_ua).not_to be
         end


### PR DESCRIPTION
## WHAT
Stop showing data with `visible: false` on student dashboards (aka "deleted" data).

## WHY
We thought this would be a nice-to-have with the feature around closed activity packs that shipped last week, but it ended up [causing issues](https://www.notion.so/quill/Glitch-with-closed-activity-packs-72cf4e4d8f014e20b3288f58689b730c?d=b02d26b0873d44319f7fcdf187335470) with diagnostic recommendation re-assignment and we decided it was best to just pull it for now.

## HOW
Basically just undo most of [this PR](https://github.com/empirical-org/Empirical-Core/pull/10095), but we are still letting students see work they completed in closed activity packs (the truly problematic part here were the `activity_sessions` with `visible: false` being shown, but if we remove those it doesn't make sense to keep any of the other records because setting a `unit`, a `unit_activity`, or a `classroom_unit` to `visible: false` will always also update the activity session.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Go-back-to-not-showing-data-with-visible-false-deleted-on-student-dashboards-7adab855a68044dd922df9112ce36c78

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
