### PR TITLE
Lms/cache admin reports

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/progress-reports-2018.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/progress-reports-2018.scss
@@ -50,6 +50,9 @@
         font-weight: normal;
       }
     }
+    p {
+      margin-bottom: 8px;
+    }
   }
 
   .dropdown-container {

--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -9,6 +9,9 @@ class PreCacheAdminDashboardsWorker
 
     active_admin_ids.each do |id|
       FindAdminUsersWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
+      FindDistrictActivityScoresWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
+      FindDistrictStandardsReportsWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
+      FindDistrictConceptReportsWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
     end
   end
 end

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/__tests__/__snapshots__/standardsReports.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/__tests__/__snapshots__/standardsReports.test.tsx.snap
@@ -16,6 +16,11 @@ exports[`StandardsReports component should match snapshot 1`] = `
       <p>
         Each activity on Quill is aligned to a Common Core standard. This report shows the school’s overall progress on each of the standards. You can print this report by downloading a PDF file or export this data by downloading a CSV file. The data you see below is capturing historical activity data for your school.
       </p>
+      <p>
+        <b>
+          These reports are updated nightly.
+        </b>
+      </p>
     </div>
     <div
       className="csv-and-how-we-grade"

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/activity_scores.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/activity_scores.tsx
@@ -46,6 +46,7 @@ const ActivityScores: React.SFC<ActivityScoresProps> = ({
           <p>
             Each activity takes about 10-20 minutes to complete, and students receive a score out of 100 points based on their performance. Click on a student’s name to see a report and print it as a PDF. You can print this report by downloading a PDF file or export this data by downloading a CSV file.
           </p>
+          <p><b>These reports are updated nightly.</b></p>
         </div>
         <div className="csv-and-how-we-grade">
           <CSVDownloadForProgressReport data={csvData} />

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/concept_reports.jsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/concept_reports.jsx
@@ -25,6 +25,7 @@ const ConceptReports = ({
         <p>
             Each question on Quill targets a specific writing concept. This report shows the number of times the student correctly or incorrectly used the targeted concept to answer the question. You can print this report by downloading a PDF file or export this data by downloading a CSV file.
         </p>
+        <p><b>These reports are updated nightly.</b></p>
       </div>
       <div className="csv-and-how-we-grade">
         <CSVDownloadForProgressReport data={csvData} />

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/standardsReports.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/standardsReports.tsx
@@ -15,6 +15,7 @@ export const StandardsReports = ({
         <p>
             Each activity on Quill is aligned to a Common Core standard. This report shows the school’s overall progress on each of the standards. You can print this report by downloading a PDF file or export this data by downloading a CSV file. The data you see below is capturing historical activity data for your school.
         </p>
+        <p><b>These reports are updated nightly.</b></p>
       </div>
       <div className="csv-and-how-we-grade">
         <CSVDownloadForProgressReport data={csvData} />

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -8,29 +8,53 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
   let!(:current_admin1) { create(:user, last_sign_in: Time.current) }
   let!(:current_admin2) { create(:user, last_sign_in: Time.current) }
   let!(:not_admin) { create(:user, last_sign_in: Time.current) }
-  let(:mock_worker) {double(:perform_async)}
+  let(:mock_users_worker) {double(:mock_users_worker, perform_async: nil)}
+  let(:mock_activity_worker) {double(:mock_activity_worker, perform_async: nil)}
+  let(:mock_standards_worker) {double(:mock_standards_worker, perform_async: nil)}
+  let(:mock_concept_worker) {double(:mock_concept_worker, perform_async: nil)}
 
   before do
     create(:schools_admins, user: old_admin)
     create(:schools_admins, user: current_admin1)
     create(:schools_admins, user: current_admin2)
 
-    allow(FindAdminUsersWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_worker)
+    allow(FindAdminUsersWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_users_worker)
+    allow(FindDistrictActivityScoresWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_activity_worker)
+    allow(FindDistrictStandardsReportsWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_standards_worker)
+    allow(FindDistrictConceptReportsWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_concept_worker)
   end
 
   it 'enqueues FindAdminUsersWorker for all active admins' do
-    expect(mock_worker).to receive(:perform_async).with(current_admin1.id).once
-    expect(mock_worker).to receive(:perform_async).with(current_admin2.id).once
+    expect(mock_users_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_users_worker).to receive(:perform_async).with(current_admin2.id).once
+    worker.perform
+  end
+
+  it 'enqueues FindDistrictActivityScoresWorker for admins' do
+    expect(mock_activity_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_activity_worker).to receive(:perform_async).with(current_admin2.id).once
+    worker.perform
+  end
+
+  it 'enqueues FindDistrictStandardsReportWorker for admins' do
+    expect(mock_standards_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_standards_worker).to receive(:perform_async).with(current_admin2.id).once
+    worker.perform
+  end
+
+  it 'enqueues FindDistrictConceptReportsWorker for admins' do
+    expect(mock_concept_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_concept_worker).to receive(:perform_async).with(current_admin2.id).once
     worker.perform
   end
 
   it 'does not enqueue FindAdminUsersWorker for non-admins' do
-    expect(mock_worker).not_to receive(:perform_async).with(not_admin.id)
+    expect(mock_users_worker).not_to receive(:perform_async).with(not_admin.id)
     worker.perform
   end
 
   it 'does not enqueue FindAdminUsersWorker for non-active admins' do
-    expect(mock_worker).not_to receive(:perform_async).with(old_admin.id)
+    expect(mock_users_worker).not_to receive(:perform_async).with(old_admin.id)
     worker.perform
   end
 end


### PR DESCRIPTION
## WHAT
Add all of the additional admin report caching jobs to our nightly admin caching worker
## WHY
For some of our biggest districts these reports are becoming too unwieldy to rely on on-demand generation (taking more than 5 minutes in some cases).  So we want to pre-cache the results of these reports for admins the way we cache their teacher lists overnight.
## HOW
Just add calls to the additional report caching jobs to the nightly admin pre-caching job.  Then, in addition, add a note to the report front-end to flag the fact that this report is updated nightly so that admins aren't confused if they don't see changes in reports that they know happened during the day.

### Screenshots
![image](https://user-images.githubusercontent.com/331565/224368583-0db22acc-8ea8-41dd-a32e-2a6d8419e89a.png)

### Notion Card Links
https://www.notion.so/quill/Improve-admin-report-loading-time-for-admins-with-access-to-multiple-schools-e6d34655e6c247b4996f40acd54579c8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
