### PR TITLE
Bug-fix/ fix link on Activity Summary page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/app_legend.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/app_legend.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`AppLegend component should render 1`] = `
   >
     <a
       className="icon focus-on-light"
-      href="undefined/tools/grammar"
+      href="undefined/tools/evidence"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/app_legend.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/app_legend.tsx
@@ -55,7 +55,7 @@ export const AppLegend = () => {
   )
 
   const evidence = (
-    <a className="icon focus-on-light" href={`${process.env.DEFAULT_URL}/tools/grammar`} rel="noopener noreferrer" target="_blank">
+    <a className="icon focus-on-light" href={`${process.env.DEFAULT_URL}/tools/evidence`} rel="noopener noreferrer" target="_blank">
       <img alt="Book representing Quill Reading for Evidence" className="icon-wrapper evidence-icon" src={EVIDENCE_ICON_SRC} />
       <div className="icons-description-wrapper">
         <p className="title">Quill Reading for Evidence</p>


### PR DESCRIPTION
## WHAT
fix link on Activity Summary page for Reading For Evidence 

## WHY
it's routing to the Grammar tool

## HOW
just update the url path

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Activity-Summary-has-incorrect-link-for-Reading-for-Evidence-722d0180990a4823a683d6d94c9d2f37?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | no-- small change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
