### PR TITLE
Replace activity_sessions.* with column names

### DIFF
--- a/services/QuillLMS/app/queries/progress_reports/district_standards_reports.rb
+++ b/services/QuillLMS/app/queries/progress_reports/district_standards_reports.rb
@@ -23,6 +23,7 @@ class ProgressReports::DistrictStandardsReports
         SELECT
           activity_sessions.activity_id,
           activity_sessions.id,
+          activity_sessions.percentage,
           activity_sessions.timespent,
           activity_sessions.user_id,
           activities.standard_id
@@ -54,7 +55,8 @@ class ProgressReports::DistrictStandardsReports
         LEFT JOIN (
           SELECT
             standard_id,
-            user_id, AVG(percentage) as avg_score
+            user_id,
+            AVG(percentage) as avg_score
           FROM final_activity_sessions
           GROUP BY
             final_activity_sessions.standard_id,

--- a/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
@@ -13,6 +13,7 @@ class ProgressReports::Standards::AllClassroomsStandard
           SELECT
             activity_sessions.activity_id,
             activity_sessions.id,
+            activity_sessions.percentage,
             activity_sessions.timespent,
             activity_sessions.user_id,
             activities.standard_id

--- a/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
+++ b/services/QuillLMS/app/queries/progress_reports/standards/all_classrooms_standard.rb
@@ -11,7 +11,10 @@ class ProgressReports::Standards::AllClassroomsStandard
       <<-SQL
         WITH final_activity_sessions AS (
           SELECT
-            activity_sessions.*,
+            activity_sessions.activity_id,
+            activity_sessions.id,
+            activity_sessions.timespent,
+            activity_sessions.user_id,
             activities.standard_id
           FROM activity_sessions
           JOIN classroom_units


### PR DESCRIPTION
## WHAT
Clean up a query involving ProgressReports::Standards::AllClassroomsStandard by removing activity_sessions.* with actual columns.

## WHY
This query selects all attributes in activity_sessions when it only needs several.  This wastes temp space.

## HOW
Replace `.*` with the actual columns used.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
