### PR TITLE
LearnWorlds SSO backend integration

### DIFF
--- a/services/QuillLMS/app/controllers/auth/learn_worlds_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/learn_worlds_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Auth
+  class LearnWorldsController < ApplicationController
+    before_action :teacher!
+
+    delegate :learn_worlds_access?, to: :current_user
+
+    def courses
+      if learn_worlds_access? && sso_success?
+        create_learn_worlds_user
+        redirect_to learn_worlds_courses_endpoint
+      else
+        redirect_to root_path
+      end
+    end
+
+    private def create_learn_worlds_user
+      return if current_user.learn_worlds_account
+
+      current_user.create_learn_worlds_account(external_id: learn_worlds_external_id)
+    end
+
+    private def learn_worlds_courses_endpoint
+      sso_response["url"]
+    end
+
+    private def learn_worlds_external_id
+      sso_response["user_id"]
+    end
+
+    private def sso_response
+      @sso_response ||= LearnWorlds::SSORequest.run(current_user)
+    end
+
+    private def sso_success?
+      sso_response["success"] == true
+    end
+  end
+end

--- a/services/QuillLMS/app/models/district.rb
+++ b/services/QuillLMS/app/models/district.rb
@@ -133,6 +133,10 @@ class District < ApplicationRecord
       .count
   end
 
+  def premium?
+    subscription&.present?
+  end
+
   private def latest_subscription
     subscriptions.not_expired.not_de_activated.order(expiration: :desc).first
   end

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -184,6 +184,10 @@ class School < ApplicationRecord
     district&.name
   end
 
+  def premium?
+    subscription&.present? || district&.premium?
+  end
+
   private def generate_leap_csv_row(student, teacher, classroom, activity_session)
     [
       student.id,

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -785,6 +785,10 @@ class User < ApplicationRecord
     end
   end
 
+  def learn_worlds_access?
+    teacher? && school&.premium?
+  end
+
   private def validate_flags
     invalid_flags = flags - VALID_FLAGS
 

--- a/services/QuillLMS/app/services/auth/learn_worlds/sso_request.rb
+++ b/services/QuillLMS/app/services/auth/learn_worlds/sso_request.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Auth
+  module LearnWorlds
+    class SSORequest < ::ApplicationService
+      class NilEmailError < StandardError; end
+      class NilUserError < StandardError; end
+
+      attr_reader :user
+
+      delegate :email, :username, to: :user
+
+      def initialize(user)
+        @user = user
+      end
+
+      def run
+        raise NilUserError if user.nil?
+        raise NilEmailError if email.nil?
+
+        response = HTTParty.post(SSO_ENDPOINT, body: body, headers: headers)
+      end
+
+      private def body
+        URI.encode_www_form(data)
+      end
+
+      private def data
+        user.learn_worlds_account ? existing_user_data : new_user_data
+      end
+
+      private def existing_user_data
+        {
+          redirectURL: COURSES_ENDPOINT,
+          user_id: user.learn_worlds_account.external_id
+        }
+      end
+
+      private def new_user_data
+        {
+          email: email,
+          redirectURL: COURSES_ENDPOINT,
+          username: username || email
+        }
+      end
+
+      private def headers
+        {
+          "Lw-Client" => CLIENT_ID,
+          "Authorization" => "Bearer #{ACCESS_TOKEN}"
+        }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/auth/learn_worlds/sso_request.rb
+++ b/services/QuillLMS/app/services/auth/learn_worlds/sso_request.rb
@@ -8,7 +8,7 @@ module Auth
 
       attr_reader :user
 
-      delegate :email, :username, to: :user
+      delegate :email, :learn_worlds_account, :username, to: :user
 
       def initialize(user)
         @user = user
@@ -26,13 +26,13 @@ module Auth
       end
 
       private def data
-        user.learn_worlds_account ? existing_user_data : new_user_data
+        learn_worlds_account ? existing_user_data : new_user_data
       end
 
       private def existing_user_data
         {
           redirectURL: COURSES_ENDPOINT,
-          user_id: user.learn_worlds_account.external_id
+          user_id: learn_worlds_account.external_id
         }
       end
 

--- a/services/QuillLMS/config/initializers/auth/learn_worlds.rb
+++ b/services/QuillLMS/config/initializers/auth/learn_worlds.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Auth
+  module LearnWorlds
+    BASE_URI = ENV.fetch('LEARN_WORLDS_BASE_URI', '')
+    CLIENT_ID = ENV.fetch('LEARN_WORLDS_CLIENT_ID', '')
+    ACCESS_TOKEN = ENV.fetch('LEARN_WORLDS_ACCESS_TOKEN', '')
+
+    SSO_ENDPOINT = "#{BASE_URI}/admin/api/sso"
+    COURSES_ENDPOINT = "#{BASE_URI}/courses"
+  end
+end

--- a/services/QuillLMS/config/initializers/inflections.rb
+++ b/services/QuillLMS/config/initializers/inflections.rb
@@ -19,4 +19,5 @@
 
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.irregular 'criterion', 'criteria'
+  inflect.acronym 'SSO'
 end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -585,6 +585,7 @@ EmpiricalGrammar::Application.routes.draw do
 
   namespace :auth do
     get '/clever/callback', to: 'clever#clever'
+    post '/learn_worlds/courses', to: 'learn_worlds#courses'
   end
 
   namespace :clever_integration do

--- a/services/QuillLMS/spec/factories/learn_worlds_accounts.rb
+++ b/services/QuillLMS/spec/factories/learn_worlds_accounts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :learn_worlds_account do
+    user
+    external_id { SecureRandom.hex(12) }
+  end
+end

--- a/services/QuillLMS/spec/models/district_spec.rb
+++ b/services/QuillLMS/spec/models/district_spec.rb
@@ -243,4 +243,18 @@ describe District, type: :model do
       end
     end
   end
+
+  context '#premium?' do
+    subject { district.premium? }
+
+    context 'no subscription exists' do
+      it { expect(subject).to be_falsey }
+    end
+
+    context 'subscription exists' do
+      before { allow(district).to receive(:subscription).and_return(double(:subscription))}
+
+      it { expect(subject).to be true }
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/school_spec.rb
+++ b/services/QuillLMS/spec/models/school_spec.rb
@@ -218,11 +218,33 @@ describe School, type: :model do
     end
   end
 
-  describe('vitally_data') do
+  describe 'vitally_data'  do
     let(:school) { create(:school) }
 
     it 'sends a payload that contains the correct data for vitally' do
       expect(school.vitally_data).to eq({externalId: school.id.to_s, name: school.name})
+    end
+  end
+
+  describe '#premium?' do
+    let(:school) { create(:school) }
+
+    subject { school.premium? }
+
+    context 'no school or district subscription exists' do
+      it { expect(subject).to be_falsey }
+    end
+
+    context 'school subscription exists' do
+      before { allow(school).to receive(:subscription).and_return(double(:subscription)) }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'district is premium' do
+      before { allow(school).to receive(:district).and_return(double(:district, premium?: true)) }
+
+      it { expect(subject).to be true }
     end
   end
 end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1612,7 +1612,6 @@ describe User, type: :model do
     end
   end
 
-
   describe 'email verification logic' do
     let(:user) { create(:user) }
     let!(:user_email_verification) { create(:user_email_verification, user: user) }
@@ -1741,5 +1740,40 @@ describe User, type: :model do
     end
   end
 
+  describe '#learn_worlds_access?' do
+    subject { user.learn_worlds_access? }
+
+    context 'user is a student' do
+      let(:user) { create(:student) }
+
+      it { expect(subject).to be_falsey }
+    end
+
+    context 'user is a teacher' do
+      let(:user) { create(:teacher) }
+
+      context 'school is nil' do
+        it { expect(subject).to be_falsey }
+      end
+
+      context 'school is present' do
+        let(:school) { double(premium?: premium) }
+
+        before { allow(user).to receive(:school).and_return(school) }
+
+        context 'school is not premium' do
+          let(:premium) { false }
+
+          it { expect(subject).to be_falsey }
+        end
+
+        context 'school is premium' do
+          let(:premium) { true }
+
+          it { expect(subject).to be true}
+        end
+      end
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/services/QuillLMS/spec/requests/auth/learn_worlds_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/auth/learn_worlds_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Auth::LearnWorldsController do
   subject { post auth_learn_worlds_courses_path }
 
-  let(:courses_endpoint) { stub_const('Auth::LearnWorlds::COURSES_ENDPOINT', 'https://learnworlds.com/courses') }
+  let(:courses_endpoint) { 'https://learnworlds.com/courses' }
 
   before do
     allow(User).to receive(:find).with(user.id).and_return(user)

--- a/services/QuillLMS/spec/requests/auth/learn_worlds_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/auth/learn_worlds_controller_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Auth::LearnWorldsController do
+  subject { post auth_learn_worlds_courses_path }
+
+  let(:courses_endpoint) { stub_const('Auth::LearnWorlds::COURSES_ENDPOINT', 'https://learnworlds.com/courses') }
+
+  before do
+    allow(User).to receive(:find).with(user.id).and_return(user)
+    sign_in user
+  end
+
+  context 'user is a student' do
+    let(:user) { create(:student) }
+
+    it { expect(subject).to redirect_to new_session_path }
+  end
+
+  context 'user is a teacher' do
+    let(:user) { create(:teacher) }
+
+    before { allow(user).to receive(:learn_worlds_access?).and_return(learn_worlds_access) }
+
+    context 'user does not have learn_worlds_access' do
+      let(:learn_worlds_access) { false }
+
+      it { expect(subject).to redirect_to root_path }
+    end
+
+    context 'user has learn_worlds_access' do
+      let(:learn_worlds_access) { true }
+      let(:learn_worlds_account_external_id) { SecureRandom.hex(12) }
+
+      let(:sso_response) do
+        {
+          user_id: learn_worlds_account_external_id,
+          success: success,
+          url: courses_endpoint
+        }.stringify_keys
+      end
+
+      before { allow(Auth::LearnWorlds::SSORequest).to receive(:run).with(user).and_return(sso_response) }
+
+      context 'sso_success? is false' do
+        let(:success) { false }
+
+        it { expect(subject).to redirect_to root_path }
+      end
+
+      context 'sso_success? is true' do
+        let(:success) { true }
+
+        it { expect(subject).to redirect_to courses_endpoint }
+
+        context 'user does not have a learn_worlds_account' do
+          it { expect { subject }.to change(user, :learn_worlds_account).from(nil).to be_a(LearnWorldsAccount) }
+        end
+
+        context 'user has existing learn_worlds_account' do
+          before { create(:learn_worlds_account, user: user, external_id: learn_worlds_account_external_id) }
+
+          it { expect { subject }.not_to change(user, :learn_worlds_account) }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/auth/sso_request_spec.rb
+++ b/services/QuillLMS/spec/services/auth/sso_request_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Auth::LearnWorlds::SSORequest do
+  subject { described_class.run(user) }
+
+  context 'nil user' do
+    let(:user) { nil }
+
+    it { expect { subject }.to raise_error described_class::NilUserError }
+  end
+
+  context 'user exists with nil email' do
+    let(:user) { create(:user, email: nil) }
+
+    it { expect { subject }.to raise_error described_class::NilEmailError }
+  end
+
+  context 'user exists with email' do
+    let(:user) { create(:user) }
+    let(:url) { Auth::LearnWorlds::BASE_URI + "/login?code=#{SecureRandom.hex(32)}" }
+
+    let(:sso_response) do
+      {
+        user_id: user_id,
+        url: url,
+        errors: [],
+        success: true,
+      }.stringify_keys
+    end
+
+    before { allow(HTTParty).to receive(:post).and_return(sso_response) }
+
+    context 'learn_worlds_account does not exist' do
+      let(:user_id) { SecureRandom.hex(12) }
+      let(:data) do
+        {
+          email: user.email,
+          redirectURL: Auth::LearnWorlds::COURSES_ENDPOINT,
+          username: username
+        }
+      end
+
+      context 'username is not nil' do
+        let(:username) { user.username }
+
+        it { expect(subject).to eq sso_response}
+
+        it do
+          expect(URI).to receive(:encode_www_form).with(data)
+          subject
+        end
+      end
+
+      context 'username is nil' do
+        let(:username) { user.email }
+
+        before { user.update(username: nil) }
+
+        it do
+          expect(URI).to receive(:encode_www_form).with(data)
+          subject
+        end
+      end
+    end
+
+    context 'learn_worlds_account exists' do
+      let(:learn_worlds_account) { create(:learn_worlds_account, user: user)}
+      let(:user_id) { learn_worlds_account.external_id }
+
+      let(:data) do
+        {
+          redirectURL: Auth::LearnWorlds::COURSES_ENDPOINT,
+          user_id: user_id
+        }
+      end
+
+      it { expect(subject).to eq sso_response}
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add LearnWorlds SSO backend integration.

## WHY
We want teachers to be able to sign into LearnWorlds without having to create a new account.

## HOW
When user a clicks an auth_learn_worlds_course_url button/form, two actions occurs.

1) A POST request will be [sent](https://github.com/empirical-org/Empirical-Core/blob/a2f140bbba3f5c9df2cd0b89b62fc640264abd85/services/QuillLMS/app/services/auth/learn_worlds/sso_request.rb#L21) to the LearnWorlds SSO endpoint.
2) Upon successful response, the user is [redirected](https://github.com/empirical-org/Empirical-Core/blob/a2f140bbba3f5c9df2cd0b89b62fc640264abd85/services/QuillLMS/app/controllers/auth/learn_worlds_controller.rb#L9) to the LearnWorlds site, logged in.
  a) If the users has an existing learn_worlds_account, they are logged in via their learn_worlds_account.external_id
  b) Otherwise, for the initial sign on, the user is logged in via their email and a learn_worlds_account is attached to that user

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
