### PR TITLE
Remove transaction block from UserPackSequenceItemSaver and use background jobs

### DIFF
--- a/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
+++ b/services/QuillLMS/app/services/user_pack_sequence_item_saver.rb
@@ -18,10 +18,8 @@ class UserPackSequenceItemSaver < ApplicationService
   end
 
   def run
-    ActiveRecord::Base.transaction do
-      compute_statuses
-      save_statuses
-    end
+    compute_statuses
+    save_statuses
   end
 
   private def compute_statuses
@@ -54,8 +52,7 @@ class UserPackSequenceItemSaver < ApplicationService
 
   private def save_statuses
     user_pack_sequence_item_statuses.each_pair do |pack_sequence_item_id, status|
-      upsi = UserPackSequenceItem.create_or_find_by!(pack_sequence_item_id: pack_sequence_item_id, user_id: user_id)
-      upsi.update!(status: status) unless upsi.status == status
+      SaveUserPackSequenceItemWorker.perform_async(pack_sequence_item_id, status, user_id)
     end
   end
 end

--- a/services/QuillLMS/app/workers/save_user_pack_sequence_item_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_item_worker.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SaveUserPackSequenceItemWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: SidekiqQueue::CRITICAL
+
+  def perform(pack_sequence_item_id, status, user_id)
+    return if pack_sequence_item_id.nil? || user_id.nil?
+
+    upsi = UserPackSequenceItem.create_or_find_by!(pack_sequence_item_id: pack_sequence_item_id, user_id: user_id)
+    return if upsi.status == status
+
+    upsi.update!(status: status)
+  end
+end

--- a/services/QuillLMS/spec/workers/save_user_pack_sequence_item_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_user_pack_sequence_item_worker_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SaveUserPackSequenceItemWorker do
+  subject { described_class.new.perform(pack_sequence_item_id, status, user_id) }
+
+  let(:pack_sequence_item_id) { create(:pack_sequence_item).id }
+  let(:user_id) { create(:user).id }
+  let(:locked) { UserPackSequenceItem::LOCKED }
+  let(:unlocked) { UserPackSequenceItem::UNLOCKED }
+  let(:status) { [locked, unlocked].sample }
+
+  context 'nil pack_sequence_id' do
+    let(:pack_sequence_item_id) { nil }
+
+    it 'should_not_query_user_pack_sequence_item' do
+      expect(UserPackSequenceItem).not_to receive(:create_or_find_by!)
+      subject
+    end
+  end
+
+  context 'nil user_id' do
+    let(:user_id) { nil }
+
+    it 'should_not_query_user_pack_sequence_item' do
+      expect(UserPackSequenceItem).not_to receive(:create_or_find_by!)
+      subject
+    end
+  end
+
+  context 'user_pack_sequence_item does not exist' do
+    it { expect { subject }.to change(UserPackSequenceItem, :count).from(0).to(1) }
+  end
+
+  context 'user_pack_sequence_item exists' do
+    let!(:user_pack_sequence_item) do
+      create(:user_pack_sequence_item,
+        pack_sequence_item_id: pack_sequence_item_id,
+        status: locked,
+        user_id: user_id
+      )
+    end
+
+    context 'status does not change' do
+      let(:status) { locked }
+
+      it { expect { subject }.not_to change(UserPackSequenceItem, :count) }
+      it { expect { subject }.not_to change { user_pack_sequence_item.reload.status } }
+    end
+
+    context 'status does change' do
+      let(:status) { unlocked }
+
+      it { expect { subject }.not_to change(UserPackSequenceItem, :count) }
+      it { expect { subject }.to change { user_pack_sequence_item.reload.status } }
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Remove the transactions from `UserPackSequenceItemSaver` and use background jobs instead.

## WHY
Transactions add locks to the querying which sometimes results in degraded performance.  While transactions are a safe way to create objects in a loop, we can make the underlying `SaveUserPackSequenceItemsWorker` faster by breaking it up into smaller jobs.

## HOW
Add a new worker SaveUserPackSequenceItemWorker to create/update UserPackSequenceItem records.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
