### PR TITLE
Fix bug with moving student to different classroom and their classroom units

### DIFF
--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -53,9 +53,12 @@ module Student
     end
 
     def move_student_from_one_class_to_another(old_classroom, new_classroom)
-      StudentsClassrooms.unscoped.find_or_create_by(student_id: id, classroom_id: new_classroom.id).update(visible: true)
+      student_classroom = StudentsClassrooms.unscoped.find_or_create_by(student: self, classroom: new_classroom)
+      student_classroom.update(visible: true)
+      student_classroom.validate_assigned_student
+
       move_activity_sessions(old_classroom, new_classroom)
-      old_classroom_students_classrooms = StudentsClassrooms.find_by(student_id: id, classroom_id: old_classroom.id)
+      old_classroom_students_classrooms = StudentsClassrooms.find_by(student: self, classroom: old_classroom)
       # a callback on the students classroom model will remove the student from any associated classroom units
       old_classroom_students_classrooms&.update(visible: false)
     end

--- a/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
@@ -145,6 +145,27 @@ describe 'Student Concern', type: :model do
     end
   end
 
+  describe "#move_student_from_one_class_to_another" do
+    subject { student1.move_student_from_one_class_to_another(classroom, classroom3) }
+
+    let!(:classroom3) { create(:classroom) }
+    let!(:classroom_unit6) { create(:classroom_unit, classroom: classroom3, assign_on_join: assign_on_join) }
+
+    context 'assign_on_join false' do
+      let(:assign_on_join) { false }
+
+      it { expect { subject }.not_to change { classroom_unit6.reload.assigned_student_ids}.from([]) }
+      it { expect { subject }.to change { student1.reload.classrooms }.from([classroom]).to([classroom3]) }
+    end
+
+    context 'assign_on_join true' do
+      let(:assign_on_join) { true }
+
+      it { expect { subject }.to change { classroom_unit6.reload.assigned_student_ids}.from([]).to([student1.id]) }
+      it { expect { subject }.to change { student1.reload.classrooms }.from([classroom]).to([classroom3]) }
+    end
+  end
+
   describe "#merge_student_account" do
     context "called with no teacher id" do
       it "returns false when the students are not in the same classrooms" do


### PR DESCRIPTION
## WHAT
This PR addresses a bug where teachers move a student to a different classroom and that student is not automatically assigned activities from that new classroom.  

## WHY
We'd like the behavior to be the same as when a student is added to a class.

## HOW
Add a `student_classroom.validate_assigned_student` call to the `student#move_student_from_one_class_to_another` method.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Are-students-who-are-moved-from-one-class-to-another-automatically-assigned-activities-that-were-alr-c7933018845f4f7492a9590c3e61898c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
