### PR TITLE
lms/sidekiq-latency-400

### DIFF
--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -38,7 +38,7 @@ class StatusesController < ApplicationController
     queues = Sidekiq::Queue.all
     latency_hash = queues.to_h { |q| [q.name, q.latency] }
 
-    response_status = latency_hash.fetch(:critical_external, 0) > ENV.fetch('SIDEKIQ_CRITICAL_EXTERNAL_LATENCY_LIMIT', 5) ? 400 : 200
+    response_status = latency_hash.fetch(:critical_external, 0) > ENV.fetch('SIDEKIQ_CRITICAL_EXTERNAL_LATENCY_LIMIT', 60) ? 400 : 200
 
     render json: latency_hash, status: response_status
   end

--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -38,7 +38,9 @@ class StatusesController < ApplicationController
     queues = Sidekiq::Queue.all
     latency_hash = queues.to_h { |q| [q.name, q.latency] }
 
-    render json: latency_hash
+    response_status = latency_hash.fetch(:critical_external, 0) > ENV.fetch('SIDEKIQ_CRITICAL_EXTERNAL_LATENCY_LIMIT', 5) ? 400 : 200
+
+    render json: latency_hash, status: response_status
   end
 
   def sidekiq_queue_length


### PR DESCRIPTION
## WHAT
Tweak the latency status controller to 400 in certain conditions
## WHY
As far as we can tell, the easiest way for us to construct a synthetic alarm in NewRelic that cares about multiple data points is to do so using NRQL, but the features that we can query in NRQL do not include the response body of a synthetic check.  We need to differentiate the response status code in "good" situations vs "bad" ones to work up an NRQL query that can figure out if we've had multiple failures in a row, which is what we want to be querying.
## HOW
Add a segment to determine whether to respond with a 200 status code or a 400 status code to the `sidekiq_queue_latency` action.  The determinant value is always a comparison of the `critical_external` queue's latency against an ENV variable called `SIDEKIQ_CRITICAL_EXTERNAL_LATENCY_LIMIT` (or a default of 5 if that value isn't present).

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
