### PR TITLE
Fix a styling bug on Admin Dashboard

### DIFF
--- a/services/QuillLMS/client/app/bundles/admin_dashboard/containers/AdminDashboard.jsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/containers/AdminDashboard.jsx
@@ -153,7 +153,7 @@ const AdminDashboard = ({ adminId, accessType, passedModel, }) => {
     <div className="sub-container">
       <Snackbar text={snackbarText} visible={showSnackbar} />
       <PremiumFeatures handleClick={onClickTeacherAccess} trainingOptionsElement={trainingOptionsElement} />
-      <div className='dark-divider' id="scroll-location" />
+      <div className='dark-divider' />
       <CreateNewAccounts
         accessType={accessType}
         addTeacherAccount={addTeacherAccount}
@@ -166,7 +166,7 @@ const AdminDashboard = ({ adminId, accessType, passedModel, }) => {
         <h2>Upload Teachers via CSV</h2>
         {uploadTeachersViaCSVElement}
       </div>
-      <div className='dark-divider' />
+      <div className='dark-divider' id="scroll-location" />
       <AdminsTeachers
         accessType={accessType}
         adminAssociatedSchool={model.associated_school}

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/containers/__tests__/__snapshots__/AdminDashboard.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/containers/__tests__/__snapshots__/AdminDashboard.test.jsx.snap
@@ -109,7 +109,6 @@ exports[`AdminDashboard container should render with a full access type 1`] = `
     </PremiumFeatures>
     <div
       className="dark-divider"
-      id="scroll-location"
     />
     <CreateNewAccounts
       accessType="full"
@@ -2918,6 +2917,7 @@ exports[`AdminDashboard container should render with a full access type 1`] = `
     </div>
     <div
       className="dark-divider"
+      id="scroll-location"
     />
     <AdminsTeachers
       accessType="full"
@@ -4413,7 +4413,6 @@ exports[`AdminDashboard container should render with a limited access type 1`] =
     </PremiumFeatures>
     <div
       className="dark-divider"
-      id="scroll-location"
     />
     <CreateNewAccounts
       accessType="full"
@@ -7222,6 +7221,7 @@ exports[`AdminDashboard container should render with a limited access type 1`] =
     </div>
     <div
       className="dark-divider"
+      id="scroll-location"
     />
     <AdminsTeachers
       accessType="full"
@@ -8717,7 +8717,6 @@ exports[`AdminDashboard container should render with a restricted access type 1`
     </PremiumFeatures>
     <div
       className="dark-divider"
-      id="scroll-location"
     />
     <CreateNewAccounts
       accessType="full"
@@ -11526,6 +11525,7 @@ exports[`AdminDashboard container should render with a restricted access type 1`
     </div>
     <div
       className="dark-divider"
+      id="scroll-location"
     />
     <AdminsTeachers
       accessType="full"


### PR DESCRIPTION
## WHAT
A small bug where the wrong HTML Element was being labeled with the class `#scroll-location`. I'm just fixing this so that the right element has this label, so admins will be directed to the right location on the page when they click "View teacher access and usage".

## WHY
Fixing these bugs will give admins the optimal user experience.

## HOW
Label the second dark divider on the page with the "scroll-location" ID, not the first divider. (The second element is the section we want admin to jump to).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/The-View-teacher-access-and-usage-button-on-the-Admin-Dashboard-is-not-anchoring-to-the-correction-de1f77c3d58a4824aa4e3afb6c59f1c7?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
