### PR TITLE
Fix bug with admin role on clever import

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/creators/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/creators/teacher.rb
@@ -9,7 +9,7 @@ module CleverIntegration::Creators::Teacher
       # necessary to have both due to difference in structure between Clever Library user auth hash and district user auth hash
       clever_id: hash[:clever_id] || hash[:id],
       name: hash[:name],
-      role: User::TEACHER
+      role: teacher.admin? ? User::ADMIN : User::TEACHER
     )
 
     remove_google_link(teacher)

--- a/services/QuillLMS/spec/services/clever_integration/creators/teacher_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/creators/teacher_spec.rb
@@ -3,30 +3,59 @@
 require 'rails_helper'
 
 describe CleverIntegration::Creators::Teacher do
+  subject { described_class.run(clever_teacher_data) }
+
+  let(:clever_id) { '456' }
+
+  let(:clever_teacher_data) do
+    {
+      clever_id: clever_id,
+      email: email,
+      name: 'John Smith',
+      username: 'username'
+    }
+  end
+
+  context 'user already exists' do
+    let!(:user) { create(factory) }
+    let(:email) { user.email }
+
+    context 'as an admin' do
+      let(:factory) { :admin }
+
+      it  { expect(subject.role).to eq User::ADMIN }
+    end
+
+    context 'as a teacher' do
+      let(:factory) { :teacher }
+
+      it  { expect(subject.role).to eq User::TEACHER}
+    end
+
+    context 'as a student' do
+      let(:factory) { :student }
+
+      it  { expect(subject.role).to eq User::TEACHER }
+    end
+  end
+
   context 'linking a clever_id to an existing teacher' do
     let(:segment_event) { 'TEACHER_GOOGLE_AND_CLEVER' }
     let(:analyzer) { double(:analyzer) }
 
-    before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
-
     let!(:teacher) { create(:teacher, google_id: google_id) }
+    let(:email) { teacher.email }
 
-    let(:clever_id) { '456' }
-    let(:clever_teacher_data) do
-      {
-        clever_id: clever_id,
-        email: teacher.email,
-        name: 'John Smith',
-        username: 'username'
-      }
-    end
+
+
+    before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
 
     context 'with no google_id' do
       let(:google_id) { nil }
 
       it 'does not trigger a segment event for dual clever and google link' do
         expect(analyzer).not_to receive(:track_event_from_string).with(segment_event, teacher.id)
-        CleverIntegration::Creators::Teacher.run(clever_teacher_data)
+        subject
       end
     end
 
@@ -35,10 +64,11 @@ describe CleverIntegration::Creators::Teacher do
 
       it 'sets google_id to nil and triggers a segment event for dual clever and google linking' do
         expect(analyzer).to receive(:track_event_from_string).with(segment_event, teacher.id)
-        CleverIntegration::Creators::Teacher.run(clever_teacher_data)
+        subject
 
         expect(teacher.reload.google_id).to be_nil
       end
     end
+
   end
 end


### PR DESCRIPTION
## WHAT
Fix a bug with the importing of clever users where admin roles are overwritten with teacher.

## WHY
We'd like to keep existing users with an admin role as admins.

## HOW
Add a ternary condition to check if the user is already an admin.  Otherwise, set them as teacher.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A