### PR TITLE
Bug-fix/ fix Connect & Diagnostic student play widths

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/styles/components/_student-container.scss
+++ b/services/QuillLMS/client/app/bundles/Connect/styles/components/_student-container.scss
@@ -5,7 +5,7 @@
 
 .student-container {
   @extend .container;
-  max-width: 800px;
+  max-width: 800px !important;
 }
 
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/styles/components/_student-container.scss
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/styles/components/_student-container.scss
@@ -5,7 +5,7 @@
 
 .student-container {
   @extend .container;
-  max-width: 800px;
+  max-width: 800px !important;
 }
 
 


### PR DESCRIPTION
## WHAT
fix student play container widths for Connect & Diagnostic

## WHY
the widths are being overridden by a 3rd party library

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1408" alt="Screen Shot 2023-04-06 at 4 18 48 PM" src="https://user-images.githubusercontent.com/25959584/230486382-1f694d75-7af5-4442-9e64-fe674fad5dd4.png">
<img width="1434" alt="Screen Shot 2023-04-06 at 4 18 35 PM" src="https://user-images.githubusercontent.com/25959584/230486388-b0c6ed9b-f551-4776-9fbe-f06dbf3b2b97.png">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Display-issue-with-Diagnostic-and-Connect-student-play-7b02fd0090c54760894e6b4e23464e91?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  CSS change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
