### PR TITLE
allow users with admin roles to present lessons

### DIFF
--- a/services/QuillLessonsServer/src/constants.js
+++ b/services/QuillLessonsServer/src/constants.js
@@ -1,0 +1,4 @@
+const ADMIN = 'admin'
+const STAFF = 'staff'
+const TEACHER = 'teacher'
+export const teacherRoles = [ADMIN, STAFF, TEACHER]

--- a/services/QuillLessonsServer/src/handlers/authorization.js
+++ b/services/QuillLessonsServer/src/handlers/authorization.js
@@ -39,7 +39,7 @@ export function authorizeSession(data, token, client, callback) {
 
 export function authorizeTeacherSession(data, token, client, callback) {
   _checkToken(data, token, client, () => {
-    const userIsTeacher    = _isRoleAuthorized(['staff', 'teacher'], token.data.role);
+    const userIsTeacher    = _isRoleAuthorized(['staff', 'teacher', 'admin'], token.data.role);
     const belongsToSession = _belongsToSession(data, token);
     const isValidSession   = userIsTeacher && belongsToSession;
 

--- a/services/QuillLessonsServer/src/handlers/authorization.js
+++ b/services/QuillLessonsServer/src/handlers/authorization.js
@@ -1,3 +1,5 @@
+import { teacherRoles, } from '../constants'
+
 function _isPreviewSession(data) {
   const previewIdRegExp = RegExp('^prvw\-.+$');
   return previewIdRegExp.test(data.classroomSessionId);
@@ -39,7 +41,7 @@ export function authorizeSession(data, token, client, callback) {
 
 export function authorizeTeacherSession(data, token, client, callback) {
   _checkToken(data, token, client, () => {
-    const userIsTeacher    = _isRoleAuthorized(['staff', 'teacher', 'admin'], token.data.role);
+    const userIsTeacher    = _isRoleAuthorized(teacherRoles, token.data.role);
     const belongsToSession = _belongsToSession(data, token);
     const isValidSession   = userIsTeacher && belongsToSession;
 

--- a/services/QuillLessonsServer/src/index.js
+++ b/services/QuillLessonsServer/src/index.js
@@ -7,9 +7,11 @@ import fs from 'fs';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import path from 'path';
+
 import rethinkdbConfig from './config/rethinkdb';
 import { requestHandler } from './config/server';
 import { nrTrack } from './config/newrelic';
+import { teacherRoles, } from './constants'
 
 const Sentry = require('@sentry/node');
 
@@ -237,7 +239,7 @@ r.connect(dbConfig, (err, connection) => {
     io.on('connection', (client) => {
       client.on('authentication', (data) => {
         const adaptors = { connection, client };
-        const adminRoles = ['teacher', 'staff'];
+        const adminRoles = teacherRoles;
         const authToken = verifyToken(data.token);
         registerConnection(client);
 


### PR DESCRIPTION
## WHAT
Fix bug where users with the role "admin" couldn't present Lessons.

## WHY
Admins are supposed to be able to do everything teachers can do.

## HOW
Just update `quillLessonsServer` code to account for the new user type.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Not-allowing-teacher-to-move-past-title-slide-in-Complex-Sentences-Overview-Quill-Lesson-4180b9091b784cfe92c6b3f2fa2b784e?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - no tests for Lessons :/ but I did manually test
Have you deployed to Staging? | YES 
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
