### PR TITLE
Change UserPackSequenceItem call from find_or_create_by! to create_or_find_by!

### DIFF
--- a/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
+++ b/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
@@ -54,12 +54,8 @@ class UserPackSequenceItemSaver < ApplicationService
 
   private def save_statuses
     user_pack_sequence_item_statuses.each_pair do |pack_sequence_item_id, status|
-      UserPackSequenceItem.transaction(requires_new: true) do
-        upsi = UserPackSequenceItem.find_or_create_by!(pack_sequence_item_id: pack_sequence_item_id, user_id: user_id)
-        next if status == upsi.status
-
-        upsi.update!(status: status)
-      end
+      upsi = UserPackSequenceItem.create_or_find_by!(pack_sequence_item_id: pack_sequence_item_id, user_id: user_id)
+      upsi.update!(status: status) unless upsi.status == status
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a possible race condition [bug](https://www.notion.so/quill/Staggered-release-packs-did-not-unlock-for-student-dbd70ccc4ab043d0bf23464bf2a1cebf) involving UserPackSequenceItems

## WHY
The UserPackSequenceItem.find_by_or_create_by! is more likely subject to race conditions.

## HOW
Utilize the [create_or_find_by](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-create_or_find_by) method which attempts to create the record and then relies on exception handling to fallback on the find_by.

NB:  UserPackSequenceItem.count > 377096
### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
