### PR TITLE
fix inline tag highlighting bug in evidence activities

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -444,7 +444,6 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   }
 
   function clickedTextIsWithinInlineMarkupTag(event) {
-    console.log("clickedText: event:", event)
     return INLINE_MARKUP_TAGS.includes(event?.target?.nodeName)
   }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -58,8 +58,6 @@ const STUDENT_HIGHLIGHT_ENDS_TEXT = "(highlighted text ends here)"
 const PASSAGE_HIGHLIGHT_STARTS_TEXT = "(yellow underlined text begins here)"
 const PASSAGE_HIGHLIGHT_ENDS_TEXT = "(yellow underlined text ends here)"
 
-const INLINE_MARKUP_TAGS = ['EM', 'B', 'STRONG', 'U']
-
 export const StudentViewContainer = ({ dispatch, session, isTurk, location, activities, handleFinishActivity, user }: StudentViewContainerProps) => {
   const skipToSpecificStep = window.location.href.includes('skipToStep')
   const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts') || skipToSpecificStep
@@ -443,26 +441,16 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     refs[ref].current ? refs[ref].current.scrollIntoView(false) : null
   }
 
-  function clickedTextIsWithinInlineMarkupTag(event) {
-    return INLINE_MARKUP_TAGS.includes(event?.target?.nodeName)
-  }
-
   function handleHighlightKeyDown(e) {
     if (e.key !== 'Enter') { return }
-    toggleStudentHighlight(e)
+    toggleStudentHighlight(e.currentTarget.textContent)
   }
 
   function handleHighlightClick(e) {
-    toggleStudentHighlight(e)
+    toggleStudentHighlight(e.currentTarget.textContent)
   }
 
-  function toggleStudentHighlight(eventOrString) {
-    if (typeof(eventOrString) === 'string') {
-      let stringText = eventOrString
-    } else {
-      let stringText = clickedTextIsWithinInlineMarkupTag(eventOrString) ? eventOrString.currentTarget.textContent : eventOrString.target.textContent
-    }
-
+  function toggleStudentHighlight(stringText) {
     const textWithHighlightContentRemoved = stringText.replace(STUDENT_HIGHLIGHT_STARTS_TEXT, '').replace(STUDENT_HIGHLIGHT_ENDS_TEXT, '')
     let newHighlights = []
 

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -58,6 +58,8 @@ const STUDENT_HIGHLIGHT_ENDS_TEXT = "(highlighted text ends here)"
 const PASSAGE_HIGHLIGHT_STARTS_TEXT = "(yellow underlined text begins here)"
 const PASSAGE_HIGHLIGHT_ENDS_TEXT = "(yellow underlined text ends here)"
 
+const INLINE_MARKUP_TAGS = ['EM', 'B', 'STRONG', 'U']
+
 export const StudentViewContainer = ({ dispatch, session, isTurk, location, activities, handleFinishActivity, user }: StudentViewContainerProps) => {
   const skipToSpecificStep = window.location.href.includes('skipToStep')
   const shouldSkipToPrompts = window.location.href.includes('turk') || window.location.href.includes('skipToPrompts') || skipToSpecificStep
@@ -441,16 +443,23 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     refs[ref].current ? refs[ref].current.scrollIntoView(false) : null
   }
 
+  function clickedTextIsWithinInlineMarkupTag(event) {
+    console.log("clickedText: event:", event)
+    return INLINE_MARKUP_TAGS.includes(event?.target?.nodeName)
+  }
+
   function handleHighlightKeyDown(e) {
     if (e.key !== 'Enter') { return }
-    toggleStudentHighlight(e.target.textContent)
+    toggleStudentHighlight(e)
   }
 
   function handleHighlightClick(e) {
-    toggleStudentHighlight(e.target.textContent)
+    toggleStudentHighlight(e)
   }
 
-  function toggleStudentHighlight(text, callback=null) {
+  function toggleStudentHighlight(event) {
+    const text = clickedTextIsWithinInlineMarkupTag(event) ? event.currentTarget.textContent : event.target.textContent
+
     const textWithHighlightContentRemoved = text.replace(STUDENT_HIGHLIGHT_STARTS_TEXT, '').replace(STUDENT_HIGHLIGHT_ENDS_TEXT, '')
     let newHighlights = []
 
@@ -461,7 +470,6 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     }
 
     setStudentHighlights(newHighlights)
-    callback && callback()
   }
 
   function toggleShowStepsSummary() {
@@ -482,6 +490,7 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   function transformMarkTags(node) {
     const { activeStep } = session;
     const strippedPassageHighlights = getStrippedPassageHighlights({ activities, session, activeStep });
+
 
     if (['p'].includes(node.name) && activeStep > 1 && strippedPassageHighlights && strippedPassageHighlights.length) {
       const stringifiedInnerElements = node.children.map(n => stringifiedInnerElementsHelper(n)).join('');

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -457,16 +457,20 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
     toggleStudentHighlight(e)
   }
 
-  function toggleStudentHighlight(event) {
-    const text = clickedTextIsWithinInlineMarkupTag(event) ? event.currentTarget.textContent : event.target.textContent
+  function toggleStudentHighlight(eventOrString) {
+    if (typeof(eventOrString) === 'string') {
+      let stringText = eventOrString
+    } else {
+      let stringText = clickedTextIsWithinInlineMarkupTag(eventOrString) ? eventOrString.currentTarget.textContent : eventOrString.target.textContent
+    }
 
-    const textWithHighlightContentRemoved = text.replace(STUDENT_HIGHLIGHT_STARTS_TEXT, '').replace(STUDENT_HIGHLIGHT_ENDS_TEXT, '')
+    const textWithHighlightContentRemoved = stringText.replace(STUDENT_HIGHLIGHT_STARTS_TEXT, '').replace(STUDENT_HIGHLIGHT_ENDS_TEXT, '')
     let newHighlights = []
 
     if (studentHighlights.includes(textWithHighlightContentRemoved)) {
       newHighlights = studentHighlights.filter(hl => hl !== textWithHighlightContentRemoved)
     } else {
-      newHighlights = studentHighlights.concat(text)
+      newHighlights = studentHighlights.concat(stringText)
     }
 
     setStudentHighlights(newHighlights)


### PR DESCRIPTION
## WHAT
Fix the bug in which:

- student selects an Evidence phrase to highlight
- the phrase is inside of inline markup, like `<em>` or `<strong>`
- the computed highlight only grabs the text within the inline markup tag, not the whole passage 

## WHY
The current behavior is inconsistent with normal highlighting. 

## HOW
Have the highlight onclick event use `currentTarget` rather than `target`, which is scoped to the parent tag, not the inline markup tag. More explanation here: https://medium.com/@etherealm/currenttarget-vs-target-in-js-2f3fd3a543e5

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Highlighting-errors-in-Haitian-Rev-Evidence-activity-5a3c54610e0d4e40808f5b67262848f0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
