### PR TITLE
use identify instead of context for admin events (#10395)

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -241,6 +241,7 @@ class SegmentAnalytics
   end
 
   def track_admin_received_admin_upgrade_request_from_teacher(admin, teacher, reason)
+    identify(admin)
     track({
       user_id: admin.id,
       event: SegmentIo::BackgroundEvents::ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_TEACHER,
@@ -250,12 +251,6 @@ class SegmentAnalytics
         teacher_email: teacher.email,
         teacher_school: teacher.school&.name,
         reason: reason
-      },
-      context: {
-        traits: {
-          name: admin.name,
-          email: admin.email
-        }
       }
     })
   end
@@ -270,27 +265,21 @@ class SegmentAnalytics
       teacher_school: teacher.school&.name,
       note: note
     }
-    context = {
-      traits: {
-        name: admin_name,
-        email: admin_email
-      }
-    }
     if admin
+      identify(admin)
       track({
         user_id: admin.id,
         event: SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
         properties: properties,
-        context: context
       })
     else
+      identify_anonymous_user({ anonymous_id: admin_email, traits: { email: admin_email, name: admin_name }})
       track({
         # Segment requires us to send a unique User ID or Anonymous ID for every event
         # sending the admin email as the anonymous id because that's how we find people in Ortto
         anonymous_id: admin_email,
         event: SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
-        properties: properties,
-        context: context
+        properties: properties
       })
     end
   end
@@ -326,6 +315,12 @@ class SegmentAnalytics
 
     identify_params = user&.segment_user&.identify_params
     backend.identify(identify_params) if identify_params
+  end
+
+  def identify_anonymous_user(params)
+    return unless backend.present?
+
+    backend.identify(params)
   end
 
   private def anonymous_uid

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -332,8 +332,8 @@ describe 'SegmentAnalytics' do
       expect(track_calls[0][:properties][:teacher_email]).to eq(teacher.email)
       expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
       expect(track_calls[0][:properties][:reason]).to eq(reason)
-      expect(track_calls[0][:context][:traits][:email]).to eq(admin.email)
-      expect(track_calls[0][:context][:traits][:name]).to eq(admin.name)
+
+      expect(identify_calls.size).to eq(1)
     end
   end
 
@@ -361,8 +361,8 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:teacher_last_name]).to eq(teacher.last_name)
         expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
         expect(track_calls[0][:properties][:note]).to eq(note)
-        expect(track_calls[0][:context][:traits][:email]).to eq(admin.email)
-        expect(track_calls[0][:context][:traits][:name]).to eq(admin.name)
+
+        expect(identify_calls.size).to eq(1)
       end
     end
 
@@ -386,8 +386,9 @@ describe 'SegmentAnalytics' do
         expect(track_calls[0][:properties][:teacher_last_name]).to eq(teacher.last_name)
         expect(track_calls[0][:properties][:teacher_school]).to eq(teacher.school.name)
         expect(track_calls[0][:properties][:note]).to eq(note)
-        expect(track_calls[0][:context][:traits][:email]).to eq(admin_email)
-        expect(track_calls[0][:context][:traits][:name]).to eq(admin_name)
+        expect(identify_calls[0][:traits][:email]).to eq(admin_email)
+        expect(identify_calls[0][:traits][:name]).to eq(admin_name)
+        expect(identify_calls[0][:traits][:anonymous_id]).to eq(admin_email)
       end
     end
   end


### PR DESCRIPTION
* use identify instead of context for admin events

* fix tests

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
