### PR TITLE
Synthetic Seed Data - Allow Label Examples to be run on their own. (#…

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/seedDataForm.tsx
@@ -5,7 +5,7 @@ import ReactHtmlParser from 'react-html-parser'
 import SubmissionModal from '../shared/submissionModal';
 import { fetchActivity, createSeedData } from '../../../utils/evidence/activityAPIs';
 import { renderHeader, quillCloseX } from "../../../helpers/evidence/renderHelpers";
-import { Input, Spinner } from '../../../../Shared/index';
+import { Input, Spinner, DropdownInput, } from '../../../../Shared/index';
 import { TITLE, BECAUSE, BUT, SO } from "../../../../../constants/evidence";
 
 const SeedDataForm = ({ history, match }) => {
@@ -14,7 +14,17 @@ const SeedDataForm = ({ history, match }) => {
   const [errorOrSuccessMessage, setErrorOrSuccessMessage] = React.useState<string>(null);
   const [errors, setErrors] = React.useState<string[]>([]);
   const [showSubmissionModal, setShowSubmissionModal] = React.useState<boolean>(false);
-  const queryClient = useQueryClient()
+
+  const trueString = 'true';
+  const falseString = 'false';
+
+  const [usePassage, setUsePassage] = React.useState<string>(trueString);
+  const queryClient = useQueryClient();
+
+  const runOptions = [
+    { value: trueString, label: 'Full Run'},
+    { value: falseString, label: 'Label Examples Only'},
+  ];
 
   const [activityNouns, setActivityNouns] = React.useState<string>('');
 
@@ -22,6 +32,10 @@ const SeedDataForm = ({ history, match }) => {
   const blankLabelConfigs = { [BECAUSE] : [], [BUT] : [], [SO] : [], };
 
   const [labelConfigs, setLabelConfigs] = React.useState({...blankLabelConfigs});
+
+  function handleUsePassageChange(runOption) {
+    setUsePassage(runOption.value);
+  };
 
   function handleLabelConfigsChange(event, index, conjunction, key) {
     const data = {...labelConfigs}
@@ -104,7 +118,7 @@ const SeedDataForm = ({ history, match }) => {
   function handleCreateSeedData() {
     if (!confirm('⚠️ Are you sure you want to generate seed data?')) return
 
-    createSeedData(activityNouns, labelConfigs, activityId).then((response) => {
+    createSeedData(activityNouns, labelConfigs, activityId, usePassage).then((response) => {
       const { errors } = response;
       if(errors && errors.length) {
         setErrors(errors);
@@ -112,6 +126,7 @@ const SeedDataForm = ({ history, match }) => {
         setErrors([]);
         setErrorOrSuccessMessage('Seed Data started! You will receive an email with the csv files');
         setActivityNouns('');
+        setUsePassage(trueString);
         setLabelConfigs({...blankLabelConfigs});
         toggleSubmissionModal();
       }
@@ -235,6 +250,16 @@ const SeedDataForm = ({ history, match }) => {
       {renderLabelSection(BECAUSE)}
       {renderLabelSection(BUT)}
       {renderLabelSection(SO)}
+      <br />
+      <div className='run-type-dropdown'>
+        <DropdownInput
+          handleChange={handleUsePassageChange}
+          isSearchable={false}
+          label="Run Type"
+          options={runOptions}
+          value={runOptions.find(ro => ro.value === usePassage)}
+        />
+      </div>
       <br />
       <div className="button-and-id-container">
         <button className="quill-button fun large primary contained focus-on-light" id="activity-submit-button" onClick={handleCreateSeedData} type="submit">

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/seed_data.scss
@@ -37,5 +37,9 @@
   .plus {
     font-size: 30px;
   }
+
+  .run-type-dropdown {
+    width: 250px;
+  }
 }
 

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
@@ -53,10 +53,10 @@ export const updateActivityVersion = async (activityNote: string, activityId: st
   return { errors: [] };
 }
 
-export const createSeedData = async (nouns: string, labelConfigs: object, activityId: string) => {
+export const createSeedData = async (nouns: string, labelConfigs: object, activityId: string, usePassage: string) => {
   const response = await apiFetch(`activities/${activityId}/seed_data`, {
     method: 'POST',
-    body: JSON.stringify({nouns: nouns, label_configs: labelConfigs})
+    body: JSON.stringify({nouns: nouns, label_configs: labelConfigs, use_passage: usePassage})
   });
   const { status } = response;
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -100,7 +100,11 @@ module Evidence
 
       label_configs = seed_data_params[:label_configs]&.to_h || {}
 
-      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs)
+      use_passage_param = ActiveModel::Type::Boolean.new.cast(seed_data_params[:use_passage])
+      # default to true for missing param
+      use_passage = use_passage_param.nil? ? true : use_passage_param
+
+      Evidence::ActivitySeedDataWorker.perform_async(@activity.id, nouns_array, label_configs, use_passage)
 
       head :no_content
     end
@@ -132,7 +136,7 @@ module Evidence
     end
 
     private def seed_data_params
-      params.permit(:id, :nouns, label_configs: {}, activity: {})
+      params.permit(:id, :nouns, :use_passage, label_configs: {}, activity: {})
     end
 
     private def activity_params

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/activity_seed_data_worker.rb
@@ -5,11 +5,12 @@ module Evidence
     include Evidence.sidekiq_module
     sidekiq_options retry: 0
 
-    def perform(activity_id, nouns, label_configs)
+    def perform(activity_id, nouns, label_configs, use_passage)
       csv_hash = Evidence::Synthetic::SeedDataGenerator.csvs_for_activity(
         activity_id: activity_id,
         nouns: nouns,
-        label_configs: label_configs
+        label_configs: label_configs,
+        use_passage: use_passage
       )
 
       activity = Evidence::Activity.find(activity_id)

--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/synthetic/seed_data_generator.rb
@@ -48,10 +48,10 @@ module Evidence
 
       PARAPHRASE_INSTRUCTION = "rephrase with some synonyms:\n\n"
 
-      attr_reader :passage, :stem, :conjunction, :nouns, :results, :label_configs
+      attr_reader :passage, :stem, :conjunction, :nouns, :results, :label_configs, :use_passage
 
       # returns a hash of the form {'csv name' => CSVString, 'csv name2' =>...}
-      def self.csvs_for_activity(activity_id:, nouns: [], conjunctions: nil, label_configs: {})
+      def self.csvs_for_activity(activity_id:, nouns: [], conjunctions: nil, label_configs: {}, use_passage: true)
         activity = Evidence::Activity.find(activity_id)
         passage = activity.passages.first.text
         prompts = conjunctions.present? ? activity.prompts.where(conjunction: conjunctions) : activity.prompts
@@ -68,7 +68,8 @@ module Evidence
             stem: prompt.text,
             conjunction: prompt.conjunction,
             nouns: nouns,
-            label_configs: label_configs[prompt.conjunction] || []
+            label_configs: label_configs[prompt.conjunction] || [],
+            use_passage: use_passage
           )
           generator.run
 
@@ -76,48 +77,62 @@ module Evidence
         end
 
         # include a csv with a text guide to the passage chunks
-        csvs[passage_csv_name] = new(passage: passage, stem: '', conjunction: 'but').text_guide_csv_string
+        if use_passage
+          csvs[passage_csv_name] = new(passage: passage, stem: '', conjunction: 'but').text_guide_csv_string
+        end
 
         csvs
       end
 
-      def initialize(passage:, stem:, conjunction:, nouns: [], label_configs: [])
+      def initialize(passage:, stem:, conjunction:, nouns: [], label_configs: [], use_passage: true)
         @passage = Evidence::HTMLTagRemover.run(passage)
         @stem = stem
         @conjunction = conjunction
         @nouns = nouns
         @label_configs = label_configs
         @results = []
+        @use_passage = use_passage
         raise InvalidConjunctionError unless conjunction.in?(CONJUNCTIONS)
       end
 
       def run
-        # whole passage plus prompt
+        if use_passage
+          generate_full_passage_responses
+          generate_full_passage_noun_responses
+          generate_chunk_responses
+        end
+
+        generate_label_paraphrases
+
+        results
+      end
+
+      # whole passage plus prompt
+      private def generate_full_passage_responses
         TEMPS_PASSAGE.each do |temp|
           stem_variants_hash.each do |conjunction, stem_variant|
             prompt = prompt_text(context: passage, stem_variant: stem_variant)
             run_prompt(prompt: prompt, count: FULL_COUNT, seed: "full_passage_temp#{temp}_#{conjunction}", temperature: temp)
           end
         end
+      end
 
-        # whole passage plus prompt for each noun
+      # whole passage plus prompt for each noun
+      private def generate_full_passage_noun_responses
         nouns.each do |noun|
           prompt = prompt_text(context: passage, noun: noun)
           run_prompt(prompt: prompt, count: FULL_NOUN_COUNT, noun: noun, seed: "full_passage_noun_#{noun.gsub(SPACE,BLANK)}")
         end
+      end
 
-        # chunks plus prompt
+      # chunks plus prompt
+      private def generate_chunk_responses
         split_passage.each.with_index do |text_chunk, index|
           stem_variants_hash.each do |conjunction, stem_variant|
             prompt = prompt_text(context: text_chunk, stem_variant: stem_variant)
             run_prompt(prompt: prompt, count: SECTION_COUNT, seed: "text_chunk_#{index + 1}_temp#{TEMP_SECTION}_#{conjunction}", temperature: TEMP_SECTION)
           end
         end
-
-        # label examples to paraphrase
-        generate_label_paraphrases
-
-        results
       end
 
       LABEL_KEY = 'label'

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -348,19 +348,18 @@ module Evidence
 
     context "#seed_data" do
       let(:activity) { create(:evidence_activity) }
-      # TODO: fill out test when frontend is complete
       let(:label_configs) {{}}
 
       it "should call background worker" do
-        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs)
-        post :seed_data, params: { id: activity.id, nouns: "" }
+        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs, true)
+        post :seed_data, params: { id: activity.id, nouns: ""}
 
         expect(response).to have_http_status(:success)
       end
 
       it "should call background worker with noun string converted to array" do
-        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, ['noun1','noun two','noun3'], label_configs)
-        post :seed_data, params: { id: activity.id, nouns: "noun1, noun two,,noun3" }
+        expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, ['noun1','noun two','noun3'], label_configs, true)
+        post :seed_data, params: { id: activity.id, nouns: "noun1, noun two,,noun3"}
 
         expect(response).to have_http_status(:success)
       end
@@ -375,12 +374,29 @@ module Evidence
         let(:label_configs) {{'so' => [label_config1, label_config2], 'because' => [label_config2]}}
 
         it "should call background worker" do
-          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs)
+          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs, true)
           post :seed_data, params: { id: activity.id, nouns: "", label_configs: label_configs }
 
           expect(response).to have_http_status(:success)
         end
+      end
 
+      context 'use_passage=false' do
+        it "should call background worker" do
+          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], {}, false)
+          post :seed_data, params: { id: activity.id, nouns: "", use_passage: false }
+
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context 'use_passage=nil' do
+        it "should call background worker with use_passage=true" do
+          expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], {}, true)
+          post :seed_data, params: { id: activity.id, nouns: "", use_passage: nil }
+
+          expect(response).to have_http_status(:success)
+        end
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/activity_seed_data_worker_spec.rb
@@ -20,16 +20,28 @@ module Evidence
       let(:mailer) { double('mailer', deliver_now!: true) }
       let(:label_configs) {{'because' => [{'label' => 'Label1', 'examples' => ['hello', 'goodbye']}]}}
 
-      it 'call generate and call file_mailer' do
+      it 'call generate and call file_mailer with defaults' do
         expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)
-          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs)
+          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs, use_passage: true)
           .and_return(generator_response)
 
         expect(FileMailer).to receive(:send_multiple_files)
           .with(email, email_subject, generator_response)
           .and_return(mailer)
 
-        subject.perform(activity.id, nouns, label_configs)
+        subject.perform(activity.id, nouns, label_configs, true)
+      end
+
+      it 'call generate and call file_mailer with use_passage config' do
+        expect(Evidence::Synthetic::SeedDataGenerator).to receive(:csvs_for_activity)
+          .with(activity_id: activity.id, nouns: nouns, label_configs: label_configs, use_passage: false)
+          .and_return(generator_response)
+
+        expect(FileMailer).to receive(:send_multiple_files)
+          .with(email, email_subject, generator_response)
+          .and_return(mailer)
+
+        subject.perform(activity.id, nouns, label_configs, false)
       end
     end
   end

--- a/services/QuillLMS/spec/models/user_activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/user_activity_classification_spec.rb
@@ -13,7 +13,7 @@
 #
 #  index_user_activity_classifications_on_classifications  (activity_classification_id)
 #  index_user_activity_classifications_on_user_id          (user_id)
-#  user_activity_classification_unique_index               (user_id,activity_classification_id) UNIQUE
+#  user_activity_classification_unique_index               (user_id,activity_classification_id)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
…10273)

* Refactor run method of seed data.

* Add Basic options for use_passage.

* Add some tests.

* Add more tests.

* Add some casting and some more tests.

* Add React frontend.

* Remove default value (lint)

* Constantine logic strings.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
