### PR TITLE
lms/procfile-sidekiq-tweaks

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -3,14 +3,14 @@ web: bundle exec puma -C ./config/puma.rb
 # Note, using MALLOC_ARENA_MAX=2 based on this article:
 # https://github.com/mperham/sidekiq/wiki/Deployment#heroku
 
-worker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q critical_external -q default
+worker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q critical_external -q default
 
-reportworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low -q critical -q critical_external
+reportworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low -q critical -q critical_external
 
 # Backup workers that we can use in case we need to isolate external jobs from the queue
-externalworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical_external
+externalworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical_external
 
-internalworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default
+internalworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q default
 
 # Migration workers to be turned on only in cases where we have complex migration jobs to process
-migrationworker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -q migration
+migrationworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q migration


### PR DESCRIPTION
## WHAT
Update Procfile so that Sidekiq workers increase databse pool size based on the number of worker threads we intend to run on Sidekiq
## WHY
We want to make sure that there are enough database connections in the pool to serve however many worker threads we want to run
## HOW
Set the `MAX_THREADS` (which is used to set pool size in `config/database.yml`) to the value of `SIDEKIQ_PROCESS_MAX_THREADS` (which is used to set concurrency in `config/sidekiq.yml`) in the Procfile so that the number of database connections in the pool and the number of worker threads in Sidekiq are sycned up.

### Notion Card Links
https://www.notion.so/quill/Experiments-with-large-bg-workers-cc42dc8a144d4c3791f09afd39acd26c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Just a config change.
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A