### PR TITLE
add cron job and spec to make an identify call for every admin nightly

### DIFF
--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -37,6 +37,7 @@ class Cron
     # third party analytics
     SyncVitallyWorker.perform_async
     CalculateAndCacheSchoolsDataForSegmentWorker.perform_async
+    SendSegmentIdentifyCallForAllAdminsWorker.perform_async
 
     # caching
     MaterializedViewRefreshWorker.perform_async

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -215,6 +215,7 @@ class User < ApplicationRecord
   # This is a little weird, but in our current conception, all Admins are Teachers
   scope :teacher, -> { where(role: [ADMIN, TEACHER]) }
   scope :student, -> { where(role: STUDENT) }
+  scope :admin, ->  { where(role: ADMIN) }
 
   def self.deleted_users
     where(

--- a/services/QuillLMS/app/workers/send_segment_identify_call_for_all_admins_worker.rb
+++ b/services/QuillLMS/app/workers/send_segment_identify_call_for_all_admins_worker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CalculateAndCacheSchoolsDataForSegmentWorker
+class SendSegmentIdentifyCallForAllAdminsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 

--- a/services/QuillLMS/app/workers/send_segment_identify_call_for_all_admins_worker.rb
+++ b/services/QuillLMS/app/workers/send_segment_identify_call_for_all_admins_worker.rb
@@ -5,6 +5,6 @@ class SendSegmentIdentifyCallForAllAdminsWorker
   sidekiq_options queue: SidekiqQueue::LOW
 
   def perform
-    User.admin.ids { |id| IdentifyWorker.perform_async(id) }
+    User.admin.ids.each { |id| IdentifyWorker.perform_async(id) }
   end
 end

--- a/services/QuillLMS/app/workers/send_segment_identify_call_for_all_admins_worker.rb
+++ b/services/QuillLMS/app/workers/send_segment_identify_call_for_all_admins_worker.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CalculateAndCacheSchoolsDataForSegmentWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::LOW
+
+  def perform
+    user_ids = User.where(role: User::ADMIN).ids
+    user_ids.each do |id|
+      IdentifyWorker.perform_async(id)
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/send_segment_identify_call_for_all_admins_worker.rb
+++ b/services/QuillLMS/app/workers/send_segment_identify_call_for_all_admins_worker.rb
@@ -5,9 +5,6 @@ class SendSegmentIdentifyCallForAllAdminsWorker
   sidekiq_options queue: SidekiqQueue::LOW
 
   def perform
-    user_ids = User.where(role: User::ADMIN).ids
-    user_ids.each do |id|
-      IdentifyWorker.perform_async(id)
-    end
+    User.admin.ids { |id| IdentifyWorker.perform_async(id) }
   end
 end

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -109,6 +109,11 @@ describe "Cron", type: :model do
       expect(CalculateAndCacheSchoolsDataForSegmentWorker).to receive(:perform_async)
       Cron.interval_1_day
     end
+
+    it "enqueues SendSegmentIdentifyCallForAllAdminsWorker" do
+      expect(SendSegmentIdentifyCallForAllAdminsWorker).to receive(:perform_async)
+      Cron.interval_1_day
+    end
   end
 
   describe "#run_weekday" do

--- a/services/QuillLMS/spec/workers/send_segment_identify_call_for_all_admins_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/send_segment_identify_call_for_all_admins_worker_spec.rb
@@ -6,18 +6,13 @@ describe SendSegmentIdentifyCallForAllAdminsWorker do
   subject { described_class.new }
 
   describe '#perform' do
-    let!(:schools_admins) { create_list(:schools_admins, 5) }
-    let!(:random_other_school) { create(:school)}
+    let!(:admins) { create_list(:admin, 5) }
 
-    it 'should kick off a worker for the school of every school admin' do
-      schools_admins.each do |sa|
-        expect(CalculateAndCacheSchoolDataForSegmentWorker).to receive(:perform_async).with(sa.school_id)
+    it 'should kick off a worker for every admin user' do
+      admins.each do |admin|
+        expect(IdentifyWorker).to receive(:perform_async).with(admin.id)
       end
       subject.perform
-    end
-
-    it 'should not kick off a worker for any other schools' do
-      expect(CalculateAndCacheSchoolDataForSegmentWorker).not_to receive(:perform_async).with(random_other_school.id)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/send_segment_identify_call_for_all_admins_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/send_segment_identify_call_for_all_admins_worker_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SendSegmentIdentifyCallForAllAdminsWorker do
+  subject { described_class.new }
+
+  describe '#perform' do
+    let!(:schools_admins) { create_list(:schools_admins, 5) }
+    let!(:random_other_school) { create(:school)}
+
+    it 'should kick off a worker for the school of every school admin' do
+      schools_admins.each do |sa|
+        expect(CalculateAndCacheSchoolDataForSegmentWorker).to receive(:perform_async).with(sa.school_id)
+      end
+      subject.perform
+    end
+
+    it 'should not kick off a worker for any other schools' do
+      expect(CalculateAndCacheSchoolDataForSegmentWorker).not_to receive(:perform_async).with(random_other_school.id)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add a worker to make an identify call for every admin user, and make sure the cron job calls it nightly. 

## WHY
So that we have info for admin users who aren't necessarily active.

## HOW
Just add a worker and update the cron file.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-the-properties-for-all-admins-in-Ortto-nightly-3fe86b500705412d9f46d2a94129c367?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  YES