### PR TITLE
Add a uniq call to prevent duplicates

### DIFF
--- a/services/QuillLMS/app/models/unit.rb
+++ b/services/QuillLMS/app/models/unit.rb
@@ -92,6 +92,7 @@ class Unit < ApplicationRecord
         .joins("JOIN units ON unit_activities.unit_id = #{id}")
         .where( "activities.activity_classification_id = 6 AND activities.supporting_info IS NOT NULL")
         .pluck(:id)
+        .uniq
 
     return if activity_ids.empty?
 


### PR DESCRIPTION
## WHAT
Get rid of duplicate ids in a calculation of activity_ids.

## WHY
This job can sometimes pass unnecessary duplicates of to sidekiq:
https://user-images.githubusercontent.com/2057805/224562083-4447d32d-f39b-4ec4-9e56-72cebc32ac65.mov


## HOW
Add a `.uniq` call to the calculation.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
