### PR TITLE
lms/fix-clever-auth-role-changes

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/teacher_updater.rb
+++ b/services/QuillLMS/app/services/clever_integration/teacher_updater.rb
@@ -5,7 +5,7 @@ module CleverIntegration
     attr_reader :data, :teacher
 
     ACCOUNT_TYPE = ::User::CLEVER_ACCOUNT
-    ROLE = ::User::TEACHER
+    DEFAULT_ROLE = ::User::TEACHER
 
     def initialize(teacher, data)
       @teacher = teacher
@@ -17,8 +17,14 @@ module CleverIntegration
       teacher
     end
 
+    private def role
+      return @teacher.role if User::TEACHER_INFO_ROLES.include?(@teacher.role)
+
+      DEFAULT_ROLE
+    end
+
     private def teacher_attrs
-      data.merge(account_type: ACCOUNT_TYPE, google_id: nil, role: ROLE, signed_up_with_google: false)
+      data.merge(account_type: ACCOUNT_TYPE, google_id: nil, role: role, signed_up_with_google: false)
     end
 
     private def update

--- a/services/QuillLMS/spec/services/clever_integration/teacher_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_updater_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe CleverIntegration::TeacherUpdater do
     it { expect { subject }.to change(teacher, :name).from(name).to(data_name) }
     it { expect { subject }.to change(teacher, :email).from(email).to(data_email) }
     it { expect { subject}.not_to change(teacher, :clever_id) }
+
+    it 'should update the user role to "teacher" if they do not have a TEACHER_INFO role (indicating that they are school staff)' do
+      teacher.update(role: User::STUDENT)
+
+      expect { subject }.to change(teacher, :role).from(User::STUDENT).to(User::TEACHER)
+    end
+
+    it 'should not update the user role if they have a TEACHER_INFO role already' do
+      teacher.update(role: User::ADMIN)
+
+      expect { subject }.not_to change(teacher, :role)
+    end
   end
 
   context 'teacher is linked with google' do


### PR DESCRIPTION
## WHAT
Update the Clever TeacherUpdater so that it doesn't make admins into teachers
## WHY
This code was overly-aggressive about assigning the "teacher" role to users when they logged in.  This change makes it so that they only get made a teacher if they're not already some other kind of "school staff" type of user (as proxied by having a role in `TEACHER_INFO_ROLES`).
## HOW
When running the `TeacherUpdater` don't blindly set the user's role to "teacher".  Check to see if the user has a different valid school-related role, and leave that intact if they do.

### Notion Card Links
https://www.notion.so/quill/An-admin-reverted-to-teacher-status-when-logging-in-through-Clever-55aae465585a4db18b96705081a6cba1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A