### PR TITLE
Turn back on pre-cache admin dashboard

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/progress-reports-2018.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/progress-reports-2018.scss
@@ -50,6 +50,9 @@
         font-weight: normal;
       }
     }
+    p {
+      margin-bottom: 8px;
+    }
   }
 
   .dropdown-container {

--- a/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
@@ -5,12 +5,12 @@ class FindDistrictConceptReportsWorker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
   def perform(admin_id)
-    # return unless admin_id
+    return unless admin_id
 
-    # serialized_district_concept_reports_cache_life = 60*60*25
-    # serialized_district_concept_reports = ProgressReports::DistrictConceptReports.new(admin_id).results.to_json
-    # $redis.set("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_concept_reports)
-    # $redis.expire("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_concept_reports_cache_life)
-    # PusherDistrictConceptReportsCompleted.run(admin_id)
+    serialized_district_concept_reports_cache_life = 60*60*25
+    serialized_district_concept_reports = ProgressReports::DistrictConceptReports.new(admin_id).results.to_json
+    $redis.set("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_concept_reports)
+    $redis.expire("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_concept_reports_cache_life)
+    PusherDistrictConceptReportsCompleted.run(admin_id)
   end
 end

--- a/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
@@ -2,7 +2,7 @@
 
 class FindDistrictConceptReportsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::CRITICAL, retry: 2
 
   def perform(admin_id)
     return unless admin_id

--- a/services/QuillLMS/app/workers/find_district_standards_reports_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_standards_reports_worker.rb
@@ -5,12 +5,12 @@ class FindDistrictStandardsReportsWorker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
   def perform(admin_id)
-    # return unless admin_id
+    return unless admin_id
 
-    # serialized_district_standards_reports_cache_life = 60*60*25
-    # serialized_district_standards_reports = ProgressReports::DistrictStandardsReports.new(admin_id).results.to_json
-    # $redis.set("#{SchoolsAdmins::DISTRICT_STANDARD_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_standards_reports)
-    # $redis.expire("#{SchoolsAdmins::DISTRICT_STANDARD_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_standards_reports_cache_life)
-    # PusherDistrictStandardsReportsCompleted.run(admin_id)
+    serialized_district_standards_reports_cache_life = 60*60*25
+    serialized_district_standards_reports = ProgressReports::DistrictStandardsReports.new(admin_id).results.to_json
+    $redis.set("#{SchoolsAdmins::DISTRICT_STANDARD_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_standards_reports)
+    $redis.expire("#{SchoolsAdmins::DISTRICT_STANDARD_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_standards_reports_cache_life)
+    PusherDistrictStandardsReportsCompleted.run(admin_id)
   end
 end

--- a/services/QuillLMS/app/workers/find_district_standards_reports_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_standards_reports_worker.rb
@@ -2,7 +2,7 @@
 
 class FindDistrictStandardsReportsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL
+  sidekiq_options queue: SidekiqQueue::CRITICAL, retry: 2
 
   def perform(admin_id)
     return unless admin_id

--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -13,6 +13,9 @@ class PreCacheAdminDashboardsWorker
 
     active_admin_ids.each do |id|
       FindAdminUsersWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
+      FindDistrictActivityScoresWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
+      FindDistrictStandardsReportsWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
+      FindDistrictConceptReportsWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
     end
   end
 end

--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -13,9 +13,9 @@ class PreCacheAdminDashboardsWorker
 
     active_admin_ids.each do |id|
       FindAdminUsersWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
-      FindDistrictActivityScoresWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
-      FindDistrictStandardsReportsWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
-      FindDistrictConceptReportsWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
+      FindDistrictActivityScoresWorker.set(queue: SidekiqQueue::LOW, retry: 0).perform_async(id)
+      FindDistrictStandardsReportsWorker.set(queue: SidekiqQueue::LOW, retry: 0).perform_async(id)
+      FindDistrictConceptReportsWorker.set(queue: SidekiqQueue::LOW, retry: 0).perform_async(id)
     end
   end
 end

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/__tests__/__snapshots__/standardsReports.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/__tests__/__snapshots__/standardsReports.test.tsx.snap
@@ -16,6 +16,11 @@ exports[`StandardsReports component should match snapshot 1`] = `
       <p>
         Each activity on Quill is aligned to a Common Core standard. This report shows the school’s overall progress on each of the standards. You can print this report by downloading a PDF file or export this data by downloading a CSV file. The data you see below is capturing historical activity data for your school.
       </p>
+      <p>
+        <b>
+          These reports are updated nightly.
+        </b>
+      </p>
     </div>
     <div
       className="csv-and-how-we-grade"

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/activity_scores.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/activity_scores.tsx
@@ -46,6 +46,7 @@ const ActivityScores: React.SFC<ActivityScoresProps> = ({
           <p>
             Each activity takes about 10-20 minutes to complete, and students receive a score out of 100 points based on their performance. Click on a student’s name to see a report and print it as a PDF. You can print this report by downloading a PDF file or export this data by downloading a CSV file.
           </p>
+          <p><b>These reports are updated nightly.</b></p>
         </div>
         <div className="csv-and-how-we-grade">
           <CSVDownloadForProgressReport data={csvData} />

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/concept_reports.jsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/concept_reports.jsx
@@ -25,6 +25,7 @@ const ConceptReports = ({
         <p>
             Each question on Quill targets a specific writing concept. This report shows the number of times the student correctly or incorrectly used the targeted concept to answer the question. You can print this report by downloading a PDF file or export this data by downloading a CSV file.
         </p>
+        <p><b>These reports are updated nightly.</b></p>
       </div>
       <div className="csv-and-how-we-grade">
         <CSVDownloadForProgressReport data={csvData} />

--- a/services/QuillLMS/client/app/bundles/admin_dashboard/components/standardsReports.tsx
+++ b/services/QuillLMS/client/app/bundles/admin_dashboard/components/standardsReports.tsx
@@ -15,6 +15,7 @@ export const StandardsReports = ({
         <p>
             Each activity on Quill is aligned to a Common Core standard. This report shows the school’s overall progress on each of the standards. You can print this report by downloading a PDF file or export this data by downloading a CSV file. The data you see below is capturing historical activity data for your school.
         </p>
+        <p><b>These reports are updated nightly.</b></p>
       </div>
       <div className="csv-and-how-we-grade">
         <CSVDownloadForProgressReport data={csvData} />

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -19,9 +19,9 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
     create(:schools_admins, user: current_admin2)
 
     allow(FindAdminUsersWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_users_worker)
-    allow(FindDistrictActivityScoresWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_activity_worker)
-    allow(FindDistrictStandardsReportsWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_standards_worker)
-    allow(FindDistrictConceptReportsWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_concept_worker)
+    allow(FindDistrictActivityScoresWorker).to receive(:set).with(queue: SidekiqQueue::LOW, retry: 0).and_return(mock_activity_worker)
+    allow(FindDistrictStandardsReportsWorker).to receive(:set).with(queue: SidekiqQueue::LOW, retry: 0).and_return(mock_standards_worker)
+    allow(FindDistrictConceptReportsWorker).to receive(:set).with(queue: SidekiqQueue::LOW, retry: 0).and_return(mock_concept_worker)
   end
 
   it 'enqueues FindAdminUsersWorker for all active admins' do
@@ -62,8 +62,8 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
     let!(:new_admin_old_user) { create(:schools_admins, user: current_admin1) }
 
     it "should not queue duplicates" do
-      expect(mock_worker).to receive(:perform_async).with(current_admin1.id).once
-      expect(mock_worker).to receive(:perform_async).with(current_admin2.id).once
+      expect(mock_users_worker).to receive(:perform_async).with(current_admin1.id).once
+      expect(mock_users_worker).to receive(:perform_async).with(current_admin2.id).once
       worker.perform
     end
   end

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -8,29 +8,53 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
   let!(:current_admin1) { create(:user, last_sign_in: Time.current) }
   let!(:current_admin2) { create(:user, last_sign_in: Time.current) }
   let!(:not_admin) { create(:user, last_sign_in: Time.current) }
-  let(:mock_worker) {double(:perform_async)}
+  let(:mock_users_worker) {double(:mock_users_worker, perform_async: nil)}
+  let(:mock_activity_worker) {double(:mock_activity_worker, perform_async: nil)}
+  let(:mock_standards_worker) {double(:mock_standards_worker, perform_async: nil)}
+  let(:mock_concept_worker) {double(:mock_concept_worker, perform_async: nil)}
 
   before do
     create(:schools_admins, user: old_admin)
     create(:schools_admins, user: current_admin1)
     create(:schools_admins, user: current_admin2)
 
-    allow(FindAdminUsersWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_worker)
+    allow(FindAdminUsersWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_users_worker)
+    allow(FindDistrictActivityScoresWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_activity_worker)
+    allow(FindDistrictStandardsReportsWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_standards_worker)
+    allow(FindDistrictConceptReportsWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_concept_worker)
   end
 
   it 'enqueues FindAdminUsersWorker for all active admins' do
-    expect(mock_worker).to receive(:perform_async).with(current_admin1.id).once
-    expect(mock_worker).to receive(:perform_async).with(current_admin2.id).once
+    expect(mock_users_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_users_worker).to receive(:perform_async).with(current_admin2.id).once
+    worker.perform
+  end
+
+  it 'enqueues FindDistrictActivityScoresWorker for admins' do
+    expect(mock_activity_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_activity_worker).to receive(:perform_async).with(current_admin2.id).once
+    worker.perform
+  end
+
+  it 'enqueues FindDistrictStandardsReportWorker for admins' do
+    expect(mock_standards_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_standards_worker).to receive(:perform_async).with(current_admin2.id).once
+    worker.perform
+  end
+
+  it 'enqueues FindDistrictConceptReportsWorker for admins' do
+    expect(mock_concept_worker).to receive(:perform_async).with(current_admin1.id).once
+    expect(mock_concept_worker).to receive(:perform_async).with(current_admin2.id).once
     worker.perform
   end
 
   it 'does not enqueue FindAdminUsersWorker for non-admins' do
-    expect(mock_worker).not_to receive(:perform_async).with(not_admin.id)
+    expect(mock_users_worker).not_to receive(:perform_async).with(not_admin.id)
     worker.perform
   end
 
   it 'does not enqueue FindAdminUsersWorker for non-active admins' do
-    expect(mock_worker).not_to receive(:perform_async).with(old_admin.id)
+    expect(mock_users_worker).not_to receive(:perform_async).with(old_admin.id)
     worker.perform
   end
 


### PR DESCRIPTION
## WHAT
Turn back on pre-cache admin dashboard jobs.

## WHY
There were some slow queries that needed to be cleaned up before running this over all admins.

## HOW
I've added in a couple settings for these jobs
1)  queue: LOW so that these jobs are lowest priority 
2) retry: 0 so that they won't be re-run upon failure clogging up the retry queue

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
