### PR TITLE
Bug-fix/ reset user role for google signup

### DIFF
--- a/services/QuillLMS/app/controllers/auth/google_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/google_controller.rb
@@ -86,6 +86,7 @@ class Auth::GoogleController < ApplicationController
     @user = GoogleIntegration::User.new(@profile).update_or_initialize
 
     update_role_from_sales_contact
+    update_role_from_individual_contributor
     show_user_not_found_if_necessary
   end
 
@@ -99,6 +100,12 @@ class Auth::GoogleController < ApplicationController
     return unless @user.sales_contact? && in_sign_up_flow?
 
     @user.update(role: session[:role])
+  end
+
+  private def update_role_from_individual_contributor
+    return unless in_sign_up_flow? && session[:role] == User::INDIVIDUAL_CONTRIBUTOR
+
+    @user.update(role: User::TEACHER)
   end
 
   private def show_user_not_found_if_necessary

--- a/services/QuillLMS/spec/controllers/auth/google_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/auth/google_controller_spec.rb
@@ -34,4 +34,17 @@ describe Auth::GoogleController, type: :controller do
     expect(flash[:error]).to be(nil)
     expect(user.reload.role).to eq(session_role)
   end
+
+  it 'updates role to teacher for user when session[:role] is set to individual contributor' do
+    session_role = User::INDIVIDUAL_CONTRIBUTOR
+    user = create(:user, role: User::INDIVIDUAL_CONTRIBUTOR)
+
+    google_user_double = double
+    expect(GoogleIntegration::User).to receive(:new).and_return(google_user_double)
+    expect(google_user_double).to receive(:update_or_initialize).and_return(user)
+
+    get 'online_access_callback', params: { email: user.email, role: nil }, session: { role: session_role }
+    expect(flash[:error]).to be(nil)
+    expect(user.reload.role).to eq(User::TEACHER)
+  end
 end


### PR DESCRIPTION
## WHAT
reset role for users when signing up via Google and "Parent/Caregiver/Tutor" option has been selected

## WHY
I missed this in testing, but if a user signs up via google, we set their role to the role set in session so this was causing errors to show in Sentry: https://sentry.io/organizations/quillorg-5s/issues/3882688643/?project=11238

## HOW
add a method similar to `update_role_from_sales_contact` that handles this case

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
