### PR TITLE
lms/report-worker-concurrency

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -5,7 +5,7 @@ web: bundle exec puma -C ./config/puma.rb
 
 worker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q critical_external -q default
 
-reportworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low -q critical -q critical_external
+reportworker: MAX_THREADS=$SIDEKIQ_REPORTWORKER_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low -q critical -q critical_external
 
 # Backup workers that we can use in case we need to isolate external jobs from the queue
 externalworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical_external


### PR DESCRIPTION
## WHAT
Use a separate ENV variable for reportworker Sidekiq concurrency
## WHY
So that we can tweak concurrency for `worker` and `reportworker` dyno instances independently of each other.  Specifically, we want to test lower concurrency for `reportworker` instances to see if it resolves database temp space issues with some of the jobs.
## HOW
Add a new ENV variable for the LMS, and use that value to set concurrency for `reportworker` instances

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on pure config
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A