### PR TITLE
only cache-affecting backend updates for diagnostic progress indicators

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -379,14 +379,16 @@ class Teachers::UnitsController < ApplicationController
       classroom_units.assigned_student_ids AS assigned_student_ids,
       greatest(unit_activities.created_at, classroom_units.created_at) AS assigned_date,
       activities.follow_up_activity_id AS post_test_id,
-      classroom_units.id AS classroom_unit_id
+      classroom_units.id AS classroom_unit_id,
+      activities_unit_templates.unit_template_id AS unit_template_id
     ")
     .joins("JOIN classrooms ON classrooms_teachers.classroom_id = classrooms.id AND classrooms.visible = TRUE AND classrooms_teachers.user_id = #{current_user.id}")
     .joins("JOIN classroom_units ON classroom_units.classroom_id = classrooms.id AND classroom_units.visible")
     .joins("JOIN units ON classroom_units.unit_id = units.id AND units.visible")
     .joins("JOIN unit_activities ON unit_activities.unit_id = classroom_units.unit_id AND unit_activities.activity_id IN (#{diagnostic_activity_ids.join(',')}) AND unit_activities.visible")
     .joins("JOIN activities ON unit_activities.activity_id = activities.id")
-    .group("classrooms.name, activities.name, activities.id, classroom_units.unit_id, classroom_units.id, units.name, classrooms.id, classroom_units.assigned_student_ids, unit_activities.created_at, classroom_units.created_at")
+    .joins("LEFT JOIN activities_unit_templates ON activities_unit_templates.activity_id = activities.id")
+    .group("classrooms.name, activities.name, activities.id, classroom_units.unit_id, classroom_units.id, units.name, classrooms.id, classroom_units.assigned_student_ids, unit_activities.created_at, classroom_units.created_at, activities_unit_templates.unit_template_id")
     .order(Arel.sql("classrooms.name, greatest(classroom_units.created_at, unit_activities.created_at) DESC"))
 
     records.map do |r|
@@ -400,7 +402,8 @@ class Teachers::UnitsController < ApplicationController
         "classroom_id" => r['classroom_id'],
         "assigned_date" => r['assigned_date'],
         "post_test_id" => r['post_test_id'],
-        "classroom_unit_id" => r['classroom_unit_id']
+        "classroom_unit_id" => r['classroom_unit_id'],
+        "unit_template_id" => r['unit_template_id']
       }
     end
   end

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -7,7 +7,8 @@ describe Teachers::UnitsController, type: :controller do
   let!(:classroom) { create(:classroom) }
   let!(:students_classrooms) { create(:students_classrooms, classroom: classroom, student: student)}
   let!(:teacher) { classroom.owner }
-  let!(:unit) {create(:unit, user: teacher)}
+  let!(:unit_template) { create(:unit_template) }
+  let!(:unit) {create(:unit, user: teacher, unit_template: unit_template)}
   let!(:unit2) {create(:unit, user: teacher)}
 
   let!(:classroom_unit) do
@@ -28,6 +29,7 @@ describe Teachers::UnitsController, type: :controller do
 
   let!(:diagnostic) { create(:diagnostic) }
   let!(:diagnostic_activity) { create(:diagnostic_activity)}
+  let!(:activities_unit_template) { create(:activities_unit_template, activity: diagnostic_activity, unit_template: unit_template) }
   let!(:unit_activity) { create(:unit_activity, unit: unit, activity: diagnostic_activity, due_date: Time.current, publish_date: 1.hour.ago )}
 
   let!(:completed_activity_session) do
@@ -65,11 +67,10 @@ describe Teachers::UnitsController, type: :controller do
 
   describe '#prohibited_unit_names' do
     let(:unit_names) { teacher.units.pluck(:name).map(&:downcase) }
-    let(:unit_template_names) { UnitTemplate.pluck(:name).map(&:downcase) }
 
     it 'should render the correct json' do
       get :prohibited_unit_names, as: :json
-      expect(JSON.parse(response.body)['prohibitedUnitNames']).to match_array(unit_names.concat(unit_template_names))
+      expect(JSON.parse(response.body)['prohibitedUnitNames']).to match_array(unit_names)
     end
 
     it 'should not include unit names from archived classrooms' do
@@ -148,6 +149,7 @@ describe Teachers::UnitsController, type: :controller do
               assigned_date: unit_activity.created_at,
               post_test_id: diagnostic_activity.follow_up_activity_id,
               classroom_unit_id: classroom_unit.id,
+              unit_template_id: unit.unit_template_id,
               completed_count: 1,
               assigned_count: 1
             }


### PR DESCRIPTION
## WHAT
Adding the `unit_template_id` to the standard `diagnostic_unit_record` query.

## WHY
This is data that we need for the diagnostic progress indicator project, but this query is cached, so I'm hoping to ship this change 24 hours before we launch the rest of the project so we don't have to deal with invalidating the cache manually. It is only additive, so it shouldn't be a problem to ship it early.

## HOW
Just add an extra join to the table.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Diagnostic-Progress-Indicator-919c78414c0c4da8b8c640db65102c21

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A