### PR TITLE
lms/strip-stripe-ids-before-validation

### DIFF
--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -117,7 +117,7 @@ class Subscription < ApplicationRecord
   validates :stripe_invoice_id, allow_blank: true, stripe_uid: { prefix: :in }
   validates :stripe_subscription_id, allow_blank: true, stripe_uid: { prefix: :sub }
 
-  before_validation :strip_stripe_id_whitespace, only: [:stripe_invoice_id, :strip_subscription_id]
+  before_validation :strip_stripe_id_whitespace
 
   delegate :stripe_cancel_at_period_end, :stripe_subscription_url,
     to: :stripe_subscription

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -117,6 +117,8 @@ class Subscription < ApplicationRecord
   validates :stripe_invoice_id, allow_blank: true, stripe_uid: { prefix: :in }
   validates :stripe_subscription_id, allow_blank: true, stripe_uid: { prefix: :sub }
 
+  before_validation :strip_stripe_id_whitespace, only: [:stripe_invoice_id, :strip_subscription_id]
+
   delegate :stripe_cancel_at_period_end, :stripe_subscription_url,
     to: :stripe_subscription
 
@@ -334,5 +336,10 @@ class Subscription < ApplicationRecord
 
   def stripe?
     stripe_invoice_id.present? && stripe_subscription_id.present?
+  end
+
+  private def strip_stripe_id_whitespace
+    self.stripe_invoice_id = self.stripe_invoice_id&.strip
+    self.stripe_subscription_id = self.stripe_subscription_id&.strip
   end
 end

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -339,7 +339,7 @@ class Subscription < ApplicationRecord
   end
 
   private def strip_stripe_id_whitespace
-    self.stripe_invoice_id = self.stripe_invoice_id&.strip
-    self.stripe_subscription_id = self.stripe_subscription_id&.strip
+    self.stripe_invoice_id = stripe_invoice_id&.strip
+    self.stripe_subscription_id = stripe_subscription_id&.strip
   end
 end

--- a/services/QuillLMS/app/models/validators/stripe_uid_validator.rb
+++ b/services/QuillLMS/app/models/validators/stripe_uid_validator.rb
@@ -43,7 +43,7 @@ class StripeUidValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if regex(options[:prefix]).match?(value)
 
-    record.errors[attribute] << "is not a valid Stripe #{PREFIX_TRANSLATION[options[:prefix]]}"
+    record.errors.add(attribute, "is not a valid Stripe #{PREFIX_TRANSLATION[options[:prefix]]}")
   end
 
   private def regex(prefix)

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -36,8 +36,45 @@ describe Subscription, type: :model do
     let(:subscription) { build(:subscription) }
 
     it 'expects stripe_invoice_id to be of a given format' do
+      subscription.stripe_invoice_id = 'not_the_invoice_format'
+      expect(subscription).not_to be_valid
+    end
+
+    it 'expects stripe_subscription_id to be of a given format' do
       subscription.stripe_invoice_id = 'not_the_subscription_format'
       expect(subscription).not_to be_valid
+    end
+  end
+
+  context 'before_validation' do
+    let(:subscription) { build(:subscription) }
+
+    context '#strip_stripe_id_whitespace' do
+      it 'should strip whitespace from stripe_invoice_id if present' do
+        invoice_id = " in_#{SecureRandom.hex} "
+        subscription.stripe_invoice_id = invoice_id
+
+        expect(subscription).to be_valid
+        expect(subscription.stripe_invoice_id).to eq(invoice_id.strip)
+      end
+
+      it 'should do nothing to stripe_invoice_id if it is not set' do
+        expect(subscription).to be_valid
+        expect(subscription.stripe_invoice_id).to be(nil)
+      end
+
+      it 'should strip whitespace from stripe_subscription_id if present' do
+        subscription_id = " sub_#{SecureRandom.hex} "
+        subscription.stripe_subscription_id = subscription_id
+
+        expect(subscription).to be_valid
+        expect(subscription.stripe_subscription_id).to eq(subscription_id.strip)
+      end
+
+      it 'should do nothing to stripe_subscription_id if not set' do
+        expect(subscription).to be_valid
+        expect(subscription.stripe_subscription_id).to be(nil)
+      end
     end
   end
 


### PR DESCRIPTION
## WHAT
Strip Stripe Invoice and Subscription ID whitespace before validation
## WHY
So that if someone copy/pastes an ID but misses leading or trailing whitespace, validation will still work, and the value we care about will be stored.  (This happened to Partnerships, and making their lives easier so that they don't have to super-carefully check the IDs they're pasting for whitespace seems like a reasonable thing to do.
## HOW
Add a `before_validation` callback in the `Subscription` model to handle cases with whitespace

### Notion Card Links
https://www.notion.so/quill/New-subs-not-adding-in-locker-0b51db87f5954b55b25379fca7d57afc?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
