### PR TITLE
lms/disable-extra-admin-report-precaching

### DIFF
--- a/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_admin_dashboards_worker.rb
@@ -13,9 +13,6 @@ class PreCacheAdminDashboardsWorker
 
     active_admin_ids.each do |id|
       FindAdminUsersWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
-      FindDistrictActivityScoresWorker.set(queue: SidekiqQueue::LOW, retry: 0).perform_async(id)
-      FindDistrictStandardsReportsWorker.set(queue: SidekiqQueue::LOW, retry: 0).perform_async(id)
-      FindDistrictConceptReportsWorker.set(queue: SidekiqQueue::LOW, retry: 0).perform_async(id)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_admin_dashboard_worker_spec.rb
@@ -9,9 +9,6 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
   let!(:current_admin2) { create(:user, last_sign_in: Time.current) }
   let!(:not_admin) { create(:user, last_sign_in: Time.current) }
   let(:mock_users_worker) {double(:mock_users_worker, perform_async: nil)}
-  let(:mock_activity_worker) {double(:mock_activity_worker, perform_async: nil)}
-  let(:mock_standards_worker) {double(:mock_standards_worker, perform_async: nil)}
-  let(:mock_concept_worker) {double(:mock_concept_worker, perform_async: nil)}
 
   before do
     create(:schools_admins, user: old_admin)
@@ -19,32 +16,11 @@ describe PreCacheAdminDashboardsWorker, type: :worker do
     create(:schools_admins, user: current_admin2)
 
     allow(FindAdminUsersWorker).to receive(:set).with(queue: SidekiqQueue::DEFAULT).and_return(mock_users_worker)
-    allow(FindDistrictActivityScoresWorker).to receive(:set).with(queue: SidekiqQueue::LOW, retry: 0).and_return(mock_activity_worker)
-    allow(FindDistrictStandardsReportsWorker).to receive(:set).with(queue: SidekiqQueue::LOW, retry: 0).and_return(mock_standards_worker)
-    allow(FindDistrictConceptReportsWorker).to receive(:set).with(queue: SidekiqQueue::LOW, retry: 0).and_return(mock_concept_worker)
   end
 
   it 'enqueues FindAdminUsersWorker for all active admins' do
     expect(mock_users_worker).to receive(:perform_async).with(current_admin1.id).once
     expect(mock_users_worker).to receive(:perform_async).with(current_admin2.id).once
-    worker.perform
-  end
-
-  it 'enqueues FindDistrictActivityScoresWorker for admins' do
-    expect(mock_activity_worker).to receive(:perform_async).with(current_admin1.id).once
-    expect(mock_activity_worker).to receive(:perform_async).with(current_admin2.id).once
-    worker.perform
-  end
-
-  it 'enqueues FindDistrictStandardsReportWorker for admins' do
-    expect(mock_standards_worker).to receive(:perform_async).with(current_admin1.id).once
-    expect(mock_standards_worker).to receive(:perform_async).with(current_admin2.id).once
-    worker.perform
-  end
-
-  it 'enqueues FindDistrictConceptReportsWorker for admins' do
-    expect(mock_concept_worker).to receive(:perform_async).with(current_admin1.id).once
-    expect(mock_concept_worker).to receive(:perform_async).with(current_admin2.id).once
     worker.perform
   end
 


### PR DESCRIPTION
## WHAT
Turn off admin pre-caching
## WHY
We want to avoid temp space issues on the database which we were trying to solve via concurrency tweaks over the weekend, but that didn't work so we'll just disable for now
## HOW
Just take the extra caching jobs out of the nightly cron job

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, overnight job change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
