### PR TITLE
add verification reason and url to segment

### DIFF
--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -37,6 +37,8 @@ module SegmentIntegration
         admin_sub_role: admin_sub_role,
         email_verification_status: email_verification_status,
         admin_approval_status: admin_approval_status,
+        admin_reason: admin_verification_reason,
+        admin_linkedin_or_url: admin_verification_url,
         number_of_schools_administered: schools_admins.any? ? schools_admins.count : nil,
         number_of_districts_administered: district_admins.any? ? district_admins.count : nil
       }.reject {|_,v| v.nil? }

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -758,6 +758,14 @@ class User < ApplicationRecord
     units.where('name ILIKE ?', name)
   end
 
+  def admin_verification_reason
+    admin_info&.verification_reason
+  end
+
+  def admin_verification_url
+    admin_info&.verification_url
+  end
+
   def admin_sub_role
     admin_info&.sub_role
   end

--- a/services/QuillLMS/spec/models/segment_integration/user_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/user_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SegmentIntegration::User do
   context 'admin' do
     let(:admin) { create(:admin) }
-    let(:admin_info) { create(:admin_info, admin: admin) }
+    let(:admin_info) { create(:admin_info, admin: admin, verification_url: 'quill.org', verification_reason: 'I am an admin.') }
     let(:user_email_verification ) { create(:user_email_verification, user: admin, verified_at: Time.zone.today, verification_method: UserEmailVerification::EMAIL_VERIFICATION) }
     let(:schools) { create_list(:school, 3) }
     let(:districts) { create_list(:district, 3) }
@@ -46,6 +46,8 @@ RSpec.describe SegmentIntegration::User do
           admin_sub_role: admin.admin_sub_role,
           email_verification_status: admin.email_verification_status,
           admin_approval_status: admin.admin_approval_status,
+          admin_reason: admin.admin_verification_reason,
+          admin_linkedin_or_url: admin.admin_verification_url,
           number_of_schools_administered: schools.count,
           number_of_districts_administered: districts.count
         }.reject {|_,v| v.nil? }

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1555,6 +1555,42 @@ describe User, type: :model do
     end
   end
 
+  describe '#admin_verification_url' do
+    let(:user) { create(:user) }
+
+    context 'user has admin info' do
+      let!(:admin_info) { create(:admin_info, user: user, verification_url: 'quill.org')}
+
+      it 'returns the approval status from the admin info' do
+        expect(user.admin_verification_url).to eq(admin_info.verification_url)
+      end
+    end
+
+    context 'user has no admin info' do
+      it 'returns nil' do
+        expect(user.admin_verification_url).to eq(nil)
+      end
+    end
+  end
+
+  describe '#admin_verification_reason' do
+    let(:user) { create(:user) }
+
+    context 'user has admin info' do
+      let!(:admin_info) { create(:admin_info, user: user, verification_reason: 'I really want to be an admin.')}
+
+      it 'returns the approval status from the admin info' do
+        expect(user.admin_verification_reason).to eq(admin_info.verification_reason)
+      end
+    end
+
+    context 'user has no admin info' do
+      it 'returns nil' do
+        expect(user.admin_verification_reason).to eq(nil)
+      end
+    end
+  end
+
   describe '#admin_sub_role=' do
     let(:user) { create(:user) }
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1561,7 +1561,7 @@ describe User, type: :model do
     context 'user has admin info' do
       let!(:admin_info) { create(:admin_info, user: user, verification_url: 'quill.org')}
 
-      it 'returns the approval status from the admin info' do
+      it 'returns the verification url from the admin info' do
         expect(user.admin_verification_url).to eq(admin_info.verification_url)
       end
     end
@@ -1579,7 +1579,7 @@ describe User, type: :model do
     context 'user has admin info' do
       let!(:admin_info) { create(:admin_info, user: user, verification_reason: 'I really want to be an admin.')}
 
-      it 'returns the approval status from the admin info' do
+      it 'returns the verification reason from the admin info' do
         expect(user.admin_verification_reason).to eq(admin_info.verification_reason)
       end
     end


### PR DESCRIPTION
## WHAT
Add verification reason and url to Segment info.

## WHY
This was requested by the partnerships team.

## HOW
Add methods to get this data directly from the user model, and then do so in the Segment serializer. Note that we do not need to add a counterpart in Vitally, because Segment traits end up in Vitally anyway and sending them from both causes confusion (see discussion in this card: https://www.notion.so/quill/Some-new-admin-properties-are-not-syncing-to-Vitally-4c45782bf3c346f8b4a4e2a4e948ac6d?pvs=4).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-Admin-reason-and-Admin-LinkedIn-or-URL-to-the-Segment-Identify-call-and-Vitally-sync-for-adm-c792a4beae2b4ebba72e0035b231e124?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
