### PR TITLE
make sure read button in article spotlight renders correctly in safari

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/styles/article-spotlight.scss
+++ b/services/QuillLMS/client/app/bundles/Teacher/styles/article-spotlight.scss
@@ -25,8 +25,13 @@
         }
       }
     }
+    .preview-card-link {
+      display: block;
+      height: min-content;
+    }
     .preview-card {
       height: auto;
+      margin-bottom: 0px;
       .preview-card-body {
         h3 {
           height: auto;


### PR DESCRIPTION
## WHAT
Fix bug where the "Read" button for the teacher center article spotlight was rendering outside of the component on Safari.

## WHY
We want this to look nice on all browsers.

## HOW
Just add some extra CSS rules so Safari recognizes the `preview-link-button` as the relatively-positioned parent correctly.

### Screenshots
<img width="1174" alt="Screen Shot 2023-04-13 at 11 06 34 AM" src="https://user-images.githubusercontent.com/18669014/231803945-a4da90e2-7aa3-4cad-abde-0a726f6395d4.png">

### Notion Card Links
https://www.notion.so/quill/New-Helpful-Article-Teacher-Center-Footer-section-layout-broken-on-Safari-Version-16-3-18614-4-6-118b54619b33497d8d5c8a177a5081f9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
