### PR TITLE
lms/isolate-batch-worker

### DIFF
--- a/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
@@ -3,7 +3,7 @@
 class BatchAssignRecommendationsWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::MIGRATION
 
   def perform(assigning_all_recommended_packs, pack_sequence_id, selections_with_students)
     return if selections_with_students.empty?

--- a/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
@@ -42,7 +42,7 @@ class BatchAssignRecommendationsWorker
     else
       batch = Sidekiq::Batch.new
       batch.description = 'Assigning Recommendations with Pack Sequence'
-      batch.callback_queue = SidekiqQueue::CRITICAL
+      batch.callback_queue = SidekiqQueue::MIGRATION
       batch.on(:success, self.class, pack_sequence_id: pack_sequence_id)
       batch.jobs { assign_recommendations.call }
     end


### PR DESCRIPTION
## WHAT
Move BatchAssignRecommendationsWorker to MIGRATION queue temporarily
## WHY
So that we can test its impact on our Sidekiq work in isolation
## HOW
Update the configuration for the job so that it goes to another queue.  (Discussion with @brendanshean about the priority of this job led to us both agreeing that this should be safe to put in its own queue even if it's in the critical queue now because being by itself, no other jobs will block it.)

### Notion Card Links
https://www.notion.so/quill/Out-of-Memory-errors-for-background-workers-7fbcb78248754df5beb4ba099511b5cd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests for Sidekiq priority
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
