### PR TITLE
Admin user management/ adding users as admins for multiple schools

### DIFF
--- a/services/QuillLMS/app/controllers/admins_controller.rb
+++ b/services/QuillLMS/app/controllers/admins_controller.rb
@@ -147,8 +147,9 @@ class AdminsController < ApplicationController
     if SchoolsAdmins.exists?(user: @teacher, school: @school)
       @message = t('admin_created_account.existing_account.admin.linked', school_name: @school.name)
     else
+      existing_admin = SchoolsAdmins.find_by(user_id: @teacher.id)
       SchoolsAdmins.create(user: @teacher, school: @school)
-      @message = t('admin_created_account.existing_account.admin.new')
+      @message = existing_admin ? t('admin_created_account.existing_account.admin.admin_for_other_school') : t('admin_created_account.existing_account.admin.new')
       handle_new_school_admin_email
     end
   end

--- a/services/QuillLMS/app/controllers/cms/school_admins_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/school_admins_controller.rb
@@ -40,30 +40,32 @@ class Cms::SchoolAdminsController < Cms::CmsController
     end
   end
 
+  private def school_admin_save_message(new_user, user)
+    if new_user
+      t('admin.make_admin')
+    elsif user.is_admin_for_multiple_schools?
+      t('admin_created_account.existing_account.admin.admin_for_other_school')
+    else
+      t('admin_created_account.existing_account.admin.new')
+    end
+  end
+
   private def handle_school_admin_save(user, school_id, new_user)
     determine_school_admin_worker(user, school_id, new_user)
-    returned_message = t('admin_created_account.existing_account.admin.new')
-
-    if new_user
-      returned_message = t('admin.make_admin')
-    elsif SchoolsAdmins.where(user_id: user.id).count > 1
-      returned_message = t('admin_created_account.existing_account.admin.admin_for_other_school')
-    end
 
     if params[:is_make_admin_button]
       flash[:success] = t('admin.make_admin')
       redirect_to cms_school_path(school_id)
     else
-      render json: { message: returned_message }, status: 200
+      render json: { message: school_admin_save_message(new_user, user) }, status: 200
     end
   end
 
   private def create_admin_user_for_existing_user(user, new_user: false)
     school_id = params[:school_id]
-    school_admin_for_school = SchoolsAdmins.find_by(school_id: school_id, user_id: user.id)
+    school_name = SchoolsAdmins.find_by(school_id: school_id, user_id: user.id)&.school&.name
 
-    if school_admin_for_school
-      school_name = school_admin_for_school.school.name
+    if school_name
       return render json: { message: t('admin_created_account.existing_account.admin.linked', school_name: school_name) }
     end
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -385,6 +385,15 @@ class User < ApplicationRecord
     SchoolsAdmins.find_by_user_id(id).present?
   end
 
+  def is_admin_for_one_school?
+    schools_admins.count == 1
+  end
+
+  def is_admin_for_multiple_schools?
+    schools_admins.count > 1
+  end
+
+
   def self.find_by_username_or_email(login_name)
     login_name = login_name.downcase
     User.where("email = ? OR username = ?", login_name, login_name).first

--- a/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_change_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_change_school_email_worker.rb
@@ -11,7 +11,7 @@ class AdminDashboard::MadeSchoolAdminChangeSchoolEmailWorker
 
     return unless user && admin_name && new_school && existing_school
 
-    if SchoolsAdmins.where(user_id: user_id).count == 1
+    if user.is_admin_for_one_school?
       user.mailer_user.send_admin_dashboard_made_school_admin_change_school_email(admin_name, new_school, existing_school)
     end
 

--- a/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_change_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_change_school_email_worker.rb
@@ -11,7 +11,9 @@ class AdminDashboard::MadeSchoolAdminChangeSchoolEmailWorker
 
     return unless user && admin_name && new_school && existing_school
 
-    user.mailer_user.send_admin_dashboard_made_school_admin_change_school_email(admin_name, new_school, existing_school)
+    if SchoolsAdmins.where(user_id: user_id).count == 1
+      user.mailer_user.send_admin_dashboard_made_school_admin_change_school_email(admin_name, new_school, existing_school)
+    end
 
     SegmentAnalytics.new.track_school_admin_user(
       user,

--- a/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_email_worker.rb
+++ b/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_email_worker.rb
@@ -10,7 +10,7 @@ class AdminDashboard::MadeSchoolAdminEmailWorker
 
     return unless user && admin_name && school_name
 
-    if SchoolsAdmins.where(user_id: user_id).count == 1
+    if user.is_admin_for_one_school?
       user.mailer_user.send_admin_dashboard_made_school_admin_email(admin_name, school_name)
     end
 

--- a/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_email_worker.rb
+++ b/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_email_worker.rb
@@ -10,7 +10,9 @@ class AdminDashboard::MadeSchoolAdminEmailWorker
 
     return unless user && admin_name && school_name
 
-    user.mailer_user.send_admin_dashboard_made_school_admin_email(admin_name, school_name)
+    if SchoolsAdmins.where(user_id: user_id).count == 1
+      user.mailer_user.send_admin_dashboard_made_school_admin_email(admin_name, school_name)
+    end
 
     SegmentAnalytics.new.track_school_admin_user(
       user,

--- a/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_link_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_link_school_email_worker.rb
@@ -10,7 +10,9 @@ class AdminDashboard::MadeSchoolAdminLinkSchoolEmailWorker
 
     return unless user && admin_name && school
 
-    user.mailer_user.send_admin_dashboard_made_school_admin_link_school_email(admin_name, school)
+    if SchoolsAdmins.where(user_id: user_id).count == 1
+      user.mailer_user.send_admin_dashboard_made_school_admin_link_school_email(admin_name, school)
+    end
 
     SegmentAnalytics.new.track_school_admin_user(
       user,

--- a/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_link_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/admin_dashboard/made_school_admin_link_school_email_worker.rb
@@ -10,7 +10,7 @@ class AdminDashboard::MadeSchoolAdminLinkSchoolEmailWorker
 
     return unless user && admin_name && school
 
-    if SchoolsAdmins.where(user_id: user_id).count == 1
+    if user.is_admin_for_one_school?
       user.mailer_user.send_admin_dashboard_made_school_admin_link_school_email(admin_name, school)
     end
 

--- a/services/QuillLMS/app/workers/internal_tool/made_district_admin_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_district_admin_email_worker.rb
@@ -9,7 +9,7 @@ class InternalTool::MadeDistrictAdminEmailWorker
 
     return unless user && district_name
 
-    user.mailer_user&.send_internal_tool_made_district_admin_email(district_name)
+    user.mailer_user.send_internal_tool_made_district_admin_email(district_name)
 
     SegmentAnalytics.new.track_district_admin_user(
       user,

--- a/services/QuillLMS/app/workers/internal_tool/made_school_admin_change_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_school_admin_change_school_email_worker.rb
@@ -10,7 +10,9 @@ class InternalTool::MadeSchoolAdminChangeSchoolEmailWorker
 
     return unless user && new_school && existing_school
 
-    user.mailer_user.send_internal_tool_made_school_admin_change_school_email(new_school, existing_school)
+    if SchoolsAdmins.where(user_id: user_id).count == 1
+      user.mailer_user.send_internal_tool_made_school_admin_change_school_email(new_school, existing_school)
+    end
 
     SegmentAnalytics.new.track_school_admin_user(
       user,

--- a/services/QuillLMS/app/workers/internal_tool/made_school_admin_change_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_school_admin_change_school_email_worker.rb
@@ -10,7 +10,7 @@ class InternalTool::MadeSchoolAdminChangeSchoolEmailWorker
 
     return unless user && new_school && existing_school
 
-    if SchoolsAdmins.where(user_id: user_id).count == 1
+    if user.is_admin_for_one_school?
       user.mailer_user.send_internal_tool_made_school_admin_change_school_email(new_school, existing_school)
     end
 

--- a/services/QuillLMS/app/workers/internal_tool/made_school_admin_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_school_admin_email_worker.rb
@@ -9,7 +9,9 @@ class InternalTool::MadeSchoolAdminEmailWorker
 
     return unless user && school_name
 
-    user.mailer_user.send_internal_tool_made_school_admin_email(school_name)
+    if SchoolsAdmins.where(user_id: user_id).count == 1
+      user.mailer_user.send_internal_tool_made_school_admin_email(school_name)
+    end
 
     SegmentAnalytics.new.track_school_admin_user(
       user,

--- a/services/QuillLMS/app/workers/internal_tool/made_school_admin_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_school_admin_email_worker.rb
@@ -9,7 +9,7 @@ class InternalTool::MadeSchoolAdminEmailWorker
 
     return unless user && school_name
 
-    if SchoolsAdmins.where(user_id: user_id).count == 1
+    if user.is_admin_for_one_school?
       user.mailer_user.send_internal_tool_made_school_admin_email(school_name)
     end
 

--- a/services/QuillLMS/app/workers/internal_tool/made_school_admin_link_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_school_admin_link_school_email_worker.rb
@@ -9,7 +9,7 @@ class InternalTool::MadeSchoolAdminLinkSchoolEmailWorker
 
     return unless user && school
 
-    if SchoolsAdmins.where(user_id: user_id).count == 1
+    if user.is_admin_for_one_school?
       user.mailer_user.send_internal_tool_made_school_admin_link_school_email(school)
     end
 

--- a/services/QuillLMS/app/workers/internal_tool/made_school_admin_link_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_school_admin_link_school_email_worker.rb
@@ -9,7 +9,9 @@ class InternalTool::MadeSchoolAdminLinkSchoolEmailWorker
 
     return unless user && school
 
-    user.mailer_user.send_internal_tool_made_school_admin_link_school_email(school)
+    if SchoolsAdmins.where(user_id: user_id).count == 1
+      user.mailer_user.send_internal_tool_made_school_admin_link_school_email(school)
+    end
 
     SegmentAnalytics.new.track_school_admin_user(
       user,

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/__tests__/__snapshots__/adminsTeachers.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/__tests__/__snapshots__/adminsTeachers.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`AdminsTeachers component should match snapshot 1`] = `
     <DataTable
       averageFontWidth={7}
       className="progress-report has-green-arrow"
+      defaultSortAttribute="role"
       headers={
         Array [
           Object {

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/adminsTeachers.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/adminsTeachers.tsx
@@ -222,6 +222,7 @@ export const AdminsTeachers: React.SFC<AdminsTeachersProps> = ({
       <div className="admins-teachers">
         <DataTable
           className='progress-report has-green-arrow'
+          defaultSortAttribute="role"
           headers={teacherColumns}
           rows={filteredData}
         />

--- a/services/QuillLMS/config/locales/en.yml
+++ b/services/QuillLMS/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
     existing_account:
       admin:
         linked: "This account already exists and is an admin of %{school_name}."
+        admin_for_other_school: "This account already exists and is an admin for another school. They were also made an admin for this school."
         new: "This account already exists. They were made an admin and notified by email."
       teacher:
         linked: "This account already exists and is linked to %{school_name}."

--- a/services/QuillLMS/spec/controllers/admins_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/admins_controller_spec.rb
@@ -154,17 +154,18 @@ describe AdminsController  do
             end
           end
 
-          # describe 'and they already an admin for another school' do
-          #   it 'creates a school admin record, returns a message and fires an email worker' do
-          #     other_school = create(:school)
-          #     create(:schools_users, school: other_school, user: existing_teacher)
+          describe 'and they are already an admin for another school' do
+            it 'creates a school admin record, returns a message and does not send an additional email' do
+              other_school = create(:school)
+              create(:schools_users, school: other_school, user: existing_teacher)
+              create(:schools_admins, user: existing_teacher, school: other_school)
 
-          #     expect(AdminDashboard::MadeSchoolAdminChangeSchoolEmailWorker).to receive(:perform_async)
-          #     post :create_and_link_accounts, params: { id: admin.id, school_id: school.id, teacher: { role: 'admin', email: existing_teacher.email }}
-          #     expect(response.body).to eq({message: I18n.t('admin_created_account.existing_account.admin.new')}.to_json)
-          #     expect(SchoolsAdmins.find_by(school: school, user: existing_teacher)).to be
-          #   end
-          # end
+              post :create_and_link_accounts, params: { id: admin.id, school_id: school.id, teacher: { role: 'admin', email: existing_teacher.email }}
+              expect(response.body).to eq({message: I18n.t('admin_created_account.existing_account.admin.admin_for_other_school')}.to_json)
+              expect(ActionMailer::Base.deliveries.count).to eq(0)
+              expect(SchoolsAdmins.find_by(school: school, user: existing_teacher)).to be
+            end
+          end
 
         end
 

--- a/services/QuillLMS/spec/controllers/admins_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/admins_controller_spec.rb
@@ -154,6 +154,18 @@ describe AdminsController  do
             end
           end
 
+          # describe 'and they already an admin for another school' do
+          #   it 'creates a school admin record, returns a message and fires an email worker' do
+          #     other_school = create(:school)
+          #     create(:schools_users, school: other_school, user: existing_teacher)
+
+          #     expect(AdminDashboard::MadeSchoolAdminChangeSchoolEmailWorker).to receive(:perform_async)
+          #     post :create_and_link_accounts, params: { id: admin.id, school_id: school.id, teacher: { role: 'admin', email: existing_teacher.email }}
+          #     expect(response.body).to eq({message: I18n.t('admin_created_account.existing_account.admin.new')}.to_json)
+          #     expect(SchoolsAdmins.find_by(school: school, user: existing_teacher)).to be
+          #   end
+          # end
+
         end
 
       end

--- a/services/QuillLMS/spec/controllers/cms/school_admins_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/school_admins_controller_spec.rb
@@ -68,5 +68,16 @@ describe Cms::SchoolAdminsController do
         expect(body_contains_expected_content).to be true
       end
     end
+
+    it 'creates a new school admin for an existing admin user and does not send an additional email' do
+      Sidekiq::Testing.inline! do
+        school2.users.push(admin2)
+        admin2.reload
+        post :create, params: { school_id: school1.id, email: admin2.email}
+        post :create, params: { school_id: school2.id, email: admin2.email}
+
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+    end
   end
 end

--- a/services/QuillLMS/spec/workers/admin_dashboard/made_school_admin_change_school_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/admin_dashboard/made_school_admin_change_school_email_worker_spec.rb
@@ -9,6 +9,7 @@ describe AdminDashboard::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker d
   let!(:referring_admin) { create(:teacher) }
   let!(:new_school) { create(:school) }
   let!(:existing_school) { create(:school) }
+  let!(:school_admin) { create(:schools_admins, user: teacher, school: existing_school)}
   let!(:mailer_user) { Mailer::User.new(teacher) }
   let!(:mailer_class)  { AdminDashboardUserMailer }
   let!(:mailer_method) { :made_school_admin_change_school_email}
@@ -25,6 +26,7 @@ describe AdminDashboard::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker d
 
     before do
       allow(User).to receive(:find_by).and_return(nil)
+      allow(SchoolsAdmins).to receive(:where).and_return([])
     end
 
     it 'should not send the mail with user mailer' do
@@ -42,6 +44,7 @@ describe AdminDashboard::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker d
 
     before do
       allow(User).to receive(:find_by).and_return(teacher, referring_admin)
+      allow(SchoolsAdmins).to receive(:where).and_return([school_admin])
     end
 
     it 'should send the mail with user mailer' do

--- a/services/QuillLMS/spec/workers/admin_dashboard/made_school_admin_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/admin_dashboard/made_school_admin_email_worker_spec.rb
@@ -8,6 +8,7 @@ describe AdminDashboard::MadeSchoolAdminEmailWorker, type: :worker do
   let!(:teacher) { create(:teacher) }
   let!(:referring_admin) { create(:teacher) }
   let!(:school) { create(:school) }
+  let!(:school_admin) { create(:schools_admins, user: teacher, school: school)}
   let!(:mailer_user) { Mailer::User.new(teacher) }
   let!(:mailer_class)  { AdminDashboardUserMailer }
   let!(:mailer_method) { :made_school_admin_email}
@@ -24,6 +25,7 @@ describe AdminDashboard::MadeSchoolAdminEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(nil)
+      allow(SchoolsAdmins).to receive(:where).and_return([])
     end
 
     it 'should not send the mail with user mailer' do
@@ -41,6 +43,7 @@ describe AdminDashboard::MadeSchoolAdminEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(teacher, referring_admin)
+      allow(SchoolsAdmins).to receive(:where).and_return([school_admin])
     end
 
     it 'should send the mail with user mailer' do

--- a/services/QuillLMS/spec/workers/admin_dashboard/made_school_admin_link_school_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/admin_dashboard/made_school_admin_link_school_email_worker_spec.rb
@@ -8,6 +8,7 @@ describe AdminDashboard::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
   let!(:teacher) { create(:teacher) }
   let!(:referring_admin) { create(:teacher) }
   let!(:school) { create(:school) }
+  let!(:school_admin) { create(:schools_admins, user: teacher, school: school)}
   let!(:mailer_user) { Mailer::User.new(teacher) }
   let!(:mailer_class)  { AdminDashboardUserMailer }
   let!(:mailer_method) { :made_school_admin_link_school_email}
@@ -24,6 +25,7 @@ describe AdminDashboard::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(nil)
+      allow(SchoolsAdmins).to receive(:where).and_return([])
     end
 
     it 'should not send the mail with user mailer' do
@@ -41,6 +43,7 @@ describe AdminDashboard::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(teacher, referring_admin)
+      allow(SchoolsAdmins).to receive(:where).and_return([school_admin])
     end
 
     it 'should send the mail with user mailer' do

--- a/services/QuillLMS/spec/workers/internal_tool/made_school_admin_change_school_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/made_school_admin_change_school_email_worker_spec.rb
@@ -7,6 +7,7 @@ describe InternalTool::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker do
 
   let!(:teacher) { create(:teacher) }
   let!(:new_school) { create(:school) }
+  let!(:school_admin) { create(:schools_admins, user: teacher, school: new_school)}
   let!(:existing_school) { create(:school) }
   let!(:mailer_user) { Mailer::User.new(teacher) }
   let!(:mailer_class)  { InternalToolUserMailer }
@@ -24,6 +25,7 @@ describe InternalTool::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(nil)
+      allow(SchoolsAdmins).to receive(:where).and_return([])
     end
 
     it 'should not send the mail with user mailer' do
@@ -41,6 +43,7 @@ describe InternalTool::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(teacher)
+      allow(SchoolsAdmins).to receive(:where).and_return([school_admin])
     end
 
     it 'should send the mail with user mailer' do

--- a/services/QuillLMS/spec/workers/internal_tool/made_school_admin_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/made_school_admin_email_worker_spec.rb
@@ -7,6 +7,7 @@ describe InternalTool::MadeSchoolAdminEmailWorker, type: :worker do
 
   let!(:teacher) { create(:teacher) }
   let!(:school) { create(:school) }
+  let!(:school_admin) { create(:schools_admins, user: teacher, school: school)}
   let!(:mailer_user) { Mailer::User.new(teacher) }
   let!(:mailer_class)  { InternalToolUserMailer }
   let!(:mailer_method) { :made_school_admin_email}
@@ -23,6 +24,7 @@ describe InternalTool::MadeSchoolAdminEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(nil)
+      allow(SchoolsAdmins).to receive(:where).and_return([])
     end
 
     it 'should not send the mail with user mailer' do
@@ -40,6 +42,7 @@ describe InternalTool::MadeSchoolAdminEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(teacher)
+      allow(SchoolsAdmins).to receive(:where).and_return([school_admin])
     end
 
     it 'should send the mail with user mailer' do

--- a/services/QuillLMS/spec/workers/internal_tool/made_school_admin_link_school_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/made_school_admin_link_school_email_worker_spec.rb
@@ -7,6 +7,7 @@ describe InternalTool::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
 
   let!(:teacher) { create(:teacher) }
   let!(:school) { create(:school) }
+  let!(:school_admin) { create(:schools_admins, user: teacher, school: school)}
   let!(:mailer_user) { Mailer::User.new(teacher) }
   let!(:mailer_class)  { InternalToolUserMailer }
   let!(:mailer_method) { :made_school_admin_link_school_email}
@@ -23,6 +24,7 @@ describe InternalTool::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(nil)
+      allow(SchoolsAdmins).to receive(:where).and_return([])
     end
 
     it 'should not send the mail with user mailer' do
@@ -40,6 +42,7 @@ describe InternalTool::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
 
     before do
       allow(User).to receive(:find_by).and_return(teacher)
+      allow(SchoolsAdmins).to receive(:where).and_return([school_admin])
     end
 
     it 'should send the mail with user mailer' do


### PR DESCRIPTION
## WHAT
add ability to add users as admins for multiple schools via the internal tool and suppress emails for existing admin users

## WHY
we want to have this functionality for the internal tool and we don't want to send more than one email once a user has been made an admin (see Notion card discussion)

## HOW
update admin check in `CMS::SchoolAdminsController` to allow admin creation for additional schools as well as add checks for multiple `SchoolsAdmins` records in the workers to only send an email on the first admin addition

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Error-when-adding-an-admin-to-multiple-schools-in-Quill-CMS-6029b30dcee041e7b6208b257a83f154

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
