### PR TITLE
Move feedback history session CSV download into an email job

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
@@ -18,8 +18,14 @@ class Api::V1::SessionFeedbackHistoriesController < Api::ApiController
 
   def email_csv_data
     options = params.permit(:activity_id, :start_date, :end_date, :filter_type, :responses_for_scoring).to_h.symbolize_keys
-    email = current_user.email
-    InternalTool::EmailFeedbackHistorySessionDataWorker.perform_async(options[:activity_id], options[:start_date], options[:end_date], options[:filter_type], options[:responses_for_scoring], email)
+    InternalTool::EmailFeedbackHistorySessionDataWorker.perform_async(
+      options[:activity_id],
+      options[:start_date],
+      options[:end_date],
+      options[:filter_type],
+      options[:responses_for_scoring],
+      current_user.email
+    )
     render plain: 'OK'
   end
 

--- a/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
@@ -19,7 +19,6 @@ class Api::V1::SessionFeedbackHistoriesController < Api::ApiController
   def email_csv_data
     options = params.permit(:activity_id, :start_date, :end_date, :filter_type, :responses_for_scoring).to_h.symbolize_keys
     email = current_user.email
-    logger.debug options
     InternalTool::EmailFeedbackHistorySessionDataWorker.perform_async(options[:activity_id], options[:start_date], options[:end_date], options[:filter_type], options[:responses_for_scoring], email)
     render plain: 'OK'
   end

--- a/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/session_feedback_histories_controller.rb
@@ -16,17 +16,12 @@ class Api::V1::SessionFeedbackHistoriesController < Api::ApiController
     }
   end
 
-  def session_data_for_csv
+  def email_csv_data
     options = params.permit(:activity_id, :start_date, :end_date, :filter_type, :responses_for_scoring).to_h.symbolize_keys
-    feedback_histories = FeedbackHistory.session_data_for_csv(**options)
-    results = []
-    feedback_histories.find_each(batch_size: 10_000) { |feedback_history| results << feedback_history.serialize_csv_data }
-    results.sort! { |a,b| b["datetime"] <=> a["datetime"] }
-    if results
-      render json: results
-    else
-      render plain: "The resource you were looking for does not exist", status: 404
-    end
+    email = current_user.email
+    logger.debug options
+    InternalTool::EmailFeedbackHistorySessionDataWorker.perform_async(options[:activity_id], options[:start_date], options[:end_date], options[:filter_type], options[:responses_for_scoring], email)
+    render plain: 'OK'
   end
 
   # GET /feedback_histories/1.json

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -152,7 +152,17 @@ class UserMailer < ActionMailer::Base
     csv = CSV.generate(headers: true) do |csv_body|
       csv_body << FEEDBACK_HISTORY_CSV_HEADERS
       data.each do |row|
-        csv_body << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
+        csv_body << [
+          row["datetime"],
+          row["session_uid"],
+          row["conjunction"],
+          row["attempt"],
+          row["optimal"],
+          row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS,
+          row["response"],
+          row["feedback"],
+          "#{row['feedback_type']}: #{row['name']}"
+        ]
       end
     end
 

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -23,6 +23,8 @@ class UserMailer < ActionMailer::Base
   COTEACHER_SUPPORT_ARTICLE = 'http://support.quill.org/getting-started-for-teachers/manage-classes/how-do-i-share-a-class-with-my-co-teacher'
   DEFAULT_MAX_ATTEMPTS = 5
   FEEDBACK_HISTORY_CSV_HEADERS = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
+  FEEDBACK_SESSIONS_CSV_DOWNLOAD = "Feedback Sessions CSV Download"
+  FEEDBACK_SESSIONS_CSV_FILENAME = "feedback_sessions.csv"
 
   def invitation_to_non_existing_user invitation_email_hash
     @email_hash = invitation_email_hash.merge(support_article_link: COTEACHER_SUPPORT_ARTICLE, join_link: new_account_url).stringify_keys
@@ -166,8 +168,8 @@ class UserMailer < ActionMailer::Base
       end
     end
 
-    attachments['feedback_sessions.csv'] = {mime_type: 'text/csv', content: csv}
-    mail from: "The Quill Team <hello@quill.org>", to: email, subject: "Feedback Sessions CSV Download"
+    attachments[FEEDBACK_SESSIONS_CSV_FILENAME] = {mime_type: 'text/csv', content: csv}
+    mail from: "The Quill Team <hello@quill.org>", to: email, subject: FEEDBACK_SESSIONS_CSV_DOWNLOAD
   end
 
   private def link_for_setting_password(role)

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -157,7 +157,7 @@ class UserMailer < ActionMailer::Base
     end
 
     attachments['feedback_sessions.csv'] = {mime_type: 'text/csv', content: @csv}
-    mail from: "Quill Evidence Internal Tool", to: email, subject: "Feedback Sessions CSV Download"
+    mail from: "The Quill Team <hello@quill.org>", to: email, subject: "Feedback Sessions CSV Download"
   end
 
   private def link_for_setting_password(role)

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -21,6 +21,7 @@ class UserMailer < ActionMailer::Base
   before_action { @constants = CONSTANTS }
 
   COTEACHER_SUPPORT_ARTICLE = 'http://support.quill.org/getting-started-for-teachers/manage-classes/how-do-i-share-a-class-with-my-co-teacher'
+  DEFAULT_MAX_ATTEMPTS = 5
 
   def invitation_to_non_existing_user invitation_email_hash
     @email_hash = invitation_email_hash.merge(support_article_link: COTEACHER_SUPPORT_ARTICLE, join_link: new_account_url).stringify_keys
@@ -152,10 +153,11 @@ class UserMailer < ActionMailer::Base
     @csv = CSV.generate(headers: true) do |csv|
       csv << attributes
       data.each do |row|
-        csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], row["completed"], row["response"], row["feedback"], row["name"]]
+        csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], "#{row["optimal"] || row["attempt"] == DEFAULT_MAX_ATTEMPTS}", row["response"], row["feedback"], "#{row["feedback_type"]}: #{row["name"]}"]
       end
     end
 
+    binding.pry
     attachments['feedback_sessions.csv'] = {mime_type: 'text/csv', content: @csv}
     mail from: "The Quill Team <hello@quill.org>", to: email, subject: "Feedback Sessions CSV Download"
   end

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -146,6 +146,12 @@ class UserMailer < ActionMailer::Base
     mail from: "The Quill Team <hello@quill.org>", to: email, subject: "ELL Starter Diagnostic Next Steps"
   end
 
+  def feedback_history_session_csv_download(email, data)
+    @data = data
+
+    mail from: "Quill Evidence Internal Tool", to: email, subject: "Feedback Sessions CSV Download"
+  end
+
   private def link_for_setting_password(role)
     params = {
       accountType: role,

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -157,7 +157,6 @@ class UserMailer < ActionMailer::Base
       end
     end
 
-    binding.pry
     attachments['feedback_sessions.csv'] = {mime_type: 'text/csv', content: @csv}
     mail from: "The Quill Team <hello@quill.org>", to: email, subject: "Feedback Sessions CSV Download"
   end

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -148,16 +148,26 @@ class UserMailer < ActionMailer::Base
   end
 
   def feedback_history_session_csv_download(email, data)
-    attributes = %w{ Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
+    # csv_headers = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
 
-    @csv = CSV.generate(headers: true) do |csv|
-      csv << attributes
+    # @csv = CSV.generate(headers: true) do |csv|
+    #   csv << csv_headers
+    #   # data.each do |row|
+    #   #   csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
+    #   # end
+    # end
+
+    csv_headers = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
+
+    data = []
+    csv = CSV.generate(headers: true) do |csv|
+      csv << csv_headers
       data.each do |row|
-        csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], "#{row["optimal"] || row["attempt"] == DEFAULT_MAX_ATTEMPTS}", row["response"], row["feedback"], "#{row["feedback_type"]}: #{row["name"]}"]
+        csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
       end
     end
 
-    attachments['feedback_sessions.csv'] = {mime_type: 'text/csv', content: @csv}
+    attachments['feedback_sessions.csv'] = {mime_type: 'text/csv', content: csv}
     mail from: "The Quill Team <hello@quill.org>", to: email, subject: "Feedback Sessions CSV Download"
   end
 

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -147,8 +147,16 @@ class UserMailer < ActionMailer::Base
   end
 
   def feedback_history_session_csv_download(email, data)
-    @data = data
+    attributes = %w{ Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
 
+    @csv = CSV.generate(headers: true) do |csv|
+      csv << attributes
+      data.each do |row|
+        csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], row["completed"], row["response"], row["feedback"], row["name"]]
+      end
+    end
+
+    attachments['feedback_sessions.csv'] = {mime_type: 'text/csv', content: @csv}
     mail from: "Quill Evidence Internal Tool", to: email, subject: "Feedback Sessions CSV Download"
   end
 

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -22,6 +22,7 @@ class UserMailer < ActionMailer::Base
 
   COTEACHER_SUPPORT_ARTICLE = 'http://support.quill.org/getting-started-for-teachers/manage-classes/how-do-i-share-a-class-with-my-co-teacher'
   DEFAULT_MAX_ATTEMPTS = 5
+  FEEDBACK_HISTORY_CSV_HEADERS = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
 
   def invitation_to_non_existing_user invitation_email_hash
     @email_hash = invitation_email_hash.merge(support_article_link: COTEACHER_SUPPORT_ARTICLE, join_link: new_account_url).stringify_keys
@@ -148,10 +149,8 @@ class UserMailer < ActionMailer::Base
   end
 
   def feedback_history_session_csv_download(email, data)
-    csv_headers = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
-
     csv = CSV.generate(headers: true) do |csv_body|
-      csv_body << csv_headers
+      csv_body << FEEDBACK_HISTORY_CSV_HEADERS
       data.each do |row|
         csv_body << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
       end

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -148,22 +148,12 @@ class UserMailer < ActionMailer::Base
   end
 
   def feedback_history_session_csv_download(email, data)
-    # csv_headers = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
-
-    # @csv = CSV.generate(headers: true) do |csv|
-    #   csv << csv_headers
-    #   # data.each do |row|
-    #   #   csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
-    #   # end
-    # end
-
     csv_headers = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
 
-    data = []
-    csv = CSV.generate(headers: true) do |csv|
-      csv << csv_headers
+    csv = CSV.generate(headers: true) do |csv_body|
+      csv_body << csv_headers
       data.each do |row|
-        csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
+        csv_body << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
       end
     end
 

--- a/services/QuillLMS/app/views/user_mailer/feedback_history_session_csv_download.html.erb
+++ b/services/QuillLMS/app/views/user_mailer/feedback_history_session_csv_download.html.erb
@@ -2,4 +2,3 @@
 
 <p>Please find the activity session data attached in this email.</p>
 
-<p>@data</p>

--- a/services/QuillLMS/app/views/user_mailer/feedback_history_session_csv_download.html.erb
+++ b/services/QuillLMS/app/views/user_mailer/feedback_history_session_csv_download.html.erb
@@ -1,0 +1,5 @@
+<p>Hello Quill Staff Member,</p>
+
+<p>Please find the activity session data attached in this email.</p>
+
+<p>@data</p>

--- a/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class InternalTool::EmailFeedbackHistorySessionDataWorker
+  include Sidekiq::Worker
+
+  def perform(activity_id, start_date, end_date, filter_type, responses_for_scoring, email)
+    feedback_histories = FeedbackHistory.session_data_for_csv({activity_id: activity_id, start_date: start_date, end_date: end_date, filter_type: filter_type, responses_for_scoring: responses_for_scoring})
+    results = []
+    feedback_histories.find_each(batch_size: 10_000) { |feedback_history| results << feedback_history.serialize_csv_data }
+    results.sort! { |a,b| b["datetime"] <=> a["datetime"] }
+    return if !results
+
+    UserMailer.feedback_history_session_csv_download(email, results).deliver_now!
+  end
+end

--- a/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -5,7 +5,13 @@ class InternalTool::EmailFeedbackHistorySessionDataWorker
   sidekiq_options queue: SidekiqQueue::LOW
 
   def perform(activity_id, start_date, end_date, filter_type, responses_for_scoring, email)
-    feedback_histories = FeedbackHistory.session_data_for_csv({activity_id: activity_id, start_date: start_date, end_date: end_date, filter_type: filter_type, responses_for_scoring: responses_for_scoring})
+    feedback_histories = FeedbackHistory.session_data_for_csv(
+        activity_id: activity_id,
+        start_date: start_date,
+        end_date: end_date,
+        filter_type: filter_type,
+        responses_for_scoring: responses_for_scoring
+    )
     results = []
     feedback_histories.find_each(batch_size: 10_000) { |feedback_history| results << feedback_history.serialize_csv_data }
     results.sort! { |a,b| b["datetime"] <=> a["datetime"] }

--- a/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -2,6 +2,7 @@
 
 class InternalTool::EmailFeedbackHistorySessionDataWorker
   include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::LOW
 
   def perform(activity_id, start_date, end_date, filter_type, responses_for_scoring, email)
     feedback_histories = FeedbackHistory.session_data_for_csv({activity_id: activity_id, start_date: start_date, end_date: end_date, filter_type: filter_type, responses_for_scoring: responses_for_scoring})

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
@@ -6,7 +6,7 @@ import FilterWidget from "../shared/filterWidget";
 import { getVersionOptions, handlePageFilterClick, activitySessionIndexResponseHeaders, colorCodeAttemptsCount, formatSessionsData } from "../../../helpers/evidence/miscHelpers";
 import { renderHeader } from "../../../helpers/evidence/renderHelpers";
 import { Error, Spinner, DropdownInput, ReactTable, Tooltip, informationIcon } from '../../../../Shared/index';
-import { fetchActivity, fetchActivitySessions, fetchActivityVersions, fetchActivitySessionsDataForCSV } from '../../../utils/evidence/activityAPIs';
+import { fetchActivity, fetchActivitySessions, fetchActivityVersions, emailActivitySessionsDataForCSV } from '../../../utils/evidence/activityAPIs';
 import { DropdownObjectInterface, ActivitySessionInterface, ActivitySessionsInterface } from '../../../interfaces/evidenceInterfaces';
 import { activitySessionFilterOptions, SESSION_INDEX } from '../../../../../constants/evidence';
 import { renderCSVDownloadButton } from "../../../helpers/evidence/miscHelpers";
@@ -48,12 +48,6 @@ const SessionsIndex = ({ match }) => {
   const { data: sessionsData } = useQuery({
     queryKey: [`activity-${activityId}-sessions`, activityId, pageNumberForQuery, startDateForQuery, filterOptionForQuery, endDateForQuery, responsesForScoringForQuery],
     queryFn: fetchActivitySessions
-  });
-
-  // cache activity sessions data for updates
-  const { data: sessionsCSVData } = useQuery({
-    queryKey: [`activity-${activityId}-sessions-csv-data`, activityId, startDateForQuery, filterOptionForQuery, endDateForQuery, responsesForScoringForQuery, csvDataLoadInitiated],
-    queryFn: fetchActivitySessionsDataForCSV
   });
 
   const { data: activityVersionData } = useQuery({
@@ -141,7 +135,7 @@ const SessionsIndex = ({ match }) => {
   }
 
   function handleLoadCSVDataClick() {
-    setCsvDataLoadInitiated(true);
+    emailActivitySessionsDataForCSV(activityId, startDateForQuery, filterOptionForQuery, endDateForQuery, responsesForScoringForQuery)
   }
 
   function getSortedRows({ activitySessions, id, directionOfSort }) {
@@ -236,7 +230,7 @@ const SessionsIndex = ({ match }) => {
               startDate={startDate}
               versionOptions={versionOptions}
             />
-            {renderCSVDownloadButton(csvDataLoadInitiated, handleLoadCSVDataClick, sessionsCSVData)}
+            {renderCSVDownloadButton(handleLoadCSVDataClick)}
           </section>
         </section>
         <ReactTable

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import stripHtml from "string-strip-html";
 import moment from 'moment';
 import { matchSorter } from 'match-sorter';
-import { CSVLink } from 'react-csv';
 import { Link } from 'react-router-dom';
 
 import {
@@ -468,14 +467,8 @@ export function getCSVData(sessionsCSVData) {
   });
 }
 
-export function renderCSVDownloadButton(csvDataLoadInitiated, handleLoadCSVDataClick, sessionsCSVData) {
-  if(csvDataLoadInitiated) {
-    if(!sessionsCSVData || !sessionsCSVData.csvResponseData) {
-      return <button className="quill-button fun primary contained csv-download-button"><Spinner /></button>
-    }
-    return <CSVLink className="quill-button fun primary contained csv-download-button" data={getCSVData(sessionsCSVData)} headers={sessionsCSVHeaders}>Download CSV</CSVLink>
-  }
-  return <button className="quill-button fun primary contained csv-download-button" onClick={handleLoadCSVDataClick}>Load CSV Data</button>
+export function renderCSVDownloadButton(handleLoadCSVDataClick) {
+  return <button className="quill-button fun primary contained csv-download-button" onClick={handleLoadCSVDataClick}>Email Me CSV Data</button>
 }
 
 

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
@@ -24,7 +24,6 @@ import {
   PROMPTS,
   BREAK_TAG,
   DEFAULT_MAX_ATTEMPTS,
-  sessionsCSVHeaders
 } from '../../../../constants/evidence';
 import { DEFAULT_HIGHLIGHT_PROMPT, TextFilter, NumberFilterInput, filterNumbers, Spinner } from "../../../Shared";
 import { DropdownObjectInterface, ActivitySessionInterface } from '../../interfaces/evidenceInterfaces'

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/routingHelpers.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/routingHelpers.ts
@@ -37,7 +37,7 @@ export function getActivitySessionsUrl({ activityId, pageNumber, startDate, endD
 }
 
 export function getActivitySessionsCSVUrl({ activityId, startDate, endDate, filterType, responsesForScoring}) {
-  let url = `session_data_for_csv?&activity_id=${activityId}`;
+  let url = `email_csv_data?&activity_id=${activityId}`;
   url += startDate ? `&start_date=${startDate}` : ''
   url += endDate ? `&end_date=${endDate}` : ''
   url += filterType ? `&filter_type=${filterType}` : ''

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
@@ -119,18 +119,15 @@ export const fetchActivitySessions = async ({ queryKey, }) => {
   };
 }
 
-export const fetchActivitySessionsDataForCSV = async ({ queryKey, }) => {
-  const [key, activityId, startDate, filterOptionForQuery, endDate, responsesForScoring, csvDataLoadInitiated]: [string, string, string, DropdownObjectInterface, string, string, boolean, boolean] = queryKey
-  if(!csvDataLoadInitiated) { return }
+export const emailActivitySessionsDataForCSV = async (activityId:string, startDate: string, filterOptionForQuery: DropdownObjectInterface, endDate: string, responsesForScoring: boolean) => {
   const { value } = filterOptionForQuery
   const url = getActivitySessionsCSVUrl({ activityId, startDate, endDate, filterType: value, responsesForScoring: responsesForScoring });
-  const response = await mainApiFetch(url);
-  const csvResponseData = await response.json();
-
-  return {
-    csvResponseData,
-    error: handleApiError('Failed to fetch activity sessions, please refresh the page.', response),
-  };
+  const response = await mainApiFetch(url, {method: 'POST'});
+  if (!response.ok) {
+    handleApiError('Failed to initiate CSV download email, please try again', response)
+  } else {
+    alert("Data load has been initiated. The CSV Data will be sent to your email.")
+  }
 }
 
 export const fetchActivitySession = async ({ queryKey, }) => {

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
@@ -119,14 +119,14 @@ export const fetchActivitySessions = async ({ queryKey, }) => {
   };
 }
 
-export const emailActivitySessionsDataForCSV = async (activityId:string, startDate: string, filterOptionForQuery: DropdownObjectInterface, endDate: string, responsesForScoring: boolean) => {
+export const emailActivitySessionsDataForCSV = async (activityId:string, startDate: string, filterOptionForQuery: DropdownObjectInterface, endDate: string, responsesForScoring: boolean, onSuccess: Function, onFailure: Function) => {
   const { value } = filterOptionForQuery
   const url = getActivitySessionsCSVUrl({ activityId, startDate, endDate, filterType: value, responsesForScoring: responsesForScoring });
   const response = await mainApiFetch(url, {method: 'POST'});
   if (!response.ok) {
-    handleApiError('Failed to initiate CSV download email, please try again', response)
+    onFailure(response.errors)
   } else {
-    alert("Data load has been initiated. The CSV Data will be sent to your email.")
+    onSuccess()
   }
 }
 

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -425,7 +425,7 @@ EmpiricalGrammar::Application.routes.draw do
       get 'rule_feedback_history/:rule_uid' => 'rule_feedback_histories#rule_detail'
       get 'prompt_health' => 'rule_feedback_histories#prompt_health'
       get 'activity_health' => 'rule_feedback_histories#activity_health'
-      get 'session_data_for_csv' => 'session_feedback_histories#session_data_for_csv'
+      post 'email_csv_data' => 'session_feedback_histories#email_csv_data'
 
       resources :activities,              except: [:index, :new, :edit]
       resources :activity_flags,          only: [:index]

--- a/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
@@ -219,18 +219,6 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
   context "email_csv_data" do
     let!(:user) { create(:user)}
     let!(:activity) { create(:evidence_activity) }
-    let!(:because_prompt) { Evidence::Prompt.create!(activity: activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
-    let!(:but_prompt) { Evidence::Prompt.create!(activity: activity, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
-    let!(:so_prompt) { Evidence::Prompt.create!(activity: activity, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
-    let!(:activity_session1_uid) { SecureRandom.uuid }
-    let!(:activity_session2_uid) { SecureRandom.uuid }
-    let!(:feedback_history1) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-05T20:43:27.698Z', prompt_id: because_prompt.id) }
-    let!(:feedback_history2) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-06T20:43:27.698Z', prompt_id: because_prompt.id) }
-    let!(:feedback_history3) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-07T20:43:27.698Z', prompt_id: but_prompt.id) }
-    let!(:feedback_history4) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-08T20:43:27.698Z', prompt_id: but_prompt.id) }
-    let!(:feedback_history5) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-09T20:43:27.698Z', prompt_id: so_prompt.id) }
-    let!(:feedback_history6) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-10T20:43:27.698Z', prompt_id: so_prompt.id) }
-    let!(:feedback_history7) { create(:feedback_history, feedback_session_uid: activity_session2_uid, created_at: '2021-04-11T20:43:27.698Z', prompt_id: because_prompt.id) }
 
     before { allow(controller).to receive(:current_user) { user } }
 

--- a/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
@@ -216,7 +216,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
     end
   end
 
-  context "session_data_for_csv" do
+  context "email_csv_data" do
     let!(:user) { create(:user)}
     let!(:activity) { create(:evidence_activity) }
     let!(:because_prompt) { Evidence::Prompt.create!(activity: activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
@@ -232,47 +232,30 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
     let!(:feedback_history6) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-10T20:43:27.698Z', prompt_id: so_prompt.id) }
     let!(:feedback_history7) { create(:feedback_history, feedback_session_uid: activity_session2_uid, created_at: '2021-04-11T20:43:27.698Z', prompt_id: because_prompt.id) }
 
-    it 'should retrieve all feedback histories with no filters' do
-      get :session_data_for_csv, params: { activity_id: activity.id }, as: :json
+    before { allow(controller).to receive(:current_user) { user } }
 
-      parsed_response = JSON.parse(response.body)
+    it 'should kick off an email job' do
+      expect(InternalTool::EmailFeedbackHistorySessionDataWorker).to receive(:perform_async).with(activity.id.to_s, nil, nil, nil, nil, user.email)
+
+      get :email_csv_data, params: { activity_id: activity.id }, as: :json
 
       expect(response).to have_http_status(200)
-      expect(parsed_response.length).to eq(7)
-      expect(parsed_response[0]["session_uid"]).to eq(feedback_history7.feedback_session_uid)
-      expect(parsed_response[1]["session_uid"]).to eq(feedback_history6.feedback_session_uid)
-      expect(parsed_response[2]["session_uid"]).to eq(feedback_history5.feedback_session_uid)
-      expect(parsed_response[3]["session_uid"]).to eq(feedback_history4.feedback_session_uid)
-      expect(parsed_response[4]["session_uid"]).to eq(feedback_history3.feedback_session_uid)
-      expect(parsed_response[5]["session_uid"]).to eq(feedback_history2.feedback_session_uid)
-      expect(parsed_response[6]["session_uid"]).to eq(feedback_history1.feedback_session_uid)
     end
 
-    it 'should retrieve all feedback histories between date params' do
-      get :session_data_for_csv, params: { activity_id: activity.id, start_date: '2021-04-06T20:43:27.698Z', end_date: '2021-04-08T20:43:27.698Z' }, as: :json
+    it 'should kick off job for all feedback histories between date params' do
+      expect(InternalTool::EmailFeedbackHistorySessionDataWorker).to receive(:perform_async).with(activity.id.to_s, '2021-04-06T20:43:27.698Z', '2021-04-08T20:43:27.698Z', nil, nil, user.email)
 
-      parsed_response = JSON.parse(response.body)
+      get :email_csv_data, params: { activity_id: activity.id, start_date: '2021-04-06T20:43:27.698Z', end_date: '2021-04-08T20:43:27.698Z' }, as: :json
 
       expect(response).to have_http_status(200)
-      expect(parsed_response.length).to eq(3)
-      expect(parsed_response[0]["session_uid"]).to eq(feedback_history4.feedback_session_uid)
-      expect(parsed_response[1]["session_uid"]).to eq(feedback_history3.feedback_session_uid)
-      expect(parsed_response[2]["session_uid"]).to eq(feedback_history2.feedback_session_uid)
     end
 
-    it 'should retrieve all feedback histories qualifying for scoring' do
-      get :session_data_for_csv, params: { activity_id: activity.id, responses_for_scoring: true }, as: :json
+    it 'should kick off job for feedback histories qualifying for scoring' do
+      expect(InternalTool::EmailFeedbackHistorySessionDataWorker).to receive(:perform_async).with(activity.id.to_s, nil, nil, nil, true.to_s, user.email)
 
-      parsed_response = JSON.parse(response.body)
+      get :email_csv_data, params: { activity_id: activity.id, responses_for_scoring: true }, as: :json
 
       expect(response).to have_http_status(200)
-      expect(parsed_response.length).to eq(6)
-      expect(parsed_response[0]["session_uid"]).to eq(feedback_history6.feedback_session_uid)
-      expect(parsed_response[1]["session_uid"]).to eq(feedback_history5.feedback_session_uid)
-      expect(parsed_response[2]["session_uid"]).to eq(feedback_history4.feedback_session_uid)
-      expect(parsed_response[3]["session_uid"]).to eq(feedback_history3.feedback_session_uid)
-      expect(parsed_response[4]["session_uid"]).to eq(feedback_history2.feedback_session_uid)
-      expect(parsed_response[5]["session_uid"]).to eq(feedback_history1.feedback_session_uid)
     end
   end
 end

--- a/services/QuillLMS/spec/mailers/user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/user_mailer_spec.rb
@@ -159,7 +159,7 @@ describe UserMailer, type: :mailer do
             row["conjunction"],
             row["attempt"],
             row["optimal"],
-            row['optimal'] || row['attempt'] == described_class::MAX_ATTEMPTS,
+            row['optimal'] || row['attempt'] == described_class::DEFAULT_MAX_ATTEMPTS,
             row["response"],
             row["feedback"],
             "#{row['feedback_type']}: #{row['name']}"

--- a/services/QuillLMS/spec/mailers/user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/user_mailer_spec.rb
@@ -121,4 +121,25 @@ describe UserMailer, type: :mailer do
       expect(mail.subject).to match("Quill Daily Analytics")
     end
   end
+
+  describe 'feedback_history_session_csv_download' do
+    it 'should set the subject, receiver and the sender' do
+      mail = UserMailer.feedback_history_session_csv_download("team@quill.org", [])
+
+      csv_headers = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
+
+      data = []
+      csv = CSV.generate(headers: true) do |csv|
+        csv << csv_headers
+        data.each do |row|
+          csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
+        end
+      end
+
+      expect(mail.to).to eq(["team@quill.org"])
+      expect(mail.subject).to match("Feedback Sessions CSV Download")
+      expect(mail.attachments['feedback_sessions.csv'].mime_type).to match('text/csv')
+      expect(mail.attachments['feedback_sessions.csv'].body.raw_source).to eq(csv)
+    end
+  end
 end

--- a/services/QuillLMS/spec/mailers/user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/user_mailer_spec.rb
@@ -124,22 +124,32 @@ describe UserMailer, type: :mailer do
 
   describe 'feedback_history_session_csv_download' do
     it 'should set the subject, receiver and the sender' do
-      mail = UserMailer.feedback_history_session_csv_download("team@quill.org", [])
+      data = [
+        {
+          "datetime": "20220701",
+          "session_uid": "sessionuid",
+          "conjunction": "but",
+          "attempt": "1",
+          "optimal": "false",
+          "response": "this is a test response",
+          "feedback": "test feedback",
+          "feedback_type": "spelling"
+        }
+      ]
+      mail = UserMailer.feedback_history_session_csv_download("team@quill.org", data)
 
       csv_headers = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
-
-      data = []
-      csv = CSV.generate(headers: true) do |csv|
+      csv_body = CSV.generate(headers: true) do |csv|
         csv << csv_headers
         data.each do |row|
-          csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
+          csv << [row["datetime"], row["session_uid"], row["conjunction"], row["attempt"], row["optimal"], (row['optimal'] || row['attempt'] == 5).to_s, row["response"], row["feedback"], "#{row['feedback_type']}: #{row['name']}"]
         end
       end
 
       expect(mail.to).to eq(["team@quill.org"])
       expect(mail.subject).to match("Feedback Sessions CSV Download")
       expect(mail.attachments['feedback_sessions.csv'].mime_type).to match('text/csv')
-      expect(mail.attachments['feedback_sessions.csv'].body.raw_source).to eq(csv)
+      expect(CSV.parse(mail.attachments['feedback_sessions.csv'].body.raw_source)).to eq(CSV.parse(csv_body))
     end
   end
 end

--- a/services/QuillLMS/spec/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe InternalTool::EmailFeedbackHistorySessionDataWorker, type: :worker do
+  subject { described_class.new.perform("email", []) }
+
+  # let!(:teacher) { create(:teacher) }
+  # let!(:district) { create(:district) }
+  # let!(:mailer_user) { Mailer::User.new(teacher) }
+  # let!(:mailer_class)  { InternalToolUserMailer }
+  # let!(:mailer_method) { :district_admin_account_created_email}
+  # let!(:analytics) { double(:analytics).as_null_object }
+
+  before do
+    # allow(District).to receive(:find_by).and_return(district)
+    # allow(mailer_class).to receive(mailer_method).with(mailer_user, district.name).and_return(double(:email, deliver_now!: true))
+    # allow(teacher).to receive(:mailer_user).and_return(mailer_user)
+    # allow(SegmentAnalytics).to receive(:new) { analytics }
+  end
+
+  describe 'user is nil' do
+
+    # before do
+    #   allow(User).to receive(:find_by).and_return(nil)
+    # end
+
+    # it 'should not send the mail with user mailer' do
+    #   expect(mailer_class).not_to receive(mailer_method)
+    #   subject
+    # end
+
+    # it 'should not send a segment.io event' do
+    #   expect(analytics).not_to receive(:track_district_admin_user)
+    #   subject
+    # end
+  end
+
+  describe 'user is not nil' do
+
+    # before do
+    #   allow(User).to receive(:find_by).and_return(teacher)
+    # end
+
+    # it 'should send the mail with user mailer' do
+    #   expect(mailer_class).to receive(mailer_method).with(mailer_user, district.name)
+    #   subject
+    # end
+
+    # it 'should send a segment.io event' do
+    #   expect(analytics).to receive(:track_district_admin_user).with(
+    #     teacher,
+    #     SegmentIo::BackgroundEvents::STAFF_CREATED_DISTRICT_ADMIN_ACCOUNT,
+    #     district.name,
+    #     SegmentIo::Properties::STAFF_USER
+    #   )
+    #   subject
+    # end
+  end
+end


### PR DESCRIPTION
## WHAT
Move the feedback history session CSV download into an asynchronous email rather than a synchronous endpoint on the staff page.

## WHY
As we get more and more Evidence data, we're going to have difficulty loading the data we need on this page and encountering timeouts. To prevent this, we'll move it to a job that aggregates the data and then emails a CSV to the admin who requested it.

## HOW
Create a sidekiq job that aggregates the necessary data and then generates a CSV. Send this CSV via UserMailer to the pertinent admin.

### Screenshots
<img width="456" alt="Screen Shot 2023-02-02 at 2 04 40 AM" src="https://user-images.githubusercontent.com/57366100/216126987-f73e4471-ec5a-409a-a99d-e2f9d68c68c6.png">

<img width="546" alt="Screen Shot 2023-02-02 at 2 08 16 AM" src="https://user-images.githubusercontent.com/57366100/216127005-9ee277ea-d550-4508-8de1-6140eda95c28.png">


### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=3fd2c1db70f045a5b44b938afe0b7899&pm=c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
