### PR TITLE
Small tweaks to Quill Staff New Subscription/Edit Subscription page 

### DIFF
--- a/services/QuillLMS/app/models/bonus_days_calculator.rb
+++ b/services/QuillLMS/app/models/bonus_days_calculator.rb
@@ -18,9 +18,11 @@ class BonusDaysCalculator < ApplicationService
   end
 
   private def plan_ends
-    start.month < Subscription::SUMMER_CUTOFF_MONTH ?
-      start.change(month: Subscription::SUMMER_EXPIRATION_MONTH, day: Subscription::SUMMER_EXPIRATION_DAY) :
+    if start.month < Subscription::SUMMER_CUTOFF_MONTH
+      start.change(month: Subscription::SUMMER_EXPIRATION_MONTH, day: Subscription::SUMMER_EXPIRATION_DAY)
+    else
       start.change(month: Subscription::WINTER_EXPIRATION_MONTH, day: Subscription::WINTER_EXPIRATION_DAY)
+    end
   end
 end
 

--- a/services/QuillLMS/app/models/bonus_days_calculator.rb
+++ b/services/QuillLMS/app/models/bonus_days_calculator.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class BonusDaysCalculator < ApplicationService
-  JUNE = 6
-  JULY = 7
-  DECEMBER = 12
 
   attr_reader :user, :start
 
@@ -21,7 +18,9 @@ class BonusDaysCalculator < ApplicationService
   end
 
   private def plan_ends
-    start.month < JULY ? start.change(month: JUNE, day: 30) : start.change(month: DECEMBER, day: 31)
+    start.month < Subscription::SUMMER_CUTOFF_MONTH ?
+      start.change(month: Subscription::SUMMER_EXPIRATION_MONTH, day: Subscription::SUMMER_EXPIRATION_DAY) :
+      start.change(month: Subscription::WINTER_EXPIRATION_MONTH, day: Subscription::WINTER_EXPIRATION_DAY)
   end
 end
 

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -50,6 +50,10 @@ class Subscription < ApplicationRecord
   after_commit :check_if_purchaser_email_is_in_database
   after_initialize :set_null_start_date_to_today
 
+  DEFAULT_SUMMER_CUTOFF_MONTH = 7
+  DEFAULT_SUMMER_END_DATE = "31-7"
+  DEFAULT_WINTER_END_DATE = "31-12"
+
   CB_LIFETIME_DURATION = 365 * 50 # In days, this is approximately 50 years
 
   CB_LIFETIME_SUBSCRIPTION_TYPE = 'College Board Educator Lifetime Premium'
@@ -249,7 +253,7 @@ class Subscription < ApplicationRecord
 
   def self.promotional_dates
     today = Date.current
-    exp_month_and_day = today.month < 7 ? "31-7" : "31-12"
+    exp_month_and_day = today.month < DEFAULT_SUMMER_CUTOFF_MONTH ? DEFAULT_SUMMER_END_DATE : DEFAULT_WINTER_END_DATE
 
     { start_date: today, expiration: Date::strptime("#{exp_month_and_day}-#{today.year + 1}","%d-%m-%Y") }
   end

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -249,7 +249,7 @@ class Subscription < ApplicationRecord
 
   def self.promotional_dates
     today = Date.current
-    exp_month_and_day = today.month < 7 ? "30-6" : "31-12"
+    exp_month_and_day = today.month < 7 ? "31-7" : "31-12"
 
     { start_date: today, expiration: Date::strptime("#{exp_month_and_day}-#{today.year + 1}","%d-%m-%Y") }
   end

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -50,9 +50,12 @@ class Subscription < ApplicationRecord
   after_commit :check_if_purchaser_email_is_in_database
   after_initialize :set_null_start_date_to_today
 
-  DEFAULT_SUMMER_CUTOFF_MONTH = 7
-  DEFAULT_SUMMER_END_DATE = "31-7"
-  DEFAULT_WINTER_END_DATE = "31-12"
+  SUMMER_CUTOFF_MONTH = 7
+
+  SUMMER_EXPIRATION_MONTH = 7
+  SUMMER_EXPIRATION_DAY = 31
+  WINTER_EXPIRATION_MONTH = 12
+  WINTER_EXPIRATION_DAY = 31
 
   CB_LIFETIME_DURATION = 365 * 50 # In days, this is approximately 50 years
 
@@ -253,7 +256,9 @@ class Subscription < ApplicationRecord
 
   def self.promotional_dates
     today = Date.current
-    exp_month_and_day = today.month < DEFAULT_SUMMER_CUTOFF_MONTH ? DEFAULT_SUMMER_END_DATE : DEFAULT_WINTER_END_DATE
+    exp_month_and_day = today.month < SUMMER_CUTOFF_MONTH ?
+      "#{SUMMER_EXPIRATION_DAY}-#{SUMMER_EXPIRATION_MONTH}" :
+      "#{WINTER_EXPIRATION_DAY}-#{WINTER_EXPIRATION_MONTH}"
 
     { start_date: today, expiration: Date::strptime("#{exp_month_and_day}-#{today.year + 1}","%d-%m-%Y") }
   end

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -256,9 +256,11 @@ class Subscription < ApplicationRecord
 
   def self.promotional_dates
     today = Date.current
-    exp_month_and_day = today.month < SUMMER_CUTOFF_MONTH ?
-      "#{SUMMER_EXPIRATION_DAY}-#{SUMMER_EXPIRATION_MONTH}" :
-      "#{WINTER_EXPIRATION_DAY}-#{WINTER_EXPIRATION_MONTH}"
+    if today.month < SUMMER_CUTOFF_MONTH
+      exp_month_and_day = "#{SUMMER_EXPIRATION_DAY}-#{SUMMER_EXPIRATION_MONTH}"
+    else
+      exp_month_and_day = "#{WINTER_EXPIRATION_DAY}-#{WINTER_EXPIRATION_MONTH}"
+    end
 
     { start_date: today, expiration: Date::strptime("#{exp_month_and_day}-#{today.year + 1}","%d-%m-%Y") }
   end

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
@@ -354,6 +354,8 @@ export default class EditOrCreateSubscription extends React.Component {
           focused={firstFocused}
           id="date-picker"
           inputIconPosition="after"
+          isOutsideRange={() => false}
+          minDate={null}
           navNext="›"
           navPrev="‹"
           numberOfMonths={1}

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -143,8 +143,8 @@ describe Subscription, type: :model do
         allow(Date).to receive(:current).and_return Date.new(2018,4,4)
       end
 
-      it "returns an expiration date of June 30 the next year when called on a day prior to July" do
-        expect(Subscription.promotional_dates[:expiration]).to eq(Date.new(2019,6,30))
+      it "returns an expiration date of July 31 the next year when called on a day prior to July" do
+        expect(Subscription.promotional_dates[:expiration]).to eq(Date.new(2019,7,31))
       end
 
       it "returns a start date one year from the day it was called" do

--- a/services/QuillLMS/spec/services/bonus_days_calculator_spec.rb
+++ b/services/QuillLMS/spec/services/bonus_days_calculator_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe BonusDaysCalculator do
     let(:args) { [user, start: start] }
 
     context 'day is before JULY' do
-      let(:start) { Date.current.change(month: described_class::JUNE, day: 1) }
+      let(:start) { Date.current.change(month: 6, day: 1) }
 
-      it { expect(subject).to eq 29 }
+      it { expect(subject).to eq 60 }
     end
 
     context 'day is after JULY' do
-      let(:start) { Date.current.change(month: described_class::DECEMBER, day: 1) }
+      let(:start) { Date.current.change(month: 12, day: 1) }
 
       it { expect(subject).to eq 30 }
     end


### PR DESCRIPTION
## WHAT
1. Allow Quill staff to set a subscription start date in the past
2. Change default expiration date to 7/31 instead of 6/30

## WHY
These features will make subscription management easier for our staff.

## HOW
Pass some props to the date picker component to make it allow users to select past dates.
Change the hard-coded default date in our Subscription model.

### Screenshots
<img width="640" alt="Screen Shot 2023-03-15 at 6 59 17 PM" src="https://user-images.githubusercontent.com/57366100/225290480-8bd3db11-6ae8-4af8-84ac-a7faad33989c.png">

### Notion Card Links
https://www.notion.so/quill/Change-the-subscription-period-default-settings-in-school-district-manager-CMS-1d8c9a6533a144b29fdbbd76402797d6?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying after other front-end reviews are done
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes