### PR TITLE
update admin demo account data creation

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -71,6 +71,7 @@ gem 'haversine'
 gem 'configs'
 gem 'rack-test', '~> 0.6.3'
 gem 'secure_headers', '6.3.2'
+gem 'faker'
 
 # Engines
 gem 'evidence', path: 'engines/evidence'

--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -196,7 +196,6 @@ end
 
 group :test, :development, :cypress do
   gem 'cypress-on-rails', '~> 1.0'
-  gem 'faker'
 end
 
 group :test do

--- a/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports_controller.rb
@@ -59,11 +59,7 @@ class Teachers::ProgressReportsController < ApplicationController
 
   private def set_admin_user
     @admin_user = User.find_by(email: teacher_email) ||
-      Demo::CreateAdminReport.new(
-        admin_demo_name,
-        email_safe_school_name,
-        teacher_email
-      ).call
+      Demo::CreateAdminReport.new(teacher_email).call
   end
 
   private def teacher_email

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -11,6 +11,10 @@ class Demo::CreateAdminReport
     create_demo
   end
 
+  def data
+    @data ||= @passed_data || Demo::SessionData.new.admin_demo_data
+  end
+
   attr_reader :teacher_email
   private :teacher_email
 
@@ -68,9 +72,5 @@ class Demo::CreateAdminReport
       number_of_sessions_to_destroy = (14..28).to_a.sample # 10-20% of 140
       activity_sessions_for_classroom.sample(number_of_sessions_to_destroy).each { |as| as.destroy }
     end
-  end
-
-  def data
-    @data ||= @passed_data || Demo::SessionData.new.admin_demo_data
   end
 end

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -69,56 +69,7 @@ class Demo::CreateAdminReport
     end
   end
 
-  private def data
-    @data ||= [
-      {"School"=>"MLK Middle School", "Teacher"=>"Angie Cruz", "Classroom"=>"Period 1"},
-      {"School"=>"MLK Middle School", "Teacher"=>"James Baldwin", "Classroom"=>"Intro to Poetry"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Amy Tan", "Classroom"=>"Period 2"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Amy Tan", "Classroom"=>"Period 3"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Maya Angelou", "Classroom"=>"Period 1a"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Harper Lee", "Classroom"=>"Period 1a"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Colson Whitehead", "Classroom"=>"ELA Block 1"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Toni Morrison", "Classroom"=>"English AP - Literature"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Madeleine L'engle", "Classroom"=>"Period 4"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Madeleine L'engle", "Classroom"=>"Period 5"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Celeste Ng", "Classroom"=>"English Honors"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Celeste Ng", "Classroom"=>"English I"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Lorrie Moore", "Classroom"=>"English II - 1a"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Lorrie Moore", "Classroom"=>"English II - 2a"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Julia Alvarez", "Classroom"=>"Pre-AP"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Ta-Nehisi Coates", "Classroom"=>"Intro to Journalism"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Jhumpa Lahiri", "Classroom"=>"Short Story Writing"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Jhumpa Lahiri", "Classroom"=>"Short Story Writing (Honors)"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Zora Neale Hurston", "Classroom"=>"Pre-AP English - 7b"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Zora Neale Hurston", "Classroom"=>"Pre-AP English - 8a"},
-      {"School"=>"MLK Middle School", "Teacher"=>"N.K. Jemisin", "Classroom"=>"English AP"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Nick Hornby", "Classroom"=>"Period 3"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Octavia Butler", "Classroom"=>"Creative Writing 1"},
-      {"School"=>"MLK Middle School", "Teacher"=>"Octavia Butler", "Classroom"=>"Creative Writing 2"},
-      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 4"},
-      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 5"},
-      {"School"=>"Douglass High School", "Teacher"=>"Bram Stoker", "Classroom"=>"ELA Block 2"},
-      {"School"=>"Douglass High School", "Teacher"=>"Emily Acevedo", "Classroom"=>"Period 2"},
-      {"School"=>"Douglass High School", "Teacher"=>"Paul Coelho", "Classroom"=>"Humanities 1a"},
-      {"School"=>"Douglass High School", "Teacher"=>"Paul Coelho", "Classroom"=>"Humanities 2a"},
-      {"School"=>"Douglass High School", "Teacher"=>"George Orwell", "Classroom"=>"Period 8"},
-      {"School"=>"Douglass High School", "Teacher"=>"James Joyce", "Classroom"=>"European Literature 7a"},
-      {"School"=>"Douglass High School", "Teacher"=>"James Joyce", "Classroom"=>"European Literature 8a"},
-      {"School"=>"Douglass High School", "Teacher"=>"Harriet Beecher Stowe", "Classroom"=>"Period 9"},
-      {"School"=>"Douglass High School", "Teacher"=>"Ralph Ellison", "Classroom"=>"AP English - Composition"},
-      {"School"=>"Douglass High School", "Teacher"=>"Judy Blume", "Classroom"=>"AP English - Composition"},
-      {"School"=>"Douglass High School", "Teacher"=>"Zadie Smith", "Classroom"=>"English II - Period 1"},
-      {"School"=>"Douglass High School", "Teacher"=>"Zadie Smith", "Classroom"=>"English II - Period 2"},
-      {"School"=>"Douglass High School", "Teacher"=>"Marie Shelley", "Classroom"=>"Period 5"},
-      {"School"=>"Douglass High School", "Teacher"=>"Margaret Atwood", "Classroom"=>"ELA 1H"},
-      {"School"=>"Douglass High School", "Teacher"=>"James McBride", "Classroom"=>"English - Period 6"},
-      {"School"=>"Douglass High School", "Teacher"=>"William Shakespeare", "Classroom"=>"Intro to Playwriting"},
-      {"School"=>"Douglass High School", "Teacher"=>"Emily Bronte", "Classroom"=>"AP - Literature"},
-      {"School"=>"Douglass High School", "Teacher"=>"Jane Austen", "Classroom"=>"Period 2"},
-      {"School"=>"Douglass High School", "Teacher"=>"Leigh Bardugo", "Classroom"=>"Period 8"},
-      {"School"=>"Douglass High School", "Teacher"=>"Tomi Adeyemi", "Classroom"=>"Period 7"},
-      {"School"=>"Douglass High School", "Teacher"=>"Alice Walker", "Classroom"=>"Period 1"},
-      {"School"=>"Douglass High School", "Teacher"=>"Sylvia Plath", "Classroom"=>"Period 4"}
-    ]
+  def data
+    @data ||= Demo::SessionData.new.admin_demo_data
   end
 end

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -2,8 +2,9 @@
 
 class Demo::CreateAdminReport
 
-  def initialize(teacher_email)
+  def initialize(teacher_email, passed_data=nil)
     @teacher_email = teacher_email
+    @passed_data = passed_data
   end
 
   def call
@@ -40,7 +41,7 @@ class Demo::CreateAdminReport
       username: '',
       password: SecureRandom.urlsafe_base64
     )
-    subscription = Subscription.create!(purchaser_id: admin_teacher.id, account_type: 'Demo Premium', expiration: Date.current + 100.years)
+    subscription = Subscription.create!(purchaser_id: admin_teacher.id, account_type: Subscription::SCHOOL_DISTRICT_PAID, expiration: Date.current + 100.years)
 
     all_classrooms = []
 
@@ -70,6 +71,6 @@ class Demo::CreateAdminReport
   end
 
   def data
-    @data ||= Demo::SessionData.new.admin_demo_data
+    @data ||= @passed_data || Demo::SessionData.new.admin_demo_data
   end
 end

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -2,9 +2,7 @@
 
 class Demo::CreateAdminReport
 
-  def initialize(name, email_safe_school_name, teacher_email)
-    @name = name
-    @email_safe_school_name = email_safe_school_name
+  def initialize(teacher_email)
     @teacher_email = teacher_email
   end
 
@@ -12,185 +10,117 @@ class Demo::CreateAdminReport
     create_demo
   end
 
-  attr_reader :name, :email_safe_school_name, :teacher_email
-  private :name
-  private :email_safe_school_name
+  attr_reader :teacher_email
   private :teacher_email
+
+  private def find_or_create_school(school_name)
+    School.find_or_create_by(name: school_name)
+  end
+
+  private def find_or_create_teacher_data(teacher_name, school, subscription)
+    email_safe_last_name = teacher_name.split.last.downcase.gsub(/[^a-zA-Z\d]/, '').gsub(/\s/, '')
+    user = User.find_or_initialize_by(
+      name: teacher_name,
+      email: "hello+admindemo-#{email_safe_last_name}.#{school.id}@quill.org",
+    )
+    user.update(password: SecureRandom.urlsafe_base64, role: User::TEACHER)
+
+    SchoolsUsers.find_or_create_by(school: school, user: user)
+    UserSubscription.create!(user_id: user.id, subscription: subscription)
+
+    user
+  end
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
   private def create_demo
-    # Create the school
-    school = School.create!(name: name)
-
     # Create admin teacher
     admin_teacher = User.create!(
       name: 'Toni Morrison',
-      role: User::TEACHER,
+      role: User::ADMIN,
       email: teacher_email,
       username: '',
       password: SecureRandom.urlsafe_base64
     )
+    subscription = Subscription.create!(purchaser_id: admin_teacher.id, account_type: 'Demo Premium', expiration: Date.current + 100.years)
 
-    # Add admin teacher to school as an admin
-    SchoolsAdmins.create!(school_id: school.id, user_id: admin_teacher.id)
+    all_classrooms = []
 
-    # Find or create a few other teachers
-    teachers = ['Langston Hughes', 'Jane Austen', 'Maya Angelou']
-    teachers = teachers.map do |teacher|
-      User.create!(
-        name: teacher,
-        role: User::TEACHER,
-        email: "hello+admindemo-#{email_safe_school_name}-#{teacher.split.last.downcase}@quill.org",
-        username: '',
-        password: SecureRandom.urlsafe_base64
-      )
+    data.map do |row|
+      # create school data
+      school = find_or_create_school(row['School'])
+      SchoolsAdmins.find_or_create_by!(school: school, user: admin_teacher)
+      SchoolSubscription.find_or_create_by!(subscription: subscription, school: school)
+
+      # create teacher data
+      teacher = find_or_create_teacher_data(row['Teacher'], school, subscription)
+
+      # create classroom data
+      classroom = Classroom.create(name: row['Classroom'])
+      all_classrooms.push(classroom)
+      ClassroomsTeacher.create(classroom: classroom, user: teacher, role: ClassroomsTeacher::ROLE_TYPES[:owner])
+      student_names = (1..5).to_a.map { |i| "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
+      Demo::ReportDemoCreator.create_demo_classroom_data(teacher, teacher_demo: false, classroom: classroom, student_names: student_names)
     end
 
-    teachers << admin_teacher
-
-    # Upgrade everyone to premium
-    subscription_id = Subscription.create!(purchaser_id: admin_teacher.id, account_type: 'Demo Premium', expiration: Date.current + 100.years).id
-    teachers.each do |teacher|
-      UserSubscription.create!(user_id: teacher.id, subscription_id: subscription_id)
+    # delete some activity sessions to make data more varied
+    all_classrooms.sample(20).each do |classroom|
+      activity_sessions_for_classroom = ActivitySession.joins(:classroom_unit).where('classroom_units.classroom_id = ?', classroom.id)
+      number_of_sessions_to_destroy = (14..28).to_a.sample # 10-20% of 140
+      activity_sessions_for_classroom.sample(number_of_sessions_to_destroy).each { |as| as.destroy }
     end
-
-    # Create a bunch of classrooms and classrooms_teachers associations
-    classrooms = [
-      ClassroomsTeacher.create!(role: ClassroomsTeacher::ROLE_TYPES[:owner], classroom: Classroom.create!(name: 'Period 1'), user: admin_teacher).classroom,
-      ClassroomsTeacher.create!(role: ClassroomsTeacher::ROLE_TYPES[:owner], classroom: Classroom.create!(name: 'Period 2'), user: admin_teacher).classroom,
-      ClassroomsTeacher.create!(role: ClassroomsTeacher::ROLE_TYPES[:owner], classroom: Classroom.create!(name: 'English 1'), user: teachers.first).classroom,
-      ClassroomsTeacher.create!(role: ClassroomsTeacher::ROLE_TYPES[:owner], classroom: Classroom.create!(name: 'ELA 1'), user: teachers.second).classroom,
-      ClassroomsTeacher.create!(role: ClassroomsTeacher::ROLE_TYPES[:owner], classroom: Classroom.create!(name: 'Block One'), user: teachers.third).classroom
-    ]
-
-    # Choose some unit templates we want to base the units off of
-    # NOTE: if you change the unit templates, please see the note above 'exemplar_activity_sessions' below
-    unit_template_ids = [20, 3, 4, 46, 44]
-    unit_templates = unit_template_ids.map { |id| UnitTemplate.find(id) }
-
-    # Add teachers to the school, units to each teacher, and classroom units and unit activities to the units
-    teachers.each do |teacher|
-      SchoolsUsers.create!(school_id: school.id, user_id: teacher.id)
-      units = unit_templates.map { |unit_template| Unit.create!(name: unit_template.name, user_id: teacher.id) }
-      teacher.classrooms_i_teach.each do |classroom|
-        units.each_with_index do |unit, index|
-          ClassroomUnit.find_or_create_by(classroom_id: classroom.id, unit_id: unit.id, assign_on_join: true)
-          unit_templates[index].activities.to_a.uniq.each do |activity|
-            UnitActivity.find_or_create_by(activity_id: activity.id, unit_id: unit.id)
-          end
-        end
-      end
-    end
-
-    # List of author names to use for student names
-    student_names = [
-      "Richard Wright", "Alex Haley", "Ralph Ellison", "Octavia Butler", "Ursula LeGuin",
-      "John Steinbeck", "Irvine Welsh", "Mark Twain", "Isaac Asimov", "Salman Rushdie", "Aldous Huxley",
-      "George Orwell", "William Shakespeare", "Franz Kafka", "Charles Dickens", "Virginia Woolf",
-      "John Keats", "Herman Melville", "Marcel Proust", "Ernest Hemingway", "Pablo Neruda", "Leo Tolstoy",
-      "Oscar Wilde", "James Joyce", "Fyodor Dostoevsky", "Umberto Eco", "Albert Camus", "Jules Verne",
-      "Fitzgerald Scott", "Dante Alighieri", "Victor Hugo", "Charles Baudelaire", "Giovanni Boccaccio",
-      "Alexander Pushkin", "Anton Chekhov", "William Faulkner", "Arthur Rimbaud", "Ivan Turgenev",
-      "Maxim Gorky", "Nazim Hikmet", "Lord Byron", "Thomas Mann", "Alexandre Dumas", "Boris Pasternak",
-      "Pierre Beaumarchais", "Najeeb Mahfouz", "Nikolay Gogol", "Italo Calvino", "Jean Racine",
-      "Chingiz Aitmatov", "Milan Kundera", "Francois Rabelais", "Yasar Kemal", "Geoffrey Chaucer",
-      "Louis Aragon", "Alphonse Daudet", "Mikhail Sholokhov", "Stefan Zweig", "Bertolt Brecht",
-      "Sabahattin Ali", "John Fante", "Kazuo Ishiguro", "Hermann Hesse", "Doris Lessing",
-      "Mario Vargas Llosa", "Thomas Pynchon", "Haruki Murakami", "Saladin Ahmed", "James Baldwin",
-      "Jhumpa Lahiri", "Terry McMillan", "Truman Capote", "Toni Morrison", "Junot Diaz", "Zadie Smith",
-      "Sherman Alexie", "Langston Hughes", "Amy Tan", "Lorraine Hansberry", "Alice Walker",
-      "Isabel Allende", "Sandra Cisneros", "Colson Whitehead", "Khaled Hosseini", "Arundhati Roy",
-      "Jacqueline Woodson", "Celeste Ng", "Roxane Gay", "Chinua Achebe", "Nella Larsen",
-      "Tennessee Williams", "Gertrude Stein", "Allen Ginsberg", "Audre Lorde", "David Sedaris",
-      "Mindy Kaling", "Justin Chin", "Kahlil Gibran", "Eli Wiesel", "Paulo Coelho",
-      "Julia Alvarez", "Mo Willems", "George Eliot", "Lois Lowry"
-    ].shuffle
-
-    # How many students per class?
-    number_of_students_per_class = 5
-
-    # Add students to the classrooms
-    classrooms.each_with_index do |classroom, index|
-      number_of_students_per_class.times do |n|
-        student_name = student_names[(number_of_students_per_class * index) + n]
-        student = User.create!(
-          role: 'student',
-          name: student_name,
-          password: 'password',
-          username: "#{student_name.downcase.sub(' ', '-')}@#{classroom.code}"
-        )
-        StudentsClassrooms.create!(student_id: student.id, classroom_id: classroom.id)
-      end
-    end
-
-    # Create a map of classroom activity IDs to arrays of exemplar activity sessions to copy
-    # NOTE: we manually selected these activity sessions as a representative sample because
-    # it would be pretty computationally intensive to select randomly from all of the
-    # associated activity sessions. In the event this demo creator for some reason changes,
-    # you'll need to update the exemplar activity sessions manually.
-    exemplar_activity_sessions = {
-      413 => [26132834, 22674997, 23713760, 14651990, 27055198, 18415812, 22221644, 22513965, 27742073, 22158443],
-      182 => [22048631, 27667308, 8907523, 3254361, 1598630, 2019699, 28896968, 3848334, 5927654, 25256514],
-      165 => [8655355, 10384565, 7728923, 10888514, 19259048, 27499931, 9244672, 29270571, 17727174],
-      177 => [3286331, 2598862, 11393817, 21106096, 2304963, 16243410, 8292121, 4243576, 8390959],
-      176 => [3533881, 22299270, 28214093, 16169337, 2050344, 12575685, 10083611, 4728267],
-       63 => [6162798, 2781282, 7898538, 10039303, 12346263, 27200543, 17472092, 26083226, 7767661],
-       69 => [3421136, 14719539, 2306053, 8839785, 18159027, 27889910, 15582813, 123324],
-      168 => [27525129, 11107977, 13452776, 4781007, 18059935, 8594742, 22460531, 11026672],
-       77 => [22928913, 20999382, 5844732, 21162049, 9756885, 3139148, 22098329, 9906747, 9605560],
-      169 => [12499260, 8594352, 27781517, 20855319, 27675646, 23610692, 27357322, 6146957, 3927662],
-      107 => [23198318, 8985748, 6874550, 5612963, 28221047, 13513371, 28530677, 19281636],
-      113 => [7247763, 7201638, 6971429, 28153116, 15667648, 4759171, 6874847, 13623922, 23351585],
-      111 => [4412433, 7641405, 29133289, 28226170, 28738913, 1416021, 10071820, 28921073],
-      112 => [3569714, 14067307, 27587029, 17413447, 19843322, 29167975, 2483020, 308392, 2422426],
-      110 => [27402978, 3882494, 2972394, 2107590, 22332137, 29308511, 12215419, 14469882],
-      108 => [6003924, 2381787, 9059288, 22089450, 9425941, 2289906, 5124950, 10911501],
-      109 => [1394227, 13573237, 11777934, 12152451, 6408246, 8968064, 16857416, 21841339],
-      273 => [11968758, 10427339, 22435199, 17393608, 13968692, 28949511, 7522721, 9540189],
-      571 => [27919823],
-      567 => [29001738],
-      572 => [28173122]
-    }
-
-    # Add activity sessions and concept results for students of all but one teacher
-    teachers[1..-1].each do |teacher|
-      teacher.students.each do |student|
-        teacher.unit_activities.each do |unit_activity|
-          we_want_to_create_another_activity_session_for_this_student_and_unit_activity = true
-          # We want to ensure that activity 567 shows as in progress for demoing purposes
-          the_activity_session_should_be_marked_as_in_progress = unit_activity.activity.id == 567
-          classroom_unit = ClassroomUnit.find_by(unit_id: unit_activity.unit_id, classroom_id: [student.classroom_ids])
-          while we_want_to_create_another_activity_session_for_this_student_and_unit_activity
-            exemplar_activity_session = ActivitySession.unscoped.find(exemplar_activity_sessions[unit_activity.activity_id].sample)
-            activity_session = ActivitySession.create!(
-              classroom_unit: classroom_unit,
-              user_id: student.id,
-              activity_id: unit_activity.activity_id,
-              state: the_activity_session_should_be_marked_as_in_progress ? 'started' : 'finished',
-              percentage: exemplar_activity_session.percentage,
-            )
-            exemplar_activity_session.concept_results.each do |cr|
-              SaveActivitySessionConceptResultsWorker.perform_async({
-                activity_session_id: activity_session.id,
-                concept_id: cr.concept_id,
-                metadata: cr.legacy_format[:metadata],
-                question_type: cr.concept_result_question_type&.text
-              })
-            end
-            we_want_to_create_another_activity_session_for_this_student_and_unit_activity = false
-            # diagnostics and lessons cannot be repeated
-            this_activity_can_be_repeated = ![4, 6].include?(unit_activity.activity.activity_classification_id)
-            # we want to show that some of these activities have been attempted more than once
-            if this_activity_can_be_repeated && !the_activity_session_should_be_marked_as_in_progress
-              we_want_to_create_another_activity_session_for_this_student_and_unit_activity = true if Random.rand <= 0.25
-              the_activity_session_should_be_marked_as_in_progress = true if Random.rand <= 0.25
-            end
-          end
-        end
-      end
-    end
-
-    admin_teacher
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+
+  private def data
+    @data ||= [
+      {"School"=>"MLK Middle School", "Teacher"=>"Angie Cruz", "Classroom"=>"Period 1"},
+      {"School"=>"MLK Middle School", "Teacher"=>"James Baldwin", "Classroom"=>"Intro to Poetry"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Amy Tan", "Classroom"=>"Period 2"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Amy Tan", "Classroom"=>"Period 3"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Maya Angelou", "Classroom"=>"Period 1a"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Harper Lee", "Classroom"=>"Period 1a"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Colson Whitehead", "Classroom"=>"ELA Block 1"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Toni Morrison", "Classroom"=>"English AP - Literature"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Madeleine L'engle", "Classroom"=>"Period 4"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Madeleine L'engle", "Classroom"=>"Period 5"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Celeste Ng", "Classroom"=>"English Honors"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Celeste Ng", "Classroom"=>"English I"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Lorrie Moore", "Classroom"=>"English II - 1a"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Lorrie Moore", "Classroom"=>"English II - 2a"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Julia Alvarez", "Classroom"=>"Pre-AP"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Ta-Nehisi Coates", "Classroom"=>"Intro to Journalism"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Jhumpa Lahiri", "Classroom"=>"Short Story Writing"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Jhumpa Lahiri", "Classroom"=>"Short Story Writing (Honors)"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Zora Neale Hurston", "Classroom"=>"Pre-AP English - 7b"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Zora Neale Hurston", "Classroom"=>"Pre-AP English - 8a"},
+      {"School"=>"MLK Middle School", "Teacher"=>"N.K. Jemisin", "Classroom"=>"English AP"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Nick Hornby", "Classroom"=>"Period 3"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Octavia Butler", "Classroom"=>"Creative Writing 1"},
+      {"School"=>"MLK Middle School", "Teacher"=>"Octavia Butler", "Classroom"=>"Creative Writing 2"},
+      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 4"},
+      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 5"},
+      {"School"=>"Douglass High School", "Teacher"=>"Bram Stoker", "Classroom"=>"ELA Block 2"},
+      {"School"=>"Douglass High School", "Teacher"=>"Emily Acevedo", "Classroom"=>"Period 2"},
+      {"School"=>"Douglass High School", "Teacher"=>"Paul Coelho", "Classroom"=>"Humanities 1a"},
+      {"School"=>"Douglass High School", "Teacher"=>"Paul Coelho", "Classroom"=>"Humanities 2a"},
+      {"School"=>"Douglass High School", "Teacher"=>"George Orwell", "Classroom"=>"Period 8"},
+      {"School"=>"Douglass High School", "Teacher"=>"James Joyce", "Classroom"=>"European Literature 7a"},
+      {"School"=>"Douglass High School", "Teacher"=>"James Joyce", "Classroom"=>"European Literature 8a"},
+      {"School"=>"Douglass High School", "Teacher"=>"Harriet Beecher Stowe", "Classroom"=>"Period 9"},
+      {"School"=>"Douglass High School", "Teacher"=>"Ralph Ellison", "Classroom"=>"AP English - Composition"},
+      {"School"=>"Douglass High School", "Teacher"=>"Judy Blume", "Classroom"=>"AP English - Composition"},
+      {"School"=>"Douglass High School", "Teacher"=>"Zadie Smith", "Classroom"=>"English II - Period 1"},
+      {"School"=>"Douglass High School", "Teacher"=>"Zadie Smith", "Classroom"=>"English II - Period 2"},
+      {"School"=>"Douglass High School", "Teacher"=>"Marie Shelley", "Classroom"=>"Period 5"},
+      {"School"=>"Douglass High School", "Teacher"=>"Margaret Atwood", "Classroom"=>"ELA 1H"},
+      {"School"=>"Douglass High School", "Teacher"=>"James McBride", "Classroom"=>"English - Period 6"},
+      {"School"=>"Douglass High School", "Teacher"=>"William Shakespeare", "Classroom"=>"Intro to Playwriting"},
+      {"School"=>"Douglass High School", "Teacher"=>"Emily Bronte", "Classroom"=>"AP - Literature"},
+      {"School"=>"Douglass High School", "Teacher"=>"Jane Austen", "Classroom"=>"Period 2"},
+      {"School"=>"Douglass High School", "Teacher"=>"Leigh Bardugo", "Classroom"=>"Period 8"},
+      {"School"=>"Douglass High School", "Teacher"=>"Tomi Adeyemi", "Classroom"=>"Period 7"},
+      {"School"=>"Douglass High School", "Teacher"=>"Alice Walker", "Classroom"=>"Period 1"},
+      {"School"=>"Douglass High School", "Teacher"=>"Sylvia Plath", "Classroom"=>"Period 4"}
+    ]
+  end
 end

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -31,7 +31,6 @@ class Demo::CreateAdminReport
     user
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
   private def create_demo
     # Create admin teacher
     admin_teacher = User.create!(
@@ -69,7 +68,6 @@ class Demo::CreateAdminReport
       activity_sessions_for_classroom.sample(number_of_sessions_to_destroy).each { |as| as.destroy }
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
   private def data
     @data ||= [

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -5,6 +5,8 @@ class Demo::CreateAdminReport
   NUMBER_OF_CLASSROOMS_TO_DESTROY_SESSIONS_FOR = 20
   RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY = 14..28 # 10-20% of 140
 
+  attr_reader :teacher_email
+
   def initialize(teacher_email, passed_data=nil)
     @teacher_email = teacher_email
     @passed_data = passed_data
@@ -17,9 +19,6 @@ class Demo::CreateAdminReport
   def data
     @data ||= @passed_data || Demo::SessionData.new.admin_demo_data
   end
-
-  attr_reader :teacher_email
-  private :teacher_email
 
   private def find_or_create_school(school_name)
     School.find_or_create_by(name: school_name)

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -2,6 +2,9 @@
 
 class Demo::CreateAdminReport
 
+  NUMBER_OF_CLASSROOMS_TO_DELETE_SESSIONS_FOR = 20
+  RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY = 14..28 # 10-20% of 140
+
   def initialize(teacher_email, passed_data=nil)
     @teacher_email = teacher_email
     @passed_data = passed_data
@@ -67,9 +70,9 @@ class Demo::CreateAdminReport
     end
 
     # delete some activity sessions to make data more varied
-    all_classrooms.sample(20).each do |classroom|
+    all_classrooms.sample(NUMBER_OF_CLASSROOMS_TO_DESTROY_SESSIONS_FOR).each do |classroom|
       activity_sessions_for_classroom = ActivitySession.joins(:classroom_unit).where('classroom_units.classroom_id = ?', classroom.id)
-      number_of_sessions_to_destroy = (14..28).to_a.sample # 10-20% of 140
+      number_of_sessions_to_destroy = (RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY).to_a.sample
       activity_sessions_for_classroom.sample(number_of_sessions_to_destroy).each { |as| as.destroy }
     end
   end

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -2,7 +2,7 @@
 
 class Demo::CreateAdminReport
 
-  NUMBER_OF_CLASSROOMS_TO_DELETE_SESSIONS_FOR = 20
+  NUMBER_OF_CLASSROOMS_TO_DESTROY_SESSIONS_FOR = 20
   RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY = 14..28 # 10-20% of 140
 
   def initialize(teacher_email, passed_data=nil)

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -278,7 +278,7 @@ module Demo::ReportDemoCreator
   def self.create_demo_classroom_data(teacher, teacher_demo: false, classroom: nil, student_names: nil)
     units = reset_units(teacher)
 
-    classroom = classroom || create_classroom(teacher)
+    classroom ||= create_classroom(teacher)
     student_templates = student_names ? student_names.map { |name| StudentTemplate.new(name: name, email_eligible: false) } : STUDENT_TEMPLATES
     students = create_students(classroom, teacher_demo, student_templates)
 

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -276,7 +276,7 @@ module Demo::ReportDemoCreator
   end
 
   def self.create_demo_classroom_data(teacher, teacher_demo: false, classroom: nil, student_names: nil)
-    units = reset_units(teacher)
+    units = reset_units(teacher, student_names.nil?)
 
     classroom ||= create_classroom(teacher)
     student_templates = student_names ? student_names.map { |name| StudentTemplate.new(name: name, email_eligible: false) } : STUDENT_TEMPLATES
@@ -292,8 +292,10 @@ module Demo::ReportDemoCreator
     TeacherActivityFeedRefillWorker.perform_async(teacher.id)
   end
 
-  def self.reset_units(teacher)
-    teacher.units&.destroy_all
+  def self.reset_units(teacher, destroy_existing_units)
+    if destroy_existing_units
+      teacher.units&.destroy_all
+    end
 
     create_units(teacher)
   end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -275,11 +275,12 @@ module Demo::ReportDemoCreator
     # ignore invalid records
   end
 
-  def self.create_demo_classroom_data(teacher, teacher_demo: false)
+  def self.create_demo_classroom_data(teacher, teacher_demo: false, classroom: nil, student_names: nil)
     units = reset_units(teacher)
 
-    classroom = create_classroom(teacher)
-    students = create_students(classroom, teacher_demo)
+    classroom = classroom || create_classroom(teacher)
+    student_templates = student_names ? student_names.map { |name| StudentTemplate.new(name: name, email_eligible: false) } : STUDENT_TEMPLATES
+    students = create_students(classroom, teacher_demo, student_templates)
 
     classroom_units = create_classroom_units(classroom, units)
 
@@ -405,10 +406,10 @@ module Demo::ReportDemoCreator
     Subscription.create_and_attach_subscriber(attributes, teacher)
   end
 
-  def self.create_students(classroom, is_teacher_facing)
+  def self.create_students(classroom, is_teacher_facing, student_templates)
     delete_student_email_accounts if is_teacher_facing
 
-    STUDENT_TEMPLATES.map do |template|
+    student_templates.map do |template|
       student = User.create!(
         name: template.name,
         username: template.username(classroom.id),

--- a/services/QuillLMS/app/services/demo/session_data.rb
+++ b/services/QuillLMS/app/services/demo/session_data.rb
@@ -14,6 +14,7 @@ module Demo
     FILE_CONCEPT_RESULTS = 'concept_results.yml'
     FILE_CONCEPT_RESULT_QUESTION_TYPES = 'concept_result_question_types.yml'
     FILE_CONCEPT_RESULT_LEGACY_METADATA = 'concept_result_legacy_metadata.yml'
+    FILE_ADMIN_DEMO_DATA = 'admin_demo_data.yml'
 
     REPLAYED_PAIR = [Demo::ReportDemoCreator::REPLAYED_ACTIVITY_ID, Demo::ReportDemoCreator::REPLAYED_SAMPLE_USER_ID]
 
@@ -36,6 +37,10 @@ module Demo
 
     def concept_result_legacy_metadata
       @concept_result_legacy_metadata ||= load_file(FILE_CONCEPT_RESULT_LEGACY_METADATA)
+    end
+
+    def admin_demo_data
+      @admin_demo_data ||= load_file(FILE_ADMIN_DEMO_DATA)
     end
 
     private def load_file(file)

--- a/services/QuillLMS/lib/data/demo/admin_demo_data.yml
+++ b/services/QuillLMS/lib/data/demo/admin_demo_data.yml
@@ -1,0 +1,144 @@
+- School: MLK Middle School
+  Teacher: Angie Cruz
+  Classroom: Period 1
+- School: MLK Middle School
+  Teacher: James Baldwin
+  Classroom: Intro to Poetry
+- School: MLK Middle School
+  Teacher: Amy Tan
+  Classroom: Period 2
+- School: MLK Middle School
+  Teacher: Amy Tan
+  Classroom: Period 3
+- School: MLK Middle School
+  Teacher: Maya Angelou
+  Classroom: Period 1a
+- School: MLK Middle School
+  Teacher: Harper Lee
+  Classroom: Period 1a
+- School: MLK Middle School
+  Teacher: Colson Whitehead
+  Classroom: ELA Block 1
+- School: MLK Middle School
+  Teacher: Toni Morrison
+  Classroom: English AP - Literature
+- School: MLK Middle School
+  Teacher: Madeleine L'engle
+  Classroom: Period 4
+- School: MLK Middle School
+  Teacher: Madeleine L'engle
+  Classroom: Period 5
+- School: MLK Middle School
+  Teacher: Celeste Ng
+  Classroom: English Honors
+- School: MLK Middle School
+  Teacher: Celeste Ng
+  Classroom: English I
+- School: MLK Middle School
+  Teacher: Lorrie Moore
+  Classroom: English II - 1a
+- School: MLK Middle School
+  Teacher: Lorrie Moore
+  Classroom: English II - 2a
+- School: MLK Middle School
+  Teacher: Julia Alvarez
+  Classroom: Pre-AP
+- School: MLK Middle School
+  Teacher: Ta-Nehisi Coates
+  Classroom: Intro to Journalism
+- School: MLK Middle School
+  Teacher: Jhumpa Lahiri
+  Classroom: Short Story Writing
+- School: MLK Middle School
+  Teacher: Jhumpa Lahiri
+  Classroom: Short Story Writing (Honors)
+- School: MLK Middle School
+  Teacher: Zora Neale Hurston
+  Classroom: Pre-AP English - 7b
+- School: MLK Middle School
+  Teacher: Zora Neale Hurston
+  Classroom: Pre-AP English - 8a
+- School: MLK Middle School
+  Teacher: N.K. Jemisin
+  Classroom: English AP
+- School: MLK Middle School
+  Teacher: Nick Hornby
+  Classroom: Period 3
+- School: MLK Middle School
+  Teacher: Octavia Butler
+  Classroom: Creative Writing 1
+- School: MLK Middle School
+  Teacher: Octavia Butler
+  Classroom: Creative Writing 2
+- School: Douglass High School
+  Teacher: Kevin Kwan
+  Classroom: Period 4
+- School: Douglass High School
+  Teacher: Kevin Kwan
+  Classroom: Period 5
+- School: Douglass High School
+  Teacher: Bram Stoker
+  Classroom: ELA Block 2
+- School: Douglass High School
+  Teacher: Emily Acevedo
+  Classroom: Period 2
+- School: Douglass High School
+  Teacher: Paul Coelho
+  Classroom: Humanities 1a
+- School: Douglass High School
+  Teacher: Paul Coelho
+  Classroom: Humanities 2a
+- School: Douglass High School
+  Teacher: George Orwell
+  Classroom: Period 8
+- School: Douglass High School
+  Teacher: James Joyce
+  Classroom: European Literature 7a
+- School: Douglass High School
+  Teacher: James Joyce
+  Classroom: European Literature 8a
+- School: Douglass High School
+  Teacher: Harriet Beecher Stowe
+  Classroom: Period 9
+- School: Douglass High School
+  Teacher: Ralph Ellison
+  Classroom: AP English - Composition
+- School: Douglass High School
+  Teacher: Judy Blume
+  Classroom: AP English - Composition
+- School: Douglass High School
+  Teacher: Zadie Smith
+  Classroom: English II - Period 1
+- School: Douglass High School
+  Teacher: Zadie Smith
+  Classroom: English II - Period 2
+- School: Douglass High School
+  Teacher: Marie Shelley
+  Classroom: Period 5
+- School: Douglass High School
+  Teacher: Margaret Atwood
+  Classroom: ELA 1H
+- School: Douglass High School
+  Teacher: James McBride
+  Classroom: English - Period 6
+- School: Douglass High School
+  Teacher: William Shakespeare
+  Classroom: Intro to Playwriting
+- School: Douglass High School
+  Teacher: Emily Bronte
+  Classroom: AP - Literature
+- School: Douglass High School
+  Teacher: Jane Austen
+  Classroom: Period 2
+- School: Douglass High School
+  Teacher: Leigh Bardugo
+  Classroom: Period 8
+- School: Douglass High School
+  Teacher: Tomi Adeyemi
+  Classroom: Period 7
+- School: Douglass High School
+  Teacher: Alice Walker
+  Classroom: Period 1
+- School: Douglass High School
+  Teacher: Sylvia Plath
+  Classroom: Period 4

--- a/services/QuillLMS/lib/data/demo/admin_demo_data.yml
+++ b/services/QuillLMS/lib/data/demo/admin_demo_data.yml
@@ -20,7 +20,7 @@
   Teacher: Colson Whitehead
   Classroom: ELA Block 1
 - School: MLK Middle School
-  Teacher: Toni Morrison
+  Teacher: Taffy Brodesser-Akner
   Classroom: English AP - Literature
 - School: MLK Middle School
   Teacher: Madeleine L'engle

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
@@ -99,7 +99,7 @@ describe Teachers::ProgressReportsController do
 
         expect(Demo::CreateAdminReport)
           .to receive(:new)
-          .with("test", "test", "hello+demoadmin-test@quill.org")
+          .with("test")
           .and_return(admin_report_service)
 
         get :admin_demo, params: { name: "test" }
@@ -122,7 +122,7 @@ describe Teachers::ProgressReportsController do
 
         expect(Demo::CreateAdminReport)
           .to receive(:new)
-          .with("Admin Demo School", "admindemoschool", "hello+demoadmin-admindemoschool@quill.org")
+          .with("Admin Demo School")
           .and_return(admin_report_service)
 
         get :admin_demo

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports_controller_spec.rb
@@ -99,7 +99,7 @@ describe Teachers::ProgressReportsController do
 
         expect(Demo::CreateAdminReport)
           .to receive(:new)
-          .with("test")
+          .with("hello+demoadmin-test@quill.org")
           .and_return(admin_report_service)
 
         get :admin_demo, params: { name: "test" }
@@ -122,7 +122,7 @@ describe Teachers::ProgressReportsController do
 
         expect(Demo::CreateAdminReport)
           .to receive(:new)
-          .with("Admin Demo School")
+          .with("hello+demoadmin-admindemoschool@quill.org")
           .and_return(admin_report_service)
 
         get :admin_demo

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Demo::CreateAdminReport do
+  let!(:teacher_email) { 'hello+demoadmin-admindemoschool@quill.org' }
+
+  subject { described_class.new(teacher_email) }
+
+  before do
+    Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES
+      .map {|template| Demo::ReportDemoCreator.activity_ids_for_config(template) }
+      .flatten
+      .uniq
+      .each {|activity_id|  create(:activity, id: activity_id) }
+
+    Demo::SessionData.new
+      .concept_results
+      .map(&:concept_id)
+      .uniq
+      .each {|concept_id| create(:concept, id: concept_id)}
+  end
+
+  it 'should create an admin user with the passed email who has purchased a district subscription' do
+    subject.call
+    expect(admin).to be
+    expect(subscription).to be
+  end
+
+  it 'should create the schools from the data hash and make the admin an administrator of them' do
+    subject.call
+    school_names = subject.data.map { |d| d['School'] }.uniq
+    school_names.each do |name|
+      school = School.find_by_name(name)
+      expect(school).to be
+      expect(SchoolsAdmins.find_by(user: admin, school: school)).to be
+      expect(SchoolSubscription.find_by(school: school, subscription: subscription)).to be
+    end
+  end
+
+  it 'should create every teacher account from the data hash, associated with the correct school' do
+    subject.call
+    schools_and_teachers = subject.data.map { |d| { 'School': d['School'], 'Teacher': d['Teacher'] } }.uniq
+    schools_and_teachers.each do |row|
+      teacher = User.find_by_name(row['Teacher'])
+      school = School.find_by_name(row['School'])
+      expect(SchoolsUsers.find_by(school: school, user: teacher)).to be
+      expect(UserSubscription.find_by(user: teacher, subscription: subscription)).to be
+    end
+  end
+
+  it 'should create every classroom from the data hash, associated with the correct teacher, each with five students and between 112-140 activity sessions' do
+    subject.call
+    subject.data.each do |row|
+      classroom = Classroom.find_by_name(row['Classroom'])
+      teacher = User.find_by_name(row['Teacher'])
+      expect(classroom).to be
+      expect(classroom.owner).to eq(teacher)
+      expect(classroom.students.count).to eq(5)
+      expect(classroom.activity_sessions.count).to be_between(112, 140)
+    end
+  end
+
+  def admin
+    User.find_by(email: teacher_email, role: User::ADMIN)
+  end
+
+  def subscription
+    Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID)
+  end
+
+end

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Demo::CreateAdminReport do
   let!(:teacher_email) { 'hello+demoadmin-admindemoschool@quill.org' }
 
   subject { described_class.new(teacher_email, passed_data) }
-  let!(:data) { subject.data }
 
   before do
     Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES
@@ -21,7 +20,7 @@ RSpec.describe Demo::CreateAdminReport do
       .uniq
       .each {|concept_id| create(:concept, id: concept_id)}
 
-      subject.call
+    subject.call
   end
 
   it 'should create an admin user with the passed email who has purchased a district subscription' do
@@ -30,7 +29,7 @@ RSpec.describe Demo::CreateAdminReport do
   end
 
   it 'should create the schools from the data hash and make the admin an administrator of them' do
-    school_names = data.map { |d| d['School'] }.uniq
+    school_names = subject.data.map { |d| d['School'] }.uniq
     school_names.each do |name|
       school = School.find_by_name(name)
       expect(school).to be
@@ -40,7 +39,7 @@ RSpec.describe Demo::CreateAdminReport do
   end
 
   it 'should create every teacher account from the data hash, associated with the correct school' do
-    schools_and_teachers = data.map { |d| { 'School' => d['School'], 'Teacher' => d['Teacher'] } }.uniq
+    schools_and_teachers = subject.data.map { |d| { 'School' => d['School'], 'Teacher' => d['Teacher'] } }.uniq
     schools_and_teachers.each do |row|
       teacher = User.find_by_name(row['Teacher'])
       school = School.find_by_name(row['School'])
@@ -72,7 +71,7 @@ RSpec.describe Demo::CreateAdminReport do
     [
       {"School"=>"MLK Middle School", "Teacher"=>"Maya Angelou", "Classroom"=>"Period 1a"},
       {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 4"},
-      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 5"},
+      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 5"}
     ]
   end
 

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Demo::CreateAdminReport do
   end
 
   it 'should create every classroom from the data hash, associated with the correct teacher, each with five students and between 112-140 activity sessions' do
-    data.each do |row|
+    subject.data.each do |row|
       classroom = Classroom.find_by_name(row['Classroom'])
       teacher = User.find_by_name(row['Teacher'])
       expect(classroom).to be

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe Demo::CreateAdminReport do
   let!(:teacher_email) { 'hello+demoadmin-admindemoschool@quill.org' }
 
-  subject { described_class.new(teacher_email) }
+  subject { described_class.new(teacher_email, passed_data) }
+  let!(:data) { subject.data }
 
   before do
     Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES
@@ -19,17 +20,17 @@ RSpec.describe Demo::CreateAdminReport do
       .map(&:concept_id)
       .uniq
       .each {|concept_id| create(:concept, id: concept_id)}
+
+      subject.call
   end
 
   it 'should create an admin user with the passed email who has purchased a district subscription' do
-    subject.call
     expect(admin).to be
     expect(subscription).to be
   end
 
   it 'should create the schools from the data hash and make the admin an administrator of them' do
-    subject.call
-    school_names = subject.data.map { |d| d['School'] }.uniq
+    school_names = data.map { |d| d['School'] }.uniq
     school_names.each do |name|
       school = School.find_by_name(name)
       expect(school).to be
@@ -39,8 +40,7 @@ RSpec.describe Demo::CreateAdminReport do
   end
 
   it 'should create every teacher account from the data hash, associated with the correct school' do
-    subject.call
-    schools_and_teachers = subject.data.map { |d| { 'School': d['School'], 'Teacher': d['Teacher'] } }.uniq
+    schools_and_teachers = data.map { |d| { 'School' => d['School'], 'Teacher' => d['Teacher'] } }.uniq
     schools_and_teachers.each do |row|
       teacher = User.find_by_name(row['Teacher'])
       school = School.find_by_name(row['School'])
@@ -50,8 +50,7 @@ RSpec.describe Demo::CreateAdminReport do
   end
 
   it 'should create every classroom from the data hash, associated with the correct teacher, each with five students and between 112-140 activity sessions' do
-    subject.call
-    subject.data.each do |row|
+    data.each do |row|
       classroom = Classroom.find_by_name(row['Classroom'])
       teacher = User.find_by_name(row['Teacher'])
       expect(classroom).to be
@@ -67,6 +66,14 @@ RSpec.describe Demo::CreateAdminReport do
 
   def subscription
     Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID)
+  end
+
+  def passed_data
+    [
+      {"School"=>"MLK Middle School", "Teacher"=>"Maya Angelou", "Classroom"=>"Period 1a"},
+      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 4"},
+      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 5"},
+    ]
   end
 
 end

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -4,6 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Demo::CreateAdminReport do
   let!(:teacher_email) { 'hello+demoadmin-admindemoschool@quill.org' }
+  let!(:passed_data) {
+    [
+      {"School"=>"MLK Middle School", "Teacher"=>"Maya Angelou", "Classroom"=>"Period 1a"},
+      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 4"},
+      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 5"}
+    ]
+  }
 
   subject { described_class.new(teacher_email, passed_data) }
 
@@ -65,14 +72,6 @@ RSpec.describe Demo::CreateAdminReport do
 
   def subscription
     Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID)
-  end
-
-  def passed_data
-    [
-      {"School"=>"MLK Middle School", "Teacher"=>"Maya Angelou", "Classroom"=>"Period 1a"},
-      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 4"},
-      {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 5"}
-    ]
   end
 
 end

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -11,11 +11,10 @@ RSpec.describe Demo::CreateAdminReport do
       {"School"=>"Douglass High School", "Teacher"=>"Kevin Kwan", "Classroom"=>"Period 5"}
     ]
   }
+  let(:admin) { User.find_by(email: teacher_email, role: User::ADMIN) }
+  let(:subscription) { Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID) }
 
   subject { described_class.new(teacher_email, passed_data) }
-
-  let!(:admin) { User.find_by(email: teacher_email, role: User::ADMIN) }
-  let!(:subscription) { Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID) }
 
   before do
     Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Demo::CreateAdminReport do
 
   subject { described_class.new(teacher_email, passed_data) }
 
+  let!(:admin) { User.find_by(email: teacher_email, role: User::ADMIN) }
+  let!(:subscription) { Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID) }
+
   before do
     Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES
       .map {|template| Demo::ReportDemoCreator.activity_ids_for_config(template) }
@@ -65,13 +68,4 @@ RSpec.describe Demo::CreateAdminReport do
       expect(classroom.activity_sessions.count).to be_between(112, 140)
     end
   end
-
-  def admin
-    User.find_by(email: teacher_email, role: User::ADMIN)
-  end
-
-  def subscription
-    Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID)
-  end
-
 end

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Demo::ReportDemoCreator do
       subject { classroom.students }
 
       context 'teacher-facing' do
-        before { Demo::ReportDemoCreator.create_students(classroom, true) }
+        before { Demo::ReportDemoCreator.create_students(classroom, true, Demo::ReportDemoCreator::STUDENT_TEMPLATES) }
 
         it { expect(subject.count).to eq 5 }
         it { expect(subject.map(&:name).sort).to eq student_names }
@@ -146,7 +146,7 @@ RSpec.describe Demo::ReportDemoCreator do
       end
 
       context 'not teacher-facing' do
-        before { Demo::ReportDemoCreator.create_students(classroom, false) }
+        before { Demo::ReportDemoCreator.create_students(classroom, false, Demo::ReportDemoCreator::STUDENT_TEMPLATES) }
 
         it { expect(subject.count).to eq 5 }
         it { expect(subject.map(&:name).sort).to eq student_names }


### PR DESCRIPTION
## WHAT
Update the admin demo account script to generate a greater and more varied quantity of data, based on the spec (namely, a total of 48 classrooms spread across two schools, with five students each and between 112-140 activities completed per classroom).

## WHY
To provide better representation of what the dashboard would look like for active schools.

## HOW
Just adjust the existing admin script, having it utilize some of the functions from the regular demo account generator as requested and populate a larger amount of data overall.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-Admin-Account-data-54279ad9b9c64ed68d90ab458f3a12a3?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES