### PR TITLE
Optimize district_standards_report query

### DIFF
--- a/services/QuillLMS/app/queries/progress_reports/district_standards_reports.rb
+++ b/services/QuillLMS/app/queries/progress_reports/district_standards_reports.rb
@@ -21,7 +21,10 @@ class ProgressReports::DistrictStandardsReports
     <<~SQL
       WITH final_activity_sessions AS (
         SELECT
-          activity_sessions.*,
+          activity_sessions.activity_id,
+          activity_sessions.id,
+          activity_sessions.timespent,
+          activity_sessions.user_id,
           activities.standard_id
         FROM activity_sessions
         JOIN classroom_units


### PR DESCRIPTION
## WHAT
Clean up a query involving DistrictStandardsReports by removing `activity_sessions.*` with actual columns.

## WHY
This query runs out of temp space and it's selecting columns it doesn't need.

## HOW
Add in only the used columns.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
