### PR TITLE
Disable skip-for-now in stripe school subscription flow

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_and_district_premium_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_and_district_premium_modal.tsx
@@ -41,7 +41,7 @@ const SchoolSelectionStage = ({ eligibleSchools, selectedSchool, goToStripeWithS
       <div className="modal-container school-and-district-premium-modal-container">
         <div className="modal-background" />
         <div className="school-and-district-premium-modal stage-two quill-modal modal-body">
-          <SchoolSelector selectSchool={selectSchool} />
+          <SchoolSelector disableSkipForNow={true} selectSchool={selectSchool} />
         </div>
       </div>
     )

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/school_selector.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/school_selector.jsx
@@ -168,28 +168,7 @@ const SchoolSelector = ({ selectSchool, showDismissSchoolSelectionReminderCheckb
     return <ul className="list quill-list double-line">{schoolItems}{noSchoolSelectedSchoolOption}</ul>
   }
 
-  const renderSchoolsListSection = () => {
-    let title
-    let schoolsListOrEmptyState
-
-    if (loading) {
-      schoolsListOrEmptyState = renderLoading()
-    } else if (search.length >= MINIMUM_SEARCH_LENGTH) {
-      schoolsListOrEmptyState = renderSchoolsList(schools)
-    } else {
-      schoolsListOrEmptyState = renderDefault()
-    }
-
-    return (
-      <div className="schools-list-section">
-        <div className="title">Results</div>
-        {schoolsListOrEmptyState}
-        {schoolNotListed()}
-      </div>
-    )
-  }
-
-  const schoolNotListed = () => {
+  const skipForNowCheckbox = () => {
     if (disableSkipForNow) { return }
 
     let checkbox = (
@@ -225,6 +204,27 @@ const SchoolSelector = ({ selectSchool, showDismissSchoolSelectionReminderCheckb
       <div className="school-not-listed">
         <button className="interactive-wrapper" onClick={handleSkipClick} type="button">Skip for now</button>
         {checkboxWrapper}
+      </div>
+    )
+  }
+
+  const renderSchoolsListSection = () => {
+    let title
+    let schoolsListOrEmptyState
+
+    if (loading) {
+      schoolsListOrEmptyState = renderLoading()
+    } else if (search.length >= MINIMUM_SEARCH_LENGTH) {
+      schoolsListOrEmptyState = renderSchoolsList(schools)
+    } else {
+      schoolsListOrEmptyState = renderDefault()
+    }
+
+    return (
+      <div className="schools-list-section">
+        <div className="title">Results</div>
+        {schoolsListOrEmptyState}
+        {skipForNowCheckbox()}
       </div>
     )
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/school_selector.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/school_selector.jsx
@@ -13,7 +13,7 @@ const DEBOUNCE_LENGTH = 500
 const MINIMUM_SEARCH_LENGTH = 2
 const WHOLE_SEARCH_IS_NUMBERS_REGEX = /^\d+$/
 
-const SchoolSelector = ({ selectSchool, showDismissSchoolSelectionReminderCheckbox, handleDismissSchoolSelectionReminder, }) => {
+const SchoolSelector = ({ selectSchool, showDismissSchoolSelectionReminderCheckbox, handleDismissSchoolSelectionReminder, disableSkipForNow}) => {
   const [search, setSearch] = React.useState('')
   const [schools, setSchools] = React.useState([])
   const [errors, setErrors] = React.useState({})
@@ -171,6 +171,7 @@ const SchoolSelector = ({ selectSchool, showDismissSchoolSelectionReminderCheckb
   const renderSchoolsListSection = () => {
     let title
     let schoolsListOrEmptyState
+
     if (loading) {
       schoolsListOrEmptyState = renderLoading()
     } else if (search.length >= MINIMUM_SEARCH_LENGTH) {
@@ -178,20 +179,52 @@ const SchoolSelector = ({ selectSchool, showDismissSchoolSelectionReminderCheckb
     } else {
       schoolsListOrEmptyState = renderDefault()
     }
-    let checkbox = <button aria-checked={false} aria-label="Unchecked" className="quill-checkbox unselected focus-on-light" onClick={toggleDismissReminderCheckbox} role="checkbox" type="button" />
-    if (dismissSchoolSelectionReminder) {
-      checkbox = <button aria-checked={true} className="quill-checkbox selected focus-on-light" onClick={toggleDismissReminderCheckbox} role="checkbox" type="button"><img alt={smallWhiteCheckIcon.alt} src={smallWhiteCheckIcon.src} /></button>
-    }
-    const checkboxWrapper = showDismissSchoolSelectionReminderCheckbox ? <div className="checkbox-wrapper">{checkbox} <span>Don&#39;t remind me again to select a school</span></div> : <span />
 
     return (
       <div className="schools-list-section">
         <div className="title">Results</div>
         {schoolsListOrEmptyState}
-        <div className="school-not-listed">
-          <button className="interactive-wrapper" onClick={handleSkipClick} type="button">Skip for now</button>
-          {checkboxWrapper}
-        </div>
+        {schoolNotListed()}
+      </div>
+    )
+  }
+
+  const schoolNotListed = () => {
+    if (disableSkipForNow) { return }
+
+    let checkbox = (
+      <button
+        aria-checked={false}
+        aria-label="Unchecked"
+        className="quill-checkbox unselected focus-on-light"
+        onClick={toggleDismissReminderCheckbox}
+        role="checkbox"
+        type="button"
+      />
+    )
+
+    const checkboxWrapper = showDismissSchoolSelectionReminderCheckbox
+      ? <div className="checkbox-wrapper">{checkbox} <span>Don&#39;t remind me again to select a school</span></div>
+      : <span />
+
+    if (dismissSchoolSelectionReminder) {
+      checkbox = (
+        <button
+          aria-checked={true}
+          className="quill-checkbox selected focus-on-light"
+          onClick={toggleDismissReminderCheckbox}
+          role="checkbox"
+          type="button"
+        >
+          <img alt={smallWhiteCheckIcon.alt} src={smallWhiteCheckIcon.src} />
+        </button>
+      )
+    }
+
+    return (
+      <div className="school-not-listed">
+        <button className="interactive-wrapper" onClick={handleSkipClick} type="button">Skip for now</button>
+        {checkboxWrapper}
       </div>
     )
   }


### PR DESCRIPTION
## WHAT
Remove the option 'skip for now' from the School Subscription dialog where a user selects a school.

## WHY
We need the user to select a school, otherwise the subsequent processing of the school subscription will fail.

## HOW
Add a toggle on the `SchoolSelector` component that hides the "Skip for Now" section

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
