### PR TITLE
Add some memory profiling helper classes

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -165,7 +165,6 @@ group :development do
   gem 'foreman'
   gem 'graphiql-rails'
   gem 'letter_opener'
-  gem 'memory_profiler'
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'annotate'
@@ -191,6 +190,7 @@ group :test, :development do
   gem 'rspec-retry'
   gem 'rspec-redis_helper'
   gem 'brakeman', '= 4.1.1'
+  gem 'memory_profiler'
 end
 
 group :test, :development, :cypress do

--- a/services/QuillLMS/app/lib/memory_profiler_report.rb
+++ b/services/QuillLMS/app/lib/memory_profiler_report.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class MemoryProfilerReport < ApplicationService
+  attr_reader :report
+
+  def initialize(&block)
+    @report = ::MemoryProfiler.report(&block)
+  end
+
+  def run
+    {
+      memory_allocated: memory_allocated,
+      objects_allocated: objects_allocated,
+      memory_retained: memory_retained,
+      objects_retained: objects_retained
+    }
+  end
+
+  private def objects_allocated
+    report.total_allocated
+  end
+
+  private def objects_retained
+    report.total_retained
+  end
+
+  private def memory_allocated
+    report.total_allocated_memsize
+  end
+
+  private def memory_retained
+    report.total_retained_memsize
+  end
+end

--- a/services/QuillLMS/app/lib/memory_profiler_report_comparator.rb
+++ b/services/QuillLMS/app/lib/memory_profiler_report_comparator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class MemoryProfilerReportComparator < ApplicationService
+  include ActionView::Helpers::NumberHelper
+
+  attr_reader :report1, :report2
+
+  def initialize(report1, report2 = nil)
+    @report1 = report1
+    @report2 = report2
+  end
+
+  def run
+    if report2.nil?
+      {
+        memory_allocated: number_to_human_size(report1[:objects_allocated]),
+        objects_allocated: number_to_human(report1[:objects_allocated]),
+        memory_retained: number_to_human_size(report1[:objects_allocated]),
+        objects_retained: number_to_human(report1[:objects_allocated])
+      }
+    else
+      {
+        memory_allocated_diff: memory_allocated_diff,
+        objects_allocated_diff: objects_allocated_diff,
+        memory_retained_diff: memory_retained_diff,
+        objects_retained_diff: objects_retained_diff
+      }
+    end
+  end
+
+  private def objects_allocated_diff
+    number_to_human(report2[:objects_allocated] - report1[:objects_allocated])
+  end
+
+  private def objects_retained_diff
+    number_to_human(report2[:objects_retained] - report1[:objects_retained])
+  end
+
+  private def memory_allocated_diff
+    number_to_human_size(report2[:memory_allocated] - report1[:memory_allocated])
+  end
+
+  private def memory_retained_diff
+    number_to_human_size(report2[:memory_retained] - report1[:memory_retained])
+  end
+end

--- a/services/QuillLMS/spec/lib/memory_profiler_report_comparator_spec.rb
+++ b/services/QuillLMS/spec/lib/memory_profiler_report_comparator_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MemoryProfilerReportComparator do
+  let(:report1) { MemoryProfilerReport.run { create_list(:user, 1) } }
+  let(:report2) { MemoryProfilerReport.run { create_list(:user, 2) } }
+
+  context 'one report' do
+    subject { described_class.run(report1) }
+
+    it { expect(subject.keys).to eq [:memory_allocated, :objects_allocated, :memory_retained, :objects_retained] }
+  end
+
+  context 'two reports' do
+    subject { described_class.run(report1, report2) }
+
+    it { expect(subject.keys).to eq [:memory_allocated_diff, :objects_allocated_diff, :memory_retained_diff, :objects_retained_diff] }
+  end
+end

--- a/services/QuillLMS/spec/lib/memory_profiler_report_spec.rb
+++ b/services/QuillLMS/spec/lib/memory_profiler_report_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MemoryProfilerReport do
+  subject { described_class.run(&block) }
+
+  let(:block) { proc { 1 + 1 } }
+
+  it { expect(subject.keys).to eq [:memory_allocated, :objects_allocated, :memory_retained, :objects_retained] }
+end


### PR DESCRIPTION
## WHAT
Add some helper classes for profiling memory.

## WHY
`MemoryProfilerReport` is basically a wrapper for the main results of the profiling.

`MemoryProfilerReportComparator` gives more human readable numbers for the memory and objects allocated.
For example, 35234234 bytes gets printed as 35.2 MB and 535343 objects gets printed 535K objects.  

It also will compute the diff in memory and allocation between two procs.  This is useful when removing specific lines of code.

## HOW
Use the `ActionView::Helpers::NumberHelpers` convenience methods `number_to_human_size` and `number_to_human`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
