### PR TITLE
Revert "lms/isolate-batch-worker (#10215)"

### DIFF
--- a/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/batch_assign_recommendations_worker.rb
@@ -3,7 +3,7 @@
 class BatchAssignRecommendationsWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: SidekiqQueue::MIGRATION
+  sidekiq_options queue: SidekiqQueue::CRITICAL
 
   def perform(assigning_all_recommended_packs, pack_sequence_id, selections_with_students)
     return if selections_with_students.empty?
@@ -42,7 +42,7 @@ class BatchAssignRecommendationsWorker
     else
       batch = Sidekiq::Batch.new
       batch.description = 'Assigning Recommendations with Pack Sequence'
-      batch.callback_queue = SidekiqQueue::MIGRATION
+      batch.callback_queue = SidekiqQueue::CRITICAL
       batch.on(:success, self.class, pack_sequence_id: pack_sequence_id)
       batch.jobs { assign_recommendations.call }
     end


### PR DESCRIPTION
## WHAT
Put the `BatchAssignRecommendationsWorker` back on the `critical` queue.  (NOTE: the plan is to merge and deploy this at EOD.)
## WHY
We only wanted to pull it out for a test
## HOW
Revert the change we deployed for the test

### Notion Card Links
https://www.notion.so/quill/Out-of-Memory-errors-for-background-workers-7fbcb78248754df5beb4ba099511b5cd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A