### PR TITLE
Display list of Evidence Activities on Assign Activities page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
@@ -1,5 +1,4 @@
 .assignment-card {
-  border-radius: 6px;
   background-color: white;
   padding: 32px;
   text-align: left;
@@ -7,6 +6,8 @@
   width: 100%;
   flex-direction: column;
   align-items: inherit;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
+  border-radius: 20px;
   &:hover {
     text-decoration: none;
   }
@@ -25,9 +26,10 @@
       }
     }
     h2 {
-      font-size: 16px;
-      font-weight: bold;
-      line-height: 1.5;
+      font-style: normal;
+      font-weight: 700;
+      font-size: 20px;
+      line-height: 25px;
     }
     .recommended-to-start-tag {
       font-size: 12px;
@@ -49,13 +51,17 @@
       .key {
         max-width: 88px;
         width: 100%;
+        font-weight: 700;
+        font-size: 14px;
+        line-height: 21px;
+        color: #373737;
       }
     }
   }
 }
 
 .assign-a-new-activity-container {
-  background-color: white;
+  background-color: #F7F5F5;
   min-height: 100%;
 }
 
@@ -70,7 +76,7 @@
     font-size: 24px;
     font-weight: bold;
     line-height: 1.33;
-    margin-bottom: 40px;
+    margin-bottom: 23px;
     text-align: center;
   }
 
@@ -110,21 +116,34 @@
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
-    max-width: 950px;
+    max-width: $sitewidepagewidth;
     .assignment-card {
       width: 100%;
-      max-width: 463px;
+      max-width: 588px;
       margin: 0px 0px 24px;
     }
   }
 
   .previously-assigned-activities {
     text-align: center;
-    margin-top: 26px;
     font-size: 14px;
     color: #646464;
+    margin-bottom: 71px;
     a {
-      color: #027360;
+      color: #373737;
+      font-weight: 400;
+      font-size: 13px;
+      line-height: 13px;
+      width: 140px;
+      height: 13px;
+    }
+    .view-assigned-activities {
+      width: 172px;
+      height: 33px;
+      background: #FFFFFF;
+      border: 1px solid #BDBDBD;
+      border-radius: 4px;
+      margin-left: 5px;
     }
   }
 

--- a/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
@@ -124,18 +124,13 @@
     }
   }
 
-  .previously-assigned-activities {
-    text-align: center;
-    font-size: 14px;
-    color: #646464;
-    margin-bottom: 71px;
-    a {
-      color: #373737;
-      font-weight: 400;
-      font-size: 13px;
-      line-height: 13px;
-      width: 140px;
-      height: 13px;
+  .previously-assigned-container {
+    display: flex;
+    .previously-assigned-activities {
+      text-align: center;
+      font-size: 14px;
+      color: #646464;
+      margin-bottom: 71px;
     }
     .view-assigned-activities {
       width: 172px;
@@ -144,14 +139,25 @@
       border: 1px solid #BDBDBD;
       border-radius: 4px;
       margin-left: 5px;
+      margin-top: -6px;
+      padding-top: 8px;
+      padding-left: 15px;
+      a {
+        color: #373737;
+        font-weight: 400;
+        font-size: 13px;
+        line-height: 13px;
+        width: 140px;
+        height: 13px;
+      }
     }
-  }
 
-  @media (max-width: 1100px) {
-    .minis {
-      justify-content: center;
-      .assignment-card {
-        max-width: 100%;
+    @media (max-width: 1100px) {
+      .minis {
+        justify-content: center;
+        .assignment-card {
+          max-width: 100%;
+        }
       }
     }
   }
@@ -168,6 +174,9 @@
 .evidence-header {
   margin-top: 40px;
   margin-bottom: 32px;
+  @media (max-width: 850px) {
+    display: none;
+  }
 }
 
 .suggested-activities-table {
@@ -228,5 +237,29 @@
       height: 33px;
       margin-left: 16px;
     }
+  }
+
+  @media (max-width: 1200px) {
+    tr {
+      width: 800px;
+      .activity-header {
+        max-width: 200px;
+      }
+      .topics-header {
+        max-width: 200px;
+      }
+    }
+    tbody {
+      .name-col {
+        max-width: 200px;
+      }
+      .topics-col {
+        max-width: 200px;
+      }
+    }
+  }
+
+  @media (max-width: 850px) {
+    display: none !important;
   }
 }

--- a/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
@@ -200,6 +200,9 @@
     }
     .name-col {
       width: 450px;
+      a {
+        color: #027360;
+      }
     }
     .topics-col {
       font-weight: 400;

--- a/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assign_a_new_activity.scss
@@ -164,3 +164,66 @@
     margin-right: 16px;
   }
 }
+
+.evidence-header {
+  margin-top: 40px;
+  margin-bottom: 32px;
+}
+
+.suggested-activities-table {
+  border: 1px solid #E0E0E0;
+  border-radius: 6px;
+  tr {
+    background-color: white;
+    padding-top: 12px;
+    padding-bottom: 2px;
+    width: $sitewidepagewidth;
+    .activity-header {
+      width: 450px;
+    }
+    .topics-header {
+      width: 375px;
+    }
+    th {
+      padding-bottom: 15px;
+      padding-top: 10px;
+    }
+  }
+  tbody {
+    .data-table-row {
+      &:hover {
+        background-color: white;
+      }
+    }
+    .tool-col {
+      margin-right: 24px;
+    }
+    .name-col {
+      width: 450px;
+    }
+    .topics-col {
+      font-weight: 400;
+      font-size: 14px;
+      line-height: 26px;
+      width: 375px;
+    }
+    .date-col {
+      width: 96px;
+    }
+    .preview-col {
+      a {
+        color: #027360;
+      }
+      width: 60px;
+    }
+    .select-suggested {
+      font-weight: 400;
+      font-size: 13px;
+      line-height: 13px;
+      color: #373737;
+      min-width: 69px;
+      height: 33px;
+      margin-left: 16px;
+    }
+  }
+}

--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -93,6 +93,13 @@ class ActivitiesController < ApplicationController
     end
   end
 
+  def activities_to_suggest
+    return render json: {activities: []} if !current_user.teacher_info.in_eighth_through_twelfth?
+
+    activities = Activity.where(classification: ActivityClassification.evidence).order(updated_at: :desc).map(&:serialize_with_topics)
+    render json: {activities: activities}
+  end
+
   private def authorized_activity_access?
     activity &&
     classroom_unit&.assigned_student_ids&.include?(current_user.id) &&

--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -93,15 +93,16 @@ class ActivitiesController < ApplicationController
     end
   end
 
-  def activities_to_suggest
-    return render json: {activities: []} if !current_user.teaches_eighth_through_twelfth?
+  def suggested_activities
+    return render json: {activities: []} unless current_user.teaches_eighth_through_twelfth?
 
     evidence_activities = Activity.where(classification: ActivityClassification.evidence)
     selected_activities = evidence_activities.where(flags: [Flags::PRODUCTION])
 
-    if current_user.flagset == Flags::EVIDENCE_BETA2
+    case current_user.flagset
+    when Flags::EVIDENCE_BETA2
       selected_activities = selected_activities.or(evidence_activities.where(flags: [Flags::EVIDENCE_BETA2]))
-    elsif current_user.flagset == Flags::EVIDENCE_BETA1
+    when Flags::EVIDENCE_BETA1
       selected_activities = selected_activities.or(evidence_activities.where(flags: [Flags::EVIDENCE_BETA2])).or(evidence_activities.where(flags: [Flags::EVIDENCE_BETA1]))
     end
 

--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -94,9 +94,18 @@ class ActivitiesController < ApplicationController
   end
 
   def activities_to_suggest
-    return render json: {activities: []} if !current_user.teacher_info.in_eighth_through_twelfth?
+    return render json: {activities: []} if !current_user.teaches_eighth_through_twelfth?
 
-    activities = Activity.where(classification: ActivityClassification.evidence).order(updated_at: :desc).map(&:serialize_with_topics)
+    if current_user.flags.include?('evidence_beta1')
+      activities = Activity.where(classification: ActivityClassification.evidence).order(updated_at: :desc).map(&:serialize_with_topics)
+    elsif current_user.flags.include?('evidence_beta2')
+      activities = Activity.where(classification: ActivityClassification.evidence).order(updated_at: :desc).map(&:serialize_with_topics)
+    else
+      activities = Activity.where(classification: ActivityClassification.evidence, flags:[Flags::PRODUCTION])
+        .order(updated_at: :desc)
+        .map(&:serialize_with_topics_and_publication_date)
+    end
+
     render json: {activities: activities}
   end
 

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -293,6 +293,10 @@ class Activity < ApplicationRecord
     user_pack_sequence_items.locked.exists?(user: user)
   end
 
+  def serialize_with_topics
+    serializable_hash.merge({topics: topics&.map(&:genealogy) || []})
+  end
+
   private def update_evidence_title?
     is_evidence? && saved_change_to_name?
   end

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -189,6 +189,13 @@ class Activity < ApplicationRecord
     module_url_helper(initial_params)
   end
 
+  def publication_date_for_flag(flag)
+    return nil unless is_evidence?
+
+    change_log = child_activity.change_logs.find_by(changed_attribute:"flags", new_value:"[\"production\"]")
+    change_log.created_at.strftime("%m/%d/%Y")
+  end
+
   # TODO: cleanup
   def flag(flag = nil)
     return super(flag) unless flag.nil?
@@ -293,8 +300,8 @@ class Activity < ApplicationRecord
     user_pack_sequence_items.locked.exists?(user: user)
   end
 
-  def serialize_with_topics
-    serializable_hash.merge({topics: topics&.map(&:genealogy) || []})
+  def serialize_with_topics_and_publication_date
+    serializable_hash.merge({topics: topics&.map(&:genealogy) || [], publication_date: publication_date_for_flag("production")})
   end
 
   private def update_evidence_title?

--- a/services/QuillLMS/app/models/topic.rb
+++ b/services/QuillLMS/app/models/topic.rb
@@ -73,7 +73,7 @@ class Topic < ApplicationRecord
   def genealogy
     [].tap do |results|
       current_topic = self
-      while current_topic do
+      while current_topic
         results.unshift(current_topic.name)
         current_topic = current_topic.parent
       end

--- a/services/QuillLMS/app/models/topic.rb
+++ b/services/QuillLMS/app/models/topic.rb
@@ -71,13 +71,13 @@ class Topic < ApplicationRecord
   # returns a list of topic names in this order:
   # [grandparent, parent, self]
   def genealogy
-    genealogy = []
-    current_topic = self
-    while current_topic
-      genealogy.unshift(current_topic.name)
-      current_topic = current_topic.parent
+    [].tap do |results|
+      current_topic = self
+      while current_topic do
+        results.unshift(current_topic.name)
+        current_topic = current_topic.parent
+      end
     end
-    genealogy
   end
 
   private def level_two_parent?

--- a/services/QuillLMS/app/models/topic.rb
+++ b/services/QuillLMS/app/models/topic.rb
@@ -68,6 +68,8 @@ class Topic < ApplicationRecord
     Topic.find(parent_id) if parent?
   end
 
+  # returns a list of topic names in this order:
+  # [grandparent, parent, self]
   def genealogy
     genealogy = []
     current_topic = self

--- a/services/QuillLMS/app/models/topic.rb
+++ b/services/QuillLMS/app/models/topic.rb
@@ -64,6 +64,20 @@ class Topic < ApplicationRecord
     end
   end
 
+  def parent
+    Topic.find(parent_id) if parent?
+  end
+
+  def genealogy
+    genealogy = []
+    current_topic = self
+    while current_topic
+      genealogy.unshift(current_topic.name)
+      current_topic = current_topic.parent
+    end
+    genealogy
+  end
+
   private def level_two_parent?
     parent? && Topic.find(parent_id).level_two?
   end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_new_activity.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_new_activity.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`AssignANewActivity component default should render 1`] = `
 <AssignANewActivity>
   <div
-    className="assign-a-new-activity-container white-background-accommodate-footer"
+    className="assign-a-new-activity-container"
   >
     <div
       className="assign-a-new-activity container"
@@ -11,6 +11,24 @@ exports[`AssignANewActivity component default should render 1`] = `
       <h1>
         Find the perfect writing activities for your students.
       </h1>
+      <p
+        className="previously-assigned-activities"
+      >
+        You have 
+         
+        activities
+         assigned. 
+        <button
+          className="view-assigned-activities"
+          type="button"
+        >
+          <a
+            href="/teachers/classrooms/activity_planner"
+          >
+            View assigned activities
+          </a>
+        </button>
+      </p>
       <div
         className="minis"
       >
@@ -329,19 +347,6 @@ exports[`AssignANewActivity component default should render 1`] = `
           </div>
         </AssignmentCard>
       </div>
-      <p
-        className="previously-assigned-activities"
-      >
-        You have 
-         
-        activities
-         assigned. 
-        <a
-          href="/teachers/classrooms/activity_planner"
-        >
-          View assigned activities
-        </a>
-      </p>
     </div>
   </div>
 </AssignANewActivity>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_new_activity.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_new_activity.test.jsx.snap
@@ -11,24 +11,27 @@ exports[`AssignANewActivity component default should render 1`] = `
       <h1>
         Find the perfect writing activities for your students.
       </h1>
-      <p
-        className="previously-assigned-activities"
+      <div
+        className="previously-assigned-container"
       >
-        You have 
-         
-        activities
-         assigned. 
-        <button
+        <p
+          className="previously-assigned-activities"
+        >
+          You have 
+           
+          activities
+           assigned. 
+        </p>
+        <div
           className="view-assigned-activities"
-          type="button"
         >
           <a
             href="/teachers/classrooms/activity_planner"
           >
             View assigned activities
           </a>
-        </button>
-      </p>
+        </div>
+      </div>
       <div
         className="minis"
       >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.jsx
@@ -92,15 +92,15 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
   }
 
   return (
-    <div className="assign-a-new-activity-container white-background-accommodate-footer">
+    <div className="assign-a-new-activity-container">
       <div className="assign-a-new-activity container">
         <h1>Find the perfect writing activities for your students.</h1>
+        <p className="previously-assigned-activities">
+          You have {numberOfActivitiesAssigned} {numberOfActivitiesAssigned === 1 ? 'activity' : 'activities'} assigned.&nbsp;
+          <button className="view-assigned-activities" type="button"><a href="/teachers/classrooms/activity_planner">View assigned activities</a></button>
+        </p>
         {diagnosticBanner}
         <div className="minis">{minis(diagnosticBannerShowing)}</div>
-        <p className="previously-assigned-activities">
-        You have {numberOfActivitiesAssigned} {numberOfActivitiesAssigned === 1 ? 'activity' : 'activities'} assigned.&nbsp;
-          <a href="/teachers/classrooms/activity_planner">View assigned activities</a>
-        </p>
       </div>
     </div>
   )

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
@@ -78,7 +78,7 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
 
   const getData = () => {
     requestGet(
-      `${process.env.DEFAULT_URL}/activities/activities_to_suggest`,
+      `${process.env.DEFAULT_URL}/activities/suggested_activities`,
       (body) => {
         setActivitesToSuggest(body.activities)
       }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
@@ -143,7 +143,7 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
                   </td>
                   <td className="date-col">1/15/23</td>
                   <td className="preview-col"><a href={`/activity_sessions/anonymous?activity_id=${a.id}`} rel="noopener noreferrer" target="_blank">Preview</a></td>
-                  <td className="select-col"><button className="quill-button secondary medium focus-on-light outlined select-suggested" onClick={() => window.location.href = `/assign/activity-library?search=${encodeURI(a.name)}`} type="button">Select</button></td>
+                  <td className="select-col"><button className="quill-button secondary medium focus-on-light outlined select-suggested" onClick={() => window.location.href = `/assign/activity-library?activityClassificationFilters[]=evidence&search=${encodeURI(a.name)}`} type="button">Select</button></td>
                 </tr>
               )
             })}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import AssignmentCard from './assignment_card'
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
@@ -2,8 +2,19 @@ import React from 'react'
 
 import AssignmentCard from './assignment_card'
 
-import { requestPost, } from '../../../../../modules/request'
+import { requestGet, requestPost, } from '../../../../../modules/request'
+import { evidenceToolIcon } from "../../../../Shared"
 import { CLICKED_ACTIVITY_PACK_ID } from '../assignmentFlowConstants'
+
+interface ActivityToSuggest {
+  name: string;
+  classification: string,
+  topics: [],
+  link: string,
+  date_released: string,
+  preview_link: string,
+  activity_id: number
+}
 
 const diagnosticWaveSrc = `${process.env.CDN_URL}/images/illustrations/diagnostic-wave.svg`
 const activityLibrarySrc = `${process.env.CDN_URL}/images/icons/icons-activity-library.svg`
@@ -61,9 +72,23 @@ const minis = (diagnosticBannerShowing) => [
   />)
 ];
 
-
 const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }) => {
   const [diagnosticBannerShowing, setDiagnosticBannerShowing] = React.useState(showDiagnosticBanner)
+  const [activitiesToSuggest, setActivitesToSuggest] = React.useState([])
+
+  const getData = () => {
+    requestGet(
+      `${process.env.DEFAULT_URL}/activities/activities_to_suggest`,
+      (body) => {
+        setActivitesToSuggest(body.activities)
+      }
+    );
+  }
+  // Similar to componentDidMount and componentDidUpdate:
+  React.useEffect(() => {
+    // Update the document title using the browser API
+    getData()
+  }, []);
 
   React.useState(() => {
     // remove any previously stored activityPackId used for back navigation element focus in the event that user assigned pack or navigated back to dashboard before assigning
@@ -91,6 +116,43 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
     </section>)
   }
 
+  const suggestedActivitiesList = activitiesToSuggest.length > 0 &&
+  (
+    <div>
+      <h1 className="evidence-header">Browse the newest Reading for Evidence activities</h1>
+      <table className="data-table suggested-activities-table">
+        <tr className="data-table-headers">
+          <th className="data-table-header">Tool</th>
+          <th className="data-table-header activity-header">Activity</th>
+          <th className="data-table-header topics-header">Topics</th>
+          <th className="data-table-header">Date released</th>
+        </tr>
+        <tbody className="data-table-body">
+          <div className="list-item">
+            {activitiesToSuggest.map((a) => {
+              return (
+                <tr className="data-table-row" key={a.id}>
+                  <span className="tool-col"><img alt={evidenceToolIcon.alt} src={evidenceToolIcon.src} /></span>
+                  <td className="data-table-row-section name-col">
+                    {a.name}
+                  </td>
+                  <td className="data-table-row-section topics-col">
+                    {a.topics.map((t, i) => {
+                      return <p key={i}>{t.join(" / ")}</p>
+                    })}
+                  </td>
+                  <td className="date-col">1/15/23</td>
+                  <td className="preview-col"><a href={`/activity_sessions/anonymous?activity_id=${a.id}`} rel="noopener noreferrer" target="_blank">Preview</a></td>
+                  <td className="select-col"><button className="quill-button secondary medium focus-on-light outlined select-suggested" onClick={() => window.location.href = `/assign/activity-library?search=${encodeURI(a.name)}`} type="button">Select</button></td>
+                </tr>
+              )
+            })}
+          </div>
+        </tbody>
+      </table>
+    </div>
+  )
+
   return (
     <div className="assign-a-new-activity-container">
       <div className="assign-a-new-activity container">
@@ -101,6 +163,7 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
         </p>
         {diagnosticBanner}
         <div className="minis">{minis(diagnosticBannerShowing)}</div>
+        {suggestedActivitiesList}
       </div>
     </div>
   )

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
@@ -134,14 +134,14 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
                 <tr className="data-table-row" key={a.id}>
                   <span className="tool-col"><img alt={evidenceToolIcon.alt} src={evidenceToolIcon.src} /></span>
                   <td className="data-table-row-section name-col">
-                    {a.name}
+                    <a href={`/assign/activity-library?activityClassificationFilters[]=evidence&search=${encodeURI(a.name)}`}>{a.name}</a>
                   </td>
                   <td className="data-table-row-section topics-col">
                     {a.topics.map((t, i) => {
                       return <p key={i}>{t.join(" / ")}</p>
                     })}
                   </td>
-                  <td className="date-col">1/15/23</td>
+                  <td className="date-col">{a.publication_date}</td>
                   <td className="preview-col"><a href={`/activity_sessions/anonymous?activity_id=${a.id}`} rel="noopener noreferrer" target="_blank">Preview</a></td>
                   <td className="select-col"><button className="quill-button secondary medium focus-on-light outlined select-suggested" onClick={() => window.location.href = `/assign/activity-library?activityClassificationFilters[]=evidence&search=${encodeURI(a.name)}`} type="button">Select</button></td>
                 </tr>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
@@ -84,9 +84,8 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
       }
     );
   }
-  // Similar to componentDidMount and componentDidUpdate:
+
   React.useEffect(() => {
-    // Update the document title using the browser API
     getData()
   }, []);
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_new_activity.tsx
@@ -74,13 +74,13 @@ const minis = (diagnosticBannerShowing) => [
 
 const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }) => {
   const [diagnosticBannerShowing, setDiagnosticBannerShowing] = React.useState(showDiagnosticBanner)
-  const [activitiesToSuggest, setActivitesToSuggest] = React.useState([])
+  const [activitiesToSuggest, setActivitiesToSuggest] = React.useState([])
 
   const getData = () => {
     requestGet(
       `${process.env.DEFAULT_URL}/activities/suggested_activities`,
       (body) => {
-        setActivitesToSuggest(body.activities)
+        setActivitiesToSuggest(body.activities)
       }
     );
   }
@@ -142,7 +142,7 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
                   </td>
                   <td className="date-col">{a.publication_date}</td>
                   <td className="preview-col"><a href={`/activity_sessions/anonymous?activity_id=${a.id}`} rel="noopener noreferrer" target="_blank">Preview</a></td>
-                  <td className="select-col"><button className="quill-button secondary medium focus-on-light outlined select-suggested" onClick={() => window.location.href = `/assign/activity-library?activityClassificationFilters[]=evidence&search=${encodeURI(a.name)}`} type="button">Select</button></td>
+                  <button className="quill-button secondary medium focus-on-light outlined select-suggested" onClick={() => window.location.href = `/assign/activity-library?activityClassificationFilters[]=evidence&search=${encodeURI(a.name)}`} type="button">Select</button>
                 </tr>
               )
             })}
@@ -156,10 +156,12 @@ const AssignANewActivity = ({ numberOfActivitiesAssigned, showDiagnosticBanner }
     <div className="assign-a-new-activity-container">
       <div className="assign-a-new-activity container">
         <h1>Find the perfect writing activities for your students.</h1>
-        <p className="previously-assigned-activities">
-          You have {numberOfActivitiesAssigned} {numberOfActivitiesAssigned === 1 ? 'activity' : 'activities'} assigned.&nbsp;
-          <button className="view-assigned-activities" type="button"><a href="/teachers/classrooms/activity_planner">View assigned activities</a></button>
-        </p>
+        <div className="previously-assigned-container">
+          <p className="previously-assigned-activities">
+            You have {numberOfActivitiesAssigned} {numberOfActivitiesAssigned === 1 ? 'activity' : 'activities'} assigned.&nbsp;
+          </p>
+          <div className="view-assigned-activities"><a href="/teachers/classrooms/activity_planner">View assigned activities</a></div>
+        </div>
         {diagnosticBanner}
         <div className="minis">{minis(diagnosticBannerShowing)}</div>
         {suggestedActivitiesList}

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -145,7 +145,7 @@ EmpiricalGrammar::Application.routes.draw do
     post :retry, on: :member
     get :search, on: :collection
     get :index_with_unit_templates, on: :collection
-    get :activities_to_suggest, on: :collection
+    get :suggested_activities, on: :collection
   end
 
   resources :milestones, only: [] do

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -145,6 +145,7 @@ EmpiricalGrammar::Application.routes.draw do
     post :retry, on: :member
     get :search, on: :collection
     get :index_with_unit_templates, on: :collection
+    get :activities_to_suggest, on: :collection
   end
 
   resources :milestones, only: [] do

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -15,6 +15,7 @@ module Evidence
     # See activity.rb in the enclosing app for the ur-constant,
     # which is not accessible from here
     LMS_ACTIVITY_DEFAULT_FLAG = 'alpha'
+    FLAGS_ATTRIBUTE = 'flags'
 
     before_destroy :expire_turking_rounds
     before_validation :set_parent_activity, on: :create
@@ -103,6 +104,10 @@ module Evidence
           prompt_id: highlight.feedback.rule.prompts.where(activity_id: id).first.id
         }
       end
+    end
+
+    def last_flags_change_log_record
+      change_logs.where(changed_attribute: FLAGS_ATTRIBUTE).last
     end
 
     # We use update_columns to avoid triggering callbacks, specifically,

--- a/services/QuillLMS/spec/controllers/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activities_controller_spec.rb
@@ -171,4 +171,77 @@ describe ActivitiesController, type: :controller, redis: true do
       end
     end
   end
+
+  describe '#suggested_activities' do
+    let!(:production_activity1) { create(:evidence_activity, flags: [Flags::PRODUCTION])}
+    let!(:production_activity2) { create(:evidence_activity, flags: [Flags::PRODUCTION])}
+    let!(:beta2_activity) { create(:evidence_activity, flags: [Flags::EVIDENCE_BETA2])}
+    let!(:beta1_activity) { create(:evidence_activity, flags: [Flags::EVIDENCE_BETA1])}
+    let(:teacher_info) { create(:teacher_info, minimum_grade_level: 9, maximum_grade_level: 12)}
+    let(:user) { create(:user, flagset: Flags::PRODUCTION, teacher_info: teacher_info)}
+
+    before do
+      Evidence::Activity.create(parent_activity_id: production_activity1.id, notes: "notes", title: "title")
+      Evidence::Activity.create(parent_activity_id: production_activity2.id, notes: "notes", title: "title")
+      Evidence::Activity.create(parent_activity_id: beta1_activity.id, notes: "notes", title: "title")
+      Evidence::Activity.create(parent_activity_id: beta2_activity.id, notes: "notes", title: "title")
+      allow(controller).to receive(:current_user) { user }
+    end
+
+    context 'when user is flagged production' do
+      it 'should return all production evidence activities' do
+        get :suggested_activities
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["activities"].size).to eq(2)
+        expect([parsed_response["activities"][0]["id"], parsed_response["activities"][1]["id"]]).to match_array([production_activity1.id, production_activity2.id])
+      end
+    end
+
+    context 'when user is flagged evidence beta 1' do
+      it 'should return all production, evidence beta 2 and evidence beta 1 evidence activities' do
+        user.update(flagset: Flags::EVIDENCE_BETA1)
+        get :suggested_activities
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["activities"].size).to eq(4)
+        expect(
+          [
+            parsed_response["activities"][0]["id"],
+            parsed_response["activities"][1]["id"],
+            parsed_response["activities"][2]["id"],
+            parsed_response["activities"][3]["id"]
+          ]
+        ).to match_array(
+          [
+            production_activity1.id,
+            production_activity2.id,
+            beta1_activity.id,
+            beta2_activity.id
+          ]
+        )
+      end
+    end
+
+    context 'when user is flagged evidence beta 2' do
+
+      it 'should return all production and evidence beta 2 evidence activities' do
+        user.update(flagset: Flags::EVIDENCE_BETA2)
+        get :suggested_activities
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["activities"].size).to eq(3)
+        expect(
+          [
+            parsed_response["activities"][0]["id"],
+            parsed_response["activities"][1]["id"],
+            parsed_response["activities"][2]["id"],
+          ]
+        ).to match_array(
+          [
+            production_activity1.id,
+            production_activity2.id,
+            beta2_activity.id
+          ]
+        )
+      end
+    end
+  end
 end

--- a/services/QuillLMS/spec/controllers/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activities_controller_spec.rb
@@ -232,7 +232,7 @@ describe ActivitiesController, type: :controller, redis: true do
           [
             parsed_response["activities"][0]["id"],
             parsed_response["activities"][1]["id"],
-            parsed_response["activities"][2]["id"],
+            parsed_response["activities"][2]["id"]
           ]
         ).to match_array(
           [

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -736,7 +736,7 @@ describe Activity, type: :model, redis: true do
   describe '#publication_date' do
     context 'when the activity has no associated flag change log' do
       it 'returns the created_at date of that activity' do
-        activity = create(:evidence_activity, created_at: Date.today - 10.day)
+        activity = create(:evidence_activity, created_at: Time.zone.today - 10.days)
         Evidence::Activity.create(parent_activity: activity, title: "title", notes: "notes")
 
         expect(activity.publication_date).to eq(activity.created_at.strftime("%m/%d/%Y"))
@@ -747,7 +747,7 @@ describe Activity, type: :model, redis: true do
       it 'returns the created_at date of the last flag change' do
         activity = create(:evidence_activity)
         evidence_activity = Evidence::Activity.create(parent_activity: activity, title: "title", notes: "notes")
-        change_log = create(:change_log, created_at: Date.today - 20.day, changed_attribute: Activity::FLAGS_ATTRIBUTE, changed_record: evidence_activity)
+        change_log = create(:change_log, created_at: Time.zone.today - 20.days, changed_attribute: Activity::FLAGS_ATTRIBUTE, changed_record: evidence_activity)
 
         expect(activity.publication_date).to eq(change_log.created_at.strftime("%m/%d/%Y"))
       end
@@ -759,7 +759,7 @@ describe Activity, type: :model, redis: true do
       topic = create(:topic, level: 1)
       activity = create(:evidence_activity, topics: [topic])
       evidence_activity = Evidence::Activity.create(parent_activity: activity, title: "title", notes: "notes")
-      change_log = create(:change_log, created_at: Date.today - 20.day, changed_attribute: Activity::FLAGS_ATTRIBUTE, changed_record: evidence_activity)
+      change_log = create(:change_log, created_at: Time.zone.today - 20.days, changed_attribute: Activity::FLAGS_ATTRIBUTE, changed_record: evidence_activity)
 
       serialized_hash = activity.serialize_with_topics_and_publication_date
       expect(serialized_hash["id"]).to eq(activity.id)

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -732,4 +732,39 @@ describe Activity, type: :model, redis: true do
       end
     end
   end
+
+  describe '#publication_date' do
+    context 'when the activity has no associated flag change log' do
+      it 'returns the created_at date of that activity' do
+        activity = create(:evidence_activity, created_at: Date.today - 10.day)
+        Evidence::Activity.create(parent_activity: activity, title: "title", notes: "notes")
+
+        expect(activity.publication_date).to eq(activity.created_at.strftime("%m/%d/%Y"))
+      end
+    end
+
+    context 'when the activity has an associated flag change log' do
+      it 'returns the created_at date of the last flag change' do
+        activity = create(:evidence_activity)
+        evidence_activity = Evidence::Activity.create(parent_activity: activity, title: "title", notes: "notes")
+        change_log = create(:change_log, created_at: Date.today - 20.day, changed_attribute: Activity::FLAGS_ATTRIBUTE, changed_record: evidence_activity)
+
+        expect(activity.publication_date).to eq(change_log.created_at.strftime("%m/%d/%Y"))
+      end
+    end
+  end
+
+  describe '#serialize_with_topics_and_publication_date' do
+    it 'returns the serialized activity hash with topics genealogy and publication date added' do
+      topic = create(:topic, level: 1)
+      activity = create(:evidence_activity, topics: [topic])
+      evidence_activity = Evidence::Activity.create(parent_activity: activity, title: "title", notes: "notes")
+      change_log = create(:change_log, created_at: Date.today - 20.day, changed_attribute: Activity::FLAGS_ATTRIBUTE, changed_record: evidence_activity)
+
+      serialized_hash = activity.serialize_with_topics_and_publication_date
+      expect(serialized_hash["id"]).to eq(activity.id)
+      expect(serialized_hash[:topics]).to eq([topic.genealogy])
+      expect(serialized_hash[:publication_date]).to eq(change_log.created_at.strftime("%m/%d/%Y"))
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/topic_spec.rb
+++ b/services/QuillLMS/spec/models/topic_spec.rb
@@ -138,25 +138,20 @@ describe Topic, type: :model do
   end
 
   describe '#genealogy' do
+    subject { topic.genealogy }
+
+    let(:topic) { create(:topic, level: level)}
+
     context 'when topic is level 1' do
-      it 'should return an array containing the names of the grandparent, parent, and topic' do
-        topic = create(:topic, level: 1)
-        genealogy = topic.genealogy
-        expect(genealogy.size).to eq(3)
-        expect(genealogy[0]).to eq(topic.parent.parent.name)
-        expect(genealogy[1]).to eq(topic.parent.name)
-        expect(genealogy[2]).to eq(topic.name)
-      end
+      let(:level) { 1 }
+
+      it { expect(subject).to eq [topic.parent.parent.name, topic.parent.name, topic.name] }
     end
 
     context 'when topic is level 2' do
-      it 'should return an array containing the names of parent and topic' do
-        topic = create(:topic, level: 2)
-        genealogy = topic.genealogy
-        expect(genealogy.size).to eq(2)
-        expect(genealogy[0]).to eq(topic.parent.name)
-        expect(genealogy[1]).to eq(topic.name)
-      end
+      let(:level) { 2 }
+
+      it { expect(subject).to eq [topic.parent.name, topic.name] }
     end
   end
 end

--- a/services/QuillLMS/spec/models/topic_spec.rb
+++ b/services/QuillLMS/spec/models/topic_spec.rb
@@ -110,4 +110,53 @@ describe Topic, type: :model do
     end
   end
 
+  describe '#parent' do
+    context 'when a topic is level 2' do
+      it 'should return the parent' do
+        parent = create(:topic, level: 3)
+        topic = create(:topic, level: 2)
+        topic.update(parent_id: parent.id)
+        expect(topic.parent).to eq(parent)
+      end
+    end
+
+    context 'when a topic is level 1' do
+      it 'should return the parent' do
+        parent = create(:topic, level: 2)
+        topic = create(:topic, level: 1)
+        topic.update(parent_id: parent.id)
+        expect(topic.parent).to eq(parent)
+      end
+    end
+
+    context 'when a topic is level 3' do
+      it 'should return nil' do
+        topic = create(:topic, level: 3)
+        expect(topic.parent).to eq(nil)
+      end
+    end
+  end
+
+  describe '#genealogy' do
+    context 'when topic is level 1' do
+      it 'should return an array containing the names of the grandparent, parent, and topic' do
+        topic = create(:topic, level: 1)
+        genealogy = topic.genealogy
+        expect(genealogy.size).to eq(3)
+        expect(genealogy[0]).to eq(topic.parent.parent.name)
+        expect(genealogy[1]).to eq(topic.parent.name)
+        expect(genealogy[2]).to eq(topic.name)
+      end
+    end
+
+    context 'when topic is level 2' do
+      it 'should return an array containing the names of parent and topic' do
+        topic = create(:topic, level: 2)
+        genealogy = topic.genealogy
+        expect(genealogy.size).to eq(2)
+        expect(genealogy[0]).to eq(topic.parent.name)
+        expect(genealogy[1]).to eq(topic.name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
When a teacher clicks "Assign Activities", we want to display a list of recently published Evidence Activities below the current options.

## WHY
This will help publicize the Assign Activities page to teachers who don't know about newly published Evidence activities.

## HOW
Front end display elements; back end controller endpoint to fetch new Evidence Activities based on the teacher's current flagset.

### Screenshots
![Screen Shot 2023-02-16 at 12 38 25 PM](https://user-images.githubusercontent.com/57366100/219270054-3d9b76a2-5a68-4e1f-a1d0-9c7765aa9d04.png)

### Notion Card Links
https://www.notion.so/quill/Assign-Activities-Flow-Reading-for-Evidence-Activities-Feed-1b1e0a04ee8547f898669fbff5e367bd?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes