### PR TITLE
Add an additional premium banner promoting school/district premium deal

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_banner.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_banner.scss
@@ -34,3 +34,50 @@
     h4 {margin-bottom: 7px;}
   }
 }
+.school-premium-banner {
+  margin-left: 0px !important;
+  margin-right: 0px !important;
+  color: #333333;
+  font-size: 14px;
+  padding-top: 27px;
+  min-height: 115px;
+  text-align: left;
+  background-color: #FFE7BE;
+  width: 100%;
+  .pull-left {
+    padding-left: 0px !important;
+    padding-right: 0px !important;
+    max-width: 705px;
+  }
+  .pull-right {
+    padding-left: 45px;
+  }
+  .spinner-container {
+    max-height: 97px;
+    margin: 0;
+    padding: 0 0 22px;
+  }
+  h4 {
+    font-size: 18px;
+    font-weight: 700;
+  }
+  a {
+    color: #027360;
+  }
+  .row > div {
+    margin-bottom: 24px;
+    padding-top: 10px;
+  }
+  .free-trial-promo > div {
+    margin-bottom: 24px;
+  }
+  h4,
+  .btn-orange {
+    margin-bottom: 7px;
+  }
+  .new-sign-up-banner {
+    margin-bottom: 0px;
+    .button-green{ width: 326px;}
+    h4 {margin-bottom: 7px;}
+  }
+}

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_banner.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_banner.scss
@@ -32,6 +32,21 @@
     .button-green{ width: 326px;}
     h4 {margin-bottom: 7px;}
   }
+  .pull-right {
+    padding-right: 12px !important;
+    .premium-button-box {
+      float: right;
+    }
+  }
+
+  @media screen and (max-width: 1000px) {
+    .pull-right {
+      .premium-button-box {
+        float: none !important;
+      }
+    }
+  }
+
 }
 .school-premium-banner {
   margin-left: 0px !important;
@@ -44,7 +59,7 @@
   background-color: #F7F5F5;
   width: 100%;
   .pull-left {
-    padding-left: 0px !important;
+    padding-left: 15px !important;
     padding-right: 0px !important;
     max-width: 715px;
     margin-top: 5px;
@@ -52,8 +67,11 @@
   .pull-right {
     margin-top: 20px;
     margin-bottom: 20px;
+    margin-left: 0px !important;
+    padding-right: 10px;
     .premium-button-box {
       min-width: 115px;
+      float: right;
     }
   }
   h4 {
@@ -69,11 +87,10 @@
     margin-bottom: 7px;
   }
 
-  @media screen and (min-width: 1000px) {
+  @media screen and (max-width: 1000px) {
     .pull-right {
       .premium-button-box {
-        margin-left: 78px;
-        margin-right: -27px;
+        float: none !important;
       }
     }
   }

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_banner.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_banner.scss
@@ -1,8 +1,7 @@
 #premium-banner {
   color: #333333;
-  font-size: 14px;
+  font-size: 15px;
   padding-top: 27px;
-  background-image: url(/images/star_pattern_5.png);
   min-height: 115px;
   text-align: left;
   .spinner-container {
@@ -11,7 +10,7 @@
     padding: 0 0 22px;
   }
   h4 {
-    font-size: 18px;
+    font-size: 20px;
     font-weight: 700;
   }
   a {
@@ -38,46 +37,44 @@
   margin-left: 0px !important;
   margin-right: 0px !important;
   color: #333333;
-  font-size: 14px;
+  font-size: 15px;
   padding-top: 27px;
-  min-height: 115px;
+  min-height: 135px;
   text-align: left;
-  background-color: #FFE7BE;
+  background-color: #F7F5F5;
   width: 100%;
   .pull-left {
     padding-left: 0px !important;
     padding-right: 0px !important;
-    max-width: 705px;
+    max-width: 715px;
+    margin-top: 5px;
   }
   .pull-right {
-    padding-left: 45px;
-  }
-  .spinner-container {
-    max-height: 97px;
-    margin: 0;
-    padding: 0 0 22px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+    .premium-button-box {
+      min-width: 115px;
+    }
   }
   h4 {
-    font-size: 18px;
+    font-size: 20px;
     font-weight: 700;
-  }
-  a {
-    color: #027360;
   }
   .row > div {
     margin-bottom: 24px;
     padding-top: 10px;
   }
-  .free-trial-promo > div {
-    margin-bottom: 24px;
-  }
   h4,
   .btn-orange {
     margin-bottom: 7px;
   }
-  .new-sign-up-banner {
-    margin-bottom: 0px;
-    .button-green{ width: 326px;}
-    h4 {margin-bottom: 7px;}
+
+  @media screen and (min-width: 1000px) {
+    .pull-right {
+      .premium-button-box {
+        margin-left: 78px;
+        margin-right: -27px;
+      }
+    }
   }
 }

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
@@ -718,8 +718,6 @@ li.premium-tab > a:hover {
 
 @media (max-width: 991px) {
   .premium-page {
-    padding-left: 10px;
-    padding-right: 10px;
 
     .school-and-district-premium-modal {
       flex-direction: column;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -87,15 +87,19 @@ export default class PremiumBannerBuilder extends React.Component {
           </div>
           <div className='row school-premium-banner'>
             <div className='container'>
-              <div className='col-md-9 col-xs-12 pull-left'>
-                <h4>Representing a School or District?</h4>
-                <span>Starting April 1st, when you purchase School or District Premium, you&apos;ll receive Quill Premium for free for the remainder of the school year!</span>
-              </div>
-              <div className='col-md-3 col-xs-12 pull-right'>
-                <div className='premium-button-box text-center'>
-                  <a href='/premium/request-school-quote'><button className='btn-orange' type='button'>Get in touch!</button></a>
+              <span>
+                <div className='row'>
+                  <div className='col-md-9 col-xs-12 pull-left'>
+                    <h4>Representing a School or District?</h4>
+                    <span>Starting April 1st, when you purchase School or District Premium, you&apos;ll receive Quill Premium for free for the remainder of the school year!</span>
+                  </div>
+                  <div className='col-md-3 col-xs-12 pull-right'>
+                    <div className='premium-button-box text-center'>
+                      <a href='/premium/request-school-quote'><button className='btn-orange' type='button'>Get in touch!</button></a>
+                    </div>
+                  </div>
                 </div>
-              </div>
+              </span>
             </div>
           </div>
         </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -90,9 +90,24 @@ export default class PremiumBannerBuilder extends React.Component {
     } else
     {
       return (
-        <div id='premium-banner' style={divStyle}>
-          <div className='container'>
-            {this.stateSpecificComponents()}
+        <div>
+          <div id='premium-banner' style={divStyle}>
+            <div className='container'>
+              {this.stateSpecificComponents()}
+            </div>
+          </div>
+          <div className='row school-premium-banner'>
+            <div className='container'>
+              <div className='col-md-9 col-xs-12 pull-left'>
+                <h4>Representing a School or District?</h4>
+                <span>Starting April 1st, when you purchase School or District Premium, you&apos;ll receive Quill Premium for free for the remainder of the school year!</span>
+              </div>
+              <div className='col-md-3 col-xs-12 pull-right'>
+                <div className='premium-button-box text-center'>
+                  <a href='/premium/request-school-quote'><button className='btn-orange' type='button'>Get in touch!</button></a>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       );

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -68,22 +68,11 @@ export default class PremiumBannerBuilder extends React.Component {
     }
   };
 
-  stateSpecificBackGroundImage = () => {
-    const { daysLeft, } = this.props
-    if (daysLeft === 30){
-      return('none');
-    } else {
-      return('url(/images/star_pattern_5.png)');
-    }
-  };
-
   hasPremium = () => {
     const { has_premium, first_day_of_premium_or_trial, } = this.state
     let color = this.stateSpecificBackGroundColor();
-    let img = this.stateSpecificBackGroundImage();
     let divStyle = {
-      backgroundColor: color,
-      backgroundImage: img
+      backgroundColor: color
     };
     if ((has_premium === null) || (has_premium === 'school') || ((has_premium === 'paid') && (first_day_of_premium_or_trial === false))) {
       return (<span />);


### PR DESCRIPTION
## WHAT
Add a new banner urging teachers to sign up for School and District premium.

## WHY
We have a new promotion for teachers to get school/district premium free until the end of the year, so we want to promote this deal.

## HOW
Add a new banner and appropriate styling (and change some old styling so it doesn't clash with the new banner).

### Screenshots
<img width="1155" alt="Screen Shot 2023-04-05 at 9 04 42 PM" src="https://user-images.githubusercontent.com/57366100/230089446-e82f2e59-938a-4a32-a4e0-33d9fb6d3e14.png">



### Notion Card Links
https://www.notion.so/quill/Banner-on-Premium-Page-to-let-Schools-Districts-know-if-they-sign-up-now-they-get-the-rest-of-this-y-7694da0b8f054e63858afd0208187375?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, small front end change
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
