### PR TITLE
add migrations and model upgrades to support teachers submitting requests to become admins

### DIFF
--- a/services/QuillLMS/app/models/admin_approval_request.rb
+++ b/services/QuillLMS/app/models/admin_approval_request.rb
@@ -19,7 +19,7 @@
 #  fk_rails_...  (admin_info_id => admin_infos.id)
 #
 class AdminApprovalRequest < ApplicationRecord
-  belongs_to :requestee, class_name: 'User', foreign_key: 'requestee_id'
+  belongs_to :requestee, class_name: 'User'
   belongs_to :admin_info
 
   validates :requestee_id, presence: true

--- a/services/QuillLMS/app/models/admin_approval_request.rb
+++ b/services/QuillLMS/app/models/admin_approval_request.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: admin_approval_requests
+#
+#  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  admin_info_id :bigint
+#  requestee_id  :integer
+#
+# Indexes
+#
+#  index_admin_approval_requests_on_admin_info_id  (admin_info_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (admin_info_id => admin_infos.id)
+#
+class AdminApprovalRequest < ApplicationRecord
+  belongs_to :requestee, class_name: 'User', foreign_key: 'requestee_id'
+  belongs_to :admin_info
+
+  validates :requestee_id, presence: true
+  validates :admin_info_id, presence: true
+end

--- a/services/QuillLMS/app/models/admin_info.rb
+++ b/services/QuillLMS/app/models/admin_info.rb
@@ -6,6 +6,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  approval_status     :string
+#  approver_role       :string
 #  sub_role            :string
 #  verification_reason :text
 #  verification_url    :string
@@ -23,6 +24,7 @@
 #
 class AdminInfo < ApplicationRecord
   belongs_to :user
+  has_many :admin_approval_requests
 
   validates :user_id, presence: true, uniqueness: true
 
@@ -43,9 +45,16 @@ class AdminInfo < ApplicationRecord
     BILLING_CONTACT = "Billing contact"
   ]
 
+  APPROVER_ROLES = [
+    User::ADMIN,
+    User::STAFF
+  ]
+
   validates :approval_status, :inclusion=> { :in => APPROVAL_STATUSES }, :allow_nil => true
 
   validates :sub_role, :inclusion=> { :in => SUB_ROLES }, :allow_nil => true
+
+  validates :approver_role, :inclusion=> { :in => APPROVER_ROLES }, :allow_nil => true
 
   def admin
     user

--- a/services/QuillLMS/app/models/admin_info.rb
+++ b/services/QuillLMS/app/models/admin_info.rb
@@ -24,7 +24,7 @@
 #
 class AdminInfo < ApplicationRecord
   belongs_to :user
-  has_many :admin_approval_requests
+  has_many :admin_approval_requests, dependent: :destroy
 
   validates :user_id, presence: true, uniqueness: true
 

--- a/services/QuillLMS/db/migrate/20230301151808_add_approver_role_to_admin_info_table.rb
+++ b/services/QuillLMS/db/migrate/20230301151808_add_approver_role_to_admin_info_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddApproverRoleToAdminInfoTable < ActiveRecord::Migration[6.1]
   def change
     add_column :admin_infos, :approver_role, :string

--- a/services/QuillLMS/db/migrate/20230301151808_add_approver_role_to_admin_info_table.rb
+++ b/services/QuillLMS/db/migrate/20230301151808_add_approver_role_to_admin_info_table.rb
@@ -1,0 +1,5 @@
+class AddApproverRoleToAdminInfoTable < ActiveRecord::Migration[6.1]
+  def change
+    add_column :admin_infos, :approver_role, :string
+  end
+end

--- a/services/QuillLMS/db/migrate/20230301160642_create_admin_approval_request.rb
+++ b/services/QuillLMS/db/migrate/20230301160642_create_admin_approval_request.rb
@@ -3,7 +3,7 @@
 class CreateAdminApprovalRequest < ActiveRecord::Migration[6.1]
   def change
     create_table :admin_approval_requests do |t|
-      t.references :admin_info, foreign_key: true, dependent: :destroy
+      t.references :admin_info, foreign_key: true
       t.integer :requestee_id
 
       t.timestamps

--- a/services/QuillLMS/db/migrate/20230301160642_create_admin_approval_request.rb
+++ b/services/QuillLMS/db/migrate/20230301160642_create_admin_approval_request.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateAdminApprovalRequest < ActiveRecord::Migration[6.1]
+  def change
+    create_table :admin_approval_requests do |t|
+      t.references :admin_info, foreign_key: true, dependent: :destroy
+      t.integer :requestee_id
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -686,6 +686,38 @@ ALTER SEQUENCE public.admin_accounts_teachers_id_seq OWNED BY public.admin_accou
 
 
 --
+-- Name: admin_approval_requests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.admin_approval_requests (
+    id bigint NOT NULL,
+    admin_info_id bigint,
+    requestee_id integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: admin_approval_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.admin_approval_requests_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: admin_approval_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.admin_approval_requests_id_seq OWNED BY public.admin_approval_requests.id;
+
+
+--
 -- Name: admin_infos; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -697,7 +729,8 @@ CREATE TABLE public.admin_infos (
     verification_reason text,
     user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    approver_role character varying
 );
 
 
@@ -4858,6 +4891,13 @@ ALTER TABLE ONLY public.admin_accounts_teachers ALTER COLUMN id SET DEFAULT next
 
 
 --
+-- Name: admin_approval_requests id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.admin_approval_requests ALTER COLUMN id SET DEFAULT nextval('public.admin_approval_requests_id_seq'::regclass);
+
+
+--
 -- Name: admin_infos id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5757,6 +5797,14 @@ ALTER TABLE ONLY public.admin_accounts
 
 ALTER TABLE ONLY public.admin_accounts_teachers
     ADD CONSTRAINT admin_accounts_teachers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: admin_approval_requests admin_approval_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.admin_approval_requests
+    ADD CONSTRAINT admin_approval_requests_pkey PRIMARY KEY (id);
 
 
 --
@@ -6888,6 +6936,13 @@ CREATE INDEX index_admin_accounts_teachers_on_admin_account_id ON public.admin_a
 --
 
 CREATE INDEX index_admin_accounts_teachers_on_teacher_id ON public.admin_accounts_teachers USING btree (teacher_id);
+
+
+--
+-- Name: index_admin_approval_requests_on_admin_info_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_admin_approval_requests_on_admin_info_id ON public.admin_approval_requests USING btree (admin_info_id);
 
 
 --
@@ -8489,6 +8544,14 @@ ALTER TABLE ONLY public.topics
 
 
 --
+-- Name: admin_approval_requests fk_rails_60654ded5f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.admin_approval_requests
+    ADD CONSTRAINT fk_rails_60654ded5f FOREIGN KEY (admin_info_id) REFERENCES public.admin_infos(id);
+
+
+--
 -- Name: comprehension_labels fk_rails_6112e49a74; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9290,6 +9353,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230113132638'),
 ('20230130190215'),
 ('20230201202210'),
-('20230206203447');
+('20230206203447'),
+('20230301151808'),
+('20230301160642');
 
 

--- a/services/QuillLMS/spec/factories/admin_infos.rb
+++ b/services/QuillLMS/spec/factories/admin_infos.rb
@@ -6,6 +6,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  approval_status     :string
+#  approver_role       :string
 #  sub_role            :string
 #  verification_reason :text
 #  verification_url    :string

--- a/services/QuillLMS/spec/models/admin_approval_request_spec.rb
+++ b/services/QuillLMS/spec/models/admin_approval_request_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: admin_approval_requests
+#
+#  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  admin_info_id :bigint
+#  requestee_id  :integer
+#
+# Indexes
+#
+#  index_admin_approval_requests_on_admin_info_id  (admin_info_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (admin_info_id => admin_infos.id)
+#
+require 'rails_helper'
+
+describe AdminApprovalRequest, type: :model, redis: true do
+  it { should belong_to(:admin_info) }
+  it { should belong_to(:requestee) }
+
+  it { should validate_presence_of(:admin_info_id) }
+  it { should validate_presence_of(:requestee_id) }
+end

--- a/services/QuillLMS/spec/models/admin_info_spec.rb
+++ b/services/QuillLMS/spec/models/admin_info_spec.rb
@@ -82,7 +82,7 @@ describe AdminInfo, type: :model, redis: true do
     end
   end
 
-  describe '#approval_status' do
+  describe '#approver_role' do
 
     it "should allow valid values" do
       AdminInfo::APPROVER_ROLES.each do |v|

--- a/services/QuillLMS/spec/models/admin_info_spec.rb
+++ b/services/QuillLMS/spec/models/admin_info_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  approval_status     :string
+#  approver_role       :string
 #  sub_role            :string
 #  verification_reason :text
 #  verification_url    :string
@@ -77,6 +78,24 @@ describe AdminInfo, type: :model, redis: true do
 
     it "should not allow invalid values" do
       admin_info.sub_role = 'other'
+      expect(admin_info).not_to be_valid
+    end
+  end
+
+  describe '#approval_status' do
+
+    it "should allow valid values" do
+      AdminInfo::APPROVER_ROLES.each do |v|
+        admin_info.approver_role = v
+        expect(admin_info).to be_valid
+      end
+
+      admin_info.approver_role = nil
+      expect(admin_info).to be_valid
+    end
+
+    it "should not allow invalid values" do
+      admin_info.approver_role = 'other'
       expect(admin_info).not_to be_valid
     end
   end


### PR DESCRIPTION
## WHAT
Add a new column, `approver_role`, to the `admin_info` table, and a new table called `admin_approval_requests` to join `admin_info` records with the admins who've been requested to approve the user's upgrade to `admin`.

## WHY
In V1 of the admin project, we set up the infrastructure for users to sign up as admins and be verified by staff members. Now we're making it so that existing users who belong to a school that already has admins can make a request to become an admin, which will be verified by the existing admins. In order to do that, we need to a) be able to differentiate at the database level between users who need to be approved as admins by staff members vs existing admins, and b) in the latter case, store which existing admins the request will be sent to.

## HOW
Just add migrations and update model files and specs.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Migrations-model-changes-for-teacher-admin-upgrade-requests-40a94d42a8464eecacffdc2f791c8d68?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES