### PR TITLE
Ask teachers to confirm when removing activity from Activity Pack

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/activity_table.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/activity_table.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as moment from 'moment';
 
 import CopyModal from './copy_modal'
+import RemoveActivityModal from './remove_activity_modal';
 
 import * as api from '../../modules/call_api';
 import {
@@ -73,6 +74,8 @@ const ActivityTable = ({ data, onSuccess, isOwner, handleActivityClicked, handle
   const [activityOrder, setActivityOrder] = React.useState(classroomActivityArray.map(ca => ca.activityId) || [])
   const [showCopyPublishDateModal, setShowCopyPublishDateModal] = React.useState(false)
   const [showCopyDueDateModal, setShowCopyDueDateModal] = React.useState(false)
+  const [showRemoveActivityModal, setShowRemoveActivityModal] = React.useState(false)
+  const [unitActivityIdToRemove, setUnitActivityIdToRemove] = React.useState(null)
   const [erroredUnitActivityIds, setErroredUnitActivityIds] = React.useState([])
   const [showSnackbar, setShowSnackbar] = React.useState(false)
   const [snackbarText, setSnackbarText] = React.useState('')
@@ -83,8 +86,9 @@ const ActivityTable = ({ data, onSuccess, isOwner, handleActivityClicked, handle
     setErroredUnitActivityIds([])
   }, [data])
 
-  function hideUnitActivity(unitActivityId) {
+  function removeActivity(unitActivityId) {
     requestPut(`${process.env.DEFAULT_URL}/teachers/unit_activities/${unitActivityId}/hide`, {}, () => onSuccess('Activity removed'))
+    setShowRemoveActivityModal(false)
   }
 
   function closeDatePicker(date, unitActivityId, dateAttributeKey) {
@@ -104,9 +108,16 @@ const ActivityTable = ({ data, onSuccess, isOwner, handleActivityClicked, handle
 
   function closeCopyDueDateModal() { setShowCopyDueDateModal(false) }
 
+  function closeRemoveActivityModal() { setShowRemoveActivityModal(false) }
+
   function openCopyPublishDateModal() { setShowCopyPublishDateModal(true) }
 
   function openCopyDueDateModal() { setShowCopyDueDateModal(true) }
+
+  function openRemoveActivityModal(unitActivityId) {
+    setUnitActivityIdToRemove(unitActivityId)
+    setShowRemoveActivityModal(true)
+  }
 
   function copyPublishDateToAll() {
     const publishDate = classroomActivityArray[0].publishDate
@@ -149,6 +160,10 @@ const ActivityTable = ({ data, onSuccess, isOwner, handleActivityClicked, handle
   function handleShareActivityClick(activity) {
     handleActivityClicked(activity)
     handleToggleModal()
+  }
+
+  function getActivityNameToRemove() {
+    return classroomActivityArray.find(act => act.uaId === unitActivityIdToRemove).name
   }
 
   const activityRows = activityOrder.map((activityId, i) => {
@@ -239,11 +254,18 @@ const ActivityTable = ({ data, onSuccess, isOwner, handleActivityClicked, handle
           copyFunction={copyPublishDateToAll}
         />
       )}
+      {showRemoveActivityModal && (
+        <RemoveActivityModal
+          activityName={getActivityNameToRemove()}
+          closeFunction={closeRemoveActivityModal}
+          removeFunction={() => removeActivity(unitActivityIdToRemove)}
+        />
+      )}
       <DataTable
         className={isOwner ? 'is-owner' : ''}
         headers={tableHeaders(isOwner)}
         isReorderable={isOwner}
-        removeRow={hideUnitActivity}
+        removeRow={openRemoveActivityModal}
         reorderCallback={reorderCallback}
         rows={activityRows}
         showRemoveIcon={isOwner}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/remove_activity_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/remove_activity_modal.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+const RemoveActivityModal = ({ activityName, closeFunction, removeFunction, }) => {
+  return (
+    <div aria-live="polite" className="modal-container copy-dates-modal-container" tabIndex={-1}>
+      <div className="modal-background" />
+      <div className="copy-dates-modal quill-modal modal-body">
+        <div className="top-section">
+          <h1>Remove this activity?</h1>
+          <p>Are you sure you want to remove {activityName} from this activity pack? </p>
+        </div>
+        <div className="button-section">
+          <button className="quill-button medium secondary outlined focus-on-light" onClick={closeFunction} type="button">Cancel</button>
+          <button className="quill-button medium primary contained focus-on-light" onClick={removeFunction} type="button">Yes, remove</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RemoveActivityModal


### PR DESCRIPTION
## WHAT
Add a modal to double check with teachers before they remove an activity from an activity pack.

## WHY
It sometimes happens that teachers accidentally remove activities from activity packs because they don't realize they clicked the "remove" icon.

## HOW
Add a modal component in and trigger it before activity removal.

### Screenshots
![Screen Shot 2023-01-23 at 3 35 05 PM](https://user-images.githubusercontent.com/57366100/213987196-d7148425-e391-4991-9ccb-73abc8e290a6.png)

### Notion Card Links
https://www.notion.so/quill/PS-Ask-teachers-to-confirm-before-an-activity-is-removed-from-a-pack-1afb69adcda44f5ba2fb4acd012fb137

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes