### PR TITLE
Admin user management/ show unlinked school admins

### DIFF
--- a/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
+++ b/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
@@ -16,7 +16,7 @@ class Admin::TeacherSerializer < ApplicationSerializer
   type :teacher
 
   def schools
-    [object&.school].concat(object&.reload.administered_schools).compact.uniq.map do |school|
+    [object&.school].concat(object&.reload&.administered_schools).compact.uniq.map do |school|
       school_hash = { name: school.name, id: school.id }
       school_hash[:role] = SchoolsAdmins.exists?(school: school, user: object) ? ADMIN : TEACHER
       school_hash

--- a/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
+++ b/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
@@ -16,7 +16,7 @@ class Admin::TeacherSerializer < ApplicationSerializer
   type :teacher
 
   def schools
-    [object&.school].concat(object&.administered_schools).compact.uniq.map do |school|
+    [object&.school].concat(object&.reload.administered_schools).compact.uniq.map do |school|
       school_hash = { name: school.name, id: school.id }
       school_hash[:role] = SchoolsAdmins.exists?(school: school, user: object) ? ADMIN : TEACHER
       school_hash

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -26,21 +26,59 @@ describe Admin::TeacherSerializer do
   describe 'serializer properties' do
     let!(:school1) { create(:school) }
     let!(:school2) { create(:school) }
-    let!(:teacher) { create(:teacher) }
+    let!(:classroom) { create(:classroom_with_a_couple_students) }
+    let!(:teacher) { classroom.owner }
+    let!(:student1) { classroom.students.first }
+    let!(:student2) { classroom.students.last }
+    let!(:school_users1) { create(:schools_users, user: teacher, school: school2) }
+    let!(:schools_users2) { create(:schools_users, user: classroom.students.first, school: school2) }
+    let!(:schools_users3) { create(:schools_users, user: classroom.students.last, school: school2) }
+    let!(:schools_admins1) { create(:schools_admins, user: teacher, school: school1) }
+    let!(:schools_admins2) { create(:schools_admins, user: teacher, school: school2) }
+    let!(:unit) { create(:unit, user_id: teacher.id)}
+    let!(:student1) { classroom.students.first }
+    let!(:student2) { classroom.students.second }
+    let!(:time2) { Time.current }
+    let!(:time1) { time2 - (10.minutes) }
+    let!(:classroom_unit) { create(:classroom_unit, classroom_id: classroom.id, unit: unit, assigned_student_ids: classroom.students.ids) }
+    let!(:activity_session1) { create(:activity_session_without_concept_results,
+                                                  user: student1,
+                                                  state: 'finished',
+                                                  started_at: time1,
+                                                  completed_at: time2,
+                                                  classroom_unit: classroom_unit
+                                                  ) }
 
-    subject { described_class.new(teacher) }
+    let!(:activity_session2) { create(:activity_session_without_concept_results,
+                                                  user: student1,
+                                                  state: 'finished',
+                                                  started_at: time1,
+                                                  completed_at: time2,
+                                                  classroom_unit: classroom_unit
+                                                  ) }
+    let!(:activity_session3) { create(:activity_session_without_concept_results,
+                                                  user: student2,
+                                                  state: 'finished',
+                                                  started_at: time1,
+                                                  completed_at: time2,
+                                                  classroom_unit: classroom_unit
+                                                  ) }
+    let!(:activity_session3) { create(:activity_session_without_concept_results,
+                                                  user: student2,
+                                                  state: 'started',
+                                                  started_at: time1,
+                                                  completed_at: time2,
+                                                  classroom_unit: classroom_unit
+                                                  ) }
+    let!(:record_instance) { TeachersData.run([teacher.id])[0] }
 
-    it 'returns the expected "schools" payload' do
-       create(:schools_users, user: teacher, school: school2)
-       create(:schools_admins, user: teacher, school: school2)
-       create(:schools_admins, user: teacher, school: school1)
-       teacher.reload
+    subject { described_class.new(record_instance) }
 
-       expect(subject.schools).to eq([
-        { name: school2.name, id: school2.id, role: 'Admin' },
-        { name: school1.name, id: school1.id, role: 'Admin' }
-       ])
+    it 'returns the expected payload' do
+      expect(subject.schools.count).to eq(2)
+      expect(subject.number_of_students).to eq(classroom.students.count)
+      expect(subject.number_of_activities_completed).to eq(3)
+      expect(subject.time_spent).to eq("0 hours")
     end
-    # TODO: add tests for remaining properties
   end
 end

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -42,7 +42,7 @@ describe Admin::TeacherSerializer do
     let!(:activity_session1) { create(:activity_session_without_concept_results, user: student1, state: 'finished', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }
     let!(:activity_session2) { create(:activity_session_without_concept_results, user: student1, state: 'finished', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }
     let!(:activity_session3) { create(:activity_session_without_concept_results, user: student2, state: 'finished', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }
-    let!(:activity_session3) { create(:activity_session_without_concept_results, user: student2, state: 'started', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }
+    let!(:activity_session4) { create(:activity_session_without_concept_results, user: student2, state: 'started', started_at: time1, completed_at: nil, classroom_unit: classroom_unit) }
     let!(:record_instance) { TeachersData.run([teacher.id])[0] }
 
     subject { described_class.new(record_instance) }

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -36,40 +36,13 @@ describe Admin::TeacherSerializer do
     let!(:schools_admins1) { create(:schools_admins, user: teacher, school: school1) }
     let!(:schools_admins2) { create(:schools_admins, user: teacher, school: school2) }
     let!(:unit) { create(:unit, user_id: teacher.id)}
-    let!(:student1) { classroom.students.first }
-    let!(:student2) { classroom.students.second }
     let!(:time2) { Time.current }
     let!(:time1) { time2 - (10.minutes) }
     let!(:classroom_unit) { create(:classroom_unit, classroom_id: classroom.id, unit: unit, assigned_student_ids: classroom.students.ids) }
-    let!(:activity_session1) { create(:activity_session_without_concept_results,
-                                                  user: student1,
-                                                  state: 'finished',
-                                                  started_at: time1,
-                                                  completed_at: time2,
-                                                  classroom_unit: classroom_unit
-                                                  ) }
-
-    let!(:activity_session2) { create(:activity_session_without_concept_results,
-                                                  user: student1,
-                                                  state: 'finished',
-                                                  started_at: time1,
-                                                  completed_at: time2,
-                                                  classroom_unit: classroom_unit
-                                                  ) }
-    let!(:activity_session3) { create(:activity_session_without_concept_results,
-                                                  user: student2,
-                                                  state: 'finished',
-                                                  started_at: time1,
-                                                  completed_at: time2,
-                                                  classroom_unit: classroom_unit
-                                                  ) }
-    let!(:activity_session3) { create(:activity_session_without_concept_results,
-                                                  user: student2,
-                                                  state: 'started',
-                                                  started_at: time1,
-                                                  completed_at: time2,
-                                                  classroom_unit: classroom_unit
-                                                  ) }
+    let!(:activity_session1) { create(:activity_session_without_concept_results, user: student1, state: 'finished', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }
+    let!(:activity_session2) { create(:activity_session_without_concept_results, user: student1, state: 'finished', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }
+    let!(:activity_session3) { create(:activity_session_without_concept_results, user: student2, state: 'finished', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }
+    let!(:activity_session3) { create(:activity_session_without_concept_results, user: student2, state: 'started', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }
     let!(:record_instance) { TeachersData.run([teacher.id])[0] }
 
     subject { described_class.new(record_instance) }

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -22,4 +22,25 @@ describe Admin::TeacherSerializer do
       }
     end
   end
+
+  describe 'serializer properties' do
+    let!(:school1) { create(:school) }
+    let!(:school2) { create(:school) }
+    let!(:teacher) { create(:teacher) }
+
+    subject { described_class.new(teacher) }
+
+    it 'returns the expected "schools" payload' do
+       create(:schools_users, user: teacher, school: school2)
+       create(:schools_admins, user: teacher, school: school2)
+       create(:schools_admins, user: teacher, school: school1)
+       teacher.reload
+
+       expect(subject.schools).to eq([
+        { name: school2.name, id: school2.id, role: 'Admin' },
+        { name: school1.name, id: school1.id, role: 'Admin' }
+       ])
+    end
+    # TODO: add tests for remaining properties
+  end
 end


### PR DESCRIPTION
## WHAT
fix bug where school admins not directly linked to a school (i.e. the teacher did not have the school linked on their account) were not showing in the "Account Management" table on the admin dashboard

## WHY
these users should be showing in this table regardless of what their linked school is

## HOW
add a `.reload` on the admin teacher serializer object so that the correct data is returned for `administered_schools`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/PS-On-the-admin-dashboard-display-users-as-an-admin-in-the-Account-Management-table-regardless-o-20c365317f63471a9666ec8de717446a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes