### PR TITLE
Premium Reports/ fix blur styling

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_progress_report.jsx
@@ -128,7 +128,7 @@ export default createReactClass({
         Header: 'Activity',
         accessor: 'activity_name',
         resizeable: false,
-        className: 'show-overflow'
+        Cell: ({ row }) => <span className="show-overflow">{row.original.activity_name}</span>
       },
       {
         Header: 'Score',

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_progress_report.jsx
@@ -107,14 +107,14 @@ export default createReactClass({
 
   columnDefinitions: function() {
     const { studentFilters, } = this.state
+    const cellClassName = this.nonPremiumBlur()
     // Student, Date, Activity, Score, Standard, Tool
     return [
       {
         Header: 'Student',
         accessor: 'student_id',
         resizeable: false,
-        Cell: ({row}) => studentFilters.find(student => student.value == row.original.student_id)?.name,
-        className: this.nonPremiumBlur(),
+        Cell: ({ row }) => <span className={cellClassName}>{studentFilters.find(student => student.value == row.original.student_id)?.name}</span>,
         maxWidth: 200
       },
       {
@@ -134,16 +134,17 @@ export default createReactClass({
         Header: 'Score',
         accessor: 'percentage',
         resizeable: false,
-        Cell: ({row}) => row.original.percentage >= 0 ? `${Math.round(row.original.percentage * 100)}%` : 'Completed',
-        className: this.nonPremiumBlur(),
+        Cell: ({row}) => {
+          const score = row.original.percentage >= 0 ? `${Math.round(row.original.percentage * 100)}%` : 'Completed'
+          return <span className={cellClassName}>{score}</span>
+        },
         maxWidth: 90
       },
       {
         Header: 'Time spent',
         accessor: 'timespent',
         resizeable: false,
-        Cell: ({row}) => getTimeSpent(row.original.timespent),
-        className: this.nonPremiumBlur(),
+        Cell: ({ row }) => <span className={cellClassName}>{getTimeSpent(row.original.timespent)}</span>,
         maxWidth: 90
       },
       {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_scores_by_classroom_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/activities_scores_by_classroom_progress_report.jsx
@@ -105,7 +105,7 @@ export class ActivitiesScoresByClassroomProgressReport extends React.Component {
         resizable: false,
         minWidth: 90,
         Cell: ({row}) => (<a className='row-link-disguise' href={`/teachers/progress_reports/student_overview?classroom_id=${row.original.classroom_id}&student_id=${row.original.student_id}`}>
-          {row.original.last_active ? moment(row.original.last_active).format("MM/DD/YYYY") : <span />}
+          {row.original.last_active ? moment(row.original.last_active).format("MM/DD/YYYY") : <span>N/A</span>}
         </a>),
         sortType: sortTableFromSQLTimeStamp,
       },

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/concepts_concepts_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/concepts_concepts_progress_report.jsx
@@ -54,20 +54,19 @@ export default class IndividualStudentConceptReport extends React.Component {
         Header: 'Correct',
         accessor: 'correct_result_count',
         resizable: false,
-        className: blurIfNotPremium,
+        Cell: ({ row }) => <span className={blurIfNotPremium}>{row.original.correct_result_count}</span>,
         maxWidth: 105
       }, {
         Header: 'Incorrect',
         accessor: 'incorrect_result_count',
         resizable: false,
-        className: blurIfNotPremium,
+        Cell: ({ row }) => <span className={blurIfNotPremium}>{row.original.incorrect_result_count}</span>,
         maxWidth: 115
       }, {
         Header: 'Percentage',
         accessor: 'percentage',
         resizable: false,
-        className: blurIfNotPremium,
-        Cell: ({row}) => row.original.percentage + '%',
+        Cell: ({ row }) => <span className={blurIfNotPremium}>{row.original.percentage + '%'}</span>,
         maxWidth: 120
       },
     ])

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/concepts_students_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/concepts_students_progress_report.jsx
@@ -54,6 +54,7 @@ export default class ConceptsStudentsProgressReport extends React.Component {
   columns() {
     const { userIsPremium, } = this.state
     const blurIfNotPremium = userIsPremium ? null : 'non-premium-blur'
+    const cellClassName = `row-link-disguise ${blurIfNotPremium}`
     return ([
       {
         Header: 'Student',
@@ -74,26 +75,23 @@ export default class ConceptsStudentsProgressReport extends React.Component {
       }, {
         Header: 'Correct',
         accessor: 'correct_result_count',
-        className: blurIfNotPremium,
         resizable: false,
         Cell: ({row}) => (
-          <a className="row-link-disguise" href={row.original['concepts_href']}>{row.original['correct_result_count']}</a>
+          <a className={cellClassName} href={row.original['concepts_href']}>{row.original['correct_result_count']}</a>
         )
       }, {
         Header: 'Incorrect',
         accessor: 'incorrect_result_count',
-        className: blurIfNotPremium,
         resizable: false,
         Cell: ({row}) => (
-          <a className="row-link-disguise" href={row.original['concepts_href']}>{row.original['incorrect_result_count']}</a>
+          <a className={cellClassName} href={row.original['concepts_href']}>{row.original['incorrect_result_count']}</a>
         )
       }, {
         Header: 'Percentage',
         accessor: 'percentage',
         resizable: false,
-        className: blurIfNotPremium,
         Cell: ({row}) => (
-          <a className="row-link-disguise" href={row.original['concepts_href']}>{row.original['percentage']}%</a>
+          <a className={cellClassName} href={row.original['concepts_href']}>{row.original['percentage']}%</a>
         )
       }, {
         Header: "",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_all_classrooms_progress_report.tsx
@@ -120,9 +120,8 @@ export default class StandardsAllClassroomsProgressReport extends React.Componen
         Header: "Proficient",
         accessor: 'proficient',
         resizable: false,
-        className: blurIfNotPremium,
         Cell: ({row}) => (
-          <a className="row-link-disguise" href={row.original['link']}>
+          <a className={`row-link-disguise ${blurIfNotPremium}`} href={row.original['link']}>
             {row.original['proficient']}
           </a>
         )

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_classroom_students_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_classroom_students_progress_report.jsx
@@ -55,16 +55,13 @@ export default class extends React.Component {
       }, {
         Header: 'Average',
         accessor: 'average_score',
-        className: blurIfNotPremium,
         resizable: false,
-        // Cell: ({row}) => {
-        //   console.log('row', row.original['average_score'])
-        // }
+        Cell: ({ row }) => <span className={blurIfNotPremium}>{row.original['average_score']}</span>
       }, {
         Header: 'Proficiency Status',
         accessor: 'mastery_status',
-        className: blurIfNotPremium,
-        resizable: false
+        resizable: false,
+        Cell: ({ row }) => <span className={blurIfNotPremium}>{row.original['mastery_status']}</span>
       }, {
         Header: "",
         accessor: 'green_arrow',

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_classroom_students_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_classroom_students_progress_report.jsx
@@ -57,6 +57,9 @@ export default class extends React.Component {
         accessor: 'average_score',
         className: blurIfNotPremium,
         resizable: false,
+        // Cell: ({row}) => {
+        //   console.log('row', row.original['average_score'])
+        // }
       }, {
         Header: 'Proficiency Status',
         accessor: 'mastery_status',

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standard_students_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standard_students_progress_report.jsx
@@ -75,26 +75,19 @@ export default class IndividualStandardsReport extends React.Component {
       }, {
         Header: 'Time spent',
         accessor: 'timespent',
-        className: blurIfNotPremium,
         resizable: false,
-        Cell: ({row}) => (
-          getTimeSpent(row.original['timespent'])
-        )
+        Cell: ({ row }) => <span className={blurIfNotPremium}>{getTimeSpent(row.original['timespent'])}</span>
       }, {
         Header: 'Avg. score',
         accessor: 'average_score',
-        className: blurIfNotPremium,
         resizable: false,
-        Cell: ({row}) => (
-          `${row.original['average_score']}`
-        )
+        Cell: ({ row }) => <span className={blurIfNotPremium}>{`${row.original['average_score']}`}</span>
       }, {
         Header: 'Proficiency Status',
         accessor: 'mastery_status',
-        className: blurIfNotPremium,
         resizable: false,
         Cell: ({row}) => (
-          <span><span className={row.original['mastery_status'] === 'Proficient' ? 'proficient-indicator' : 'not-proficient-indicator'} />{row.original['mastery_status']}</span>
+          <span className={blurIfNotPremium}><span className={row.original['mastery_status'] === 'Proficient' ? 'proficient-indicator' : 'not-proficient-indicator'} />{row.original['mastery_status']}</span>
         )
       }
     ])

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standards_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/standards_standards_progress_report.jsx
@@ -70,29 +70,22 @@ export default class StandardsProgressReport extends React.Component {
       }, {
         Header: 'Time spent',
         accessor: 'timespent',
-        className: blurIfNotPremium,
         resizable: false,
         width: 100,
-        Cell: ({row}) => (
-          getTimeSpent(row.original['timespent'])
-        )
+        Cell: ({ row }) => <span className={blurIfNotPremium}>{getTimeSpent(row.original['timespent'])}</span>
       }, {
         Header: 'Avg. score',
         accessor: 'average_score',
-        className: blurIfNotPremium,
         resizable: false,
         width: 100,
-        Cell: ({row}) => (
-          `${row.original['average_score']}`
-        )
+        Cell: ({ row }) => <span className={blurIfNotPremium}>{`${row.original['average_score']}`}</span>
       }, {
         Header: 'Proficiency Status',
         accessor: 'mastery_status',
-        className: blurIfNotPremium,
         resizable: false,
         width: 165,
         Cell: ({row}) => (
-          <span><span className={row.original['mastery_status'] === 'Proficient' ? 'proficient-indicator' : 'not-proficient-indicator'} />{row.original['mastery_status']}</span>
+          <span className={blurIfNotPremium}><span className={row.original['mastery_status'] === 'Proficient' ? 'proficient-indicator' : 'not-proficient-indicator'} />{row.original['mastery_status']}</span>
         )
       }
     ])


### PR DESCRIPTION
## WHAT
fix blur styling for the Premium reports

## WHY
the blur styling wasn't being applied to most values that should be blurred for non-Premium users

## HOW
as far as I can tell from the docs, the `className` prop no longer works for instances of `column` for `ReactTable`. I just added the `className` directly into the `Cell` element for each applicable instance

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1272" alt="Screen Shot 2023-02-27 at 12 39 04 PM" src="https://user-images.githubusercontent.com/25959584/221609024-7e1a73ad-d22c-485e-91a6-9eaf2cf27f7b.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Premium-student-reports-are-visible-to-teachers-without-Quill-Premium-46073156126346189cc70e4e5f1d42a6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | no-- manually checked UI
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
