### PR TITLE
Admin user management/ sort by role for "Account Management" table

### DIFF
--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/__tests__/__snapshots__/adminsTeachers.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/__tests__/__snapshots__/adminsTeachers.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`AdminsTeachers component should match snapshot 1`] = `
     <DataTable
       averageFontWidth={7}
       className="progress-report has-green-arrow"
+      defaultSortAttribute="role"
       headers={
         Array [
           Object {

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/adminsTeachers.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/adminsTeachers.tsx
@@ -50,8 +50,10 @@ export const AdminsTeachers: React.SFC<AdminsTeachersProps> = ({
   schools,
   adminAssociatedSchool,
 }) => {
+  console.log("🚀 ~ file: adminsTeachers.tsx:53 ~ data", data)
   const defaultSchool = schools.find(s => s.id === adminAssociatedSchool?.id) || schools[0]
   const [selectedSchoolId, setSelectedSchoolId] = React.useState(defaultSchool.id)
+  console.log("🚀 ~ file: adminsTeachers.tsx:56 ~ selectedSchoolId", selectedSchoolId)
   const [userIdForModal, setUserIdForModal] = React.useState(null)
   const [showModal, setShowModal] = React.useState(null)
 
@@ -222,6 +224,7 @@ export const AdminsTeachers: React.SFC<AdminsTeachersProps> = ({
       <div className="admins-teachers">
         <DataTable
           className='progress-report has-green-arrow'
+          defaultSortAttribute="role"
           headers={teacherColumns}
           rows={filteredData}
         />

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/adminsTeachers.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/adminsTeachers.tsx
@@ -50,10 +50,8 @@ export const AdminsTeachers: React.SFC<AdminsTeachersProps> = ({
   schools,
   adminAssociatedSchool,
 }) => {
-  console.log("🚀 ~ file: adminsTeachers.tsx:53 ~ data", data)
   const defaultSchool = schools.find(s => s.id === adminAssociatedSchool?.id) || schools[0]
   const [selectedSchoolId, setSelectedSchoolId] = React.useState(defaultSchool.id)
-  console.log("🚀 ~ file: adminsTeachers.tsx:56 ~ selectedSchoolId", selectedSchoolId)
   const [userIdForModal, setUserIdForModal] = React.useState(null)
   const [showModal, setShowModal] = React.useState(null)
 


### PR DESCRIPTION
## WHAT
sort by role for the "Account Management" table on the admin dashboard page

## WHY
we want admins to be shown first in order

## HOW
just add `defaultSortAttribute="role"` for the table

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1207" alt="Screen Shot 2023-01-27 at 3 51 47 PM" src="https://user-images.githubusercontent.com/25959584/215171052-07d7deef-642d-4b84-975e-c4fe84a56217.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/PS-On-the-admin-dashboard-sort-the-Account-Management-table-by-Role-so-admins-are-listed-at-th-7fdc87246403467483a85f99e2e67309

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change-- manually tested
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
