### PR TITLE
lms/sidekiq-queue-test

### DIFF
--- a/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
@@ -3,7 +3,7 @@
 class SaveUserPackSequenceItemsWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: SidekiqQueue::DEFAULT,
+  sidekiq_options queue: SidekiqQueue::MIGRATION,
     lock: :until_executed
 
   def perform(classroom_id, user_id)


### PR DESCRIPTION
## WHAT
Move SaveUserPackSequenceItems to MIGRATION priority queue
## WHY
This will let us isolate the job from other jobs in the Sidekiq queue to find out if it's the culprit in our Sidekiq performance issues.
## HOW
Simply update the job configuration to point it at a different queue.

### Notion Card Links
https://www.notion.so/quill/Out-of-Memory-errors-for-background-workers-7fbcb78248754df5beb4ba099511b5cd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, just a config change
Have you deployed to Staging? | No, it's just a prod-focused config change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
