### PR TITLE
fix bug with users not showing as admins

### DIFF
--- a/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
+++ b/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
@@ -18,7 +18,8 @@ class Admin::TeacherSerializer < ApplicationSerializer
   def schools
     [object&.school].concat(object&.reload&.administered_schools).compact.uniq.map do |school|
       school_hash = { name: school.name, id: school.id }
-      school_hash[:role] = object.admin? ? ADMIN : TEACHER
+      # checking for the existence of an actual school admin record here since a user with the admin role doesn't necessarily administer a school they belong to
+      school_hash[:role] = SchoolsAdmins.exists?(school: school, user: object) ? ADMIN : TEACHER
       school_hash
     end
   end

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -53,5 +53,20 @@ describe Admin::TeacherSerializer do
       expect(subject.number_of_activities_completed).to eq(3)
       expect(subject.time_spent).to eq("0 hours")
     end
+
+    describe 'role value' do
+      it 'returns the user who does have a school admin record with an Admin role' do
+        expect(subject.schools[0][:role]).to eq('Admin')
+      end
+
+      it 'returns the user who does not have a school admin record with a Teacher role' do
+        user_with_admin_role = create(:admin)
+        create(:schools_users, user: user_with_admin_role, school: school2)
+
+        record_for_user_with_admin_role = TeachersData.run([user_with_admin_role.id])[0]
+        expect(described_class.new(record_for_user_with_admin_role).schools[0][:role]).to eq('Teacher')
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## WHAT
Fix bug where users weren't showing up with an "Admin" role on the admin dashboard.

## WHY
We want users who have a `schools_admins` record for that school (regardless of their database `role`) to show as `Admin` in this table.

## HOW
Just put the line back the way it was before and add a test.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Admins-are-showing-as-Teacher-on-the-Account-Management-table-on-the-admin-dashboard-029ec850dd57464ba24db626588112ef

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | N/A
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
