### PR TITLE
LMS Protect against duplicate jobs in pre_cache job.

### DIFF
--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -5,7 +5,11 @@ class PreCacheAdminDashboardsWorker
   sidekiq_options queue: SidekiqQueue::DEFAULT
 
   def perform
-    active_admin_ids = User.where('last_sign_in >= ?', School.school_year_start(Time.current)).joins(:schools_admins).pluck(:id)
+    active_admin_ids = User
+      .where('last_sign_in >= ?', School.school_year_start(Time.current))
+      .joins(:schools_admins)
+      .pluck(:id)
+      .uniq
 
     active_admin_ids.each do |id|
       FindAdminUsersWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -33,4 +33,14 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
     expect(mock_worker).not_to receive(:perform_async).with(old_admin.id)
     worker.perform
   end
+
+  context "duplicate admins" do
+    let!(:new_admin_old_user) { create(:schools_admins, user: current_admin1) }
+
+    it "should not queue duplicates" do
+      expect(mock_worker).to receive(:perform_async).with(current_admin1.id).once
+      expect(mock_worker).to receive(:perform_async).with(current_admin2.id).once
+      worker.perform
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Remove about 1,000 duplicate caching jobs by adding a `.uniq` call to the pre-caching job.
## WHY
A user can have multiple school admins, which is causing duplicate expensive jobs to run.
## HOW
Write a failing test, fix test.
Add `.uniq` to array. 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
