### PR TITLE
make sure premium footer doesn't exceed max width

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/banner-with-button.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/banner-with-button.scss
@@ -33,12 +33,14 @@
 .premium-footer {
   background-color: #DF9E3D;
   color: white;
+  padding: 32px 61px;
   .content-container {
-    padding: 32px 61px;
     display: flex;
     justify-content: space-between;
     align-items: center;
     font-size: 16px;
+    max-width: $sitewidepagewidth;
+    margin: auto;
     @media (max-width: 410px) {
       flex-direction: column;
       align-items: flex-start;


### PR DESCRIPTION
## WHAT
Update premium footer CSS so it is capped at the site wide max width.

## WHY
So it looks okay with the new footer.

## HOW
Just CSS adjustments.

### Screenshots
<img width="1440" alt="Screen Shot 2023-02-10 at 10 20 47 AM" src="https://user-images.githubusercontent.com/18669014/218132048-5fac4f99-a64b-4bf1-a09b-f9111bd3a36d.png">


### Notion Card Links
https://www.notion.so/quill/Broken-Premium-Footer-Banner-UI-after-Footer-Update-afe0a4352e4b4a74b03544eb0910fa35

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
