### PR TITLE
speed up admin cache reset job

### DIFF
--- a/services/QuillLMS/lib/tasks/reset_admin_caches.rake
+++ b/services/QuillLMS/lib/tasks/reset_admin_caches.rake
@@ -3,12 +3,12 @@
 namespace :admin_caches do
   desc 'reset caches for district admin reports'
   task :reset => :environment do
-    SchoolsAdmins.all.select { |sa| sa.user && sa.user.last_sign_in && sa.user.last_sign_in > 1.month.ago }.each do |sa|
-      if sa.user && sa.user_id
-        FindAdminUsersWorker.perform_async(sa.user_id)
-        FindDistrictConceptReportsWorker.perform_async(sa.user_id)
-        FindDistrictStandardsReportsWorker.perform_async(sa.user_id)
-        FindDistrictActivityScoresWorker.perform_async(sa.user_id)
+    SchoolsAdmins.all.select { |sa| sa.user && sa.user.last_sign_in && sa.user.last_sign_in > 1.month.ago }.pluck(:user_id).uniq.each do |user_id|
+      if User.find_by_id(user_id)
+        FindAdminUsersWorker.perform_async(user_id)
+        FindDistrictConceptReportsWorker.perform_async(user_id)
+        FindDistrictStandardsReportsWorker.perform_async(user_id)
+        FindDistrictActivityScoresWorker.perform_async(user_id)
       end
     end
   end


### PR DESCRIPTION
## WHAT
Run the cache reset jobs on a set of unique user ids pulled from school admins that had signed in at some point in the last month, rather than each of the school admin records.

## WHY
I realized we are running a lot of duplicate jobs this way, and worse, that the duplicates tend to be the more expensive jobs (because those users have more schools). Right now in our production database, there are 453 school admin records that meet the criteria, but only 150 unique users.

## HOW
Just adjust the query to run on the actual user ids instead of the school admin records.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES