### PR TITLE
lms/rake-task-to-purge-classroom-activity-sessions

### DIFF
--- a/services/QuillLMS/lib/tasks/classrooms.rake
+++ b/services/QuillLMS/lib/tasks/classrooms.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative './progress_bar'
+
+namespace :classrooms do
+  desc 'Purge activity history for a specified list of classroom ids'
+  task :purge_histories, [:classroom_ids] => :environment do |t, args|
+    classroom_ids = args[:classroom_ids].split
+
+    classrooms = Classroom.where(id: classroom_ids)
+    classrooms_teachers = ClassroomsTeacher.where(classroom_id: classroom_ids)
+    classroom_units = ClassroomUnit.where(classroom_id: classroom_ids)
+    activity_sessions = ActivitySession.where(classroom_unit: classroom_units)
+    concept_results = ConceptResult.where(activity_session: activity_sessions)
+
+    puts "You are about to permanently destroy #{classrooms&.count || 0} classrooms, #{classrooms_teachers&.count || 0} classrooms_teachers, #{classroom_units&.count || 0} classroom_units, #{activity_sessions&.count || 0} activity_sessions, and #{concept_results&.count || 0} concept_results records. Continue? [y/N]"
+    input = STDIN.gets.chomp
+    raise "Canceling task." unless input == "y"
+
+    ActiveRecord::Base.transaction do
+      concept_results&.destroy_all
+      activity_sessions&.destroy_all
+      classroom_units&.destroy_all
+      classrooms_teachers&.destroy_all
+      classrooms&.destroy_all
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/classrooms.rake
+++ b/services/QuillLMS/lib/tasks/classrooms.rake
@@ -7,22 +7,15 @@ namespace :classrooms do
   task :purge_histories, [:classroom_ids] => :environment do |t, args|
     classroom_ids = args[:classroom_ids].split
 
-    classrooms = Classroom.where(id: classroom_ids)
-    classrooms_teachers = ClassroomsTeacher.where(classroom_id: classroom_ids)
     classroom_units = ClassroomUnit.where(classroom_id: classroom_ids)
     activity_sessions = ActivitySession.where(classroom_unit: classroom_units)
-    concept_results = ConceptResult.where(activity_session: activity_sessions)
 
-    puts "You are about to permanently destroy #{classrooms&.count || 0} classrooms, #{classrooms_teachers&.count || 0} classrooms_teachers, #{classroom_units&.count || 0} classroom_units, #{activity_sessions&.count || 0} activity_sessions, and #{concept_results&.count || 0} concept_results records. Continue? [y/N]"
+    puts "You are about to irreversibly orphan #{activity_sessions&.count || 0} activity_sessions. Continue? [y/N]"
     input = $stdin.gets.chomp
     raise "Canceling task." unless input == "y"
 
     ActiveRecord::Base.transaction do
-      concept_results&.destroy_all
-      activity_sessions&.destroy_all
-      classroom_units&.destroy_all
-      classrooms_teachers&.destroy_all
-      classrooms&.destroy_all
+      activity_sessions.update_all(user_id: nil, classroom_unit_id: nil)
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/classrooms.rake
+++ b/services/QuillLMS/lib/tasks/classrooms.rake
@@ -14,7 +14,7 @@ namespace :classrooms do
     concept_results = ConceptResult.where(activity_session: activity_sessions)
 
     puts "You are about to permanently destroy #{classrooms&.count || 0} classrooms, #{classrooms_teachers&.count || 0} classrooms_teachers, #{classroom_units&.count || 0} classroom_units, #{activity_sessions&.count || 0} activity_sessions, and #{concept_results&.count || 0} concept_results records. Continue? [y/N]"
-    input = STDIN.gets.chomp
+    input = $stdin.gets.chomp
     raise "Canceling task." unless input == "y"
 
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
 ## WHAT
Create a rake task to purge classrooms and their activity_sessions and all models in between. 
## WHY
We don't intend to use this with any regularity, but in cases where teachers or admins come to us with a request to delete PII for some classes, but not for all activities of their students (so that we can't use our usual anonymization process which removes PII from user accounts)

As far as I know we've gotten one request to do this that has been approved, for a single teacher, so there's a chance that this task will be run exactly once, but I figured it was better to have it go through the PR process just to check my approach.
## HOW
Take a list of classroom ids, then find all the models that connect that `classroom` to `activity_sessions` and flag all of them for deletion from the database.

### Notion Card Links
https://www.notion.so/quill/Engineering-Question-1440929cef0b43bfbb25ec013e2b9541?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on rake task
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
