### PR TITLE
Lms/daily stripe invoice email

### DIFF
--- a/services/QuillLMS/app/mailers/stripe_integration/mailer.rb
+++ b/services/QuillLMS/app/mailers/stripe_integration/mailer.rb
@@ -4,6 +4,8 @@ module StripeIntegration
   class Mailer < ApplicationMailer
     default from: QUILL_TEAM_EMAIL_ADDRESS
 
+    SALES_OPS_EMAIL = ENV.fetch('SALES_OPS_EMAIL', '')
+
     STRIPE_DASHBOARD_URL = 'https://dashboard.stripe.com'
     STRIPE_BANKING_NOTIFICATIONS_EMAIL = ENV.fetch('STRIPE_BANKING_NOTIFICATIONS_EMAIL', '')
     STRIPE_PAYMENT_NOTIFICATIONS_EMAIL = ENV.fetch('STRIPE_PAYMENT_NOTIFICATIONS_EMAIL', '')
@@ -28,6 +30,11 @@ module StripeIntegration
       @external_id = external_id
       @dashboard_url = "#{STRIPE_DASHBOARD_URL}/disputes?statuses[0]=needs_response"
       mail to: STRIPE_PAYMENT_NOTIFICATIONS_EMAIL, subject: 'Charge Dispute Created'
+    end
+
+    def invoices_without_subscriptions(invoice_payloads)
+      @invoice_payloads = invoice_payloads
+      mail to: SALES_OPS_EMAIL, subject: 'Stripe Invoices Without Associated Subscriptions'
     end
   end
 end

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -17,6 +17,7 @@ class Cron
   # Which is 02:00 or 03:00 Eastern depending on Daylight Savings
   def self.interval_1_day
     run_saturday if now.wday == 6
+    run_weekday if (1..5).include?(now.wday)
     run_school_year_start if now.month == 7 && now.day == 1
 
     # pass yesterday's date for stats email queries and labels
@@ -52,6 +53,10 @@ class Cron
   # Configured in Heroku Scheduler to run at XX:50
   def self.run_at_50_minute_mark
     ResetGhostInspectorAccountWorker.perform_async
+  end
+
+  def self.run_weekday
+    IdentifyStripeInvoicesWithoutSubscriptions.perform_async
   end
 
   def self.run_saturday

--- a/services/QuillLMS/app/views/stripe_integration/mailer/invoices_without_subscriptions.html.erb
+++ b/services/QuillLMS/app/views/stripe_integration/mailer/invoices_without_subscriptions.html.erb
@@ -1,0 +1,14 @@
+<p>These Stripe invoices have not yet been associated with a Quill Subscription</p>
+
+<% @invoice_payloads.each do |invoice| %>
+<ul>
+  <li>Invoice ID: <a href="https://dashboard.stripe.com/invoices/<%= invoice[:id] %>"><%= invoice[:id] %></a></li>
+  <li>Created: <%= invoice[:created] %></li>
+  <li>Invoice total: $<%= invoice[:total] %></li>
+  <li>Name: <%= invoice[:customer_name] %></li>
+  <li>Email: <a href="mailto:<%= invoice[:email] %>"><%= invoice[:email] %></a></li>
+  <li>Description: <%= invoice[:description] %></li>
+</ul>
+<% end %>
+
+<p>A standard Metabase query exists to find the inverse of this list: <a href="https://data.quill.org/question/999-active-subscriptions-without-stripe-invoices">Active Quill Subscriptions Without Associated Stripe Invoices</a></p>

--- a/services/QuillLMS/app/views/stripe_integration/mailer/invoices_without_subscriptions.html.erb
+++ b/services/QuillLMS/app/views/stripe_integration/mailer/invoices_without_subscriptions.html.erb
@@ -1,4 +1,4 @@
-<% if @invoice_payloads.length %>
+<% if @invoice_payloads.length > 0 %>
 <p>These Stripe invoices have not yet been associated with a Quill Subscription</p>
 
 <% @invoice_payloads.each do |invoice| %>
@@ -8,7 +8,7 @@
   <li>Invoice total: $<%= invoice[:total] %></li>
   <li>Name: <%= invoice[:customer_name] %></li>
   <li>Email: <a href="mailto:<%= invoice[:email] %>"><%= invoice[:email] %></a></li>
-  <li>Description: <%= invoice[:description] %></li>
+  <li>Invoice number: <%= invoice[:number] %></li>
 </ul>
 <% end %>
 

--- a/services/QuillLMS/app/views/stripe_integration/mailer/invoices_without_subscriptions.html.erb
+++ b/services/QuillLMS/app/views/stripe_integration/mailer/invoices_without_subscriptions.html.erb
@@ -1,3 +1,4 @@
+<% if @invoice_payloads.length %>
 <p>These Stripe invoices have not yet been associated with a Quill Subscription</p>
 
 <% @invoice_payloads.each do |invoice| %>
@@ -12,3 +13,6 @@
 <% end %>
 
 <p>A standard Metabase query exists to find the inverse of this list: <a href="https://data.quill.org/question/999-active-subscriptions-without-stripe-invoices">Active Quill Subscriptions Without Associated Stripe Invoices</a></p>
+<% else %>
+<p>No Stripe Invoices were found without an associated Quill Subscription.  There's nothing for you to do today!</p>
+<% end %>

--- a/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions.rb
+++ b/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions.rb
@@ -3,7 +3,7 @@
 class IdentifyStripeInvoicesWithoutSubscriptions
   include Sidekiq::Worker
 
-  # We don't care about invoices created before we began using this workflow 
+  # We don't care about invoices created before we began using this workflow
   INVOICE_START_EPOCH = DateTime.new(2023,1,1).to_i
   RELEVANT_INVOICE_STATUSES = ['open', 'paid']
 
@@ -17,7 +17,7 @@ class IdentifyStripeInvoicesWithoutSubscriptions
     invoices.map do |invoice|
       {
         id: invoice.id,
-        created: Time.at(invoice.created).to_datetime,
+        created: Time.at(invoice.created).getlocal.to_datetime,
         total: invoice.total / 100.0,
         customer_name: invoice.customer_name,
         customer_email: invoice.customer_email,

--- a/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions.rb
+++ b/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions.rb
@@ -13,7 +13,13 @@ class IdentifyStripeInvoicesWithoutSubscriptions
       invoices.append(invoice) if RELEVANT_INVOICE_STATUSES.include?(invoice.status) && !Subscription.find_by(stripe_invoice_id: invoice.id)
     end
 
-    invoice_payloads = invoices.map do |invoice|
+    invoice_payloads = map_invoices_for_template(invoices)
+
+    StripeIntegration::Mailer.invoices_without_subscriptions(invoice_payloads).deliver_now!
+  end
+
+  private def map_invoices_for_template(invoices)
+    invoices.map do |invoice|
       {
         id: invoice.id,
         created: Time.at(invoice.created).to_datetime,
@@ -23,7 +29,5 @@ class IdentifyStripeInvoicesWithoutSubscriptions
         description: invoice.description
       }
     end
-
-    StripeIntegration::Mailer.invoices_without_subscriptions(invoice_payloads).deliver_now!
   end
 end

--- a/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions.rb
+++ b/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class IdentifyStripeInvoicesWithoutSubscriptions
+  include Sidekiq::Worker
+
+  # We don't care about invoices created before we began using this workflow 
+  INVOICE_START_EPOCH = DateTime.new(2023,1,1).to_i
+  RELEVANT_INVOICE_STATUSES = ['open', 'paid']
+
+  def perform
+    invoices = []
+    Stripe::Invoice.list({limit: 100, created: {gte: INVOICE_START_EPOCH}}).auto_paging_each do |invoice|
+      invoices.append(invoice) if RELEVANT_INVOICE_STATUSES.include?(invoice.status) && !Subscription.find_by(stripe_invoice_id: invoice.id)
+    end
+
+    invoice_payloads = invoices.map do |invoice|
+      {
+        id: invoice.id,
+        created: Time.at(invoice.created).to_datetime,
+        total: invoice.total / 100.0,
+        customer_name: invoice.customer_name,
+        customer_email: invoice.customer_email,
+        description: invoice.description
+      }
+    end
+
+    StripeIntegration::Mailer.invoices_without_subscriptions(invoice_payloads).deliver_now!
+  end
+end

--- a/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_spec.rb
@@ -19,7 +19,7 @@ describe IdentifyStripeInvoicesWithoutSubscriptions do
     it 'should send an email that includes invoices with no associated Quill Subscriptions' do
       expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([{
         id: stripe_invoice.id,
-        created: Time.at(stripe_invoice.created).to_datetime,
+        created: Time.at(stripe_invoice.created).getlocal.to_datetime,
         total: stripe_invoice.total / 100.0,
         customer_name: stripe_invoice.customer_name,
         customer_email: stripe_invoice.customer_email,

--- a/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_spec.rb
@@ -11,7 +11,9 @@ describe IdentifyStripeInvoicesWithoutSubscriptions do
     let(:mailer_double) { double(deliver_now!: nil) }
 
     before do
-      allow(subject).to receive(:stripe_invoices).and_return([stripe_invoice])
+      list_double = double
+      allow(list_double).to receive(:auto_paging_each).and_yield(stripe_invoice)
+      allow(Stripe::Invoice).to receive(:list).and_return(list_double)
     end
 
     it 'should send an email that includes invoices with no associated Quill Subscriptions' do

--- a/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe IdentifyStripeInvoicesWithoutSubscriptions do
+  include_context 'Stripe Invoice'
+
+  subject { described_class.new }
+
+  describe '#perform' do
+    let(:mailer_double) { double(deliver_now!: nil) }
+
+    before do
+      allow(subject).to receive(:stripe_invoices).and_return([stripe_invoice])
+    end
+
+    it 'should send an email that includes invoices with no associated Quill Subscriptions' do
+      expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([{
+        id: stripe_invoice.id,
+        created: Time.at(stripe_invoice.created).to_datetime,
+        total: stripe_invoice.total / 100.0,
+        customer_name: stripe_invoice.customer_name,
+        customer_email: stripe_invoice.customer_email,
+        number: stripe_invoice.number
+      }]).and_return(mailer_double)
+
+      subject.perform
+    end
+
+    it 'should send an email that does not include invoices associated with Quill Subscriptions' do
+      create(:subscription, stripe_invoice_id: stripe_invoice_id)
+
+      expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([]).and_return(mailer_double)
+
+      subject.perform
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add a small nightly job that finds Stripe Invoice records that are not yet associated with a Quill Subscription, and sends that list to a combination of Sales, Operations, and Support staff.
## WHY
Once a district/school has been issued an Invoice, we consider the Premium process to be far enough along that we want to go ahead and upgrade that district/school to Premium.  This code will make it easy to identify places where we've gotten that far along (and issued an invoice), but haven't yet created associated Subscriptions.  Staff can then manually create said Subscription and the associated Invoice will stop being listed here.  The email generated by this job becomes a sort of rolling to-do list.
## HOW
- Create a new category of jobs in `cron` for things we only want to run on weekdays (there's no point in running this over the weekend since we don't expect anyone to do anything about it while they're not working)
- Create a new job that connects to Stripe's API, fetches all invoices created since the start of 2023 (we're using January 1, 2023 as a proxy for when we began using Stripe instead of Xero for invoice creation), filters for only "open" or "paid" invoices so that we don't create noise around canceled invoices, and then sends an email with details about each relevant invoice

### Notion Card Links
https://www.notion.so/quill/Implement-the-Stripe-transaction-manager-4fc1d92292d943c5b7fe8acabc41945b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
