### PR TITLE
fix malformed user name bug

### DIFF
--- a/services/QuillLMS/app/lib/utils/string.rb
+++ b/services/QuillLMS/app/lib/utils/string.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Utils::String
+  def self.last_name_or_name(first_name_last_name_string)
+    raise ArgumentError, 'Arg must respond to split' unless first_name_last_name_string.respond_to?(:split)
+
+    first, last = first_name_last_name_string.split
+    last || first
+  end
+end

--- a/services/QuillLMS/app/pdfs/login_pdf.rb
+++ b/services/QuillLMS/app/pdfs/login_pdf.rb
@@ -56,7 +56,7 @@ class LoginPdf < Prawn::Document
   def render_cover_page_table
     header = [["<b><font size='12'>Name</font></b>", "<b><font size='12'>Account Type</font></b>", "<b><font size='12'>Username</font></b>", "<b><font size='12'> Default Password</font></b>"]]
     body = []
-    @classroom.students.sort_by { |s| s.name.split[1]}.each do |student|
+    @classroom.students.sort_by { |s| Utils::String.last_name_or_name(s.name) }.each do |student|
       body << [student.name, student.account_type, username_or_email_value_for_student(student), render_password_for_student(student)]
     end
     table(header, cell_style: {

--- a/services/QuillLMS/spec/pdfs/login_pdf_spec.rb
+++ b/services/QuillLMS/spec/pdfs/login_pdf_spec.rb
@@ -65,6 +65,15 @@ describe LoginPdf do
 
   end
 
+  describe 'student name is not whitespace delineable' do
+    let(:students) { [create(:student, name: 'betty'), create(:student)] }
+    let(:classroom) { create(:classroom, students: students) }
+
+    it 'will not error' do
+      expect { LoginPdf.new(classroom) }.not_to raise_error
+    end
+  end
+
   describe 'when given a student with a username containing non-Windows-1252 characters' do
     let(:student_with_weird_username) { create(:student, username: 'studentツ' )}
     let(:students) { [student, clever_student, google_student, normal_student] }
@@ -73,6 +82,5 @@ describe LoginPdf do
     it 'will not error' do
       expect { LoginPdf.new(classroom) }.not_to raise_error
     end
-
   end
 end


### PR DESCRIPTION
## WHAT
Fix bug in Login PDF

## WHY
To optimize teacher experience 

## HOW
Handle case where User.name is not whitespace delineable. 

In the future, we may want to consider adding stricter validations on `User.name`, but that's a bigger discussion. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/500-Internal-Server-Error-when-clicking-Download-setup-instructions-button-656a8691251d4c7a9285b99284a94497
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
