### PR TITLE
fix parens regex bug

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/actions/session.ts
@@ -169,11 +169,11 @@ export const reportAProblem = ({ sessionID, entry, report, callback, isOptimal }
 
 export const getFeedback = (args: GetFeedbackArguments) => {
   const { sessionID, activityUID, entry, promptID, promptText, attempt, previousFeedback, callback, activityVersion } = args
+
   return (dispatch: Function) => {
     const feedbackURL = `${process.env.DEFAULT_URL}/api/v1/evidence/feedback/`
 
-    const promptRegex = new RegExp(`^${promptText}`)
-    const entryWithoutStem = entry.replace(promptRegex, "").trim()
+    const entryWithoutStem = entry.slice(promptText.length).trim()
     const mostRecentFeedback = previousFeedback.slice(-1)[0] || {}
 
     dispatch(TrackAnalyticsEvent(Events.EVIDENCE_ENTRY_SUBMITTED, {

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/actions/session.test.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/actions/session.test.ts
@@ -16,6 +16,7 @@ describe('Session actions', () => {
   describe('when the getFeedback action is dispatched', () => {
     const mockSessionID = 'SESSION_ID'
     const mockActivityID = 'ACTIVITY_ID'
+    const mockPromptAndEntry = 'This is great because Student entry'
     const mockEntry = 'Student entry'
     const mockPromptID = 'PROMPT_ID'
     const mockPromptText = 'This is great because'
@@ -29,7 +30,7 @@ describe('Session actions', () => {
     const mockArgs = {
       sessionID: mockSessionID,
       activityUID: mockActivityID,
-      entry: mockEntry,
+      entry: mockPromptAndEntry,
       promptID: mockPromptID,
       promptText: mockPromptText,
       attempt: mockAttempt,
@@ -47,7 +48,7 @@ describe('Session actions', () => {
         promptStemText: mockPromptText,
         sessionID: mockSessionID,
         startingFeedback: mockStartingFeedback,
-        submittedEntry: mockEntry
+        submittedEntry: mockPromptAndEntry
       })
     })
 


### PR DESCRIPTION
## WHAT, HOW, WHY
ES6's `Regexp` API does not treat parentheses as string literals. Thus, when a prompt  looks like

`lorem (ipsum), so`

no match will be found, so FeedbackHistory.entry will persist the prompt along with the student entry.

I simplified the logic to use offsets when stripping out prompts from student entries, instead of a regex comparison. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Turking-feedback-histories-contain-prompt-and-entry-in-entry-column-099a0d8deaae47968c55cecbb92a6f06

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
