### PR TITLE
Teacher Center/ update teacher center tabs

### DIFF
--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -79,7 +79,11 @@ class BlogPostsController < ApplicationController
   end
 
   def show_topic
-    topic = CGI::unescape(params[:topic]).gsub('-', ' ').capitalize
+    if params[:topic] == BlogPost::WHATS_NEW_SLUG
+      topic = BlogPost::WHATS_NEW
+    else
+      topic = CGI::unescape(params[:topic]).gsub('-', ' ').capitalize
+    end
 
     @blog_posts = BlogPost.for_topics(topic)
     @topics = topics(BlogPost::TEACHER_TOPICS)
@@ -102,6 +106,7 @@ class BlogPostsController < ApplicationController
     topic = CGI::unescape(params[:topic]).gsub('-', ' ').capitalize
     return if BlogPost::TOPICS.include?(topic)
     return if BlogPost::STUDENT_TOPICS.include?(topic)
+    return if params[:topic] == BlogPost::WHATS_NEW_SLUG
 
     flash[:error] = "Oops! We can't seem to find that topic!"
     redirect_to center_home_url and return

--- a/services/QuillLMS/app/helpers/footer_helper.rb
+++ b/services/QuillLMS/app/helpers/footer_helper.rb
@@ -44,7 +44,8 @@ module FooterHelper
   def teacher_center_links
     [
       { href: '/teacher-center', label: 'All Resources' },
-      { href: '/tools/evidence', label: 'Reading Comprehension' },
+      { href: '/teacher-center/topic/whats-new', label: "What's New?" },
+      { href: '/teacher-center/topic/using-quill-for-reading-comprehension', label: 'Reading Comprehension' },
       { href: '/teacher-center/topic/getting_started', label: 'Getting Started' },
       { href: '/teacher-center/topic/video-tutorials', label: 'Video Tutorials' },
       { href: '/teacher-center/topic/best-practices', label: 'Best Practices' },

--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -13,16 +13,16 @@ module TeacherCenterHelper
   ELA_STANDARDS = 'ELA Standards'
 
   def teacher_center_tabs(large: true)
-    premium_tab = {
-      id: PREMIUM,
-      name: PREMIUM,
-      url: '/premium'
-    }
     tabs = [
       {
         id: BlogPost::ALL_RESOURCES,
         name: ALL,
         url: '/teacher-center'
+      },
+      {
+        id: BlogPost::WHATS_NEW,
+        name: BlogPost::WHATS_NEW,
+        url: "/teacher-center/topic/whats-new"
       },
       {
         id: BlogPost::USING_QUILL_FOR_READING_COMPREHENSION,
@@ -48,9 +48,23 @@ module TeacherCenterHelper
         id: FAQ,
         name: FAQ,
         url: '/faq'
-      }
+      },
+      {
+        id: BlogPost::WEBINARS,
+        name: BlogPost::WEBINARS,
+        url: '/teacher-center/topic/webinars'
+      },
+      {
+        id: BlogPost::TEACHER_MATERIALS,
+        name: BlogPost::TEACHER_MATERIALS,
+        url: '/teacher-center/topic/teacher-materials'
+      },
+      {
+        id: BlogPost::TEACHER_STORIES,
+        name: BlogPost::TEACHER_STORIES,
+        url: '/teacher-center/topic/teacher-stories'
+      },
     ]
-    tabs << premium_tab if !current_user
     tabs
   end
 

--- a/services/QuillLMS/app/helpers/teacher_center_helper.rb
+++ b/services/QuillLMS/app/helpers/teacher_center_helper.rb
@@ -13,7 +13,7 @@ module TeacherCenterHelper
   ELA_STANDARDS = 'ELA Standards'
 
   def teacher_center_tabs(large: true)
-    tabs = [
+    [
       {
         id: BlogPost::ALL_RESOURCES,
         name: ALL,
@@ -63,9 +63,8 @@ module TeacherCenterHelper
         id: BlogPost::TEACHER_STORIES,
         name: BlogPost::TEACHER_STORIES,
         url: '/teacher-center/topic/teacher-stories'
-      },
+      }
     ]
-    tabs
   end
 
   def student_center_tabs(large: true)

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -57,6 +57,8 @@ class BlogPost < ApplicationRecord
   HOW_TO = 'How to'
   ALL_RESOURCES = 'All resources'
 
+  WHATS_NEW_SLUG = 'whats-new'
+
   TOPICS = [
     WHATS_NEW,
     USING_QUILL_FOR_READING_COMPREHENSION,

--- a/services/QuillLMS/spec/helpers/teacher_center_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/teacher_center_helper_spec.rb
@@ -17,11 +17,11 @@ describe TeacherCenterHelper do
         { id: TeacherCenterHelper::FAQ, name: TeacherCenterHelper::FAQ, url: "/faq" },
         { id: BlogPost::WEBINARS, name: BlogPost::WEBINARS, url: "/teacher-center/topic/webinars" },
         { id: BlogPost::TEACHER_MATERIALS, name: BlogPost::TEACHER_MATERIALS, url: "/teacher-center/topic/teacher-materials" },
-        { id: BlogPost::TEACHER_STORIES, name: BlogPost::TEACHER_STORIES, url: "/teacher-center/topic/teacher-stories" },
+        { id: BlogPost::TEACHER_STORIES, name: BlogPost::TEACHER_STORIES, url: "/teacher-center/topic/teacher-stories" }
       ]
     }
 
-    it 'should return the expect tabs' do
+    it 'should return the expected tabs' do
       expect(helper.teacher_center_tabs).to eq tabs
     end
   end

--- a/services/QuillLMS/spec/helpers/teacher_center_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/teacher_center_helper_spec.rb
@@ -9,46 +9,19 @@ describe TeacherCenterHelper do
     let(:tabs) {
       [
         { id: "All resources", name: "All", url: "/teacher-center" },
-        { id: "Getting started", name: "Getting started", url: "/teacher-center/topic/getting-started" },
-        { id: "Best practices", name: "Best practices", url: "/teacher-center/topic/best-practices" },
-        { id: "Writing instruction research", name: "Research", url: "/teacher-center/topic/writing-instruction-research" },
-        { id: "FAQ", name: "FAQ", url: "/faq" }
+        { id: BlogPost::WHATS_NEW, name: BlogPost::WHATS_NEW, url: "/teacher-center/topic/whats-new" },
+        { id: BlogPost::USING_QUILL_FOR_READING_COMPREHENSION, name: "Reading comprehension", url: "/teacher-center/topic/using-quill-for-reading-comprehension" },
+        { id: BlogPost::GETTING_STARTED, name: BlogPost::GETTING_STARTED, url: "/teacher-center/topic/getting-started" },
+        { id: BlogPost::BEST_PRACTICES, name: BlogPost::BEST_PRACTICES, url: "/teacher-center/topic/best-practices" },
+        { id: BlogPost::WRITING_INSTRUCTION_RESEARCH, name: "Research", url: "/teacher-center/topic/writing-instruction-research" },
+        { id: TeacherCenterHelper::FAQ, name: TeacherCenterHelper::FAQ, url: "/faq" },
+        { id: BlogPost::WEBINARS, name: BlogPost::WEBINARS, url: "/teacher-center/topic/webinars" },
+        { id: BlogPost::TEACHER_MATERIALS, name: BlogPost::TEACHER_MATERIALS, url: "/teacher-center/topic/teacher-materials" },
+        { id: BlogPost::TEACHER_STORIES, name: BlogPost::TEACHER_STORIES, url: "/teacher-center/topic/teacher-stories" },
       ]
     }
 
-    before do
-      allow(helper).to receive(:current_user) { current_user }
-    end
-
-    it 'should return the tabs with comprehension if app setting is true' do
-      comprehension_tab = { id: "Using quill for reading comprehension", name: "Reading comprehension", url: "/teacher-center/topic/using-quill-for-reading-comprehension" }
-      app_setting.enabled = true
-      app_setting.user_ids_allow_list = [current_user.id]
-      app_setting.save!
-      tabs.insert(1, comprehension_tab)
-      expect(helper.teacher_center_tabs).to eq tabs
-    end
-  end
-
-  describe '#teacher_center_tabs when not signed in' do
-    let(:tabs) {
-      [
-        { id: "All resources", name: "All", url: "/teacher-center" },
-        { id: BlogPost::USING_QUILL_FOR_READING_COMPREHENSION, name: 'Reading comprehension', url: '/teacher-center/topic/using-quill-for-reading-comprehension' },
-        { id: "Getting started", name: "Getting started", url: "/teacher-center/topic/getting-started" },
-        { id: "Best practices", name: "Best practices", url: "/teacher-center/topic/best-practices" },
-        { id: "Writing instruction research", name: "Research", url: "/teacher-center/topic/writing-instruction-research" },
-        { id: "FAQ", name: "FAQ", url: "/faq" },
-        { id: "Premium", name: "Premium", url: "/premium"}
-      ]
-    }
-
-    before do
-      allow(helper).to receive(:current_user) { nil }
-    end
-
-    it 'should return the tabs with premium tab if current user is nil' do
-      create(:app_setting, name: "comprehension")
+    it 'should return the expect tabs' do
       expect(helper.teacher_center_tabs).to eq tabs
     end
   end


### PR DESCRIPTION
## WHAT
update subnav tabs in the Teacher Center (this also removes the Premium tab and adds "What's new?" to the site footer as per spec request)

## WHY
we want to show all of the topics now that we have more subnav real estate

## HOW
update `teacher_center_tabs` helper method and add logic to account for "What's new?" slug

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="858" alt="Screen Shot 2023-03-01 at 1 54 23 PM" src="https://user-images.githubusercontent.com/25959584/222208693-03b73407-abbe-4135-81e1-57380fdd5de6.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
