### PR TITLE
Move SaveUserPackSequenceItemsWorker to critical queue

### DIFF
--- a/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_items_worker.rb
@@ -3,7 +3,7 @@
 class SaveUserPackSequenceItemsWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: SidekiqQueue::DEFAULT
+  sidekiq_options queue: SidekiqQueue::CRITICAL
 
   def perform(classroom_id, user_id)
     return if classroom_id.nil? || user_id.nil?


### PR DESCRIPTION
## WHAT
Move `SaveUserPackSequenceItemsWorker` to critical queue

## WHY
This background job is occasionally getting stuck in the default queue causing bug reports at support for unlocked activity packs.

## HOW
Change the configuration to: 
`  sidekiq_options queue: SidekiqQueue::CRITICAL`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No. Configuration change.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
