### PR TITLE
Remove sidekiq-unique-jobs

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -90,7 +90,6 @@ source "https://gems.contribsys.com/" do
 end
 gem 'sidekiq', '~> 5.2.10'
 gem 'sidekiq-retries', require: false
-gem 'sidekiq-unique-jobs'
 gem 'redis', '~> 4.5'
 gem 'redis-namespace', '~> 1.8'
 gem 'redis-rails'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -146,9 +146,6 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     brakeman (4.1.1)
-    brpoplpush-redis_script (0.1.3)
-      concurrent-ruby (~> 1.0, >= 1.0.5)
-      redis (>= 1.0, < 6)
     builder (3.2.4)
     bulk_insert (1.9.0)
       activerecord (>= 3.2.0)
@@ -702,11 +699,6 @@ GEM
       redis (~> 4.5, < 4.6.0)
     sidekiq-retries (0.4.0)
       sidekiq (>= 3.2.4)
-    sidekiq-unique-jobs (7.1.27)
-      brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
-      concurrent-ruby (~> 1.0, >= 1.0.5)
-      sidekiq (>= 5.0, < 8.0)
-      thor (>= 0.20, < 3.0)
     signet (0.12.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -899,7 +891,6 @@ DEPENDENCIES
   sidekiq (~> 5.2.10)
   sidekiq-pro!
   sidekiq-retries
-  sidekiq-unique-jobs
   slim-rails
   spring
   spring-commands-rspec

--- a/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
@@ -3,8 +3,7 @@
 class SaveUserPackSequenceItemsWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: SidekiqQueue::DEFAULT,
-    lock: :until_executed
+  sidekiq_options queue: SidekiqQueue::DEFAULT
 
   def perform(classroom_id, user_id)
     return if classroom_id.nil? || user_id.nil?

--- a/services/QuillLMS/config/initializers/sidekiq.rb
+++ b/services/QuillLMS/config/initializers/sidekiq.rb
@@ -4,17 +4,10 @@ sidekiq_url = ENV['SIDEKIQ_REDIS_URL'] || 'redis://localhost:6379'
 
 Sidekiq.configure_server do |config|
   config.redis = { url: sidekiq_url, namespace: 'sidekiq' }
-
-  config.client_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Client }
-  config.server_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Server }
-
-  SidekiqUniqueJobs::Server.configure(config)
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: sidekiq_url, namespace: 'sidekiq' }
-
-  config.client_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Client }
 end
 
 module SidekiqQueue

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -84,8 +84,6 @@ RSpec.configure do |config|
   config.silence_filter_announcements = true
   config.run_all_when_everything_filtered = true
 
-  config.before { SidekiqUniqueJobs.config.enabled = false }
-
   config.around(:each, :caching) do |example|
     caching = ActionController::Base.perform_caching
     ActionController::Base.perform_caching = example.metadata[:caching]

--- a/services/QuillLMS/spec/workers/save_user_pack_sequence_items_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_user_pack_sequence_items_worker_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe SaveUserPackSequenceItemsWorker do
   let(:classroom_id) { create(:classroom).id }
   let(:user_id) { create(:user).id }
 
-  before { SidekiqUniqueJobs.config.enabled = false }
-
   context 'nil classroom_id' do
     let(:classroom_id) { nil }
 


### PR DESCRIPTION
## WHAT
Remove the sidekiq-unique-jobs configuration from SaveUserPackSequenceItemsWorker and also remove the gem.

## WHY
The gem is orphaning locks intermittently causing downstream user issues with accessing activity packs.  
While there is a reaper configuration as well as lock_ttl to deal with the orphaned locks, these jobs are idempotent, so it might make more sense to just test if this gem is really even necessary by removing it.

## HOW
Remove  gem and worker configurations.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
