### PR TITLE
lms/add-subject-areas-to-local-data

### DIFF
--- a/services/QuillLMS/lib/tasks/local_data.rake
+++ b/services/QuillLMS/lib/tasks/local_data.rake
@@ -149,6 +149,7 @@ namespace :local_data do
       schools
       skill_concepts
       skill_group_activities
+      subject_areas
       title_cards
       unit_template_categories
       unit_templates


### PR DESCRIPTION
## WHAT
Add `subject_areas` table to `local_data` sync
## WHY
It's necessary for creating new teacher users, and wasn't in the original script
## HOW
Just add the table name to the list of tables synced by the script

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on this job
Have you deployed to Staging? | No, but I have run it on my local machine and confirmed it works
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
