### PR TITLE
Lms/fix admin email verification

### DIFF
--- a/services/QuillLMS/app/services/complete_account_creation.rb
+++ b/services/QuillLMS/app/services/complete_account_creation.rb
@@ -18,7 +18,8 @@ class CompleteAccountCreation
   def perform_admin_actions
     AdminInfo.create(admin_id: user.id, approval_status: AdminInfo::SKIPPED) # setting approval status to SKIPPED to ensure that self-created admins who exit or bypass the school verification step will have to complete it eventually
 
-    return if user.clever_id || user.google_id
+    return user.verify_email(UserEmailVerification::GOOGLE_VERIFICATION) if user.google_id
+    return user.verify_email(UserEmailVerification::CLEVER_VERIFICATION) if user.clever_id
 
     user_email_verification = user.require_email_verification
     user_email_verification.send_email

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -44,13 +44,14 @@ namespace :users do
     User.left_outer_joins(:user_email_verification)
       .joins(:admin_info) # only users who self-service sign up as admins have AdminInfo records
       .where.not(clever_id: nil)
-      .or(User.where.not(google_id: nil)) # note that the position of `or` matters a lot when you have multiple `where` clauses
+      .or(User.where.not(google_id: nil)) # the position of `or` matters a lot when you have multiple `where` clauses
       .where(role: User::ADMIN)
       .where(user_email_verification: { id: nil })
       .each do |user|
-        verification_method = UserEmailVerification::GOOGLE_VERIFICATION if user.google_id
-        verification_method = UserEmailVerification::CLEVER_VERIFICATION if user.clever_id
-        user.verify_email(verification_method)
+
+      verification_method = UserEmailVerification::GOOGLE_VERIFICATION if user.google_id
+      verification_method = UserEmailVerification::CLEVER_VERIFICATION if user.clever_id
+      user.verify_email(verification_method)
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -41,15 +41,12 @@ namespace :users do
   end
 
   task mark_google_clever_admins_verified: :environment do
-    start_date = DateTime.new(2023, 2, 27)
     User.left_outer_joins(:user_email_verification)
       .where.not(clever_id: nil)
       .or(User.where.not(google_id: nil)) # note that the position of `or` matters a lot when you have multiple `where` clauses
       .where(role: User::ADMIN)
-      # Apparently the rubocop Lint/Syntax rule at our version doesn't recognize the unterminated .. as valid syntax, even though it was introduced in Ruby 2.6
-      # rubocop:disable Lint/Syntax
-      .where(created_at: start_date..) # this is the date we launched self-service admin sign-up
-      # rubocop:enable Lint/Syntax
+      # I was going to use the open-ended `..` here, but Rubocop apparently can't handle a `..` without a value at the end and chokes.  `..nil` is documented as being equivalent to an unterminated `..`
+      .where(created_at: DateTime.new(2023, 2, 27)..nil) # this is the date we launched self-service admin sign-up
       .where(user_email_verification: { id: nil })
       .each do |user|
         verification_method = UserEmailVerification::GOOGLE_VERIFICATION if user.google_id

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -46,7 +46,10 @@ namespace :users do
       .where.not(clever_id: nil)
       .or(User.where.not(google_id: nil)) # note that the position of `or` matters a lot when you have multiple `where` clauses
       .where(role: User::ADMIN)
+      # Apparently the rubocop Lint/Syntax rule at our version doesn't recognize the unterminated .. as valid syntax, even though it was introduced in Ruby 2.6
+      # rubocop:disable Lint/Syntax
       .where(created_at: start_date..) # this is the date we launched self-service admin sign-up
+      # rubocop:enable Lint/Syntax
       .where(user_email_verification: { id: nil })
       .each do |user|
         verification_method = UserEmailVerification::GOOGLE_VERIFICATION if user.google_id

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -42,11 +42,10 @@ namespace :users do
 
   task mark_google_clever_admins_verified: :environment do
     User.left_outer_joins(:user_email_verification)
+      .joins(:admin_info) # only users who self-service sign up as admins have AdminInfo records
       .where.not(clever_id: nil)
       .or(User.where.not(google_id: nil)) # note that the position of `or` matters a lot when you have multiple `where` clauses
       .where(role: User::ADMIN)
-      # I was going to use the open-ended `..` here, but Rubocop apparently can't handle a `..` without a value at the end and chokes.  `..nil` is documented as being equivalent to an unterminated `..`
-      .where(created_at: DateTime.new(2023, 2, 27)..nil) # this is the date we launched self-service admin sign-up
       .where(user_email_verification: { id: nil })
       .each do |user|
         verification_method = UserEmailVerification::GOOGLE_VERIFICATION if user.google_id

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -41,11 +41,12 @@ namespace :users do
   end
 
   task mark_google_clever_admins_verified: :environment do
+    start_date = DateTime.new(2023, 2, 27)
     User.left_outer_joins(:user_email_verification)
       .where.not(clever_id: nil)
       .or(User.where.not(google_id: nil)) # note that the position of `or` matters a lot when you have multiple `where` clauses
       .where(role: User::ADMIN)
-      .where(created_at: DateTime.new(2023, 2, 27)..) # this is the date we launched self-service admin sign-up
+      .where(created_at: start_date..) # this is the date we launched self-service admin sign-up
       .where(user_email_verification: { id: nil })
       .each do |user|
         verification_method = UserEmailVerification::GOOGLE_VERIFICATION if user.google_id

--- a/services/QuillLMS/spec/services/complete_account_creation_spec.rb
+++ b/services/QuillLMS/spec/services/complete_account_creation_spec.rb
@@ -37,12 +37,58 @@ describe CompleteAccountCreation do
       expect(AdminInfo.find_by(user_id: user.id)).to be
     end
 
-    describe 'when the user is not a google or clever user' do
-      let!(:user) { create(:admin, google_id: nil, clever_id: nil) }
+    context 'email verification' do
+      let(:clever_id) { nil }
+      let(:google_id) { nil }
+      let(:user) { create(:admin, clever_id: clever_id, google_id: google_id) }
+      let(:verification_email_double) { double(deliver_now!: nil) }
 
-      it 'creates a user email verification record' do
-        CompleteAccountCreation.new(user, 'some_ip').call
-        expect(UserEmailVerification.find_by(user_id: user.id)).to be
+
+      describe 'when the user is not a google or clever user' do
+        it 'creates a user email verification record' do
+          CompleteAccountCreation.new(user, 'some_ip').call
+          expect(UserEmailVerification.find_by(user_id: user.id)).to be
+        end
+
+        it 'sends an verification email to the user' do
+          expect(UserMailer).to receive(:email_verification_email).and_return(verification_email_double)
+
+          CompleteAccountCreation.new(user, 'some_ip').call
+        end
+      end
+
+      describe 'when the user is a google user' do
+        let(:google_id) { 1 }
+
+        it 'marks the user as email verified' do
+          CompleteAccountCreation.new(user, 'some_ip').call
+
+          expect(user.email_verified?).to be(true)
+          expect(user.user_email_verification.verification_method).to eq(UserEmailVerification::GOOGLE_VERIFICATION)
+        end
+
+        it 'does not send an verification email to the user' do
+          expect(UserMailer).not_to receive(:email_verification_email)
+
+          CompleteAccountCreation.new(user, 'some_ip').call
+        end
+      end
+
+      describe 'when the user is a clever user' do
+        let(:clever_id) { 1 }
+
+        it 'marks the user as email verified' do
+          CompleteAccountCreation.new(user, 'some_ip').call
+
+          expect(user.email_verified?).to be(true)
+          expect(user.user_email_verification.verification_method).to eq(UserEmailVerification::CLEVER_VERIFICATION)
+        end
+
+        it 'does not send an verification email to the user' do
+          expect(UserMailer).not_to receive(:email_verification_email)
+
+          CompleteAccountCreation.new(user, 'some_ip').call
+        end
       end
     end
 


### PR DESCRIPTION
## WHAT
- Make sure that we flag users who sign up as admins with a Google or Clever account get marked as email-verified.
- Add a rake task to backfill the 14-ish admins who have signed up with Clever or Google and haven't been marked as verified
## WHY
While we don't want users signing up with Google or Clever to go through the email verification workflow, we do still want them to be marked as verified in our system for consistency.
## HOW
Add some logic the the account completion logic to just mark users as having verified their email when they're signing up with Clever or Google. 

### Notion Card Links
https://www.notion.so/quill/When-admins-sign-up-with-Google-or-Clever-set-their-Email-verification-status-to-Verified-ce876e661cb3406e906de936cd80d357?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
