### PR TITLE
lms/add-sidekiq-latency-status

### DIFF
--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -36,7 +36,7 @@ class StatusesController < ApplicationController
 
   def sidekiq_queue_latency
     queues = Sidekiq::Queue.all
-    latency_hash = queues.map { |q| [q.name, q.latency] }.to_h
+    latency_hash = queues.to_h { |q| [q.name, q.latency] }
 
     render json: latency_hash
   end

--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -34,6 +34,13 @@ class StatusesController < ApplicationController
     render plain: 'OK'
   end
 
+  def sidekiq_queue_latency
+    queues = Sidekiq::Queue.all
+    latency_hash = queues.map { |q| [q.name, q.latency] }.to_h
+
+    render json: latency_hash
+  end
+
   def sidekiq_queue_length
     queues_hash = Sidekiq::Stats.new.queues
     retry_hash = {

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -861,7 +861,7 @@ EmpiricalGrammar::Application.routes.draw do
   # Uptime status
   resource :status, only: [] do
     collection do
-      get :index, :database, :database_write, :database_follower, :redis_cache, :redis_queue, :sidekiq_queue_length
+      get :index, :database, :database_write, :database_follower, :redis_cache, :redis_queue, :sidekiq_queue_latency, :sidekiq_queue_length
       post :deployment_notification
     end
   end


### PR DESCRIPTION
## WHAT
Add new action to statuses to get Sidekiq queue latency

NOTE: We should follow this up by updating our alarms in NewRelic
## WHY
We'd like to modify our NewRelic alarms to go off when the thing we actually care about (queue latency) are not in ideal ranges rather than relying a proxy for that value (assuming that high queue length means high latency)
## HOW
Add a new action to the `StatusController` that reports on Sidekiq queue latencies

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
