### PR TITLE
Improve Activity Pack Page Speed and Metadata

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -37,6 +37,7 @@ class Teachers::UnitTemplatesController < ApplicationController
 
   def show
     @content = @unit_template.meta_description
+    @title = "Activity Pack: #{unit_template&.name}"
     @image_link = @unit_template.image_link
     @unit_template_id = @unit_template.id
     render 'public_show' if !@is_teacher

--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -10,7 +10,7 @@ class Teachers::UnitTemplatesController < ApplicationController
       format.html do
         if params[:id]
           unit_template = UnitTemplate
-            .includes(activities: :classification)
+            .includes(activities: :standard)
             .find(params[:id])
 
           @image_link = unit_template&.image_link

--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -9,12 +9,16 @@ class Teachers::UnitTemplatesController < ApplicationController
     respond_to do |format|
       format.html do
         if params[:id]
-          unit_template = UnitTemplate.find(params[:id])
-          if unit_template&.image_link
-            @image_link = unit_template.image_link
-          end
+          unit_template = UnitTemplate
+            .includes(activities: :classification)
+            .find(params[:id])
+
+          @image_link = unit_template&.image_link
+          @title = "Activity Pack: #{unit_template&.name}"
+          @content = unit_template&.meta_description
         end
         redirect_to "/assign/featured-activity-packs/#{params[:id]}" if @is_teacher
+        @defer_js = true # opt for faster page load for public page, i.e. !@is_teacher
       end
       format.json do
         render json: { unit_templates: cached_formatted_unit_templates }
@@ -32,7 +36,8 @@ class Teachers::UnitTemplatesController < ApplicationController
   end
 
   def show
-    @content = "Try out the #{@unit_template.name} Activity Pack I’m using at Quill.org"
+    @content = @unit_template.meta_description
+    @image_link = @unit_template.image_link
     @unit_template_id = @unit_template.id
     render 'public_show' if !@is_teacher
   end

--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -44,6 +44,15 @@ class ActivityClassification < ApplicationRecord
     EVIDENCE_KEY
   ]
 
+  META_DESCRIPTIONS = {
+    DIAGNOSTIC_KEY => 'Give students grammar and writing assessments and diagnostics',
+    PROOFREADER_KEY => 'Improve students\' proofreading and editing skills',
+    LESSONS_KEY => 'Teach a whole class writing lesson',
+    GRAMMAR_KEY => 'Improve students\' basic grammar skills',
+    CONNECT_KEY => 'Improve students\' writing of compound sentences, sentence construction, and conjunctions',
+    EVIDENCE_KEY => 'Improve students\' reading comprehension and thesis statement writing'
+  }
+
   scope :connect_or_grammar, -> {where(key: [CONNECT_KEY, GRAMMAR_KEY])}
 
   def self.unscored?(key)
@@ -72,6 +81,10 @@ class ActivityClassification < ApplicationRecord
 
   def self.connect
     find_by_key CONNECT_KEY
+  end
+
+  def meta_description
+    META_DESCRIPTIONS[key]
   end
 
   def form_url

--- a/services/QuillLMS/app/models/activity_classification.rb
+++ b/services/QuillLMS/app/models/activity_classification.rb
@@ -44,15 +44,6 @@ class ActivityClassification < ApplicationRecord
     EVIDENCE_KEY
   ]
 
-  META_DESCRIPTIONS = {
-    DIAGNOSTIC_KEY => 'Give students grammar and writing assessments and diagnostics',
-    PROOFREADER_KEY => 'Improve students\' proofreading and editing skills',
-    LESSONS_KEY => 'Teach a whole class writing lesson',
-    GRAMMAR_KEY => 'Improve students\' basic grammar skills',
-    CONNECT_KEY => 'Improve students\' writing of compound sentences, sentence construction, and conjunctions',
-    EVIDENCE_KEY => 'Improve students\' reading comprehension and thesis statement writing'
-  }
-
   scope :connect_or_grammar, -> {where(key: [CONNECT_KEY, GRAMMAR_KEY])}
 
   def self.unscored?(key)
@@ -81,10 +72,6 @@ class ActivityClassification < ApplicationRecord
 
   def self.connect
     find_by_key CONNECT_KEY
-  end
-
-  def meta_description
-    META_DESCRIPTIONS[key]
   end
 
   def form_url

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -97,6 +97,24 @@ class School < ApplicationRecord
 
   SCHOOL_YEAR_START_MONTH = 7
   HALF_A_YEAR = 6.months
+  ELEMENTARY = 'elementary'
+  MIDDLE = 'middle'
+  HIGH = 'high'
+
+  GRADE_DESCRIPTIONS = {
+    1 => ELEMENTARY,
+    2 => ELEMENTARY,
+    3 => ELEMENTARY,
+    4 => ELEMENTARY,
+    5 => ELEMENTARY,
+    6 => MIDDLE,
+    7 => MIDDLE,
+    8 => MIDDLE,
+    9 => HIGH,
+    10 => HIGH,
+    11 => HIGH,
+    12 => HIGH,
+  }
 
   def self.school_year_start(time)
     time.month >= SCHOOL_YEAR_START_MONTH ? time.beginning_of_year + HALF_A_YEAR : time.beginning_of_year - HALF_A_YEAR

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -77,7 +77,7 @@ class UnitTemplate < ApplicationRecord
   end
 
   def meta_description
-    "Free online writing activity pack on #{name} for teachers of #{meta_grade_description}. #{meta_activities_description}."
+    "Free online writing activity pack \"#{name}\" for teachers of #{meta_grade_description}. #{meta_activities_description}"
   end
 
   def meta_grade_description
@@ -95,7 +95,14 @@ class UnitTemplate < ApplicationRecord
   def meta_activities_description
     return nil if activities.blank?
 
-    "Lessons: #{activities.map(&:name).to_sentence}"
+    standard_codes = activities
+      .map {|a| a.standard&.name}
+      .flatten
+      .compact
+      .uniq
+      .to_sentence
+
+    "Standards: #{standard_codes}."
   end
 
   def grade_level_range

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -95,14 +95,14 @@ class UnitTemplate < ApplicationRecord
   def meta_activities_description
     return nil if activities.blank?
 
-    standard_codes = activities
+    standards = activities
       .map {|a| a.standard&.name}
       .flatten
       .compact
       .uniq
       .to_sentence
 
-    "Standards: #{standard_codes}."
+    "Standards: #{standards}."
   end
 
   def grade_level_range

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -77,7 +77,7 @@ class UnitTemplate < ApplicationRecord
   end
 
   def meta_description
-    "Free online writing activities on #{name} for teachers of #{meta_grade_description}. #{meta_activities_description}."
+    "Free online writing activity pack on #{name} for teachers of #{meta_grade_description}. #{meta_activities_description}."
   end
 
   def meta_grade_description
@@ -95,9 +95,7 @@ class UnitTemplate < ApplicationRecord
   def meta_activities_description
     return nil if activities.blank?
 
-    classifications = activities.map {|a| a.classification.meta_description }.compact.uniq
-
-    "Lesson goals: #{classifications.to_sentence}. Activities in this pack: #{activities.map(&:name).to_sentence}"
+    "Lessons: #{activities.map(&:name).to_sentence}"
   end
 
   def grade_level_range

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -76,6 +76,30 @@ class UnitTemplate < ApplicationRecord
     "#{lowest_readability_range.split('-')[0]}-#{highest_readability_range.split('-')[1]}"
   end
 
+  def meta_description
+    "Free online writing activities on #{name} for teachers of #{meta_grade_description}. #{meta_activities_description}."
+  end
+
+  def meta_grade_description
+    return "school students" if grades.blank?
+
+    levels = grades
+      .sort_by(&:to_i)
+      .map{|g| School::GRADE_DESCRIPTIONS[g.to_i]}
+      .compact
+      .uniq
+
+    "#{levels.to_sentence} school students grades #{grades.sort_by(&:to_i).to_sentence}"
+  end
+
+  def meta_activities_description
+    return nil if activities.blank?
+
+    classifications = activities.map {|a| a.classification.meta_description }.compact.uniq
+
+    "Lesson goals: #{classifications.to_sentence}. Activities in this pack: #{activities.map(&:name).to_sentence}"
+  end
+
   def grade_level_range
     activities_with_minimum_grade_levels = activities.where.not(minimum_grade_level: nil).reorder("minimum_grade_level ASC")
     return nil if activities_with_minimum_grade_levels.empty?

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -50,7 +50,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <% end %>
   <%= render partial: 'application/head_embed_codes' %>
-  <%= javascript_pack_tag((@js_file || 'app'), 'crossorigin': 'anonymous') %>
+  <%= javascript_pack_tag((@js_file || 'app'), defer: @defer_js || false, 'crossorigin': 'anonymous') %>
   <%= csrf_meta_tags %>
   <meta id='current-user-testing-flag' property="flag" content=<%= current_user&.testing_flag%> />
   <meta id='current-user-id' property="id" content=<%= current_user&.id%> />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
@@ -85,10 +85,6 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
     return `Check out the '${name}' activity pack I just assigned on Quill.org! ${this.socialShareUrl(referralCode)}`
   }
 
-  getMetaText = (name: string) => {
-    return `Check out the '${name}' activity pack I just assigned on Quill.org!`;
-  }
-
   handleGoToEditStudents = () => {
     const { history } = this.props;
     const { data } = this.state;
@@ -117,7 +113,6 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
       return <LoadingIndicator />
     } else {
       let navigation: any;
-      let container: HTMLMetaElement | null = document.querySelector("meta[name='og:description']");
       const { name, id, non_authenticated, flag } = data
       const showSocials = flag === 'production';
       if (!non_authenticated) {
@@ -126,9 +121,6 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
           unitTemplateId={id}
           unitTemplateName={name}
         />)
-      }
-      if (container instanceof HTMLMetaElement) {
-        container.content = this.getMetaText(name);
       }
       return (
         <div className="unit-template-profile">

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -146,7 +146,7 @@ describe UnitTemplate, redis: true, type: :model do
     let(:connect_classification) { create(:connect) }
     let(:activity1) { create(:activity, name: 'Conjunctions', classification: connect_classification) }
     let(:activity2) { create(:activity, name: 'Americana', classification: connect_classification) }
-    let(:description) {"Free online writing activities on Template Name for teachers of school students. Lesson goals: Improve students\' writing of compound sentences, sentence construction, and conjunctions. Activities in this pack: Conjunctions and Americana."}
+    let(:description) {"Free online writing activity pack on Template Name for teachers of school students. Lessons: Conjunctions and Americana."}
 
     subject { create(:unit_template, name: 'Template Name', activities: [activity1, activity2]) }
 
@@ -155,7 +155,7 @@ describe UnitTemplate, redis: true, type: :model do
     end
 
     context 'with grades' do
-      let(:description) {"Free online writing activities on Template Name for teachers of middle school students grades 6, 7, and 8. Lesson goals: Improve students\' writing of compound sentences, sentence construction, and conjunctions. Activities in this pack: Conjunctions and Americana."}
+      let(:description) {"Free online writing activity pack on Template Name for teachers of middle school students grades 6, 7, and 8. Lessons: Conjunctions and Americana."}
       subject { create(:unit_template, name: 'Template Name', grades: ['6','7','8'], activities: [activity1, activity2]) }
 
       it 'populate a meta decription' do
@@ -164,7 +164,7 @@ describe UnitTemplate, redis: true, type: :model do
     end
 
     context 'no activities' do
-      let(:description) {"Free online writing activities on Template Name for teachers of school students. ."}
+      let(:description) {"Free online writing activity pack on Template Name for teachers of school students. ."}
       subject { create(:unit_template, name: 'Template Name') }
 
       it 'populate a meta decription' do

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -156,6 +156,7 @@ describe UnitTemplate, redis: true, type: :model do
 
     context 'with grades' do
       let(:description) {"Free online writing activity pack on Template Name for teachers of middle school students grades 6, 7, and 8. Lessons: Conjunctions and Americana."}
+
       subject { create(:unit_template, name: 'Template Name', grades: ['6','7','8'], activities: [activity1, activity2]) }
 
       it 'populate a meta decription' do
@@ -165,6 +166,7 @@ describe UnitTemplate, redis: true, type: :model do
 
     context 'no activities' do
       let(:description) {"Free online writing activity pack on Template Name for teachers of school students. ."}
+
       subject { create(:unit_template, name: 'Template Name') }
 
       it 'populate a meta decription' do

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -142,6 +142,37 @@ describe UnitTemplate, redis: true, type: :model do
     end
   end
 
+  describe '#meta_description' do
+    let(:connect_classification) { create(:connect) }
+    let(:activity1) { create(:activity, name: 'Conjunctions', classification: connect_classification) }
+    let(:activity2) { create(:activity, name: 'Americana', classification: connect_classification) }
+    let(:description) {"Free online writing activities on Template Name for teachers of school students. Lesson goals: Improve students\' writing of compound sentences, sentence construction, and conjunctions. Activities in this pack: Conjunctions and Americana."}
+
+    subject { create(:unit_template, name: 'Template Name', activities: [activity1, activity2]) }
+
+    it 'populate a meta decription' do
+      expect(subject.meta_description).to eq description
+    end
+
+    context 'with grades' do
+      let(:description) {"Free online writing activities on Template Name for teachers of middle school students grades 6, 7, and 8. Lesson goals: Improve students\' writing of compound sentences, sentence construction, and conjunctions. Activities in this pack: Conjunctions and Americana."}
+      subject { create(:unit_template, name: 'Template Name', grades: ['6','7','8'], activities: [activity1, activity2]) }
+
+      it 'populate a meta decription' do
+        expect(subject.meta_description).to eq description
+      end
+    end
+
+    context 'no activities' do
+      let(:description) {"Free online writing activities on Template Name for teachers of school students. ."}
+      subject { create(:unit_template, name: 'Template Name') }
+
+      it 'populate a meta decription' do
+        expect(subject.meta_description).to eq description
+      end
+    end
+  end
+
   describe '#get_cached_serialized_unit_template' do
     let(:category) { create(:unit_template_category) }
     let(:author) { create(:author) }

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -143,10 +143,11 @@ describe UnitTemplate, redis: true, type: :model do
   end
 
   describe '#meta_description' do
-    let(:connect_classification) { create(:connect) }
-    let(:activity1) { create(:activity, name: 'Conjunctions', classification: connect_classification) }
-    let(:activity2) { create(:activity, name: 'Americana', classification: connect_classification) }
-    let(:description) {"Free online writing activity pack on Template Name for teachers of school students. Lessons: Conjunctions and Americana."}
+    let(:standard1) {create(:standard, name: '7.1b writing sentences')}
+    let(:standard2) {create(:standard, name: 'CCSS Grade 9')}
+    let(:activity1) { create(:activity, standard: standard1) }
+    let(:activity2) { create(:activity, standard: standard2) }
+    let(:description) {"Free online writing activity pack \"Template Name\" for teachers of school students. Standards: 7.1b writing sentences and CCSS Grade 9."}
 
     subject { create(:unit_template, name: 'Template Name', activities: [activity1, activity2]) }
 
@@ -155,7 +156,7 @@ describe UnitTemplate, redis: true, type: :model do
     end
 
     context 'with grades' do
-      let(:description) {"Free online writing activity pack on Template Name for teachers of middle school students grades 6, 7, and 8. Lessons: Conjunctions and Americana."}
+      let(:description) {"Free online writing activity pack \"Template Name\" for teachers of middle school students grades 6, 7, and 8. Standards: 7.1b writing sentences and CCSS Grade 9."}
 
       subject { create(:unit_template, name: 'Template Name', grades: ['6','7','8'], activities: [activity1, activity2]) }
 
@@ -165,7 +166,7 @@ describe UnitTemplate, redis: true, type: :model do
     end
 
     context 'no activities' do
-      let(:description) {"Free online writing activity pack on Template Name for teachers of school students. ."}
+      let(:description) {"Free online writing activity pack \"Template Name\" for teachers of school students. "}
 
       subject { create(:unit_template, name: 'Template Name') }
 


### PR DESCRIPTION
## WHAT
Improve Activity Pack Page Speed and Metadata
## WHY
Speed for SEO ranking reasons and clearer description for SEO for clickthrough and search-ability.
## HOW
Speed fix: Defer the javascript load for logged out users
Meta data description:

Before

> Check out the 'What's in Our Universe?' activity pack I just assigned on Quill.org!

After

> Free online writing activity pack "What's in Our Universe?" for teachers of middle and high school students grades 7, 8, 9, 10, 11, and 12. Standards: CCSS Grade 9 Formative Assessments and 7.1b Choose among simple, compound, complex, and compound-complex sentences to signal differing relationships among ideas.

### Screenshots


### Notion Card Links
https://www.notion.so/quill/Add-Keywords-to-Activity-Pack-Pages-255322554cdb4f63bc08d81aefff9350
https://www.notion.so/quill/Improve-the-speed-of-the-Activity-Pack-Pages-7deae23438d14140be591d9c477843e4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'
Have you deployed to Staging? |  YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
