### PR TITLE
Slight copy change on Premium Menu Tab

### DIFF
--- a/services/QuillLMS/app/helpers/navigation_helper.rb
+++ b/services/QuillLMS/app/helpers/navigation_helper.rb
@@ -42,7 +42,7 @@ module NavigationHelper
     when 'trial'
       "<span>Premium</span>#{star_img}<span>#{current_user.trial_days_remaining} Days Left</span>"
     when 'locked'
-      current_user.last_expired_subscription&.is_trial? ? "<span>Premium</span>#{star_img}<span>Trial Expired</span>" : "<span>Premium</span>#{star_img}<span>Subscription Expired</span>"
+      current_user.last_expired_subscription&.is_trial? ? "<span>Premium</span>#{star_img}<span>Trial Expired</span>" : "<span>Premium</span>#{star_img}<span>Expired</span>"
     when 'none', nil
       "<span>Explore Premium</span>#{star_img}"
     end

--- a/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
@@ -88,7 +88,7 @@ describe NavigationHelper do
       allow(helper).to receive(:current_user) { double(:user, premium_state: "trial", trial_days_remaining: 5) }
       expect(helper.premium_tab_copy).to eq "<span>Premium</span><img alt='' src='https://assets.quill.org/images/icons/star.svg'></img><span>5 Days Left</span>"
       allow(helper).to receive(:current_user) { double(:user, premium_state: "locked", last_expired_subscription: premium_subscription) }
-      expect(helper.premium_tab_copy).to eq "<span>Premium</span><img alt='' src='https://assets.quill.org/images/icons/star.svg'></img><span>Subscription Expired</span>"
+      expect(helper.premium_tab_copy).to eq "<span>Premium</span><img alt='' src='https://assets.quill.org/images/icons/star.svg'></img><span>Expired</span>"
       allow(helper).to receive(:current_user) { double(:user, premium_state: "locked", last_expired_subscription: trial_subscription) }
       expect(helper.premium_tab_copy).to eq "<span>Premium</span><img alt='' src='https://assets.quill.org/images/icons/star.svg'></img><span>Trial Expired</span>"
       allow(helper).to receive(:current_user) { double(:user, premium_state: nil) }


### PR DESCRIPTION
## WHAT
Remove the word "Subscription" from the tab that says "Premium Subscription Expired".

## WHY
It was making the tab too long and causing some display issues.

## HOW
Remove it from the copy

### Screenshots
<img width="640" alt="Screen Shot 2023-03-27 at 3 14 18 PM" src="https://user-images.githubusercontent.com/57366100/227868583-a504e955-1fe4-4fc1-9c3a-b74a7a424eba.png">


### Notion Card Links
https://www.notion.so/quill/Fix-for-the-Premium-Subscription-Expired-button-adbffb39f0be404b9eb8b1468d69be56?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
