### PR TITLE
Improve Activity Pack Page Speed and Metadata (#10182)

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -9,12 +9,16 @@ class Teachers::UnitTemplatesController < ApplicationController
     respond_to do |format|
       format.html do
         if params[:id]
-          unit_template = UnitTemplate.find(params[:id])
-          if unit_template&.image_link
-            @image_link = unit_template.image_link
-          end
+          unit_template = UnitTemplate
+            .includes(activities: :standard)
+            .find(params[:id])
+
+          @image_link = unit_template&.image_link
+          @title = "Activity Pack: #{unit_template&.name}"
+          @content = unit_template&.meta_description
         end
         redirect_to "/assign/featured-activity-packs/#{params[:id]}" if @is_teacher
+        @defer_js = true # opt for faster page load for public page, i.e. !@is_teacher
       end
       format.json do
         render json: { unit_templates: cached_formatted_unit_templates }
@@ -32,7 +36,9 @@ class Teachers::UnitTemplatesController < ApplicationController
   end
 
   def show
-    @content = "Try out the #{@unit_template.name} Activity Pack I’m using at Quill.org"
+    @content = @unit_template.meta_description
+    @title = "Activity Pack: #{unit_template&.name}"
+    @image_link = @unit_template.image_link
     @unit_template_id = @unit_template.id
     render 'public_show' if !@is_teacher
   end

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -97,6 +97,24 @@ class School < ApplicationRecord
 
   SCHOOL_YEAR_START_MONTH = 7
   HALF_A_YEAR = 6.months
+  ELEMENTARY = 'elementary'
+  MIDDLE = 'middle'
+  HIGH = 'high'
+
+  GRADE_DESCRIPTIONS = {
+    1 => ELEMENTARY,
+    2 => ELEMENTARY,
+    3 => ELEMENTARY,
+    4 => ELEMENTARY,
+    5 => ELEMENTARY,
+    6 => MIDDLE,
+    7 => MIDDLE,
+    8 => MIDDLE,
+    9 => HIGH,
+    10 => HIGH,
+    11 => HIGH,
+    12 => HIGH,
+  }
 
   def self.school_year_start(time)
     time.month >= SCHOOL_YEAR_START_MONTH ? time.beginning_of_year + HALF_A_YEAR : time.beginning_of_year - HALF_A_YEAR

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -76,6 +76,35 @@ class UnitTemplate < ApplicationRecord
     "#{lowest_readability_range.split('-')[0]}-#{highest_readability_range.split('-')[1]}"
   end
 
+  def meta_description
+    "Free online writing activity pack \"#{name}\" for teachers of #{meta_grade_description}. #{meta_activities_description}"
+  end
+
+  def meta_grade_description
+    return "school students" if grades.blank?
+
+    levels = grades
+      .sort_by(&:to_i)
+      .map{|g| School::GRADE_DESCRIPTIONS[g.to_i]}
+      .compact
+      .uniq
+
+    "#{levels.to_sentence} school students grades #{grades.sort_by(&:to_i).to_sentence}"
+  end
+
+  def meta_activities_description
+    return nil if activities.blank?
+
+    standards = activities
+      .map {|a| a.standard&.name}
+      .flatten
+      .compact
+      .uniq
+      .to_sentence
+
+    "Standards: #{standards}."
+  end
+
   def grade_level_range
     activities_with_minimum_grade_levels = activities.where.not(minimum_grade_level: nil).reorder("minimum_grade_level ASC")
     return nil if activities_with_minimum_grade_levels.empty?

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -50,7 +50,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <% end %>
   <%= render partial: 'application/head_embed_codes' %>
-  <%= javascript_pack_tag((@js_file || 'app'), 'crossorigin': 'anonymous') %>
+  <%= javascript_pack_tag((@js_file || 'app'), defer: @defer_js || false, 'crossorigin': 'anonymous') %>
   <%= csrf_meta_tags %>
   <meta id='current-user-testing-flag' property="flag" content=<%= current_user&.testing_flag%> />
   <meta id='current-user-id' property="id" content=<%= current_user&.id%> />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_profile/unit_template_profile.tsx
@@ -87,10 +87,6 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
     return `Check out the '${name}' activity pack I just assigned on Quill.org! ${this.socialShareUrl(referralCode)}`
   }
 
-  getMetaText = (name: string) => {
-    return `Check out the '${name}' activity pack I just assigned on Quill.org!`;
-  }
-
   handleGoToEditStudents = () => {
     const { history } = this.props;
     const { data } = this.state;
@@ -142,7 +138,6 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
       return <LoadingIndicator />
     } else {
       let navigation: any;
-      let container: HTMLMetaElement | null = document.querySelector("meta[name='og:description']");
       const { name, id, non_authenticated, flag } = data
       const showSocials = flag === 'production';
       if (!non_authenticated) {
@@ -151,9 +146,6 @@ export class UnitTemplateProfile extends React.Component<RouteComponentProps, Un
           unitTemplateId={id}
           unitTemplateName={name}
         />)
-      }
-      if (container instanceof HTMLMetaElement) {
-        container.content = this.getMetaText(name);
       }
       return (
         <div className="unit-template-profile">

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -142,6 +142,40 @@ describe UnitTemplate, redis: true, type: :model do
     end
   end
 
+  describe '#meta_description' do
+    let(:standard1) {create(:standard, name: '7.1b writing sentences')}
+    let(:standard2) {create(:standard, name: 'CCSS Grade 9')}
+    let(:activity1) { create(:activity, standard: standard1) }
+    let(:activity2) { create(:activity, standard: standard2) }
+    let(:description) {"Free online writing activity pack \"Template Name\" for teachers of school students. Standards: 7.1b writing sentences and CCSS Grade 9."}
+
+    subject { create(:unit_template, name: 'Template Name', activities: [activity1, activity2]) }
+
+    it 'populate a meta decription' do
+      expect(subject.meta_description).to eq description
+    end
+
+    context 'with grades' do
+      let(:description) {"Free online writing activity pack \"Template Name\" for teachers of middle school students grades 6, 7, and 8. Standards: 7.1b writing sentences and CCSS Grade 9."}
+
+      subject { create(:unit_template, name: 'Template Name', grades: ['6','7','8'], activities: [activity1, activity2]) }
+
+      it 'populate a meta decription' do
+        expect(subject.meta_description).to eq description
+      end
+    end
+
+    context 'no activities' do
+      let(:description) {"Free online writing activity pack \"Template Name\" for teachers of school students. "}
+
+      subject { create(:unit_template, name: 'Template Name') }
+
+      it 'populate a meta decription' do
+        expect(subject.meta_description).to eq description
+      end
+    end
+  end
+
   describe '#get_cached_serialized_unit_template' do
     let(:category) { create(:unit_template_category) }
     let(:author) { create(:author) }


### PR DESCRIPTION
* Add better meta descriptions to activity packs page.

* Add defer_js option for use with public pages.

* Remove overwriting of meta fields by javascript.

* Add some basic tests.

* Remove tool description for length.

* Lint

* Make show and index consistent.

* Use standards name in description.

* Clean up variable name.

* Update eager loading.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
