### PR TITLE
Embed Salesmate sales forms inside Quill

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/request_quote.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/request_quote.scss
@@ -1,0 +1,7 @@
+.quote-request-form {
+  width: 600px;
+  padding-top: 20px;
+  border-radius: 15px;
+  background-color: white;
+  margin: 0 auto !important;
+}

--- a/services/QuillLMS/app/assets/stylesheets/pages/request_quote.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/request_quote.scss
@@ -1,5 +1,6 @@
 .quote-request-form {
-  width: 600px;
+  max-width: 600px;
+  width: 100%;
   padding-top: 20px;
   border-radius: 15px;
   background-color: white;

--- a/services/QuillLMS/app/controllers/sales_form_submission_controller.rb
+++ b/services/QuillLMS/app/controllers/sales_form_submission_controller.rb
@@ -13,11 +13,7 @@ class SalesFormSubmissionController < ApplicationController
   end
 
   def request_quote
-    # Temporarily redirecting to the old wufoo form to avoid creating SalesFormSubmission
-    # records until we resolve how we want to handle 'sales-contact' User roles
-    # TODO: re-enable these after we figure that out
-    redirect_to "https://quillpremium.wufoo.com/forms/quill-premium-quote/"
-    @type = QUOTE_REQUEST
+    redirect_to '/premium/request-school-quote'
   end
 
   def create

--- a/services/QuillLMS/app/services/sales_stage_types_factory.rb
+++ b/services/QuillLMS/app/services/sales_stage_types_factory.rb
@@ -42,7 +42,7 @@ class SalesStageTypesFactory
     {
       name: 'Quote Requested',
       order: '4',
-      description: 'Fill out the Quote request form in Xero and then mark as complete in Quill. Do this for both email requests and wufoo quotes.',
+      description: 'Fill out the Quote request form in Xero and then mark as complete in Quill. Do this for both email requests and salesmate quotes.',
       trigger: 'user'
     },
     {

--- a/services/QuillLMS/app/views/pages/request_district_quote.html.erb
+++ b/services/QuillLMS/app/views/pages/request_district_quote.html.erb
@@ -1,17 +1,19 @@
 <div class="container pages-container pages-faq">
 
   <div class='container-946'>
-    <script>
-      ! function(e, t, a, i, d, n, o) {
-        var WEBFORM_DATA = {formId: '85184738-ff7c-4874-a555-7f102710b1ad', divId: 'sm_webform', linkName: 'webforms.salesmate.io' };
-        WEBFORM_DATA.loadElement = t.currentScript; e[i] = e[i] || function () {
-          (e[i].q = e[i].q || []).push(arguments)}, n = t.createElement(a), n.onload = function () {
-            if (!WEBFORM_DATA.divId || !t.getElementById(WEBFORM_DATA.divId)) {
-              ld = t.createElement('div'); ld.id = WEBFORM_DATA.formId;
-              WEBFORM_DATA.loadElement.parentNode.insertBefore(ld, WEBFORM_DATA.loadElement);
-              WEBFORM_DATA.divId = ld.id} SmFormSettings.loadForm(WEBFORM_DATA);
-            }, o = t.getElementsByTagName(a)[0], n.id = i, n.src = d, n.async = 1, o.parentNode.insertBefore(n, o)
-          }(window, document, "script", "loadFormScript", "https://webforms.salesmate.io/webforms.js");
-    </script>
+    <div class="quote-request-form">
+      <script>
+        ! function(e, t, a, i, d, n, o) {
+          var WEBFORM_DATA = {formId: '85184738-ff7c-4874-a555-7f102710b1ad', divId: 'sm_webform', linkName: 'webforms.salesmate.io' };
+          WEBFORM_DATA.loadElement = t.currentScript; e[i] = e[i] || function () {
+            (e[i].q = e[i].q || []).push(arguments)}, n = t.createElement(a), n.onload = function () {
+              if (!WEBFORM_DATA.divId || !t.getElementById(WEBFORM_DATA.divId)) {
+                ld = t.createElement('div'); ld.id = WEBFORM_DATA.formId;
+                WEBFORM_DATA.loadElement.parentNode.insertBefore(ld, WEBFORM_DATA.loadElement);
+                WEBFORM_DATA.divId = ld.id} SmFormSettings.loadForm(WEBFORM_DATA);
+              }, o = t.getElementsByTagName(a)[0], n.id = i, n.src = d, n.async = 1, o.parentNode.insertBefore(n, o)
+            }(window, document, "script", "loadFormScript", "https://webforms.salesmate.io/webforms.js");
+      </script>
+    </div>
   </div>
 </div>

--- a/services/QuillLMS/app/views/pages/request_district_quote.html.erb
+++ b/services/QuillLMS/app/views/pages/request_district_quote.html.erb
@@ -1,0 +1,17 @@
+<div class="container pages-container pages-faq">
+
+  <div class='container-946'>
+    <script>
+      ! function(e, t, a, i, d, n, o) {
+        var WEBFORM_DATA = {formId: '85184738-ff7c-4874-a555-7f102710b1ad', divId: 'sm_webform', linkName: 'webforms.salesmate.io' };
+        WEBFORM_DATA.loadElement = t.currentScript; e[i] = e[i] || function () {
+          (e[i].q = e[i].q || []).push(arguments)}, n = t.createElement(a), n.onload = function () {
+            if (!WEBFORM_DATA.divId || !t.getElementById(WEBFORM_DATA.divId)) {
+              ld = t.createElement('div'); ld.id = WEBFORM_DATA.formId;
+              WEBFORM_DATA.loadElement.parentNode.insertBefore(ld, WEBFORM_DATA.loadElement);
+              WEBFORM_DATA.divId = ld.id} SmFormSettings.loadForm(WEBFORM_DATA);
+            }, o = t.getElementsByTagName(a)[0], n.id = i, n.src = d, n.async = 1, o.parentNode.insertBefore(n, o)
+          }(window, document, "script", "loadFormScript", "https://webforms.salesmate.io/webforms.js");
+    </script>
+  </div>
+</div>

--- a/services/QuillLMS/app/views/pages/request_school_quote.html.erb
+++ b/services/QuillLMS/app/views/pages/request_school_quote.html.erb
@@ -1,19 +1,21 @@
 <div class="container pages-container pages-faq">
 
   <div class='container-946'>
-    <script>
-    ! function(e, t, a, i, d, n, o) {
-      var WEBFORM_DATA = {formId: '3fb7da9e-b986-433d-858f-c40976aa1767', divId: 'sm_webform', linkName: 'webforms.salesmate.io' };
-      WEBFORM_DATA.loadElement = t.currentScript;
-      e[i] = e[i] || function () {
-        (e[i].q = e[i].q || []).push(arguments)}, n = t.createElement(a), n.onload = function () { if (!WEBFORM_DATA.divId || !t.getElementById(WEBFORM_DATA.divId)) { ld = t.createElement('div'); ld.id = WEBFORM_DATA.formId;
-        ld.style="background: #f4f2f2";
-        WEBFORM_DATA.loadElement.parentNode.insertBefore(ld, WEBFORM_DATA.loadElement);
-         WEBFORM_DATA.divId = ld.id
-         }
-         SmFormSettings.loadForm(WEBFORM_DATA);
-         }, o = t.getElementsByTagName(a)[0], n.id = i, n.src = d, n.async = 1, o.parentNode.insertBefore(n, o) }(window, document, "script", "loadFormScript", "https://webforms.salesmate.io/webforms.js");
-    </script>
+    <div class="quote-request-form">
+      <script>
+      ! function(e, t, a, i, d, n, o) {
+        var WEBFORM_DATA = {formId: '3fb7da9e-b986-433d-858f-c40976aa1767', divId: 'sm_webform', linkName: 'webforms.salesmate.io' };
+        WEBFORM_DATA.loadElement = t.currentScript;
+        e[i] = e[i] || function () {
+          (e[i].q = e[i].q || []).push(arguments)}, n = t.createElement(a), n.onload = function () { if (!WEBFORM_DATA.divId || !t.getElementById(WEBFORM_DATA.divId)) { ld = t.createElement('div'); ld.id = WEBFORM_DATA.formId;
+          ld.style="background: #f4f2f2";
+          WEBFORM_DATA.loadElement.parentNode.insertBefore(ld, WEBFORM_DATA.loadElement);
+          WEBFORM_DATA.divId = ld.id
+          }
+          SmFormSettings.loadForm(WEBFORM_DATA);
+          }, o = t.getElementsByTagName(a)[0], n.id = i, n.src = d, n.async = 1, o.parentNode.insertBefore(n, o) }(window, document, "script", "loadFormScript", "https://webforms.salesmate.io/webforms.js");
+      </script>
+    </div>
   </div>
 </div>
 

--- a/services/QuillLMS/app/views/pages/request_school_quote.html.erb
+++ b/services/QuillLMS/app/views/pages/request_school_quote.html.erb
@@ -1,0 +1,19 @@
+<div class="container pages-container pages-faq">
+
+  <div class='container-946'>
+    <script>
+    ! function(e, t, a, i, d, n, o) {
+      var WEBFORM_DATA = {formId: '3fb7da9e-b986-433d-858f-c40976aa1767', divId: 'sm_webform', linkName: 'webforms.salesmate.io' };
+      WEBFORM_DATA.loadElement = t.currentScript;
+      e[i] = e[i] || function () {
+        (e[i].q = e[i].q || []).push(arguments)}, n = t.createElement(a), n.onload = function () { if (!WEBFORM_DATA.divId || !t.getElementById(WEBFORM_DATA.divId)) { ld = t.createElement('div'); ld.id = WEBFORM_DATA.formId;
+        ld.style="background: #f4f2f2";
+        WEBFORM_DATA.loadElement.parentNode.insertBefore(ld, WEBFORM_DATA.loadElement);
+         WEBFORM_DATA.divId = ld.id
+         }
+         SmFormSettings.loadForm(WEBFORM_DATA);
+         }, o = t.getElementsByTagName(a)[0], n.id = i, n.src = d, n.async = 1, o.parentNode.insertBefore(n, o) }(window, document, "script", "loadFormScript", "https://webforms.salesmate.io/webforms.js");
+    </script>
+  </div>
+</div>
+

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/__tests__/__snapshots__/school_and_district_premium_modal.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/__tests__/__snapshots__/school_and_district_premium_modal.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-school-quote"
         >
           Request a quote
         </a>
@@ -115,7 +115,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-district-quote"
         >
           Request a quote
         </a>
@@ -215,7 +215,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-school-quote"
         >
           Request a quote
         </a>
@@ -241,7 +241,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-district-quote"
         >
           Request a quote
         </a>
@@ -341,7 +341,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-school-quote"
         >
           Request a quote
         </a>
@@ -367,7 +367,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-district-quote"
         >
           Request a quote
         </a>
@@ -472,7 +472,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-school-quote"
         >
           Request a quote
         </a>
@@ -498,7 +498,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-district-quote"
         >
           Request a quote
         </a>
@@ -592,7 +592,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-school-quote"
         >
           Request a quote
         </a>
@@ -618,7 +618,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
         </div>
         <a
           className="quill-button outlined medium secondary focus-on-light"
-          href="https://quillpremium.wufoo.com/forms/quill-premium-quote/"
+          href="undefined/premium/request-district-quote"
         >
           Request a quote
         </a>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_and_district_premium_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_and_district_premium_modal.tsx
@@ -8,6 +8,8 @@ export const SCHOOL_SELECTION_STAGE = 'school_premium_purchase_selection_stage'
 
 const PLAN_SELECTION_STAGE_NUMBER = 1
 const SCHOOL_SELECTION_STAGE_NUMBER = 2
+const requestSchoolQuoteLink = `${process.env.DEFAULT_URL}/premium/request-school-quote`
+const requestDistrictQuoteLink = `${process.env.DEFAULT_URL}/premium/request-district-quote`
 
 const SchoolSelectionStage = ({ eligibleSchools, selectedSchool, goToStripeWithSelectedSchool, setSelectedSchool, closeModal, selectSchool, }) => {
   if (eligibleSchools.length) {
@@ -122,7 +124,8 @@ const SchoolAndDistrictPremiumModal = ({ stripeSchoolPlan, eligibleSchools, hand
   }
 
   if (stage === PLAN_SELECTION_STAGE_NUMBER) {
-    const requestAQuoteButton = <a className="quill-button outlined medium secondary focus-on-light" href="https://quillpremium.wufoo.com/forms/quill-premium-quote/">Request a quote</a>
+    const requestSchoolQuoteButton = <a className="quill-button outlined medium secondary focus-on-light" href={requestSchoolQuoteLink}>Request a quote</a>
+    const requestDistrictQuoteButton = <a className="quill-button outlined medium secondary focus-on-light" href={requestDistrictQuoteLink}>Request a quote</a>
     let schoolBuyNowButton = <button className="quill-button contained medium primary focus-on-light" onClick={goToSchoolSelectionStage} type="button">Buy now</button>
 
     if (!userIsSignedIn) {
@@ -150,7 +153,7 @@ const SchoolAndDistrictPremiumModal = ({ stripeSchoolPlan, eligibleSchools, hand
               <p>Per school, per year</p>
               <p>Complete the quote request form to receive a quote via email.</p>
             </div>
-            {requestAQuoteButton}
+            {requestSchoolQuoteButton}
           </div>
           <div className="school-and-district-premium-column pricing-info">
             <h2>Contact Us for District Premium</h2>
@@ -159,7 +162,7 @@ const SchoolAndDistrictPremiumModal = ({ stripeSchoolPlan, eligibleSchools, hand
               <p>Per school, per year</p>
               <p>Quill provides discounts for multi-school subscriptions.</p>
             </div>
-            {requestAQuoteButton}
+            {requestDistrictQuoteButton}
           </div>
         </div>
       </div>

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -19,7 +19,8 @@ SecureHeaders::Configuration.default do |config|
       "https://youtube.com",
       "https://*.youtube.com",
       "https://*.amazonaws.com",
-      "https://*.loom.com"
+      "https://*.loom.com",
+      "https://*.salesmate.io"
     ],
 
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
@@ -57,7 +58,8 @@ SecureHeaders::Configuration.default do |config|
       "https://*.intercomcdn.com",
       "https://*.coview.com",
       "https://*.sentry.io",
-      "https://*.heapanalytics.com"
+      "https://*.heapanalytics.com",
+      "https://*.salesmate.io"
     ],
 
     font_src: [

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -749,6 +749,9 @@ EmpiricalGrammar::Application.routes.draw do
     get "tutorials/#{tool}/:slide_number" => "pages#tutorials"
   end
 
+  get 'premium/request-school-quote' => 'pages#request_school_quote'
+  get 'premium/request-district-quote' => 'pages#request_district_quote'
+
   get 'teacher_fix' => 'teacher_fix#index'
   get 'teacher_fix/unarchive_units' => 'teacher_fix#index'
   get 'teacher_fix/merge_student_accounts' => 'teacher_fix#index'

--- a/services/QuillLMS/spec/controllers/sales_form_submission_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sales_form_submission_controller_spec.rb
@@ -39,9 +39,9 @@ describe SalesFormSubmissionController, type: :controller do
   end
 
   describe '#request_quote' do
-    it 'should set type variable to "request quote"' do
+    it 'should redirect to school quote request' do
       get :request_quote
-      expect(assigns(:type)).to eq(SalesFormSubmissionController::QUOTE_REQUEST)
+      expect(response).to redirect_to '/premium/request-school-quote'
     end
   end
 


### PR DESCRIPTION
## WHAT
Use iFrames to embed the new Salesmate-provided School Quote Request and District Quote Request forms directly in our website. 

## WHY
This way we don't have to redirect users to a third-party website to submit quote requests, and the quote requests can directly populate Salesmate.

## HOW
Create new routes and page templates for School Quote and District Quote requests. Add in the iFrame script provided by Salesmate.

### Screenshots
<img width="1141" alt="Screen Shot 2023-02-21 at 3 07 00 PM" src="https://user-images.githubusercontent.com/57366100/220272680-d6d59102-6a32-4334-b536-84319d189fc3.png">

### Notion Card Links
https://www.notion.so/quill/Update-Webforms-with-new-links-on-site-for-sales-e3e81c29b4434457bb9944472bd08132?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
