### PR TITLE
Make ziptz a singleton

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -144,7 +144,6 @@ gem 'clever-ruby', '~> 2.0.1'
 
 # Memory profiling
 gem 'puma_worker_killer'
-gem 'memory_profiler', require: false
 
 # temp for migrations
 gem 'paperclip'
@@ -166,6 +165,7 @@ group :development do
   gem 'foreman'
   gem 'graphiql-rails'
   gem 'letter_opener'
+  gem 'memory_profiler'
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'annotate'

--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -144,6 +144,7 @@ gem 'clever-ruby', '~> 2.0.1'
 
 # Memory profiling
 gem 'puma_worker_killer'
+gem 'memory_profiler', require: false
 
 # temp for migrations
 gem 'paperclip'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -409,6 +409,7 @@ GEM
     matrix (0.4.2)
     maxminddb (0.1.22)
     memoist (0.16.2)
+    memory_profiler (1.0.1)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -833,6 +834,7 @@ DEPENDENCIES
   letter_opener
   lograge
   maxminddb
+  memory_profiler
   mini_racer (= 0.4.0)
   newrelic_rpm (~> 7.2)
   nokogiri (>= 1.13.2)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -734,8 +734,7 @@ class User < ApplicationRecord
   end
 
   def set_time_zone
-    z = ::Ziptz.new
-    school_timezone = z.time_zone_name(school&.zipcode || school&.mail_zipcode)
+    school_timezone = ::Ziptz.instance.time_zone_name(school&.zipcode || school&.mail_zipcode)
 
     if school_timezone.present?
       self.time_zone = school_timezone

--- a/services/QuillLMS/config/initializers/ziptz.rb
+++ b/services/QuillLMS/config/initializers/ziptz.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Ziptz
+  include Singleton
+end


### PR DESCRIPTION
## WHAT
The Ziptz gem is [used](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/models/user.rb#L737) in a user callback for time_zone calculations.
This PR moves the `z = Ziptz.new` into an initializer that makes it a [singleton](https://ruby-doc.org/stdlib-2.5.1/libdoc/singleton/rdoc/Singleton.html).

## WHY
Each `z = Ziptz.new` call uses quite a bit of memory due to unzipping a [file](https://github.com/infused/ziptz/blob/master/lib/ziptz.rb#L64) containing all of the zip code info.    Here's two experiments for importing 30 students in Google Classroom.
![30-students-no-ziptz](https://user-images.githubusercontent.com/2057805/223731597-76126e47-99c5-4fed-abc5-2def441ef483.png)
![30-students-ziptz](https://user-images.githubusercontent.com/2057805/223731599-91df3932-91a3-47d0-9629-b1e5596fec02.png)

By moving this to a singleton, we cut down significantly the memory and number of objects allocated.

Here's a sample import of 90 students, one with the singleton and one without
![Screenshot 2023-03-08 at 8 09 41 AM](https://user-images.githubusercontent.com/2057805/223726577-dad63bbd-3ce2-4f41-aca7-389eef13f253.png)

This should hopefully help with the memory errors we are seeing on our worker dynos.

## HOW
Add an initializer that makes Ziptz a singleton.

Then use `::Ziptz.instance` to call the object (rather than `:Ziptz.new`)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
