### PR TITLE
lms/broader-signup-school-search

### DIFF
--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -76,7 +76,7 @@ class SchoolsController < ApplicationController
       @schools = School.select("schools.id, name, zipcode, mail_zipcode, street, mail_street, city, mail_city, state, mail_state, COUNT(schools_users.id) AS number_of_teachers")
       .joins('LEFT JOIN schools_users ON schools_users.school_id = schools.id')
       .where(
-         "lower(name) LIKE :prefix", prefix: "#{@prefix.downcase}%"
+         "lower(name) LIKE :prefix", prefix: "%#{@prefix.downcase}%"
        ).group("schools.id")
        .limit(@limit)
       $redis.set("PREFIX_TO_SCHOOL_#{@prefix}", @schools.map {|s| s.id}.to_json)

--- a/services/QuillLMS/spec/controllers/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/schools_controller_spec.rb
@@ -35,6 +35,15 @@ describe SchoolsController, type: :controller do
       expect(json['data'].first['id']).to eq(@school2.id)
     end
 
+    it 'fetches schools even if the search string is not the start of the school name' do
+      get :index, params: { search: 'Academy' }, as: :json
+
+      expect(response.status).to eq(200)
+
+      json = JSON.parse(response.body)
+      expect(json['data'].first['id']).to eq(@school2.id)
+    end
+
     it 'will return an empty array if the search length is less than the minimum' do
       get :index, params: { search: 'M' }, as: :json
 


### PR DESCRIPTION
## WHAT
Allow school search to work if you search a value in the middle nstead of only matching search terms if the search term matches the start of the school name
## WHY
We want to allow a user signing up to find their school even if they're looking for "Cityville" while the school is recorded in our database as "East Cityville Highschool".
## HOW
Modify the search query to add a `%` on left side of the `LIKE` comparison in addition to the right side

### Screenshots
![Screen Shot 2023-03-21 at 5 13 10 PM](https://user-images.githubusercontent.com/331565/226742210-045b9eb7-d50a-4f96-b181-338ac2b45785.png)

### Notion Card Links
https://www.notion.so/quill/Improve-school-search-to-ensure-we-re-checking-if-a-school-name-contains-what-the-user-typed-efcfdd06775f4794a877a01ad43b9d9c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
