### PR TITLE
lms/reset-sidekiq-queue-config

### DIFF
--- a/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
@@ -3,7 +3,7 @@
 class SaveUserPackSequenceItemsWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: SidekiqQueue::MIGRATION,
+  sidekiq_options queue: SidekiqQueue::DEFAULT,
     lock: :until_executed
 
   def perform(classroom_id, user_id)


### PR DESCRIPTION
## WHAT
Set the `SaveUserPackSequenceItemsWorker` back to the `default` queue
## WHY
We don't want this to be a permanent change, we only did it to do some testing, so we want to go back to the old config.
## HOW
Just revert the original code change.

### Notion Card Links
https://www.notion.so/quill/Out-of-Memory-errors-for-background-workers-7fbcb78248754df5beb4ba099511b5cd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, just a config change
Have you deployed to Staging? | No, just a config change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
