### PR TITLE
fix admin access bugs

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/admin_access.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/admin_access.scss
@@ -85,6 +85,8 @@
   max-width: 577px;
   width: 100%;
   height: min-content;
+  overflow: scroll;
+  max-height: 90vh;
 
   h3 {
     font-weight: 700;

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -248,7 +248,7 @@ class SegmentAnalytics
         teacher_first_name: teacher.first_name,
         teacher_last_name: teacher.last_name,
         teacher_email: teacher.email,
-        teacher_school: teacher.school,
+        teacher_school: teacher.school&.name,
         reason: reason
       }
     })
@@ -261,7 +261,7 @@ class SegmentAnalytics
       admin_email: admin_email,
       teacher_first_name: teacher.first_name,
       teacher_last_name: teacher.last_name,
-      teacher_school: teacher.school,
+      teacher_school: teacher.school&.name,
       note: note
     }
     if admin

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -273,8 +273,8 @@ class SegmentAnalytics
     else
       track({
         # Segment requires us to send a unique User ID or Anonymous ID for every event
-        # generate a random UUID here because this user doesn't yet exist in our system
-        anonymous_id: SecureRandom.uuid,
+        # sending the admin email as the anonymous id because that's how we find people in Ortto
+        anonymous_id: admin_email,
         event: SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
         properties: properties
       })

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/AdminAccess.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/AdminAccess.tsx
@@ -21,7 +21,7 @@ const AdminAccess = ({ school, hasVerifiedEmail, schoolAdmins, hasSchoolPremium,
       if (body.redirect) {
         window.location.href = body.redirect
       } else {
-        window.location.reload
+        window.location.reload()
       }
     })
   }

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -363,7 +363,7 @@ describe 'SegmentAnalytics' do
     end
 
     describe 'when the user invited to become an admin does not already exist in our system' do
-      it 'sends an event with information about the teacher and admin with an anonymous id' do
+      it 'sends an event with information about the teacher and admin with an anonymous id that is the email' do
         admin_name = 'Gregory Orr'
         admin_email = 'gregoryorr@example.com'
         note = 'I really want you to be an admin.'
@@ -375,7 +375,7 @@ describe 'SegmentAnalytics' do
         )
         expect(track_calls.size).to eq(1)
         expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER)
-        expect(track_calls[0][:anonymous_id]).to be
+        expect(track_calls[0][:anonymous_id]).to eq(admin_email)
         expect(track_calls[0][:properties][:admin_name]).to eq(admin_name)
         expect(track_calls[0][:properties][:admin_email]).to eq(admin_email)
         expect(track_calls[0][:properties][:teacher_first_name]).to eq(teacher.first_name)

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -313,7 +313,8 @@ describe 'SegmentAnalytics' do
   end
 
   context '#track_admin_received_admin_upgrade_request_from_teacher' do
-    let(:teacher) { create(:teacher) }
+    let!(:schools_users) { create(:schools_users) }
+    let(:teacher) { schools_users.user.reload }
     let(:admin) { create(:admin) }
 
     it 'sends an event with information about the teacher' do
@@ -329,13 +330,14 @@ describe 'SegmentAnalytics' do
       expect(track_calls[0][:properties][:teacher_first_name]).to eq(teacher.first_name)
       expect(track_calls[0][:properties][:teacher_last_name]).to eq(teacher.last_name)
       expect(track_calls[0][:properties][:teacher_email]).to eq(teacher.email)
-      expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school)
+      expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
       expect(track_calls[0][:properties][:reason]).to eq(reason)
     end
   end
 
   context '#track_admin_invited_by_teacher' do
-    let(:teacher) { create(:teacher) }
+    let!(:schools_users) { create(:schools_users) }
+    let(:teacher) { schools_users.user.reload }
 
     describe 'when the user invited to become an admin already exists in our system' do
       let(:admin) { create(:teacher) }
@@ -355,6 +357,7 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:admin_email]).to eq(admin.email)
         expect(track_calls[0][:properties][:teacher_first_name]).to eq(teacher.first_name)
         expect(track_calls[0][:properties][:teacher_last_name]).to eq(teacher.last_name)
+        expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
         expect(track_calls[0][:properties][:note]).to eq(note)
       end
     end
@@ -377,6 +380,7 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:admin_email]).to eq(admin_email)
         expect(track_calls[0][:properties][:teacher_first_name]).to eq(teacher.first_name)
         expect(track_calls[0][:properties][:teacher_last_name]).to eq(teacher.last_name)
+        expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
         expect(track_calls[0][:properties][:note]).to eq(note)
       end
     end


### PR DESCRIPTION
## WHAT
Fix some bugs we found testing the Segment integration for Admin Access, including:

- school needs to get passed as a school name and not a stringified version of the whole school
- verifying email as a Google or Clever user should reload the page
- request upgrade modal scrolls when there are a ton of users at the school
- trying out passing the user's email as the anon id when they don't exist in our system

## WHY
We want to make sure this whole flow, including the Ortto section, works before we allow users to actually use it.

## HOW
Just tweaks.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES