### PR TITLE
Evidence Seed Data - Set the OpenAI timeout to 5 minutes, and rescue requests that timeout.

### DIFF
--- a/services/QuillLMS/engines/evidence/app/workers/evidence/synthetic_labeled_data_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/synthetic_labeled_data_worker.rb
@@ -3,7 +3,7 @@
 module Evidence
   class SyntheticLabeledDataWorker
     include Evidence.sidekiq_module
-    sidekiq_options retry: 0
+    sidekiq_options retry: 1
 
     def perform(filename, activity_id)
       uploader = Evidence.file_uploader.new

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/concerns/api.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/concerns/api.rb
@@ -30,18 +30,22 @@ module Evidence
       def run
         return cleaned_results if response.present?
 
-        @response = self.class.post(endpoint, body: request_body.to_json, headers: headers, timeout: TIMEOUT)
+        @response = post_request
 
         cleaned_results
       rescue *Evidence::HTTP_TIMEOUT_ERRORS
         []
       end
 
-      def headers
+      private def headers
         {
           "Content-Type" => "application/json",
           "Authorization" => "Bearer #{Evidence::OpenAI::API_KEY}"
         }
+      end
+
+      private def post_request
+        self.class.post(endpoint, body: request_body.to_json, headers: headers, timeout: TIMEOUT)
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/concerns/api.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/concerns/api.rb
@@ -33,7 +33,6 @@ module Evidence
         @response = self.class.post(endpoint, body: request_body.to_json, headers: headers, timeout: TIMEOUT)
 
         cleaned_results
-
       rescue *Evidence::HTTP_TIMEOUT_ERRORS
         []
       end

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/concerns/api.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/open_ai/concerns/api.rb
@@ -5,6 +5,8 @@ module Evidence
     module Concerns::API
       extend ActiveSupport::Concern
 
+      TIMEOUT = 5.minutes.to_i
+
       included do
         include HTTParty
         base_uri 'https://api.openai.com/v1'
@@ -28,9 +30,12 @@ module Evidence
       def run
         return cleaned_results if response.present?
 
-        @response = self.class.post(endpoint, body: request_body.to_json, headers: headers)
+        @response = self.class.post(endpoint, body: request_body.to_json, headers: headers, timeout: TIMEOUT)
 
         cleaned_results
+
+      rescue *Evidence::HTTP_TIMEOUT_ERRORS
+        []
       end
 
       def headers

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/concerns/api_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/concerns/api_spec.rb
@@ -45,5 +45,12 @@ module Evidence
         expect(JSON.parse(class_with_methods.new.run)).to eq(sample_response_body)
       end
     end
+
+    context "run with a timeout" do
+      it "should rescue and return an empty array" do
+        stub_request(:post, endpoint).to_timeout
+        expect(class_with_methods.new.run).to eq([])
+      end
+    end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/concerns/api_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/concerns/api_spec.rb
@@ -46,10 +46,19 @@ module Evidence
       end
     end
 
-    context "run with a timeout" do
+    context "#run hitting a timeout" do
       it "should rescue and return an empty array" do
         stub_request(:post, endpoint).to_timeout
         expect(class_with_methods.new.run).to eq([])
+      end
+    end
+
+    context "#post_request" do
+      let(:api_response) { class_with_methods.new.send(:post_request) }
+
+      it "should pass a timeout" do
+        stub_request(:post, endpoint).to_return(sample_response)
+        expect(api_response.request.options[:timeout]).to eq 300
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -239,6 +239,23 @@ module Evidence
       end
     end
 
+    describe 'API timeout' do
+      let(:openai_url) {'https://api.openai.com/v1/completions'}
+      let(:because) {described_class.new(passage: '', stem: stem, conjunction: 'because')}
+
+      before do
+        stub_request(:post, openai_url).to_timeout
+      end
+
+      context 'run_prompt' do
+        subject { because.send(:run_prompt, prompt: '', count: 1, seed: '') }
+
+        it "return empty array" do
+          expect(subject).to eq([])
+        end
+      end
+    end
+
     describe "#stem_variants_hash" do
       let(:conjunction) {'thus'}
       let(:stem) {"It is true, #{conjunction}"}


### PR DESCRIPTION
## WHAT

Attempting to make the Seed Data code more resilient to API timeouts:

Three main changes to OpenAI API code
1. Lengthen timeout from 1 minute to 5 minutes.
2. Rescue API timeouts (each job is multiple API requests, so move on if one times out)
3. Retry an errored job once (instead of never)

## WHY
The OpenAI API has been timing out reasonably frequently. We make 100+ API requests per seed data job, so that has made the Seed Data creation a bit flaky for Quill staff (which is frustrating since they fill out a large form of example data). 

This code makes timeouts less likely (increase timeout length) and increases the chance that they will get "most of the data" instead of "all or nothing" (rescuing timeouts, allowing one retry). 
## HOW
Small config changes.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'.
Have you deployed to Staging? | No, testing this locally.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
