### PR TITLE
adjust whitespace for quill academy page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/quill_academy.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/quill_academy.scss
@@ -38,7 +38,6 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      padding: 64px;
       text-decoration: none;
       &.premium-user {
         box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## WHAT
Adjust whitespace on Quill Academy page.

## WHY
So more content appears above the fold.

## HOW
Just remove CSS rule that added extra padding.

### Screenshots
<img width="1440" alt="Screen Shot 2023-04-18 at 1 12 53 PM" src="https://user-images.githubusercontent.com/18669014/232857900-6b3598f7-f31b-47ac-b601-e0212f4792f2.png">


### Notion Card Links
https://www.notion.so/quill/Need-to-adjust-spacing-on-Quill-Academy-Landing-Page-for-better-content-visibility-65b62199813f46188e46929344553415

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES