### PR TITLE
Teacher Center/ update subnav rendering logic

### DIFF
--- a/services/QuillLMS/app/views/blog_posts/index.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: @topic || BlogPost::ALL_RESOURCES } if (!current_user || current_user&.role == 'teacher') %>
+<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: @topic || BlogPost::ALL_RESOURCES } if (!current_user || current_user&.role != 'student') %>
 <%= render partial: 'pages/shared/student_center_navbar', locals: {active_tab: @topic || BlogPost::ALL_RESOURCES } if current_user&.role == 'student' %>
 <div class="container">
   <%= react_component('BlogPostsApp', props: {

--- a/services/QuillLMS/app/views/blog_posts/index.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: @topic || BlogPost::ALL_RESOURCES } if (!current_user || current_user&.role != 'student') %>
+<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: @topic || BlogPost::ALL_RESOURCES } if (!current_user || current_user&.teacher?) %>
 <%= render partial: 'pages/shared/student_center_navbar', locals: {active_tab: @topic || BlogPost::ALL_RESOURCES } if current_user&.role == 'student' %>
 <div class="container">
   <%= react_component('BlogPostsApp', props: {

--- a/services/QuillLMS/app/views/blog_posts/show.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/show.html.erb
@@ -4,7 +4,7 @@
   <% active_tab = 'All resources'%>
 <% end %>
 
-<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: active_tab} if (!current_user || current_user&.role != 'student') %>
+<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: active_tab} if (!current_user || current_user&.teacher?) %>
 <%= render partial: 'pages/shared/student_center_navbar', locals: {active_tab: active_tab} if current_user&.role == 'student' %>
 <%= react_component('BlogPostsApp', props: {
   route: 'show',

--- a/services/QuillLMS/app/views/blog_posts/show.html.erb
+++ b/services/QuillLMS/app/views/blog_posts/show.html.erb
@@ -4,8 +4,7 @@
   <% active_tab = 'All resources'%>
 <% end %>
 
-<%= render partial: 'teachers/shared/scorebook_tabs' if current_user && current_user.role != 'student' %>
-<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: active_tab} if (!current_user || current_user&.role == 'teacher') %>
+<%= render partial: 'pages/shared/teacher_center_navbar', locals: {active_tab: active_tab} if (!current_user || current_user&.role != 'student') %>
 <%= render partial: 'pages/shared/student_center_navbar', locals: {active_tab: active_tab} if current_user&.role == 'student' %>
 <%= react_component('BlogPostsApp', props: {
   route: 'show',


### PR DESCRIPTION
## WHAT
update subnav rendering logic for Teacher Center

## WHY
the subnav wasn't showing for admins due to the new `admin` role being added for users; there was also a request to hide the scorebook tabs when in the teacher center
 
## HOW
update conditional rendering logic to account for new `admin` role and remove code that renders scorebook partial for teacher center routes

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1131" alt="Screen Shot 2023-03-29 at 1 04 29 PM" src="https://user-images.githubusercontent.com/25959584/228614536-257beca0-8de0-4099-8dd2-f004a2731eea.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Bugs-with-Teacher-Center-Sub-Nav-Showing-the-right-sub-nav-bb4dfd92889647c6b64aecba7849be85

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
