### PR TITLE
Increase footer padding across site

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/footer.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/footer.scss
@@ -283,10 +283,10 @@
 }
 
 .white-background-accommodate-footer {
-  padding-bottom: 300px;
+  padding-bottom: 500px;
   background-color: white;
 }
 
 .gray-background-accommodate-footer {
-  padding-bottom: 300px;
+  padding-bottom: 500px;
 }


### PR DESCRIPTION
## WHAT
Increase the footer padding to 500px across the site.

## WHY
The new premium footer is very bright and it would help for visual purposes to add some more white space before this footer.

## HOW
Just increase the padding on the footer elements.

### Screenshots
<img width="927" alt="Screen Shot 2023-03-31 at 8 12 31 PM" src="https://user-images.githubusercontent.com/57366100/229362577-170742c9-c449-4a44-b183-82a84cb3e242.png">


### Notion Card Links
https://www.notion.so/quill/P4-White-Space-Buffer-on-Pages-for-Premium-adf1e1206672411f8213b9167e4203d9?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, tiny change
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
