### PR TITLE
remove filtering from admin standards report

### DIFF
--- a/services/QuillLMS/client/app/bundles/admin_dashboard/containers/DistrictStandardsReports.jsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/containers/DistrictStandardsReports.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+
 import LoadingSpinner from '../../Teacher/components/shared/loading_indicator';
 import StandardsReports from '../components/standards_reports';
 import {
@@ -31,24 +32,6 @@ class DistrictStandardsReports extends React.Component {
   }
 }
 
-function getClassroomNames(classrooms, selectedSchool, selectTeacher) {
-  let filtered = filterBySchool(classrooms, selectedSchool);
-  filtered = filterByTeacher(filtered, selectTeacher);
-  const names = filtered.map(row => row.classroom_name);
-  return ['All Classrooms', ...Array.from(new Set(names))];
-}
-
-function getSchoolNames(classrooms) {
-  const names = classrooms.map(row => row.school_name);
-  return ['All Schools', ...Array.from(new Set(names))];
-}
-
-function getTeacherNames(classrooms, selectedSchool) {
-  const filtered = filterBySchool(classrooms, selectedSchool);
-  const names = filtered.map(row => row.teacher_name);
-  return ['All Teachers', ...Array.from(new Set(names))];
-}
-
 function formatDataForCSV(data) {
   const csvData = [];
   const csvHeader = [
@@ -74,80 +57,18 @@ function formatDataForCSV(data) {
   return csvData;
 }
 
-function filterBySchool(classrooms, selected) {
-  if (selected !== 'All Schools') {
-    return classrooms.filter(row => row.school_name === selected);
-  }
-
-  return classrooms;
-}
-
-function filterByClass(classrooms, selected) {
-  if (selected !== 'All Classrooms') {
-    return classrooms.filter(row => row.classroom_name === selected);
-  }
-
-  return classrooms;
-}
-
-function filterByTeacher(classrooms, selected) {
-  if (selected !== 'All Teachers') {
-    return classrooms.filter(row => row.teacher_name === selected);
-  }
-
-  return classrooms;
-}
-
-function filterClassrooms(
-  classrooms,
-  selectedSchool,
-  selectedTeacher,
-  selectedClassroom
-) {
-  let filtered = filterBySchool(classrooms, selectedSchool);
-  filtered = filterByTeacher(filtered, selectedTeacher);
-  filtered = filterByClass(filtered, selectedClassroom);
-
-  return filtered;
-}
-
 const mapStateToProps = (state) => {
-  const filteredStandardsReportsData = filterClassrooms(
-    state.district_standards_reports.standardsReportsData,
-    state.district_standards_reports.selectedSchool,
-    state.district_standards_reports.selectedTeacher,
-    state.district_standards_reports.selectedClassroom
-  );
-
-  const teacherNames = getTeacherNames(
-    state.district_standards_reports.standardsReportsData,
-    state.district_standards_reports.selectedSchool
-  );
-
-  const classroomNames = getClassroomNames(
-    state.district_standards_reports.standardsReportsData,
-    state.district_standards_reports.selectedSchool,
-    state.district_standards_reports.selectedTeacher,
-  );
+  const filteredStandardsReportsData = state.district_standards_reports.standardsReportsData
 
   return {
     loading: state.district_standards_reports.loading,
     errors: state.district_standards_reports.errors,
-    selectedClassroom: state.district_standards_reports.selectedClassroom,
-    selectedSchool: state.district_standards_reports.selectedSchool,
-    selectedTeacher: state.district_standards_reports.selectedTeacher,
     standardsReportsData: state.district_standards_reports.standardsReportsData,
     filteredStandardsReportsData,
-    csvData: formatDataForCSV(filteredStandardsReportsData),
-    classroomNames,
-    teacherNames,
-    schoolNames: getSchoolNames(state.district_standards_reports.standardsReportsData),
+    csvData: formatDataForCSV(filteredStandardsReportsData)
   };
 };
 const mapDispatchToProps = dispatch => ({
-  switchSchool: school => dispatch(switchSchool(school)),
-  switchClassroom: classroom => dispatch(switchClassroom(classroom)),
-  switchTeacher: teacher => dispatch(switchTeacher(teacher)),
   getDistrictStandardsReports: () => dispatch(getDistrictStandardsReports()),
 });
 

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/containers/__tests__/__snapshots__/DistrictStandardsReports.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/containers/__tests__/__snapshots__/DistrictStandardsReports.test.jsx.snap
@@ -18,11 +18,6 @@ exports[`DistrictStandardsReports when the access type is limited renders 1`] = 
 >
   <DistrictStandardsReports
     accessType="limited"
-    classroomNames={
-      Array [
-        "All Classrooms",
-      ]
-    }
     csvData={
       Array [
         Array [
@@ -39,14 +34,6 @@ exports[`DistrictStandardsReports when the access type is limited renders 1`] = 
     filteredStandardsReportsData={Array []}
     getDistrictStandardsReports={[Function]}
     loading={false}
-    schoolNames={
-      Array [
-        "All Schools",
-      ]
-    }
-    selectedClassroom="All Classrooms"
-    selectedSchool="All Schools"
-    selectedTeacher="All Teachers"
     standardsReportsData={Array []}
     store={
       Object {
@@ -59,14 +46,6 @@ exports[`DistrictStandardsReports when the access type is limited renders 1`] = 
         "replaceReducer": [Function],
         "subscribe": [Function],
       }
-    }
-    switchClassroom={[Function]}
-    switchSchool={[Function]}
-    switchTeacher={[Function]}
-    teacherNames={
-      Array [
-        "All Teachers",
-      ]
     }
   >
     <div
@@ -99,11 +78,6 @@ exports[`DistrictStandardsReports when the access type is restricted renders 1`]
 >
   <DistrictStandardsReports
     accessType="restricted"
-    classroomNames={
-      Array [
-        "All Classrooms",
-      ]
-    }
     csvData={
       Array [
         Array [
@@ -120,14 +94,6 @@ exports[`DistrictStandardsReports when the access type is restricted renders 1`]
     filteredStandardsReportsData={Array []}
     getDistrictStandardsReports={[Function]}
     loading={false}
-    schoolNames={
-      Array [
-        "All Schools",
-      ]
-    }
-    selectedClassroom="All Classrooms"
-    selectedSchool="All Schools"
-    selectedTeacher="All Teachers"
     standardsReportsData={Array []}
     store={
       Object {
@@ -140,14 +106,6 @@ exports[`DistrictStandardsReports when the access type is restricted renders 1`]
         "replaceReducer": [Function],
         "subscribe": [Function],
       }
-    }
-    switchClassroom={[Function]}
-    switchSchool={[Function]}
-    switchTeacher={[Function]}
-    teacherNames={
-      Array [
-        "All Teachers",
-      ]
     }
   >
     <div


### PR DESCRIPTION
## WHAT
Remove filtering from admin standards report.

## WHY
We don't actually have the data on this page that the filters need to run (classrooms, schools, and teachers), so it just shows no data if any of them are applied from the other pages.

## HOW
Remove filtering logic so it just doesn't get applied.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Admin-Standards-Reports-incorrectly-suggests-there-is-no-data-because-of-persistent-dropdown-selec-f7a0ecb85c7e423e948aec5c321a1aeb?d=68d14e93d1d443f0871cd0096623ecfd#8109ee1bc3c14cd399dde365e015cce5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES