### PR TITLE
Update the default meta tags on blog posts

### DIFF
--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -9,6 +9,7 @@ class BlogPostsController < ApplicationController
   before_action :set_root_url
   before_action :set_defer_js, except: :search
 
+  SOCIAL_MEDIA_SHARE_IMAGE = "#{ENV['CDN_URL']}/images/share/facebook.png"
 
   def index
     topic_names = BlogPost::TEACHER_TOPICS
@@ -89,8 +90,8 @@ class BlogPostsController < ApplicationController
 
     @related_posts = @blog_post.related_posts
     @title = @blog_post.title
-    @description = @blog_post.subtitle || @title
-    @image_link = @blog_post.image_link
+    @description = @blog_post.subtitle.present? ? @blog_post.subtitle : @title
+    @image_link = SOCIAL_MEDIA_SHARE_IMAGE
   end
 
   private def attempt_corrected_slug_and_redirect(slug, draft_statuses)

--- a/services/QuillLMS/app/controllers/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/blog_posts_controller.rb
@@ -90,7 +90,7 @@ class BlogPostsController < ApplicationController
 
     @related_posts = @blog_post.related_posts
     @title = @blog_post.title
-    @description = @blog_post.subtitle.present? ? @blog_post.subtitle : @title
+    @description = @blog_post.subtitle.presence || @title
     @image_link = SOCIAL_MEDIA_SHARE_IMAGE
   end
 

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -15,7 +15,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:type"               content="website" />
   <meta property="og:title"              content= "<%= @title || "Free tools to make your students better writers." %>" />
-  <meta property="og:image"              content=<%=@image_link || image_url('share/facebook.png') %> />
+  <meta property="og:image"              content="<%=@image_link || image_url('share/facebook.png') %>"/>
 
   <meta name="description" content="<%= @description || @content %>">
   <meta name="og:description" content="<%= @description || @content %>">

--- a/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/blog_posts_controller_spec.rb
@@ -84,8 +84,19 @@ describe BlogPostsController, type: :controller do
       expect(assigns(:description)).to eq(blog_post.subtitle)
     end
 
+    it 'should return the image link' do
+      get :show, params: { slug: blog_post.slug }
+      expect(assigns(:image_link)).to eq(BlogPostsController::SOCIAL_MEDIA_SHARE_IMAGE)
+    end
+
     it 'should return the title as description if no subtitle exists' do
       blog_post = create(:blog_post, subtitle: nil)
+      get :show, params: { slug: blog_post.slug }
+      expect(assigns(:description)).to eq(blog_post.title)
+    end
+
+    it 'should return the title as description if the subtitle is an empty string' do
+      blog_post = create(:blog_post, subtitle: "")
       get :show, params: { slug: blog_post.slug }
       expect(assigns(:description)).to eq(blog_post.title)
     end


### PR DESCRIPTION
## WHAT
Update the default meta tags on all our blog posts so that they contain relevant and updated data, instead of being blank.

## WHY
This will help bump up our SEO rankings, because Google looks at these tags to determine completeness of our web pages.

## HOW
Add a default social media sharing image to all blog posts. Fix the code for displaying description so that the description tag displays a blog post's title if the subtitle is blank (empty string).

### Screenshots
<img width="605" alt="Screen Shot 2023-03-24 at 5 30 57 PM" src="https://user-images.githubusercontent.com/57366100/227481566-74cb1228-3bed-4f3c-b7d0-1d569cf7dcab.png">
<img width="634" alt="Screen Shot 2023-03-24 at 5 31 03 PM" src="https://user-images.githubusercontent.com/57366100/227481590-0b42bb31-7397-4adf-a07e-d06d7bb2940e.png">
<img width="639" alt="Screen Shot 2023-03-24 at 5 31 07 PM" src="https://user-images.githubusercontent.com/57366100/227481615-c353a286-d349-4f45-b964-3d684ccd5ef2.png">
<img width="584" alt="Screen Shot 2023-03-24 at 5 31 11 PM" src="https://user-images.githubusercontent.com/57366100/227481643-47cab2f4-bf27-4a4d-b988-efeff878a15c.png">


### Notion Card Links
https://www.notion.so/quill/Improve-descriptions-in-Public-pages-for-better-SEO-75c03b92753744ac9803ae6d5172f4c7?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
