### PR TITLE
Send additional Segment Identify calls as part of the admin verification process

### DIFF
--- a/services/QuillLMS/app/controllers/admin_infos_controller.rb
+++ b/services/QuillLMS/app/controllers/admin_infos_controller.rb
@@ -10,6 +10,7 @@ class AdminInfosController < ApplicationController
     if admin_info.approval_status == AdminInfo::SKIPPED && admin_info.verification_url && admin_info.verification_reason
       admin_info.update(approval_status: AdminInfo::PENDING)
       UserRequestedAdminVerificationEmailWorker.perform_async(current_user.id)
+      IdentifyWorker.perform_async(current_user.id)
     end
 
     render json: {}, status: 200

--- a/services/QuillLMS/app/controllers/cms/admin_verification_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/admin_verification_controller.rb
@@ -19,23 +19,32 @@ class Cms::AdminVerificationController < Cms::CmsController
 
   def set_approved
     @admin_info.update(approval_status: AdminInfo::APPROVED)
-    school = @admin_info.user.school
-    SchoolsAdmins.create(user: @admin_info.user, school: school)
+    user = @admin_info.user
+    school = user.school
+    SchoolsAdmins.create(user: user, school: school)
     ApprovedAdminVerificationEmailWorker.perform_async(@admin_info.user_id, school.id)
+    IdentifyWorker.perform_async(@admin_info.user_id)
+
     render json: {}
   end
 
   def set_denied
     @admin_info.update(approval_status: AdminInfo::DENIED)
-    school = @admin_info.user.school
+    user = @admin_info.user
+    school = user.school
     DeniedAdminVerificationEmailWorker.perform_async(@admin_info.user_id, school.id)
+    IdentifyWorker.perform_async(@admin_info.user_id)
+
     render json: {}
   end
 
   def set_pending
     @admin_info.update(approval_status: AdminInfo::PENDING)
-    school = @admin_info.user.school
-    SchoolsAdmins.destroy_by(user: @admin_info.user, school: school)
+    user = @admin_info.user
+    school = user.school
+    SchoolsAdmins.destroy_by(user: user, school: school)
+    IdentifyWorker.perform_async(@admin_info.user_id)
+
     render json: {}
   end
 

--- a/services/QuillLMS/app/workers/identify_worker.rb
+++ b/services/QuillLMS/app/workers/identify_worker.rb
@@ -2,7 +2,6 @@
 
 class IdentifyWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::LOW
 
   def perform(id)
     user = User.find_by_id(id)

--- a/services/QuillLMS/app/workers/identify_worker.rb
+++ b/services/QuillLMS/app/workers/identify_worker.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class IdentifyWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::LOW
+
+  def perform(id)
+    user = User.find_by_id(id)
+    return unless user
+
+    analytics = SegmentAnalytics.new
+    analytics.identify(user)
+  end
+end

--- a/services/QuillLMS/spec/controllers/admin_infos_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/admin_infos_controller_spec.rb
@@ -25,9 +25,10 @@ describe AdminInfosController do
       end
 
       describe 'when the admin info record has a skipped approval status and now has a verification reason and url' do
-        it 'should call the UserRequestedAdminVerificationEmailWorker and set the approval status to PENDING' do
+        it 'should call the UserRequestedAdminVerificationEmailWorker, the IdentifyWorker, and set the approval status to PENDING' do
           admin_info = create(:admin_info, user: user, approval_status: AdminInfo::SKIPPED)
 
+          expect(IdentifyWorker).to receive(:perform_async).with(user.id)
           expect(UserRequestedAdminVerificationEmailWorker).to receive(:perform_async).with(user.id)
           put :update, params: { verification_reason: verification_reason, verification_url: verification_url }
           expect(admin_info.reload.approval_status).to eq(AdminInfo::PENDING)

--- a/services/QuillLMS/spec/workers/identify_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_worker_spec.rb
@@ -7,7 +7,7 @@ describe IdentifyWorker do
 
   let(:analyzer) { double(:analyzer, track: true) }
 
-  before { allow(Analyzer).to receive(:new) { analyzer } }
+  before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
 
   describe '#perform' do
     let!(:user) { create(:user) }

--- a/services/QuillLMS/spec/workers/identify_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_worker_spec.rb
@@ -12,9 +12,9 @@ describe IdentifyWorker do
   describe '#perform' do
     let!(:user) { create(:user) }
 
-      it 'should call identify on the analytics instance' do
-        expect(analyzer).to receive(:identify).with(user)
-        subject.perform(user.id)
-      end
+    it 'should call identify on the analytics instance' do
+      expect(analyzer).to receive(:identify).with(user)
+      subject.perform(user.id)
     end
+  end
 end

--- a/services/QuillLMS/spec/workers/identify_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_worker_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe IdentifyWorker do
+  subject { described_class.new }
+
+  let(:analyzer) { double(:analyzer, track: true) }
+
+  before { allow(Analyzer).to receive(:new) { analyzer } }
+
+  describe '#perform' do
+    let!(:user) { create(:user) }
+
+      it 'should call identify on the analytics instance' do
+        expect(analyzer).to receive(:identify).with(user)
+        subject.perform(user.id)
+      end
+    end
+end


### PR DESCRIPTION
## WHAT
Add a worker to perform Segment identify calls and call it when a new admin a) fills out the verification form and b) has their verification approval status updated by a staff member.

## WHY
We need this data to update immediately in Ortto in order to create funnels correctly, as opposed to just whenever the user signs in.

## HOW
Add a new worker and call it in the relevant controller actions.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Send-additional-Segment-Identify-calls-as-part-of-the-admin-verification-process-04c19f2e8788463fa1b01b5c0cc2b895

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A