### PR TITLE
Synthetic Seed Data - Allow Label Examples to be run on their own.

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -5,7 +5,7 @@ import ReactHtmlParser from 'react-html-parser'
 import SubmissionModal from '../shared/submissionModal';
 import { fetchActivity, createSeedData } from '../../../utils/evidence/activityAPIs';
 import { renderHeader, quillCloseX } from "../../../helpers/evidence/renderHelpers";
-import { Input, Spinner } from '../../../../Shared/index';
+import { Input, Spinner, DropdownInput, } from '../../../../Shared/index';
 import { TITLE, BECAUSE, BUT, SO } from "../../../../../constants/evidence";
 
 const SeedDataForm = ({ history, match }) => {
@@ -14,7 +14,13 @@ const SeedDataForm = ({ history, match }) => {
   const [errorOrSuccessMessage, setErrorOrSuccessMessage] = React.useState<string>(null);
   const [errors, setErrors] = React.useState<string[]>([]);
   const [showSubmissionModal, setShowSubmissionModal] = React.useState<boolean>(false);
-  const queryClient = useQueryClient()
+  const [usePassage, setUsePassage] = React.useState<string>("true");
+  const queryClient = useQueryClient();
+
+  const runOptions = [
+    { value: "true", label: 'Full Run'},
+    { value: "false", label: 'Label Examples Only'},
+  ];
 
   const [activityNouns, setActivityNouns] = React.useState<string>('');
 
@@ -22,6 +28,10 @@ const SeedDataForm = ({ history, match }) => {
   const blankLabelConfigs = { [BECAUSE] : [], [BUT] : [], [SO] : [], };
 
   const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});
+
+  function handleUsePassageChange(runOption) {
+    setUsePassage(runOption.value);
+  };
 
   function handleLabelConfigsChange(event, index, conjunction, key) {
     const data = {...labelConfigs}
@@ -104,7 +114,7 @@ const SeedDataForm = ({ history, match }) => {
   function handleCreateSeedData() {
     if (!confirm('⚠️ Are you sure you want to generate seed data?')) return
 
-    createSeedData(activityNouns, labelConfigs, activityId).then((response) => {
+    createSeedData(activityNouns, labelConfigs, activityId, usePassage).then((response) => {
       const { errors } = response;
       if(errors && errors.length) {
         setErrors(errors);
@@ -112,6 +122,7 @@ const SeedDataForm = ({ history, match }) => {
         setErrors([]);
         setErrorOrSuccessMessage('Seed Data started! You will receive an email with the csv files');
         setActivityNouns('');
+        setUsePassage("true");
         setLabelConfigs({...blankLabelConfigs});
         toggleSubmissionModal();
       }
@@ -235,6 +246,16 @@ const SeedDataForm = ({ history, match }) => {
       {renderLabelSection(BECAUSE)}
       {renderLabelSection(BUT)}
       {renderLabelSection(SO)}
+      <br />
+      <div className='run-type-dropdown'>
+        <DropdownInput
+          handleChange={handleUsePassageChange}
+          isSearchable={false}
+          label="Run Type"
+          options={runOptions}
+          value={runOptions.find(ro => ro.value === usePassage)}
+        />
+      </div>
       <br />
       <div className="button-and-id-container">
         <button className="quill-button fun large primary contained focus-on-light" id="activity-submit-button" onClick={handleCreateSeedData} type="submit">

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -14,12 +14,16 @@ const SeedDataForm = ({ history, match }) => {
   const [errorOrSuccessMessage, setErrorOrSuccessMessage] = React.useState<string>(null);
   const [errors, setErrors] = React.useState<string[]>([]);
   const [showSubmissionModal, setShowSubmissionModal] = React.useState<boolean>(false);
-  const [usePassage, setUsePassage] = React.useState<string>("true");
+
+  const trueString = 'true';
+  const falseString = 'false';
+
+  const [usePassage, setUsePassage] = React.useState<string>(trueString);
   const queryClient = useQueryClient();
 
   const runOptions = [
-    { value: "true", label: 'Full Run'},
-    { value: "false", label: 'Label Examples Only'},
+    { value: trueString, label: 'Full Run'},
+    { value: falseString, label: 'Label Examples Only'},
   ];
 
   const [activityNouns, setActivityNouns] = React.useState<string>('');
@@ -122,7 +126,7 @@ const SeedDataForm = ({ history, match }) => {
         setErrors([]);
         setErrorOrSuccessMessage('Seed Data started! You will receive an email with the csv files');
         setActivityNouns('');
-        setUsePassage("true");
+        setUsePassage(trueString);
         setLabelConfigs({...blankLabelConfigs});
         toggleSubmissionModal();
       }

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
@@ -37,5 +37,9 @@
   .plus {
     font-size: 30px;
   }
+
+  .run-type-dropdown {
+    width: 250px;
+  }
 }
 

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
@@ -53,10 +53,10 @@ export const updateActivityVersion = async (activityNote: string, activityId: st
   return { errors: [] };
 }
 
-export const createSeedData = async (nouns: string, labelConfigs: object, activityId: string) => {
+export const createSeedData = async (nouns: string, labelConfigs: object, activityId: string, usePassage: string) => {
   const response = await apiFetch(`activities/${activityId}/seed_data`, {
     method: 'POST',
-    body: JSON.stringify({nouns: nouns, label_configs: labelConfigs})
+    body: JSON.stringify({nouns: nouns, label_configs: labelConfigs, use_passage: usePassage})
   });
   const { status } = response;
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -99,7 +99,10 @@ module Evidence
         .uniq
 
       label_configs = seed_data_params[:label_configs]&.to_h || {}
-      use_passage = seed_data_params[:use_passage] || true
+
+      use_passage_param = ActiveModel::Type::Boolean.new.cast(seed_data_params[:use_passage])
+      # default to true for missing param
+      use_passage = use_passage_param.nil? ? true : use_passage_param
 
       Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs, use_passage)
 
@@ -133,7 +136,7 @@ module Evidence
     end
 
     private def seed_data_params
-      params.permit(:id, :nouns, label_configs: {}, activity: {})
+      params.permit(:id, :nouns, :use_passage, label_configs: {}, activity: {})
     end
 
     private def activity_params

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -99,8 +99,9 @@ module Evidence
         .uniq
 
       label_configs = seed_data_params[:label_configs]&.to_h || {}
+      use_passage = seed_data_params[:use_passage] || true
 
-      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs)
+      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs, use_passage)
 
       head :no_content
     end

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
@@ -5,7 +5,7 @@ module Evidence
     include Evidence.sidekiq_module
     sidekiq_options retry: 0
 
-    def perform(activity_id, nouns, label_configs, use_passage = true)
+    def perform(activity_id, nouns, label_configs, use_passage)
       csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(
         activity_id: activity_id,
         nouns: nouns,

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
@@ -5,11 +5,12 @@ module Evidence
     include Evidence.sidekiq_module
     sidekiq_options retry: 0
 
-    def perform(activity_id, nouns, label_configs)
+    def perform(activity_id, nouns, label_configs, use_passage = true)
       csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(
         activity_id: activity_id,
         nouns: nouns,
-        label_configs: label_configs
+        label_configs: label_configs,
+        use_passage: use_passage
       )
 
       activity = Evidence::Activity.find(activity_id)

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -92,32 +92,40 @@ module Evidence
       end
 
       def run
-        # whole passage plus prompt
+        generate_full_passage_responses
+        generate_full_passage_noun_responses
+        generate_chunk_responses
+        generate_label_paraphrases
+
+        results
+      end
+
+      # whole passage plus prompt
+      private def generate_full_passage_responses
         TEMPS_PASSAGE.each do |temp|
           stem_variants_hash.each do |conjunction, stem_variant|
             prompt = prompt_text(context: passage, stem_variant: stem_variant)
             run_prompt(prompt: prompt, count: FULL_COUNT, seed: "full_passage_temp#{temp}_#{conjunction}", temperature: temp)
           end
         end
+      end
 
-        # whole passage plus prompt for each noun
+      # whole passage plus prompt for each noun
+      private def generate_full_passage_noun_responses
         nouns.each do |noun|
           prompt = prompt_text(context: passage, noun: noun)
           run_prompt(prompt: prompt, count: FULL_NOUN_COUNT, noun: noun, seed: "full_passage_noun_#{noun.gsub(SPACE,BLANK)}")
         end
+      end
 
-        # chunks plus prompt
+      # chunks plus prompt
+      private def generate_chunk_responses
         split_passage.each.with_index do |text_chunk, index|
           stem_variants_hash.each do |conjunction, stem_variant|
             prompt = prompt_text(context: text_chunk, stem_variant: stem_variant)
             run_prompt(prompt: prompt, count: SECTION_COUNT, seed: "text_chunk_#{index + 1}_temp#{TEMP_SECTION}_#{conjunction}", temperature: TEMP_SECTION)
           end
         end
-
-        # label examples to paraphrase
-        generate_label_paraphrases
-
-        results
       end
 
       LABEL_KEY = 'label'

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -389,6 +389,15 @@ module Evidence
           expect(response).to have_http_status(:success)
         end
       end
+
+      context 'use_passage=nil' do
+        it "should call background worker with use_passage=true" do
+          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], {}, true)
+          post :seed_data, params: { id: activity.id, nouns: "", use_passage: nil }
+
+          expect(response).to have_http_status(:success)
+        end
+      end
     end
 
     context "#labeled_synthetic_data" do

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -348,19 +348,18 @@ module Evidence
 
     context "#seed_data" do
       let(:activity) { create(:evidence_activity) }
-      # TODO: fill out test when frontend is complete
       let(:label_configs) {{}}
 
       it "should call background worker" do
-        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs)
-        post :seed_data, params: { id: activity.id, nouns: "" }
+        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs, true)
+        post :seed_data, params: { id: activity.id, nouns: ""}
 
         expect(response).to have_http_status(:success)
       end
 
       it "should call background worker with noun string converted to array" do
-        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, ['noun1','noun two','noun3'], label_configs)
-        post :seed_data, params: { id: activity.id, nouns: "noun1, noun two,,noun3" }
+        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, ['noun1','noun two','noun3'], label_configs, true)
+        post :seed_data, params: { id: activity.id, nouns: "noun1, noun two,,noun3"}
 
         expect(response).to have_http_status(:success)
       end
@@ -375,12 +374,20 @@ module Evidence
         let(:label_configs) {{'so' => [label_config1, label_config2], 'because' => [label_config2]}}
 
         it "should call background worker" do
-          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs)
+          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs, true)
           post :seed_data, params: { id: activity.id, nouns: "", label_configs: label_configs }
 
           expect(response).to have_http_status(:success)
         end
+      end
 
+      context 'use_passage=false' do
+        it "should call background worker" do
+          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], {}, false)
+          post :seed_data, params: { id: activity.id, nouns: "", use_passage: false }
+
+          expect(response).to have_http_status(:success)
+        end
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -39,6 +39,8 @@ module Evidence
     let(:example_prompt) { "rephrase with some synonyms:\n\nExample to paraphrase." }
     let(:example_response) { ["Example to rephrase."] }
 
+    let(:label_tag) { "label_label1_example1_temp1" }
+
     let(:seed_labels) do
       [
         "full_passage_temp1_but",
@@ -50,7 +52,7 @@ module Evidence
         "full_passage_noun_noun1",
         "text_chunk_1_temp0.4_but",
         "text_chunk_2_temp0.4_but",
-        "label_label1_example1_temp1"
+        label_tag
       ]
     end
 
@@ -158,6 +160,31 @@ module Evidence
         expect(subject.results.count).to be(10)
         expect(subject.results.map(&:seed)).to eq(seed_labels)
         expect(subject.results.map(&:label)).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, "label1"])
+      end
+
+      context "use_passage=false" do
+        subject do
+          described_class.new(
+            passage: passage,
+            stem: stem,
+            nouns: nouns,
+            conjunction: conjunction,
+            label_configs: [label_config],
+            use_passage: false
+          )
+        end
+        it "should generate ONLY label paraphrases" do
+          # label example
+          expect(Evidence::OpenAI::Completion).to receive(:run)
+            .with(prompt: example_prompt, count: 1, temperature: 1, options: {max_tokens: 40})
+            .and_return(example_response)
+
+          subject.run
+
+          expect(subject.results.count).to be(1)
+          expect(subject.results.map(&:seed)).to eq([label_tag])
+          expect(subject.results.map(&:label)).to eq(["label1"])
+        end
       end
     end
 
@@ -307,16 +334,30 @@ module Evidence
         allow(Evidence::OpenAI::Completion).to receive(:run).and_return(full_passage_response)
       end
 
-      it "should generate a hash" do
-        output = described_class.csvs_for_activity(activity_id: activity.id, nouns: ['hello'])
+      subject { described_class.csvs_for_activity(activity_id: activity.id, nouns: ['hello']) }
 
-        expect(output.class).to be Hash
-        expect(output.keys).to eq(['Some_Activity_Name_because.csv', 'Some_Activity_Name_passage_chunks.csv'])
+      it "should generate a hash" do
+        expect(subject.class).to be Hash
+        expect(subject.keys).to eq(['Some_Activity_Name_because.csv', 'Some_Activity_Name_passage_chunks.csv'])
 
         # values should be a multi-line valid CSV
-        csv = CSV.parse(output.values.first)
+        csv = CSV.parse(subject.values.first)
         expect(csv.size).to be 3
         expect(csv.first).to eq(["Text", "Seed", "Initial Label"])
+      end
+
+      context "label examples only" do
+        subject { described_class.csvs_for_activity(activity_id: activity.id, label_configs: label_config, use_passage: false) }
+
+        it "should generate a hash without prompt_chunks csv" do
+          expect(subject.class).to be Hash
+          expect(subject.keys).to eq(['Some_Activity_Name_because.csv'])
+
+          # values should be a multi-line valid CSV
+          csv = CSV.parse(subject.values.first)
+          expect(csv.size).to be 3
+          expect(csv.first).to eq(["Text", "Seed", "Initial Label"])
+        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -355,7 +355,7 @@ module Evidence
 
           # values should be a multi-line valid CSV
           csv = CSV.parse(subject.values.first)
-          expect(csv.size).to be 3
+          expect(csv.size).to be 1
           expect(csv.first).to eq(["Text", "Seed", "Initial Label"])
         end
       end

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
@@ -19,8 +19,9 @@ module Evidence
       let(:email_subject) {"Evidence Seed Data: Activity #{activity.id} - #{activity.title}"}
       let(:mailer) { double('mailer', deliver_now!: true) }
       let(:label_configs) {{'because' => [{'label' => 'Label1', 'examples' => ['hello', 'goodbye']}]}}
+      let(:use_passage) {false}
 
-      it 'call generate and call file_mailer' do
+      it 'call generate and call file_mailer with defaults' do
         expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)
           .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs, use_passage: true)
           .and_return(generator_response)
@@ -30,6 +31,18 @@ module Evidence
           .and_return(mailer)
 
         subject.perform(activity.id, nouns, label_configs)
+      end
+
+      it 'call generate and call file_mailer with use_passage confi' do
+        expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)
+          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs, use_passage: use_passage)
+          .and_return(generator_response)
+
+        expect(FileMailer).to receive(:send_multiple_files)
+          .with(email, email_subject, generator_response)
+          .and_return(mailer)
+
+        subject.perform(activity.id, nouns, label_configs, use_passage)
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
@@ -19,7 +19,6 @@ module Evidence
       let(:email_subject) {"Evidence Seed Data: Activity #{activity.id} - #{activity.title}"}
       let(:mailer) { double('mailer', deliver_now!: true) }
       let(:label_configs) {{'because' => [{'label' => 'Label1', 'examples' => ['hello', 'goodbye']}]}}
-      let(:use_passage) {false}
 
       it 'call generate and call file_mailer with defaults' do
         expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)
@@ -30,19 +29,19 @@ module Evidence
           .with(email, email_subject, generator_response)
           .and_return(mailer)
 
-        subject.perform(activity.id, nouns, label_configs)
+        subject.perform(activity.id, nouns, label_configs, true)
       end
 
-      it 'call generate and call file_mailer with use_passage confi' do
+      it 'call generate and call file_mailer with use_passage config' do
         expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)
-          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs, use_passage: use_passage)
+          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs, use_passage: false)
           .and_return(generator_response)
 
         expect(FileMailer).to receive(:send_multiple_files)
           .with(email, email_subject, generator_response)
           .and_return(mailer)
 
-        subject.perform(activity.id, nouns, label_configs, use_passage)
+        subject.perform(activity.id, nouns, label_configs, false)
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
@@ -22,7 +22,7 @@ module Evidence
 
       it 'call generate and call file_mailer' do
         expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)
-          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs)
+          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs, use_passage: true)
           .and_return(generator_response)
 
         expect(FileMailer).to receive(:send_multiple_files)

--- a/services/QuillLMS/spec/models/user_activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/user_activity_classification_spec.rb
@@ -13,7 +13,7 @@
 #
 #  index_user_activity_classifications_on_classifications  (activity_classification_id)
 #  index_user_activity_classifications_on_user_id          (user_id)
-#  user_activity_classification_unique_index               (user_id,activity_classification_id) UNIQUE
+#  user_activity_classification_unique_index               (user_id,activity_classification_id)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
## WHAT
Adding the ability to just create seed data for label examples.
## WHY
This is a request from the Curriculum Team. Occasionally they just need a little more data for a certain label, so this will give them more flexibility in creating that.
## HOW
Added a new "use_passage" option that gets passed from the form to the backend. Toggles whether we should run all of the generators or just the label examples
### Screenshots
Run Type Options
![Screenshot 2023-02-15 at 4 27 42 PM](https://user-images.githubusercontent.com/1304933/219173934-a89fab60-3293-4f46-b574-c61262baebf0.png)

How it appears on the page:
![Screenshot 2023-02-15 at 4 27 30 PM](https://user-images.githubusercontent.com/1304933/219173941-28bb04d6-97da-4257-94eb-0610176841ea.png)


### Notion Card Links
https://www.notion.so/quill/Add-ability-to-generate-responses-from-labeled-examples-separately-from-seed-data-24b9e54616aa4eb08384ae754b6a34fa

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? |  YES,
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
