### PR TITLE
Add check for nil pack_sequence_item

### DIFF
--- a/services/QuillLMS/app/workers/save_user_pack_sequence_item_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_item_worker.rb
@@ -7,6 +7,7 @@ class SaveUserPackSequenceItemWorker
 
   def perform(pack_sequence_item_id, status, user_id)
     return if pack_sequence_item_id.nil? || user_id.nil?
+    return unless PackSequenceItem.exists?(id: pack_sequence_item_id)
 
     upsi = UserPackSequenceItem.create_or_find_by!(pack_sequence_item_id: pack_sequence_item_id, user_id: user_id)
     return if upsi.status == status

--- a/services/QuillLMS/spec/workers/save_user_pack_sequence_item_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_user_pack_sequence_item_worker_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SaveUserPackSequenceItemWorker do
   let(:unlocked) { UserPackSequenceItem::UNLOCKED }
   let(:status) { [locked, unlocked].sample }
 
-  context 'nil pack_sequence_id' do
+  context 'nil pack_sequence_item_id' do
     let(:pack_sequence_item_id) { nil }
 
     it 'should_not_query_user_pack_sequence_item' do
@@ -22,6 +22,15 @@ RSpec.describe SaveUserPackSequenceItemWorker do
 
   context 'nil user_id' do
     let(:user_id) { nil }
+
+    it 'should_not_query_user_pack_sequence_item' do
+      expect(UserPackSequenceItem).not_to receive(:create_or_find_by!)
+      subject
+    end
+  end
+
+  context 'nil pack_sequence_item' do
+    before { PackSequenceItem.find_by(id: pack_sequence_item_id).destroy }
 
     it 'should_not_query_user_pack_sequence_item' do
       expect(UserPackSequenceItem).not_to receive(:create_or_find_by!)


### PR DESCRIPTION
## WHAT
Add a check for nil `pack_sequence_item` when running `SaveUserPackSequenceItemWorker` jobs.

## WHY
If a teacher turns staggered release on and then off in succession, there's a chance the `SaveUserPackSequenceItemWorker` jobs will run on a recently deleted `PackSequenceItem` object.

This will then clog up the retries queue with no hope of finishing.


## HOW
Add a guard clause that exits the job early if the `pack_sequence_item` does not exist.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
