### PR TITLE
Teacher Center/ show related articles

### DIFF
--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -78,7 +78,7 @@ class BlogPostsController < ApplicationController
     # TODO: remove SQL write from GET endpoint
     @blog_post.increment_read_count
 
-    @related_posts = BlogPost.related_posts(@blog_post)
+    @related_posts = @blog_post.related_posts
     @title = @blog_post.title
     @description = @blog_post.subtitle || @title
     @image_link = @blog_post.image_link

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -24,34 +24,18 @@ class BlogPostsController < ApplicationController
     render :index
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def show
     draft_statuses = current_user&.staff? ? [true, false] : false
+    slug = params[:slug]
 
-    @blog_post = BlogPost.find_by(slug: params[:slug], draft: draft_statuses)
+    @blog_post = BlogPost.find_by(slug: slug, draft: draft_statuses)
 
     if @blog_post
-      # TODO: remove SQL write from GET endpoint
-      @blog_post.increment_read_count
-      @most_recent_posts = BlogPost.most_recent.where.not(id: @blog_post.id)
-
-      @title = @blog_post.title
-      @description = @blog_post.subtitle || @title
-      @image_link = @blog_post.image_link
+      assign_blog_post_data_and_increment_count
     else
-      # try fixing params and redirect to correct url.
-      corrected_slug = params[:slug]&.gsub(/[^a-zA-Z\d\s-]/, '')&.downcase
-      blog_post = BlogPost.find_by(slug: corrected_slug, draft: draft_statuses)
-
-      if blog_post
-        redirect_to blog_post_path(blog_post.slug)
-      else
-        flash[:error] = "Oops! We can't seem to find that blog post. Trying searching on this page."
-        redirect_to blog_posts_path
-      end
+      attempt_corrected_slug_and_redirect(slug, draft_statuses)
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def search
     @query = params[:query]
@@ -88,6 +72,28 @@ class BlogPostsController < ApplicationController
     @title = @topic
 
     render 'index'
+  end
+
+  private def assign_blog_post_data_and_increment_count
+    # TODO: remove SQL write from GET endpoint
+    @blog_post.increment_read_count
+    @related_posts = BlogPost.related_posts(@blog_post)
+
+    @title = @blog_post.title
+    @description = @blog_post.subtitle || @title
+    @image_link = @blog_post.image_link
+  end
+
+  private def attempt_corrected_slug_and_redirect(slug, draft_statuses)
+    corrected_slug = slug&.gsub(/[^a-zA-Z\d\s-]/, '')&.downcase
+    blog_post = BlogPost.find_by(slug: corrected_slug, draft: draft_statuses)
+
+    if blog_post
+      redirect_to blog_post_path(blog_post.slug)
+    else
+      flash[:error] = "Oops! We can't seem to find that blog post. Trying searching on this page."
+      redirect_to blog_posts_path
+    end
   end
 
   private def set_announcement

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -77,8 +77,8 @@ class BlogPostsController < ApplicationController
   private def assign_blog_post_data_and_increment_count
     # TODO: remove SQL write from GET endpoint
     @blog_post.increment_read_count
-    @related_posts = BlogPost.related_posts(@blog_post)
 
+    @related_posts = BlogPost.related_posts(@blog_post)
     @title = @blog_post.title
     @description = @blog_post.subtitle || @title
     @image_link = @blog_post.image_link

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -86,8 +86,6 @@ class BlogPost < ApplicationRecord
   after_save :add_published_at
 
   scope :live, -> { where(draft: false) }
-  scope :most_recent, -> { live.order('updated_at DESC').limit(MOST_RECENT_LIMIT)}
-
   scope :for_topics, ->(topic) { live.order('order_number ASC').where(topic: topic) }
 
   def set_order_number
@@ -139,6 +137,10 @@ class BlogPost < ApplicationRecord
     return if published_at
 
     update(published_at: DateTime.current)
+  end
+
+  def self.related_posts(blog_post)
+    BlogPost.where(topic: blog_post.topic).where.not(id: blog_post.id).order('updated_at DESC').limit(MOST_RECENT_LIMIT)
   end
 
   private def generate_slug

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -139,8 +139,12 @@ class BlogPost < ApplicationRecord
     update(published_at: DateTime.current)
   end
 
-  def self.related_posts(blog_post)
-    BlogPost.where(topic: blog_post.topic).where.not(id: blog_post.id).order(created_at: :desc).limit(MOST_RECENT_LIMIT)
+  def related_posts
+    BlogPost
+      .where(topic: topic)
+      .where.not(id: id)
+      .order(created_at: :desc)
+      .limit(MOST_RECENT_LIMIT)
   end
 
   private def generate_slug

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -140,7 +140,7 @@ class BlogPost < ApplicationRecord
   end
 
   def self.related_posts(blog_post)
-    BlogPost.where(topic: blog_post.topic).where.not(id: blog_post.id).order('updated_at DESC').limit(MOST_RECENT_LIMIT)
+    BlogPost.where(topic: blog_post.topic).where.not(id: blog_post.id).order(created_at: :desc).limit(MOST_RECENT_LIMIT)
   end
 
   private def generate_slug

--- a/services/QuillLMS/app/views/blog_posts/show.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/show.html.erb
@@ -11,7 +11,7 @@
   route: 'show',
   blogPost: @blog_post,
   announcement: @announcement,
-  mostRecentPosts: @most_recent_posts,
+  relatedPosts: @related_posts,
   author: @blog_post.author,
   displayPaywall: !@blog_post.can_be_accessed_by(current_user),
   role: current_user&.role

--- a/services/QuillLMS/client/app/bundles/Teacher/components/blog_posts/__tests__/__snapshots__/blog_post.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/blog_posts/__tests__/__snapshots__/blog_post.test.jsx.snap
@@ -34,7 +34,7 @@ exports[`BlogPost component renders 1`] = `
       "updated_at": "2023-01-27T17:25:32.210Z",
     }
   }
-  mostRecentPosts={
+  relatedPosts={
     Array [
       Object {
         "author_id": null,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/blog_posts/__tests__/blog_post.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/blog_posts/__tests__/blog_post.test.jsx
@@ -6,7 +6,7 @@ import { blogPosts, blogPostWithBody, author, } from './data'
 import BlogPost from '../blog_post';
 
 const props = {
-  mostRecentPosts: blogPosts,
+  relatedPosts: blogPosts,
   blogPost: blogPostWithBody,
   author
 }
@@ -16,5 +16,4 @@ describe('BlogPost component', () => {
     const wrapper = mount(<BlogPost {...props} />)
     expect(wrapper).toMatchSnapshot()
   })
-
 })

--- a/services/QuillLMS/client/app/bundles/Teacher/components/blog_posts/blog_post.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/blog_posts/blog_post.jsx
@@ -45,10 +45,10 @@ export default class BlogPost extends React.Component {
     )
   }
 
-  renderMostRecentPosts() {
-    const { mostRecentPosts, } = this.props
+  renderRelatedPosts() {
+    const { relatedPosts, } = this.props
 
-    return mostRecentPosts.map(post =>
+    return relatedPosts.map(post =>
       (<PreviewCard
         color={BLOG_POST_TO_COLOR[post.topic]}
         content={post.preview_card_content}
@@ -100,7 +100,7 @@ export default class BlogPost extends React.Component {
               <a className="quill-button contained primary fun focus-on-light" href={`/${TEACHER_CENTER_SLUG}`}>Show more</a>
             </h2>
             <div id='preview-card-container'>
-              {this.renderMostRecentPosts()}
+              {this.renderRelatedPosts()}
             </div>
           </div>
         </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
@@ -6,7 +6,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
   defaultText="No date selected"
   handleClickCopyToAll={[Function]}
   icon={null}
-  initialValue={"2022-11-10T05:00:00.000Z"}
+  initialValue={"2022-11-10T03:00:00.000Z"}
   rowIndex={0}
 >
   <div
@@ -21,7 +21,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
         closeOnSelect={false}
         closeOnTab={true}
         dateFormat="MMM D"
-        initialValue={"2022-11-10T05:00:00.000Z"}
+        initialValue={"2022-11-10T03:00:00.000Z"}
         initialViewDate={2022-11-10T09:00:00.000Z}
         input={true}
         inputProps={Object {}}
@@ -85,7 +85,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       "onFocus": [Function],
                       "onKeyDown": [Function],
                       "type": "text",
-                      "value": "Nov 10 5:00 am",
+                      "value": "Nov 10 3:00 am",
                     }
                   }
                 >
@@ -102,7 +102,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       onKeyDown={[Function]}
                       placeholder="No date selected"
                       type="text"
-                      value="Nov 10 5:00 am"
+                      value="Nov 10 3:00 am"
                     />
                     <img
                       alt="dropdown indicator"
@@ -120,7 +120,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                   moment={[Function]}
                   navigate={[Function]}
                   renderDay={[Function]}
-                  selectedDate={"2022-11-10T05:00:00.000Z"}
+                  selectedDate={"2022-11-10T03:00:00.000Z"}
                   showView={[Function]}
                   timeFormat="h:mm a"
                   updateDate={[Function]}

--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -39,7 +39,7 @@ describe BlogPostsController, type: :controller do
     let(:related_posts_array) { [blog_post2, blog_post5, blog_post4] }
 
     before do
-      allow(BlogPost).to receive(:related_posts).and_return(related_posts_array)
+      allow_any_instance_of(BlogPost).to receive(:related_posts).and_return(related_posts_array)
     end
 
     it 'should redirect to teacher center home if no such post found' do

--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -32,7 +32,15 @@ describe BlogPostsController, type: :controller do
 
   describe '#show' do
     let(:blog_post) { create(:blog_post) }
-    let(:three_most_recent_posts) { create_list(:blog_post, 3) }
+    let(:blog_post2) { create(:blog_post, topic: "What's new", created_at: 1.day.ago) }
+    let(:blog_post3) { create(:blog_post, topic: "Getting started") }
+    let(:blog_post4) { create(:blog_post, topic: "What's new", created_at: 1.year.ago) }
+    let(:blog_post5) { create(:blog_post, topic: "What's new", created_at: 1.week.ago) }
+    let(:related_posts_array) { [blog_post2, blog_post5, blog_post4] }
+
+    before do
+      allow(BlogPost).to receive(:related_posts).and_return(related_posts_array)
+    end
 
     it 'should redirect to teacher center home if no such post found' do
       get :show, params: { slug: 'does-not-exist' }
@@ -63,7 +71,7 @@ describe BlogPostsController, type: :controller do
 
     it 'should return the three most recent posts' do
       get :show, params: { slug: blog_post.slug }
-      expect(assigns(:most_recent_posts)).to match_array(three_most_recent_posts)
+      expect(assigns(:related_posts)).to eq(related_posts_array)
     end
 
     it 'should return the title' do

--- a/services/QuillLMS/spec/models/blog_post_spec.rb
+++ b/services/QuillLMS/spec/models/blog_post_spec.rb
@@ -130,4 +130,18 @@ describe BlogPost, type: :model do
       expect(blog_post.average_rating).to be(nil)
     end
   end
+
+  describe '#self.related_posts' do
+    let(:blog_post1) { create(:blog_post, topic: "What's new") }
+    let(:blog_post2) { create(:blog_post, topic: "What's new", created_at: 1.day.ago) }
+    let(:blog_post3) { create(:blog_post, topic: "Getting started") }
+    let(:blog_post4) { create(:blog_post, topic: "What's new", created_at: 1.year.ago) }
+    let(:blog_post5) { create(:blog_post, topic: "What's new", created_at: 1.week.ago) }
+
+    subject { described_class.related_posts(blog_post1) }
+
+    it 'should fetch posts of the same topic sorted by most recent' do
+      expect(subject.all).to eq([blog_post2, blog_post5, blog_post4])
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/blog_post_spec.rb
+++ b/services/QuillLMS/spec/models/blog_post_spec.rb
@@ -131,14 +131,14 @@ describe BlogPost, type: :model do
     end
   end
 
-  describe '#self.related_posts' do
+  describe 'related_posts' do
     let(:blog_post1) { create(:blog_post, topic: "What's new") }
     let(:blog_post2) { create(:blog_post, topic: "What's new", created_at: 1.day.ago) }
     let(:blog_post3) { create(:blog_post, topic: "Getting started") }
     let(:blog_post4) { create(:blog_post, topic: "What's new", created_at: 1.year.ago) }
     let(:blog_post5) { create(:blog_post, topic: "What's new", created_at: 1.week.ago) }
 
-    subject { described_class.related_posts(blog_post1) }
+    subject { blog_post1.related_posts }
 
     it 'should fetch posts of the same topic sorted by most recent' do
       expect(subject).to eq([blog_post2, blog_post5, blog_post4])

--- a/services/QuillLMS/spec/models/blog_post_spec.rb
+++ b/services/QuillLMS/spec/models/blog_post_spec.rb
@@ -141,7 +141,7 @@ describe BlogPost, type: :model do
     subject { described_class.related_posts(blog_post1) }
 
     it 'should fetch posts of the same topic sorted by most recent' do
-      expect(subject.all).to eq([blog_post2, blog_post5, blog_post4])
+      expect(subject).to eq([blog_post2, blog_post5, blog_post4])
     end
   end
 end


### PR DESCRIPTION
## WHAT
show related articles at the end of an article in the Teacher Center

## WHY
we want to show related articles rather than most recent of other topics

## HOW
add a new `related_posts` and swap out the `most_recent` logic

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1402" alt="Screen Shot 2023-02-28 at 11 55 49 AM" src="https://user-images.githubusercontent.com/25959584/221891079-bdbbd146-f257-4cc1-a115-9fa3724f243c.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Teacher-Center-At-the-end-of-an-article-show-all-of-the-other-articles-for-that-same-section-db3ed7507fe3402e99e1d603d583c169

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
