### PR TITLE
remove gate for admin sign up access

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/__tests__/__snapshots__/select_user_type.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/__tests__/__snapshots__/select_user_type.test.tsx.snap
@@ -82,6 +82,36 @@ exports[`SelectUserType component should render 1`] = `
           </div>
         </Card>
         <Card
+          header="K-12 Administrator"
+          imgAlt="School building"
+          imgSrc="undefined/images/onboarding/school-building-colored.svg"
+          onClick={[Function]}
+          text="Select this option to manage teacher accounts, access teacher reports, and view school-wide student data. As an admin, you can still create classes and assignments."
+        >
+          <div
+            className="quill-card"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <img
+              alt="School building"
+              src="undefined/images/onboarding/school-building-colored.svg"
+            />
+            <div
+              className="text"
+            >
+              <h3>
+                K-12 Administrator
+              </h3>
+              <p>
+                Select this option to manage teacher accounts, access teacher reports, and view school-wide student data. As an admin, you can still create classes and assignments.
+              </p>
+            </div>
+          </div>
+        </Card>
+        <Card
           header="Parent, Tutor or Caregiver"
           imgAlt="home"
           imgSrc="undefined/images/onboarding/home-building-colored.svg"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/select_user_type.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/new/select_user_type.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { Card, networkIcon, STUDENT, TEACHER, INDIVIDUAL_CONTRIBUTOR, ADMIN } from '../../../../Shared/index'
 
 import AssignActivityPackBanner from '../assignActivityPackBanner'
+import { Card, networkIcon, STUDENT, TEACHER, INDIVIDUAL_CONTRIBUTOR, ADMIN } from '../../../../Shared/index'
 import { requestPost, } from '../../../../../modules/request/index'
 
 const studentPencilImg = `${process.env.CDN_URL}/images/onboarding/student-pencil-colored.svg`
@@ -73,13 +73,13 @@ export class SelectUserType extends React.Component {
               onClick={this.handleClickTeacher}
               text="Select this option to create classes, assign activities, and view reports."
             />
-            {window.location.href.includes('show-admin') && <Card
+            <Card
               header="K-12 Administrator"
               imgAlt="School building"
               imgSrc={schoolBuildingImg}
               onClick={this.handleClickAdmin}
               text="Select this option to manage teacher accounts, access teacher reports, and view school-wide student data. As an admin, you can still create classes and assignments."
-            />}
+            />
             <Card
               header="Parent, Tutor or Caregiver"
               imgAlt="home"


### PR DESCRIPTION
## WHAT
Remove conditional that blocks access to admin sign up path for users without the special url.

## WHY
We want to release this to all users.

## HOW
Just delete the conditional.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Allow-access-to-admin-sign-up-flow-for-all-users-3d9512e35612495aa6e3ac71a24800cb?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES