### PR TITLE
Bug fix/ fix hover and focus styling for Teacher Center buttons

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/blog_posts.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/blog_posts.scss
@@ -37,6 +37,9 @@ $blogpostlightteal: rgba(44, 127, 155, 0.08);
 }
 
 .topic-section, .preview-card-link {
+  .quill-button:hover, .quill-button:focus {
+    filter: brightness(110%) !important;
+  }
   &.green {
     h1, h3 {
       color: $blogpostgreen;
@@ -46,6 +49,12 @@ $blogpostlightteal: rgba(44, 127, 155, 0.08);
     }
     .quill-button {
       background-color: $blogpostgreen;
+    }
+    .quill-button:hover, .quill-button:focus {
+      background-color: $blogpostgreen;
+    }
+    .quill-button:focus {
+      outline: dashed 2px $blogpostgreen;
     }
   }
   &.purple {
@@ -58,6 +67,12 @@ $blogpostlightteal: rgba(44, 127, 155, 0.08);
     .quill-button {
       background-color: $blogpostpurple;
     }
+    .quill-button:hover, .quill-button:focus {
+      background-color: $blogpostpurple !important;
+    }
+    .quill-button:focus {
+      outline: dashed 2px $blogpostpurple;
+    }
   }
   &.blue {
     h1, h3 {
@@ -68,6 +83,12 @@ $blogpostlightteal: rgba(44, 127, 155, 0.08);
     }
     .quill-button {
       background-color: $blogpostblue;
+    }
+    .quill-button:hover, .quill-button:focus {
+      background-color: $blogpostblue !important;
+    }
+    .quill-button:focus {
+      outline: dashed 2px $blogpostblue;
     }
   }
   &.gold {
@@ -80,6 +101,12 @@ $blogpostlightteal: rgba(44, 127, 155, 0.08);
     .quill-button {
       background-color: $blogpostgold;
     }
+    .quill-button:hover, .quill-button:focus {
+      background-color: $blogpostgold !important;
+    }
+    .quill-button:focus {
+      outline: dashed 2px $blogpostgold;
+    }
   }
   &.red {
     h1, h3 {
@@ -90,6 +117,12 @@ $blogpostlightteal: rgba(44, 127, 155, 0.08);
     }
     .quill-button {
       background-color: $blogpostred;
+    }
+    .quill-button:hover, .quill-button:focus {
+      background-color: $blogpostred !important;
+    }
+    .quill-button:focus {
+      outline: dashed 2px $blogpostred;
     }
   }
   &.violet {
@@ -102,6 +135,12 @@ $blogpostlightteal: rgba(44, 127, 155, 0.08);
     .quill-button {
       background-color: $blogpostviolet;
     }
+    .quill-button:hover, .quill-button:focus {
+      background-color: $blogpostviolet !important;
+    }
+    .quill-button:focus {
+      outline: dashed 2px $blogpostviolet;
+    }
   }
   &.teal {
     h1, h3 {
@@ -112,6 +151,12 @@ $blogpostlightteal: rgba(44, 127, 155, 0.08);
     }
     .quill-button {
       background-color: $blogpostteal;
+    }
+    .quill-button:hover, .quill-button:focus {
+      background-color: $blogpostteal !important;
+    }
+    .quill-button:focus {
+      outline: dashed 2px $blogpostteal;
     }
   }
 }


### PR DESCRIPTION
## WHAT
fix hover and focus styling for Teacher Center buttons

## WHY
they should match the color scheme of the topic rather than just default to the lighter Quill green

## HOW
add some CSS to increase brightness and default to the same background color for focus/hover as the applied color scheme

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1296" alt="Screen Shot 2023-03-13 at 5 06 33 PM" src="https://user-images.githubusercontent.com/25959584/224820083-22d0e31a-78fa-44a9-8e5b-45da52534151.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Fix-hover-focus-styling-for-Teacher-Center-buttons-378549eaefb4432fa980816f0343e684?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small style change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
