### PR TITLE
Fix bug where schools with expired subscriptions were not searchable

### DIFF
--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -247,8 +247,15 @@ class Cms::SchoolsController < Cms::CmsController
 
   private def where_query_string_builder
     conditions = [
-      "(subscriptions.expiration IS NULL OR subscriptions.expiration > '#{Date.current}')",
-      "subscriptions.de_activated_date IS NULL"
+      "(
+        subscriptions.expiration IS NULL OR
+        (subscriptions.expiration, schools.id) IN (
+          SELECT max(subscriptions.expiration), school_subscriptions.school_id
+          FROM subscriptions
+          INNER JOIN school_subscriptions ON subscriptions.id = school_subscriptions.subscription_id
+          GROUP BY school_subscriptions.school_id
+        )
+      )"
     ]
     # This converts all of the search inputs into strings so we can iterate
     # over them and grab the value from params. The weird ternary here is in


### PR DESCRIPTION
## WHAT
I accidentally caused a bug in the admin School Search tool where admin became unable to search for schools that have one or more expired subscriptions. 
This PR fixes that bug, while still filtering the SQL query to avoid double results for schools with 2+ old subscriptions.

## WHY
We want this very important admin and Support Team internal tool to work perfectly!

## HOW
The bug was happening because I added a filter `WHERE subscriptions.expiration > Date.today` to the school search SQL query.
I initially added this filter because admin were getting double and triple result rows when they searched for a school that had, for example, three old Subscriptions of three different types. This is because the query GROUPS BY subscription.account_type. 
The line I added -- `WHERE subscriptions.expiration > Date.today` -- fixed the double results problem by only showing unexpired subscriptions. However, it inadvertently caused the query to filter out schools that have only expired subscriptions, because those records fail at the filter `WHERE subscriptions.expiration IS NULL OR subscriptions.expiration > Date.today`.
I took out this filter and added a more sophisticated filtering inner SQL query that compares the subscription ID to that school's subscriptions and makes sure the subscription is the most recent subscription (ordered by expiration date). This avoids the double results problem and also fixes the bug.

### Screenshots
<img width="1213" alt="Screen Shot 2023-02-03 at 4 05 15 AM" src="https://user-images.githubusercontent.com/57366100/216437987-1b4ec59e-4fbb-44e0-938a-1865435ed808.png">

### Notion Card Links
https://www.notion.so/quill/Some-schools-are-not-searchable-by-name-in-the-Quill-CMS-39612f5ddf8b4660af7a3ba850e08f89

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes