### PR TITLE
Log lock conflicts with SaveUserPackSequenceItemsWorker

### DIFF
--- a/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
@@ -4,7 +4,9 @@ class SaveUserPackSequenceItemsWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: SidekiqQueue::DEFAULT,
-    lock: :until_executed
+    lock: :until_executed,
+    on_conflict: :log,
+    lock_ttl: 2.minutes
 
   def perform(classroom_id, user_id)
     return if classroom_id.nil? || user_id.nil?

--- a/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
@@ -5,8 +5,7 @@ class SaveUserPackSequenceItemsWorker
 
   sidekiq_options queue: SidekiqQueue::DEFAULT,
     lock: :until_executed,
-    on_conflict: :log,
-    lock_ttl: 2.minutes
+    on_conflict: :log
 
   def perform(classroom_id, user_id)
     return if classroom_id.nil? || user_id.nil?

--- a/services/QuillLMS/spec/workers/save_user_pack_sequence_items_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_user_pack_sequence_items_worker_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'sidekiq_unique_jobs/testing'
 
 RSpec.describe SaveUserPackSequenceItemsWorker do
   subject { described_class.new.perform(classroom_id, user_id) }
@@ -9,6 +10,8 @@ RSpec.describe SaveUserPackSequenceItemsWorker do
   let(:user_id) { create(:user).id }
 
   before { SidekiqUniqueJobs.config.enabled = false }
+
+  it { expect(described_class).to have_valid_sidekiq_options }
 
   context 'nil classroom_id' do
     let(:classroom_id) { nil }


### PR DESCRIPTION
## WHAT
Add `on_conflict: :log` to the SaveUserPackSequenceItemsWorker's sidekiq-unique-jobs configuration.

## WHY
On conflict will log a conflict message when a worker is attempted that is already in the queue.

## HOW
Add to the configuration section of the worker.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manual testing on staging.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
