### PR TITLE
Bug-fix/ Evidence CMS model activation lag

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/activateModelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/activateModelForm.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useQuery } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { withRouter, Link } from 'react-router-dom';
 
 import { activateModel, fetchModel, fetchModels } from '../../../utils/evidence/modelAPIs';
@@ -19,6 +19,8 @@ const ActivateModelForm = ({ match }) => {
   const [existingLabels, setExistingLabels] = React.useState(null);
   const [modelReady, setModelReady] = React.useState(false);
   const [modelToActivate, setModelToActivate] = React.useState(null);
+
+  const queryClient = useQueryClient()
 
   // cache model data for updates
   const { data: modelData } = useQuery({
@@ -81,6 +83,7 @@ const ActivateModelForm = ({ match }) => {
         setActiveModel(modelToActivate);
         updateActiveLabels(modelToActivate);
         setIsLoading(false);
+        queryClient.clear();
       }
     })
   }


### PR DESCRIPTION
## WHAT
fix issue in the Evidence CMS where the models index isn't updating after a model is activated

## WHY
we want the data displayed to be up-to-date

## HOW
clear the `queryClient` instance upon model activation

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Lag-in-landing-page-update-when-activating-new-models-in-CMS-d9192d6fe3204b6d82b6543e30d4f64f?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
