### PR TITLE
Internal tool/ clear add admin form

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/newAdminOrDistrictUser.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/newAdminOrDistrictUser.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 
-import { Input, Snackbar, defaultSnackbarTimeout, Spinner, } from '../../Shared';
+import { Input, Snackbar, defaultSnackbarTimeout, Spinner } from '../../Shared';
 import useSnackbarMonitor from '../../Shared/hooks/useSnackbarMonitor'
 import { InputEvent } from '../interfaces/evidenceInterfaces';
 import { requestPost } from '../../../modules/request';
 
-const ADMIN = 'admin'
+const ADMIN = 'admin';
 
 interface NewAdminOrDistrictUserProps {
   type: string,
   returnUrl: string,
-  schoolId?: any,
-  districtId?: any
+  schoolId?: number,
+  districtId?: number
 }
 
 const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAdminOrDistrictUserProps) => {
@@ -21,7 +21,7 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
   const [error, setError] = React.useState<string>('');
   const [showSnackbar, setShowSnackbar] = React.useState<boolean>(false);
   const [snackbarText, setSnackbarText] = React.useState<string>('');
-  const [loading, setLoading] = React.useState<boolean>(false)
+  const [loading, setLoading] = React.useState<boolean>(false);
 
   useSnackbarMonitor(showSnackbar, setShowSnackbar, defaultSnackbarTimeout)
 
@@ -79,6 +79,7 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
   const header = type === ADMIN ? 'New Admin' : 'New District Admin'
   const linkLabel = type === ADMIN ? 'School Directory > Add New Admin User' : 'District Directory > Add New District Admin User'
   const innerSubmitButtonElement = loading ? <Spinner /> : 'Submit';
+
   return (
     <section className='container new-admin-user-container'>
       <Snackbar text={snackbarText} visible={showSnackbar} />

--- a/services/QuillLMS/client/app/bundles/Staff/components/newAdminOrDistrictUser.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/newAdminOrDistrictUser.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Input, Snackbar, defaultSnackbarTimeout, } from '../../Shared';
+import { Input, Snackbar, defaultSnackbarTimeout, Spinner, } from '../../Shared';
 import useSnackbarMonitor from '../../Shared/hooks/useSnackbarMonitor'
 import { InputEvent } from '../interfaces/evidenceInterfaces';
 import { requestPost } from '../../../modules/request';
@@ -19,8 +19,9 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
   const [lastName, setLastName] = React.useState<string>('');
   const [email, setEmail] = React.useState<string>('');
   const [error, setError] = React.useState<string>('');
-  const [showSnackbar, setShowSnackbar] = React.useState(false)
-  const [snackbarText, setSnackbarText] = React.useState('')
+  const [showSnackbar, setShowSnackbar] = React.useState<boolean>(false);
+  const [snackbarText, setSnackbarText] = React.useState<string>('');
+  const [loading, setLoading] = React.useState<boolean>(false)
 
   useSnackbarMonitor(showSnackbar, setShowSnackbar, defaultSnackbarTimeout)
 
@@ -46,6 +47,7 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
     if(!firstName || !lastName || !email) {
       setError('Form fields cannot be blank.');
     } else {
+      setLoading(true);
       setError('');
       const requestUrl = type === ADMIN ? `/cms/schools/${schoolId}/school_admins` : `/cms/districts/${districtId}/district_admins`
       const params = {
@@ -57,9 +59,14 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
         if(body.error) {
           setSnackbarText(body.error);
           setShowSnackbar(true);
+          setLoading(false);
         } else {
           setSnackbarText(body.message);
           setShowSnackbar(true);
+          setLoading(false);
+          setFirstName('');
+          setLastName('');
+          setEmail('');
         }
       })
     }
@@ -71,7 +78,7 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
 
   const header = type === ADMIN ? 'New Admin' : 'New District Admin'
   const linkLabel = type === ADMIN ? 'School Directory > Add New Admin User' : 'District Directory > Add New District Admin User'
-
+  const innerSubmitButtonElement = loading ? <Spinner /> : 'Submit';
   return (
     <section className='container new-admin-user-container'>
       <Snackbar text={snackbarText} visible={showSnackbar} />
@@ -100,7 +107,7 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
           value={email}
         />
         <section className="buttons-container">
-          <button className="quill-button small primary contained" onClick={handleSubmitClick}>Submit</button>
+          <button className="quill-button small primary contained" onClick={handleSubmitClick}>{innerSubmitButtonElement}</button>
           <button className="quill-button small secondary outlined" onClick={handleCancelClick}>Cancel</button>
         </section>
         {error && <p className="error-message">{error}</p>}

--- a/services/QuillLMS/client/app/bundles/Staff/styles/new_admin_user.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/new_admin_user.scss
@@ -22,6 +22,9 @@
       margin-top: 32px;
       .quill-button:first-of-type {
         margin-right: 16px;
+        .spinner {
+          height: 24px;
+        }
       }
     }
   }


### PR DESCRIPTION
## WHAT
clear add admin form for Schools and Districts after submission

## WHY
this is better user experience for when staff are adding multiple admin

## HOW
just reset `firstName`, `lastName` and `email` pieces of state after successful submission (I also opted to add a loading spinner to indicate the form is submitting because it takes a few seconds to process when a brand new user is created)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/PS-Clear-the-admin-creation-form-when-it-is-submitted-399b5eb50dbd466b826c70c196c6f68f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
