### PR TITLE
use identify instead of context for admin events

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -279,8 +279,7 @@ class SegmentAnalytics
         # sending the admin email as the anonymous id because that's how we find people in Ortto
         anonymous_id: admin_email,
         event: SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
-        properties: properties,
-        context: context
+        properties: properties
       })
     end
   end

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -273,7 +273,7 @@ class SegmentAnalytics
         properties: properties,
       })
     else
-      identify_anonymous_user({ traits: { email: admin_email, name: admin_name }})
+      identify_anonymous_user({ anonymous_id: admin_email, traits: { email: admin_email, name: admin_name }})
       track({
         # Segment requires us to send a unique User ID or Anonymous ID for every event
         # sending the admin email as the anonymous id because that's how we find people in Ortto

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -332,8 +332,10 @@ describe 'SegmentAnalytics' do
       expect(track_calls[0][:properties][:teacher_email]).to eq(teacher.email)
       expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
       expect(track_calls[0][:properties][:reason]).to eq(reason)
-      expect(track_calls[0][:context][:traits][:email]).to eq(admin.email)
-      expect(track_calls[0][:context][:traits][:name]).to eq(admin.name)
+
+      expect(identify_calls.size).to eq(1)
+      expect(identify_calls[0][:traits][:email]).to eq(admin.email)
+      expect(identify_calls[0][:traits][:name]).to eq(admin.name)
     end
   end
 
@@ -361,8 +363,10 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:teacher_last_name]).to eq(teacher.last_name)
         expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
         expect(track_calls[0][:properties][:note]).to eq(note)
-        expect(track_calls[0][:context][:traits][:email]).to eq(admin.email)
-        expect(track_calls[0][:context][:traits][:name]).to eq(admin.name)
+
+        expect(identify_calls.size).to eq(1)
+        expect(identify_calls[0][:traits][:email]).to eq(admin.email)
+        expect(identify_calls[0][:traits][:name]).to eq(admin.name)
       end
     end
 
@@ -386,8 +390,8 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:teacher_last_name]).to eq(teacher.last_name)
         expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
         expect(track_calls[0][:properties][:note]).to eq(note)
-        expect(track_calls[0][:context][:traits][:email]).to eq(admin_email)
-        expect(track_calls[0][:context][:traits][:name]).to eq(admin_name)
+        expect(identify_calls[0][:traits][:email]).to eq(admin_email)
+        expect(identify_calls[0][:traits][:name]).to eq(admin_name)
       end
     end
   end

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -388,6 +388,7 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:note]).to eq(note)
         expect(identify_calls[0][:traits][:email]).to eq(admin_email)
         expect(identify_calls[0][:traits][:name]).to eq(admin_name)
+        expect(identify_calls[0][:traits][:anonymous_id]).to eq(admin_email)
       end
     end
   end

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -334,8 +334,6 @@ describe 'SegmentAnalytics' do
       expect(track_calls[0][:properties][:reason]).to eq(reason)
 
       expect(identify_calls.size).to eq(1)
-      expect(identify_calls[0][:traits][:email]).to eq(admin.email)
-      expect(identify_calls[0][:traits][:name]).to eq(admin.name)
     end
   end
 
@@ -365,8 +363,6 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:note]).to eq(note)
 
         expect(identify_calls.size).to eq(1)
-        expect(identify_calls[0][:traits][:email]).to eq(admin.email)
-        expect(identify_calls[0][:traits][:name]).to eq(admin.name)
       end
     end
 


### PR DESCRIPTION
## WHAT
The other implementation wasn't successfully firing the events on the newly created users - maybe due to the order in which they're created. Hopefully, explicitly calling `identify` first will do the trick.

## WHY
We need these users to get the admin emails.

## HOW
Add a new method to call `identify` for anonymous users, and explicitly call it where necessary.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Trigger-a-Segment-Identify-call-for-admin-related-Segment-events-c079566f74184c84a2c69b0627e07c74?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
