### PR TITLE
remove restriction for admin_access page and tests

### DIFF
--- a/services/QuillLMS/app/helpers/navigation_helper.rb
+++ b/services/QuillLMS/app/helpers/navigation_helper.rb
@@ -75,7 +75,7 @@ module NavigationHelper
   end
 
   def should_show_admin_access_tab?
-    !!(request.original_url&.include?('admin_access') && current_user.teacher? && !current_user.admin? && current_user.school && School::ALTERNATIVE_SCHOOL_NAMES.exclude?(current_user.school.name))
+    !!(current_user.teacher? && !current_user.admin? && current_user.school && School::ALTERNATIVE_SCHOOL_NAMES.exclude?(current_user.school.name))
   end
 
   # this is a duplicate of the QuillAuthentication method, used here because we can't import it directly

--- a/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
@@ -113,55 +113,43 @@ describe NavigationHelper do
   end
 
   describe '#should_show_admin_access_tab?' do
-    it 'should return false if the url does not contain admin_access' do
-      allow_any_instance_of(ActionController::TestRequest).to receive(:original_url) { 'localhost:5000' }
+    it 'should return false if current_user.teacher? is falsy' do
+      student = create(:student)
+      allow(helper).to receive(:current_user) { student }
+
       expect(helper.should_show_admin_access_tab?).to eq false
     end
 
-    context 'the url contains admin_access' do
-      before do
-        allow_any_instance_of(ActionController::TestRequest).to receive(:original_url) { 'localhost:5000/admin_access' }
-      end
+    it 'should return false if current_user.admin? is truthy' do
+      admin = create(:admin)
+      allow(helper).to receive(:current_user) { admin }
 
-      it 'should return false if current_user.teacher? is falsy' do
-        student = create(:student)
-        allow(helper).to receive(:current_user) { student }
+      expect(helper.should_show_admin_access_tab?).to eq false
+    end
 
-        expect(helper.should_show_admin_access_tab?).to eq false
-      end
+    it 'should return false if current_user.school is falsy' do
+      teacher = create(:teacher)
+      allow(helper).to receive(:current_user) { teacher }
 
-      it 'should return false if current_user.admin? is truthy' do
-        admin = create(:admin)
-        allow(helper).to receive(:current_user) { admin }
+      expect(helper.should_show_admin_access_tab?).to eq false
+    end
 
-        expect(helper.should_show_admin_access_tab?).to eq false
-      end
+    it 'should return false if the current user has a school that is one of the alternative schools' do
+      teacher = create(:teacher)
+      school = create(:school, name: School::ALTERNATIVE_SCHOOL_NAMES.sample)
+      create(:schools_users, user: teacher, school: school)
+      allow(helper).to receive(:current_user) { teacher.reload }
 
-      it 'should return false if current_user.school is falsy' do
-        teacher = create(:teacher)
-        allow(helper).to receive(:current_user) { teacher }
+      expect(helper.should_show_admin_access_tab?).to eq false
+    end
 
-        expect(helper.should_show_admin_access_tab?).to eq false
-      end
+    it 'should return true if none of the above conditions are met' do
+      teacher = create(:teacher)
+      school = create(:school)
+      create(:schools_users, user: teacher, school: school)
+      allow(helper).to receive(:current_user) { teacher.reload }
 
-      it 'should return false if the current user has a school that is one of the alternative schools' do
-        teacher = create(:teacher)
-        school = create(:school, name: School::ALTERNATIVE_SCHOOL_NAMES.sample)
-        create(:schools_users, user: teacher, school: school)
-        allow(helper).to receive(:current_user) { teacher.reload }
-
-        expect(helper.should_show_admin_access_tab?).to eq false
-      end
-
-      it 'should return true if none of the above conditions are met' do
-        teacher = create(:teacher)
-        school = create(:school)
-        create(:schools_users, user: teacher, school: school)
-        allow(helper).to receive(:current_user) { teacher.reload }
-
-        expect(helper.should_show_admin_access_tab?).to eq true
-      end
-
+      expect(helper.should_show_admin_access_tab?).to eq true
     end
   end
 end


### PR DESCRIPTION
## WHAT
Remove the requirement that the user be on a page that includes `admin_access` in the url to view the "Admin Access" tab.

## WHY
This was added so that staff members could test the new admin access functionality in production, via `quill.org/teachers/classrooms/dashboard?show_admin_access=true`, but other users wouldn't see it. We want to release this to all users Thursday morning, so we want to deploy this PR then.

## HOW
Just remove the code that performed the restriction based on the URL, and update tests.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Allow-all-eligible-users-to-see-the-Admin-Access-page-d372e2f175094e35a21503d86ffec1a5?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
