### PR TITLE
require email veriification for contact button

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/admin_access.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/admin_access.scss
@@ -57,6 +57,12 @@
       color: #009A80;
       text-decoration: none;
     }
+    .disabled-link {
+      color: #878787;
+    }
+    .quill-tooltip {
+      font-weight: 400;
+    }
   }
   .email-verification-paragraph {
     margin-top: 40px;

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/AdminAccess.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/AdminAccess.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import AdminRequestModal from '../components/admin_access/adminRequestModal'
 import InviteAdminModal from '../components/admin_access/inviteAdminModal'
 import { requestPost, } from '../../../modules/request'
-import { Snackbar, defaultSnackbarTimeout, Input, } from '../../Shared/index'
+import { Snackbar, defaultSnackbarTimeout, Tooltip, } from '../../Shared/index'
 import useSnackbarMonitor from '../../Shared/hooks/useSnackbarMonitor'
 
 const ADMIN_REQUEST_MODAL = 'adminRequestModal'
@@ -70,9 +70,21 @@ const AdminAccess = ({ school, hasVerifiedEmail, schoolAdmins, hasSchoolPremium,
     const adminTable = (
       <div className="admin-table">
         <h2>{school.name} admins</h2>
-        {schoolAdmins.map(sa => (
-          <p key={sa.id}><span>{sa.name}</span><a href={`mailto:${sa.email}`} rel="noopener noreferrer" target="_blank">Contact</a></p>
-        ))}
+        {schoolAdmins.map(sa => {
+          let link = <a href={`mailto:${sa.email}`} rel="noopener noreferrer" target="_blank">Contact</a>
+          if (!hasVerifiedEmail) {
+            link = (
+              <Tooltip
+                tooltipText="This action is disabled until your email is verified."
+                tooltipTriggerText="Contact"
+                tooltipTriggerTextClass="disabled-link"
+              />
+            )
+          }
+          return (
+            <p key={sa.id}><span>{sa.name}</span>{link}</p>
+          )
+        })}
       </div>
     )
     content = (

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/AdminAccess.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/AdminAccess.test.jsx.snap
@@ -162,13 +162,40 @@ exports[`AdminAccounts container when the user does not have a verified email an
           <span>
             Toni Morrison
           </span>
-          <a
-            href="mailto:toni.morrison@quill.org"
-            rel="noopener noreferrer"
-            target="_blank"
+          <Tooltip
+            isTabbable={true}
+            tooltipText="This action is disabled until your email is verified."
+            tooltipTriggerText="Contact"
+            tooltipTriggerTextClass="disabled-link"
           >
-            Contact
-          </a>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+            >
+              <span
+                className="disabled-link"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                Contact
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </p>
         <p
           key="2"
@@ -176,13 +203,40 @@ exports[`AdminAccounts container when the user does not have a verified email an
           <span>
             James Baldwin
           </span>
-          <a
-            href="mailto:james.baldwin@quill.org"
-            rel="noopener noreferrer"
-            target="_blank"
+          <Tooltip
+            isTabbable={true}
+            tooltipText="This action is disabled until your email is verified."
+            tooltipTriggerText="Contact"
+            tooltipTriggerTextClass="disabled-link"
           >
-            Contact
-          </a>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+            >
+              <span
+                className="disabled-link"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                Contact
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </p>
       </div>
       <div
@@ -377,13 +431,40 @@ exports[`AdminAccounts container when the user does not have a verified email an
           <span>
             Toni Morrison
           </span>
-          <a
-            href="mailto:toni.morrison@quill.org"
-            rel="noopener noreferrer"
-            target="_blank"
+          <Tooltip
+            isTabbable={true}
+            tooltipText="This action is disabled until your email is verified."
+            tooltipTriggerText="Contact"
+            tooltipTriggerTextClass="disabled-link"
           >
-            Contact
-          </a>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+            >
+              <span
+                className="disabled-link"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                Contact
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </p>
         <p
           key="2"
@@ -391,13 +472,40 @@ exports[`AdminAccounts container when the user does not have a verified email an
           <span>
             James Baldwin
           </span>
-          <a
-            href="mailto:james.baldwin@quill.org"
-            rel="noopener noreferrer"
-            target="_blank"
+          <Tooltip
+            isTabbable={true}
+            tooltipText="This action is disabled until your email is verified."
+            tooltipTriggerText="Contact"
+            tooltipTriggerTextClass="disabled-link"
           >
-            Contact
-          </a>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+            >
+              <span
+                className="disabled-link"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                Contact
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </p>
       </div>
       <div


### PR DESCRIPTION
## WHAT
Require users to verify their emails before they can use the Contact button to contact admins at their school.

## WHY
To avoid the possibility of users joining a school and spamming the admins.

## HOW
Just swap out the element for a tooltip and style.

### Screenshots
<img width="680" alt="Screen Shot 2023-03-15 at 11 33 30 AM" src="https://user-images.githubusercontent.com/18669014/225364780-2e11e7f4-314b-4f0e-af02-75f38955518d.png">

### Notion Card Links
https://www.notion.so/quill/Require-a-user-to-verify-their-email-before-they-can-use-admin-Contact-links-under-admin-access-ec683a5db2c5436fb1b4d413843c7572?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES