### PR TITLE
Lms/add admin role

### DIFF
--- a/services/QuillLMS/app/controllers/admins_controller.rb
+++ b/services/QuillLMS/app/controllers/admins_controller.rb
@@ -167,7 +167,7 @@ class AdminsController < ApplicationController
 
   private def handle_new_user
     # Create a new teacher, and automatically join them to the school.
-    @teacher = @school.users.create(teacher_params.merge({ role: 'teacher', password: teacher_params[:last_name] }))
+    @teacher = @school.users.create(teacher_params.merge({ role: User::TEACHER, password: teacher_params[:last_name] }))
     @teacher.refresh_token!
     ExpirePasswordTokenWorker.perform_in(30.days, @teacher.id)
     if @is_admin

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -47,9 +47,8 @@ class ApplicationController < ActionController::Base
     auth_failed
   end
 
-  def teacher_admin_or_staff!
+  def teacher_or_staff!
     return if current_user.try(:teacher?)
-    return if current_user.try(:admin?)
 
     staff!
   end

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -47,8 +47,9 @@ class ApplicationController < ActionController::Base
     auth_failed
   end
 
-  def teacher_or_staff!
+  def teacher_admin_or_staff!
     return if current_user.try(:teacher?)
+    return if current_user.try(:admin?)
 
     staff!
   end

--- a/services/QuillLMS/app/controllers/cms/district_admins_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/district_admins_controller.rb
@@ -75,6 +75,6 @@ class Cms::DistrictAdminsController < Cms::CmsController
   private def user_params
     first_name = params[:first_name]
     last_name = params[:last_name]
-    { role: "teacher", email: params[:email], name: "#{first_name} #{last_name}", password: last_name }
+    { role: User::TEACHER, email: params[:email], name: "#{first_name} #{last_name}", password: last_name }
   end
 end

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -20,7 +20,7 @@ class Cms::RostersController < Cms::CmsController
         raise "Please provide a last name or password for teacher #{t[:name]}, otherwise this account will have no password." if t[:password].blank? && t[:name].split[1].blank?
 
         password = t[:password].present? ? t[:password] : t[:name].split[1]
-        teacher = User.create!(name: t[:name], email: email, password: password, password_confirmation: password, role: 'teacher')
+        teacher = User.create!(name: t[:name], email: email, password: password, password_confirmation: password, role: User::TEACHER)
         SchoolsUsers.create!(school: school, user: teacher)
       end
 

--- a/services/QuillLMS/app/controllers/cms/school_admins_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/school_admins_controller.rb
@@ -93,6 +93,6 @@ class Cms::SchoolAdminsController < Cms::CmsController
   private def user_params
     first_name = params[:first_name]
     last_name = params[:last_name]
-    { role: "teacher", email: params[:email], name: "#{first_name} #{last_name}", password: last_name }
+    { role: User::TEACHER, email: params[:email], name: "#{first_name} #{last_name}", password: last_name }
   end
 end

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -125,7 +125,7 @@ class Cms::SchoolsController < Cms::CmsController
   def add_existing_user_by_email
     begin
       user = User.find_by!(email: params[:email_address])
-      raise ArgumentError if user.role != 'teacher'
+      raise ArgumentError unless user.teacher?
 
       school = School.find_by!(id: params[:id])
       SchoolsUsers.where(user: user).destroy_all

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -56,7 +56,7 @@ class ProfilesController < ApplicationController
   end
 
   def admin
-    return redirect_to dashboard_teachers_classrooms_path if !admin_impersonating_user?(@user)
+    return redirect_to dashboard_teachers_classrooms_path if admin_impersonating_user?(@user)
 
     redirect_to teachers_admin_dashboard_path
   end

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -55,12 +55,14 @@ class ProfilesController < ApplicationController
     render json: {classrooms: students_classrooms_with_join_info}
   end
 
+  def admin
+    return redirect_to dashboard_teachers_classrooms_path if !admin_impersonating_user?(@user)
+
+    redirect_to teachers_admin_dashboard_path
+  end
+
   def teacher
-    if @user.schools_admins.any? && !admin_impersonating_user?(@user)
-      redirect_to teachers_admin_dashboard_path
-    else
-      redirect_to dashboard_teachers_classrooms_path
-    end
+    redirect_to dashboard_teachers_classrooms_path
   end
 
   def staff

--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -11,7 +11,7 @@ class TeacherFixController < ApplicationController
   def archived_units
     if !@user
       render json: {error: 'No such user.'}
-    elsif !@user.teacher? 
+    elsif !@user.teacher?
       render json: {error: 'This user is not a teacher.'}
     elsif archived_units_for_user.any?
       render json: {archived_units: archived_units_for_user}

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -397,7 +397,7 @@ class Teachers::ClassroomManagerController < ApplicationController
         redirect_to "/activities/packs"
       end
     else
-      teacher_or_staff!
+      teacher_admin_or_staff!
     end
   end
 

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -397,7 +397,7 @@ class Teachers::ClassroomManagerController < ApplicationController
         redirect_to "/activities/packs"
       end
     else
-      teacher_admin_or_staff!
+      teacher_or_staff!
     end
   end
 

--- a/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
@@ -49,7 +49,7 @@ class Teachers::ProgressReportsController < ApplicationController
   end
 
   private def authorize!
-    teacher_admin_or_staff!
+    teacher_or_staff!
   end
 
   private def switch_current_user(user)

--- a/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
@@ -49,9 +49,7 @@ class Teachers::ProgressReportsController < ApplicationController
   end
 
   private def authorize!
-    return if current_user.try(:teacher?)
-
-    auth_failed
+    teacher_admin_or_staff!
   end
 
   private def switch_current_user(user)

--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -72,7 +72,7 @@ class Teachers::UnitTemplatesController < ApplicationController
   end
 
   private def is_teacher?
-    @is_teacher = (current_user && current_user.role == 'teacher')
+    @is_teacher = current_user&.teacher?
   end
 
   private def redirect_to_public_index_if_no_unit_template_found

--- a/services/QuillLMS/app/controllers/teachers_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers_controller.rb
@@ -142,7 +142,7 @@ class TeachersController < ApplicationController
 
   private def teacher_params
     params.require(:teacher).permit(:admin_id, :first_name, :last_name, :email)
-           .merge({role: 'teacher'})
+           .merge({role: User::TEACHER})
 
   end
 

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -118,15 +118,15 @@ class UserMailer < ActionMailer::Base
     end_time = date_object.end_of_day
     subject_date = date_object.strftime('%m/%d/%Y')
 
-    teacher_count = User.where(role: "teacher").count
-    new_premium_accounts = User.joins(:user_subscription).where(users: {role: "teacher"}).where(user_subscriptions: {created_at: start_time..end_time}).count
+    teacher_count = User.teacher.count
+    new_premium_accounts = User.teacher.joins(:user_subscription).where(user_subscriptions: {created_at: start_time..end_time}).count
     conversion_rate = new_premium_accounts/teacher_count.to_f
 
     @current_date = date_object.strftime("%A, %B %d")
-    @daily_active_teachers = User.where(role: "teacher").where(last_sign_in: start_time..end_time).size
-    @daily_active_students = User.where(role: "student").where(last_sign_in: start_time..end_time).size
-    @new_teacher_signups = User.where(role: "teacher").where(created_at: start_time..end_time).size
-    @new_student_signups = User.where(role: "student").where(created_at: start_time..end_time).size
+    @daily_active_teachers = User.teacher.where(last_sign_in: start_time..end_time).size
+    @daily_active_students = User.student.where(last_sign_in: start_time..end_time).size
+    @new_teacher_signups = User.teacher.where(created_at: start_time..end_time).size
+    @new_student_signups = User.student.where(created_at: start_time..end_time).size
     @classrooms_created = Classroom.where(created_at: start_time..end_time).size
     @activities_assigned = UnitActivity.where(created_at: start_time..end_time).size
     # Sentences written is quantified by number of activities completed multiplied by 10 because

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -24,7 +24,7 @@ module Teacher
     delegate :first, :find, :where, :all, :count, to: :scope
 
     def scope
-      User.where(role: User::TEACHER)
+      User.teacher
     end
   end
 

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -24,7 +24,7 @@ module Teacher
     delegate :first, :find, :where, :all, :count, to: :scope
 
     def scope
-      User.where(role: 'teacher')
+      User.where(role: User::TEACHER)
     end
   end
 
@@ -359,7 +359,7 @@ module Teacher
   def update_teacher params
     return if !teacher?
 
-    params[:role] = 'teacher' if params[:role] != 'student'
+    params[:role] = User::TEACHER if params[:role] != User::STUDENT
     params.permit(
       :id,
       :name,

--- a/services/QuillLMS/app/models/schools_admins.rb
+++ b/services/QuillLMS/app/models/schools_admins.rb
@@ -20,7 +20,13 @@ class SchoolsAdmins < ApplicationRecord
   belongs_to :school
   belongs_to :user
 
+  before_save :set_user_role
+
   def admin
     user
+  end
+
+  private def set_user_role
+    user.update(role: User::ADMIN) unless user.admin?
   end
 end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -207,7 +207,8 @@ class User < ApplicationRecord
   after_save :check_for_school
   after_create :generate_referrer_id, if: proc { teacher? }
 
-  scope :teacher, -> { where(role: TEACHER) }
+  # This is a little weird, but in our current conception, all Admins are Teachers
+  scope :teacher, -> { where(role: [ADMIN, TEACHER]) }
   scope :student, -> { where(role: STUDENT) }
 
   def self.deleted_users
@@ -419,7 +420,7 @@ class User < ApplicationRecord
   end
 
   def teacher?
-    role.teacher?
+    role.teacher? || admin? # This is a bit weird, but all Admins are Teachers
   end
 
   def staff?
@@ -616,7 +617,7 @@ class User < ApplicationRecord
   end
 
   def is_new_teacher_without_school?
-    role == 'teacher' && !school && previous_changes["id"]
+    teacher? && !school && previous_changes["id"]
   end
 
   def generate_username(classroom_id=nil)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -82,15 +82,16 @@ class User < ApplicationRecord
     USERNAME_UNIQUENESS_CONSTRAINT_MINIMUM_ID
   ].max
 
+  ADMIN = 'admin'
   TEACHER = 'teacher'
   STUDENT = 'student'
   STAFF = 'staff'
   SALES_CONTACT = 'sales-contact'
   INDIVIDUAL_CONTRIBUTOR = 'individual-contributor'
-  ONBOARDING_ROLES   = [STUDENT, TEACHER, INDIVIDUAL_CONTRIBUTOR]
-  TEACHER_INFO_ROLES = [TEACHER, INDIVIDUAL_CONTRIBUTOR]
-  ROLES              = [TEACHER, STUDENT, STAFF, SALES_CONTACT]
-  SAFE_ROLES         = [STUDENT, TEACHER, SALES_CONTACT]
+  ONBOARDING_ROLES   = [STUDENT, TEACHER, INDIVIDUAL_CONTRIBUTOR, ADMIN]
+  TEACHER_INFO_ROLES = [TEACHER, INDIVIDUAL_CONTRIBUTOR, ADMIN]
+  ROLES              = [TEACHER, STUDENT, STAFF, SALES_CONTACT, ADMIN]
+  SAFE_ROLES         = [STUDENT, TEACHER, SALES_CONTACT, ADMIN]
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
 
   ALPHA = 'alpha'
@@ -382,7 +383,7 @@ class User < ApplicationRecord
   end
 
   def admin?
-    SchoolsAdmins.find_by_user_id(id).present?
+    role.admin?
   end
 
   def is_admin_for_one_school?

--- a/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
+++ b/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
@@ -18,7 +18,7 @@ class Admin::TeacherSerializer < ApplicationSerializer
   def schools
     [object&.school].concat(object&.administered_schools).compact.uniq.map do |school|
       school_hash = { name: school.name, id: school.id }
-      school_hash[:role] = SchoolsAdmins.exists?(school: school, user: object) ? ADMIN : TEACHER
+      school_hash[:role] = object.admin? ? ADMIN : TEACHER
       school_hash
     end
   end

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -255,7 +255,7 @@ class SegmentAnalytics
 
   def identify(user)
     return unless backend.present?
-    return unless user&.teacher? || user&.admin?
+    return unless user&.teacher?
 
     identify_params = user&.segment_user&.identify_params
     backend.identify(identify_params) if identify_params

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -255,7 +255,7 @@ class SegmentAnalytics
 
   def identify(user)
     return unless backend.present?
-    return unless user&.teacher?
+    return unless [User::ADMIN, User::TEACHER].include?(user&.role)
 
     identify_params = user&.segment_user&.identify_params
     backend.identify(identify_params) if identify_params

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -255,7 +255,7 @@ class SegmentAnalytics
 
   def identify(user)
     return unless backend.present?
-    return unless [User::ADMIN, User::TEACHER].include?(user&.role)
+    return unless user&.teacher? || user&.admin?
 
     identify_params = user&.segment_user&.identify_params
     backend.identify(identify_params) if identify_params

--- a/services/QuillLMS/app/services/clever_integration/creators/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/creators/teacher.rb
@@ -9,7 +9,7 @@ module CleverIntegration::Creators::Teacher
       # necessary to have both due to difference in structure between Clever Library user auth hash and district user auth hash
       clever_id: hash[:clever_id] || hash[:id],
       name: hash[:name],
-      role: 'teacher'
+      role: User::TEACHER
     )
 
     remove_google_link(teacher)

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -25,7 +25,7 @@ class Demo::CreateAdminReport
     # Create admin teacher
     admin_teacher = User.create!(
       name: 'Toni Morrison',
-      role: 'teacher',
+      role: User::TEACHER,
       email: teacher_email,
       username: '',
       password: SecureRandom.urlsafe_base64
@@ -39,7 +39,7 @@ class Demo::CreateAdminReport
     teachers = teachers.map do |teacher|
       User.create!(
         name: teacher,
-        role: 'teacher',
+        role: User::TEACHER,
         email: "hello+admindemo-#{email_safe_school_name}-#{teacher.split.last.downcase}@quill.org",
         username: '',
         password: SecureRandom.urlsafe_base64

--- a/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
@@ -20,7 +20,7 @@ module Demo::ReportDemoAPCreator
     values = {
       name: "Demo Teacher",
       email: email,
-      role: "teacher",
+      role: User::TEACHER,
       password: 'password',
       password_confirmation: 'password',
     }

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -298,7 +298,7 @@ module Demo::ReportDemoCreator
   end
 
   def self.reset_account(teacher_id)
-    teacher = User.find_by(id: teacher_id, role: User::TEACHER)
+    teacher = User.teacher.find_by(id: teacher_id)
 
     return unless teacher
 
@@ -312,7 +312,7 @@ module Demo::ReportDemoCreator
   def self.reset_demo_classroom_if_needed(teacher_id)
     # Wrap the lookup and actions within a transaction to avoid race conditions
     ActiveRecord::Base.transaction do
-      teacher = User.find_by(id: teacher_id, role: User::TEACHER)
+      teacher = User.teacher.find_by(id: teacher_id)
 
       # Note, you can't early return within a transaction in Rails 6.1+
       if teacher && demo_classroom_modified?(teacher)
@@ -344,7 +344,7 @@ module Demo::ReportDemoCreator
     User.create(
       name: "Demo Teacher",
       email: email,
-      role: "teacher",
+      role: User::TEACHER,
       password: 'password',
       password_confirmation: 'password',
       flags: ["beta"]

--- a/services/QuillLMS/app/services/google_integration/classroom/parsers/courses.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom/parsers/courses.rb
@@ -9,7 +9,7 @@ module GoogleIntegration::Classroom::Parsers::Courses
   #
 
   def self.run(user, course_response, student_requester)
-    if user.role == 'teacher'
+    if user.teacher?
       parse_courses_for_teacher(course_response, user, student_requester)
     else
       parse_courses_for_student(course_response, user)

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -83,7 +83,7 @@ class SerializeVitallySalesAccount
   end
 
   private def employee_count
-    @school.users.where(role: 'teacher').count || 0
+    @school.users.teacher.count || 0
   end
 
   private def paid_teacher_subscriptions

--- a/services/QuillLMS/app/views/application/_sub_header.html.erb
+++ b/services/QuillLMS/app/views/application/_sub_header.html.erb
@@ -58,7 +58,7 @@
   		<%- if current_user.nil? %>
 				<a class="text-white nav-element" href="/session/new">Log In</a>
 				<a class="text-white nav-element sign-up-button" href="/account/new">Sign Up</a>
-  		<%- elsif current_user.role == 'teacher' %>
+  		<%- elsif current_user.teacher? %>
   			<div id="nav-user-dropdown" class="dropdown-closed hide-on-mobile nav-element <%= show_notification_badges_class %> <%= user_dropdown_class %>">
   				<span onclick="toggleDropdown()" class='user-dropdown-button notification-badge-relative'>
             <%="#{truncate(current_user.name, length: 50)}"%>

--- a/services/QuillLMS/app/views/cms/users/_form.html.erb
+++ b/services/QuillLMS/app/views/cms/users/_form.html.erb
@@ -31,7 +31,7 @@
     </div>
     <div class='cms-form-row'>
       <%= f.label :role %>
-      <%= f.select :role, [['student', 'student'], ['teacher', 'teacher'], ['staff', 'staff']], autocomplete: 'off' %>
+      <%= f.select :role, [['student', 'student'], ['teacher', 'teacher'], ['admin', 'admin'], ['staff', 'staff']], autocomplete: 'off' %>
     </div>
     <div class='cms-form-row'>
       <%= f.label :flagset %>

--- a/services/QuillLMS/app/views/cms/users/show.html.erb
+++ b/services/QuillLMS/app/views/cms/users/show.html.erb
@@ -92,7 +92,7 @@
     <p><%= "#{@user.school_mail_city || @user.school&.city || 'N/A' }, #{@user.school_mail_state || @user.school&.state || 'N/A' }" %></p>
     <br />
 
-    <% if @user.role == 'teacher' %>
+    <% if @user.teacher? %>
     <% if @user.subscriptions.any? %>
       <%= react_component('SubscriptionApp', props: {view: 'subscriptionHistory', subscriptions: @user.subscriptions, premiumCredits: @user.credit_transactions, authorityLevel: 'purchaser' }) %>
     <% end %>

--- a/services/QuillLMS/app/views/pages/premium.html.erb
+++ b/services/QuillLMS/app/views/pages/premium.html.erb
@@ -1,4 +1,4 @@
-<% if (current_user && current_user.role == 'teacher') %>
+<% if (current_user&.teacher?) %>
   <%= render 'teachers/shared/scorebook_tabs' %>
 <% else %>
   <%= render partial: 'pages/shared/teacher_center_navbar', locals: { active_tab: TeacherCenterHelper::PREMIUM} %>

--- a/services/QuillLMS/app/workers/account_creation_worker.rb
+++ b/services/QuillLMS/app/workers/account_creation_worker.rb
@@ -8,7 +8,7 @@ class AccountCreationWorker
 
     # tell segment.io
     analytics = Analyzer.new
-    return unless @user.role.teacher?
+    return unless @user.teacher?
 
     events = [SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION]
     events += [SegmentIo::BackgroundEvents::TEACHER_SIGNED_UP_FOR_NEWSLETTER] if @user.send_newsletter

--- a/services/QuillLMS/app/workers/populate_annual_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/populate_annual_vitally_worker.rb
@@ -21,7 +21,7 @@ class PopulateAnnualVitallyWorker
   end
 
   def schools_to_sync
-    School.select(:id).distinct.joins(:users).where('users.role = ?', 'teacher')
+    School.select(:id).distinct.joins(:users).merge(User.teacher)
   end
 
   def users_to_sync

--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -48,7 +48,7 @@ class SyncVitallyWorker
       .select(:id, :district_id)
       .distinct
       .joins(:users)
-      .where(users: {role: User::TEACHER})
+      .merge(User.teacher) # adds the User scope :teacher to the query
   end
 
   private def users_to_sync

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -33,4 +33,10 @@ namespace :users do
       puts "Failed to update for user #{row['user_id']}"
     end
   end
+
+  task update_admin_user_roles: :environment do
+    User.joins(:schools_admins).where.not(role: User::ADMIN).distinct.each do |admin_user|
+      admin_user.update(role: User::ADMIN)
+    end
+  end
 end

--- a/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
@@ -19,8 +19,7 @@ describe TeachersController, type: :controller do
       end
 
       it 'render admin dashboard' do
-        user = create(:user)
-        user.schools_admins.create
+        user = create(:user, role: User::ADMIN)
         allow(controller).to receive(:current_user) { user }
         get :admin_dashboard
         expect(response).to render_template('admin')

--- a/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
@@ -19,7 +19,7 @@ describe TeachersController, type: :controller do
       end
 
       it 'render admin dashboard' do
-        user = create(:user, role: User::ADMIN)
+        user = create(:admin)
         allow(controller).to receive(:current_user) { user }
         get :admin_dashboard
         expect(response).to render_template('admin')

--- a/services/QuillLMS/spec/factories/users.rb
+++ b/services/QuillLMS/spec/factories/users.rb
@@ -78,6 +78,10 @@ FactoryBot.define do
       role 'staff'
     end
 
+    factory :admin do
+      role User::ADMIN
+    end
+
     factory :teacher do
       role 'teacher'
 

--- a/services/QuillLMS/spec/models/firebase_app_spec.rb
+++ b/services/QuillLMS/spec/models/firebase_app_spec.rb
@@ -125,8 +125,7 @@ describe FirebaseApp, type: :model do
     end
 
     context 'when admin user' do
-      let(:user) { create(:user) }
-      let!(:admin) { user.schools_admins.create }
+      let(:user) { create(:user, role: User::ADMIN) }
 
       it 'should return the encoded payload with admin claims' do
         connect_token = firebase_app.connect_token_for(user)

--- a/services/QuillLMS/spec/models/firebase_app_spec.rb
+++ b/services/QuillLMS/spec/models/firebase_app_spec.rb
@@ -125,7 +125,7 @@ describe FirebaseApp, type: :model do
     end
 
     context 'when admin user' do
-      let(:user) { create(:user, role: User::ADMIN) }
+      let(:user) { create(:admin) }
 
       it 'should return the encoded payload with admin claims' do
         connect_token = firebase_app.connect_token_for(user)

--- a/services/QuillLMS/spec/models/schools_admin_spec.rb
+++ b/services/QuillLMS/spec/models/schools_admin_spec.rb
@@ -7,11 +7,29 @@ describe SchoolsAdmins, type: :model, redis: true do
   it { should belong_to(:user) }
 
   let(:user) { create(:user, email: 'test@quill.org') }
-  let(:admins) { create(:schools_admins, user: user) }
 
   describe '#admin' do
+    let(:admins) { create(:schools_admins, user: user) }
+
     it 'should return the user associated' do
       expect(admins.admin).to eq(admins.user)
+    end
+  end
+
+  describe '#set_user_role' do
+    let(:school) { create(:school) }
+
+    it 'should set the User.role value to "admin" if it is not already set' do
+      expect(user).to receive(:update).with(role: User::ADMIN)
+
+      SchoolsAdmins.create(school: school, user: user)
+    end
+
+    it 'should not make any changes if the User.role is already "admin"' do
+      user.update(role: User::ADMIN)
+      expect(user).not_to receive(:update).with(role: User::ADMIN)
+
+      SchoolsAdmins.create(school: school, user: user)
     end
   end
 end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -314,8 +314,8 @@ describe User, type: :model do
 
   describe 'constants' do
     it "should give the correct value for all the constants" do
-      expect(User::ROLES).to eq(%w(teacher student staff sales-contact))
-      expect(User::SAFE_ROLES).to eq(%w(student teacher sales-contact))
+      expect(User::ROLES).to eq(%w(teacher student staff sales-contact admin))
+      expect(User::SAFE_ROLES).to eq(%w(student teacher sales-contact admin))
       expect(User::VALID_EMAIL_REGEX).to eq(/\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i)
     end
   end
@@ -337,11 +337,9 @@ describe User, type: :model do
   end
 
   describe '#admin?' do
-    let!(:user) { create(:user) }
+    let!(:user) { create(:user, role: User::ADMIN) }
 
     context 'when admin exists' do
-      let!(:schools_admins) { create(:schools_admins, user: user) }
-
       it 'should return true' do
         expect(user.admin?).to eq true
       end
@@ -349,6 +347,8 @@ describe User, type: :model do
 
     context 'when admin does not exist' do
       it 'should return false' do
+        user.update(role: User::TEACHER)
+
         expect(user.admin?).to eq false
       end
     end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1043,6 +1043,11 @@ describe User, type: :model do
       expect(user).to be_teacher
     end
 
+    it "must be true for 'admin' roles because all admins are teachers" do
+      user.safe_role_assignment User::ADMIN
+      expect(user).to be_teacher
+    end
+
     it 'must be false for other roles' do
       user.safe_role_assignment 'other'
       expect(user).to_not be_teacher

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -337,7 +337,7 @@ describe User, type: :model do
   end
 
   describe '#admin?' do
-    let!(:user) { create(:user, role: User::ADMIN) }
+    let!(:user) { create(:admin) }
 
     context 'when admin exists' do
       it 'should return true' do

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -318,7 +318,7 @@ describe 'SegmentAnalytics' do
     let(:school) { create(:school, district: district) }
     let(:school_without_district) { create(:school) }
     let(:teacher1) { create(:teacher, school: school) }
-    let(:teacher2) { create(:teacher, school: school) }
+    let(:teacher2) { create(:teacher, school: school, role: User::ADMIN) }
     let(:teacher3) { create(:teacher, school: school_without_district) }
     let!(:schools_admins) { create(:schools_admins, school: school, user: teacher2) }
 


### PR DESCRIPTION
## WHAT
Add a new `admin` value for `User.role` that will be used to flag Users as school or district admins.  Historically, we have left admins with the role of `teacher`, and just determined the user to be an admin if they have any records in the `schools_admins` table.  NOTE: while a user can have the role `admin` to get to the admin dashboard, if they don't have any entries in the `schools_admins` table, the dashboard is broken and loads empty.
## WHY
As we begin treating admins more like a real user class, we should differentiate them properly.  That said, we don't want existing user behavior to change, so admins should still have access to all the various teacher-specific dashboards and reports.
## HOW
- Add a new value for `User.role`
- Trace through a bunch of auth pathways to ensure that users with the `admin` role are authorized to view pages that have historically required `teacher` roles
- Add an `after_save` callback to the `SchoolsAdmins` model to ensure that any time a User is assigned as an admin for a School (the way our current code denotes admins) it updates the `User.role` value to its new expectation.

### Notion Card Links
https://www.notion.so/quill/Create-a-new-admin-user-role-and-migrate-existing-admins-19d6e4118a3d41a0a626f3c571c38793

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
