### PR TITLE
add context to segment workers; update snackbar text

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -250,6 +250,12 @@ class SegmentAnalytics
         teacher_email: teacher.email,
         teacher_school: teacher.school&.name,
         reason: reason
+      },
+      context: {
+        traits: {
+          name: admin.name,
+          email: admin.email
+        }
       }
     })
   end
@@ -264,11 +270,18 @@ class SegmentAnalytics
       teacher_school: teacher.school&.name,
       note: note
     }
+    context = {
+      traits: {
+        name: admin_name,
+        email: admin_email
+      }
+    }
     if admin
       track({
         user_id: admin.id,
         event: SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
-        properties: properties
+        properties: properties,
+        context: context
       })
     else
       track({
@@ -276,7 +289,8 @@ class SegmentAnalytics
         # sending the admin email as the anonymous id because that's how we find people in Ortto
         anonymous_id: admin_email,
         event: SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
-        properties: properties
+        properties: properties,
+        context: context
       })
     end
   end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/admin_access/inviteAdminModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/admin_access/inviteAdminModal.tsx
@@ -21,7 +21,7 @@ const InviteAdminModal = ({ onSuccess, closeModal, }) => {
       admin_email: adminEmail,
       note
     }, () => {
-      onSuccess('Your request has been sent')
+      onSuccess('Your invite has been sent')
     })
   }
 

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -332,6 +332,8 @@ describe 'SegmentAnalytics' do
       expect(track_calls[0][:properties][:teacher_email]).to eq(teacher.email)
       expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
       expect(track_calls[0][:properties][:reason]).to eq(reason)
+      expect(track_calls[0][:context][:traits][:email]).to eq(admin.email)
+      expect(track_calls[0][:context][:traits][:name]).to eq(admin.name)
     end
   end
 
@@ -359,6 +361,8 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:teacher_last_name]).to eq(teacher.last_name)
         expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
         expect(track_calls[0][:properties][:note]).to eq(note)
+        expect(track_calls[0][:context][:traits][:email]).to eq(admin.email)
+        expect(track_calls[0][:context][:traits][:name]).to eq(admin.name)
       end
     end
 
@@ -382,6 +386,8 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:teacher_last_name]).to eq(teacher.last_name)
         expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
         expect(track_calls[0][:properties][:note]).to eq(note)
+        expect(track_calls[0][:context][:traits][:email]).to eq(admin_email)
+        expect(track_calls[0][:context][:traits][:name]).to eq(admin_name)
       end
     end
   end


### PR DESCRIPTION
## WHAT
Add [context](https://segment.com/docs/connections/spec/common/#context) attribute with traits to Segment events that rely on the admin user already being present in Ortto in order to send the emails we need to send. Also, a copy change.

## WHY
We were having an issue where users weren't being created in Ortto for the users who didn't exist in our system (ie had an anonymous id). After talking to Ortto, they indicated that this is what we need to do to solve the issue. We also decided to add the `context` for when admins receive upgrade requests from teachers, since it's possible that even existing admin accounts have never actually been active on Quill and therefore do not have an Ortto counterpart.

## HOW
Just update the payloads for the events and test.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES