### PR TITLE
lms/simplipfy-started-count-query

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -292,14 +292,7 @@ class Teachers::UnitsController < ApplicationController
             WHEN count(pack_sequence_items.id) > 0 THEN true
             ELSE false
           END AS staggered,
-          (
-            SELECT COUNT(DISTINCT user_id)
-            FROM activity_sessions
-            WHERE state = 'started'
-              AND classroom_unit_id = cu.id
-              AND activity_sessions.activity_id = activities.id
-              AND activity_sessions.visible
-          ) AS started_count
+          SUM(CASE WHEN act_sesh.state = 'started' AND act_sesh.visible THEN 1 ELSE 0 END) AS started_count
         FROM units
         JOIN classroom_units AS cu
           ON cu.unit_id = units.id

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -292,7 +292,7 @@ class Teachers::UnitsController < ApplicationController
             WHEN count(pack_sequence_items.id) > 0 THEN true
             ELSE false
           END AS staggered,
-          SUM(CASE WHEN act_sesh.state = 'started' AND act_sesh.visible THEN 1 ELSE 0 END) AS started_count
+          COUNT(DISTINCT CASE WHEN act_sesh.state = 'started' AND act_sesh.visible THEN act_sesh.user_id ELSE NULL END) AS started_count
         FROM units
         JOIN classroom_units AS cu
           ON cu.unit_id = units.id


### PR DESCRIPTION
## WHAT
Tweak the `started_count` subquery to use a `SUM(CASE ...)` rollup instead of a subquery
## WHY
Subqueries are much more likely in SQL to require temp space, and this particular implementation creates multiple subqueries (one for each row) which SQL needs to keep somewhere while it does the rest of the calculations.  Often the query planner will stash that data in temporary tables.

Given that we're already `JOIN`ing the table with the data we care about into this query, this approach should give us the same value as the subquery.  Importantly, even if it doesn't, a search of our front-end code suggests that the only thing we actually care about is whether the value returned is non-0.  From what I can see we don't actually care what the actual count ends up being.  (It's also possible that the value doesn't actually get used on the front-end anymore, but there are a couple of references to it.)

That said, testing in staging environments (comparing payloads on Staging with the old query vs my personal environment with the new query) reveals that this code returns exactly the same results as the old sub-query approach.
## HOW
Instead of using a subquery, use `CASE` to add the extra filters for visibility and state, then count the same value from our `group_by` aggregation.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  There is no test coverage of these super-complex queries.  I'd like to write one for this, but I also want to get the fix out in a reasonable timeline.  I'm working on another, more complex PR that reworks these queries anyway, so I'll add tests there.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
