### PR TITLE
email verification in user manager

### DIFF
--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -147,7 +147,7 @@ class Cms::UsersController < Cms::CmsController
   end
 
   protected def user_params
-    params.require(:user).permit([:name, :email, :flagset, :username, :title, :role, :admin_sub_role, :classcode, :password, :password_confirmation, :flags =>[]] + default_params
+    params.require(:user).permit([:name, :email, :flagset, :username, :title, :role, :admin_sub_role, :classcode, :password, :password_confirmation, :email_verification_status, :flags =>[]] + default_params
     )
   end
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -261,14 +261,17 @@ class User < ApplicationRecord
 
   def email_verification_status
     return UserEmailVerification::PENDING if email_verification_pending?
+
     return UserEmailVerification::VERIFIED if email_verified?
+
     return nil
   end
 
   def email_verification_status=(status)
-    if status == UserEmailVerification::VERIFIED
+    case status
+    when UserEmailVerification::VERIFIED
       verify_email(UserEmailVerification::STAFF_VERIFICATION)
-    elsif status == UserEmailVerification::PENDING
+    when UserEmailVerification::PENDING
       require_email_verification
       user_email_verification.update(verification_method: nil, verified_at: nil)
     end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -259,6 +259,21 @@ class User < ApplicationRecord
     user_email_verification.verify(verification_method, verification_token)
   end
 
+  def email_verification_status
+    return UserEmailVerification::PENDING if email_verification_pending?
+    return UserEmailVerification::VERIFIED if email_verified?
+    return nil
+  end
+
+  def email_verification_status=(status)
+    if status == UserEmailVerification::VERIFIED
+      verify_email(UserEmailVerification::STAFF_VERIFICATION)
+    elsif status == UserEmailVerification::PENDING
+      require_email_verification
+      user_email_verification.update(verification_method: nil, verified_at: nil)
+    end
+  end
+
   def testing_flag
     role == STAFF ? ARCHIVED : flags.detect{|f| TESTING_FLAGS.include?(f)}
   end

--- a/services/QuillLMS/app/models/user_email_verification.rb
+++ b/services/QuillLMS/app/models/user_email_verification.rb
@@ -36,6 +36,11 @@ class UserEmailVerification < ApplicationRecord
     STAFF_VERIFICATION = 'staff'
   ]
 
+  VERIFICATION_STATUSES = [
+    PENDING = 'Pending',
+    VERIFIED = 'Verified'
+  ]
+
   def verify(verification_method, verification_token = nil)
     raise InvalidVerificationMethodError unless VERIFICATION_METHODS.include?(verification_method)
 

--- a/services/QuillLMS/app/views/cms/users/_form.html.erb
+++ b/services/QuillLMS/app/views/cms/users/_form.html.erb
@@ -42,6 +42,10 @@
         <%= f.label :admin_approval_status %>
         <%= f.text_field :admin_approval_status, :readonly => true %>
       </div>
+      <div class='cms-form-row'>
+        <%= f.label :email_verification_status %>
+        <%= f.select :email_verification_status, [nil, UserEmailVerification::PENDING, UserEmailVerification::VERIFIED] %>
+      </div>
     <% end %>
     <div class='cms-form-row'>
       <%= f.label :flagset %>

--- a/services/QuillLMS/app/views/cms/users/show.html.erb
+++ b/services/QuillLMS/app/views/cms/users/show.html.erb
@@ -80,6 +80,10 @@
       <p style='font-weight: 700;'>Admin approval status</p>
       <p><%= @user.admin_approval_status || 'N/A' %></p>
       <br />
+
+      <p style='font-weight: 700;'>Admin email verification</p>
+      <p><%= @user.email_verification_status || N/A %></p>
+      <br />
     <% end %>
 
     <% if @user.role == 'student' %>


### PR DESCRIPTION
## WHAT
Allow staff members to see and change email verification status from the user manager.

## WHY
In case a user has some issue completing email verification on their own and we need to set it for them.

## HOW
Add new getter and setter functions to `user` called `email_verification_status`, and use these in the erb forms to get and set the values.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Expose-email-verification-and-make-editable-in-the-user-manager-make-sure-admin-appears-as-selectab-3f59a08071564bb9a4e134fe7290e424?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
