### PR TITLE
replace react datetime picker with react datetime

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/filterWidget.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/filterWidget.test.tsx.snap
@@ -20,71 +20,29 @@ exports[`FilterWidget component should render FilterWidget 1`] = `
       >
         Start Date:
       </p>
-      <DateTimePicker
-        ampm={false}
-        calendarIcon={
-          <svg
-            className="react-datetime-picker__calendar-button__icon react-datetime-picker__button__icon"
-            height={19}
-            stroke="black"
-            strokeWidth={2}
-            viewBox="0 0 19 19"
-            width={19}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <rect
-              fill="none"
-              height="15"
-              width="15"
-              x="2"
-              y="2"
-            />
-            <line
-              x1="6"
-              x2="6"
-              y1="0"
-              y2="4"
-            />
-            <line
-              x1="13"
-              x2="13"
-              y1="0"
-              y2="4"
-            />
-          </svg>
-        }
-        className="start-date-picker"
-        clearIcon={
-          <svg
-            className="react-datetime-picker__clear-button__icon react-datetime-picker__button__icon"
-            height={19}
-            stroke="black"
-            strokeWidth={2}
-            viewBox="0 0 19 19"
-            width={19}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <line
-              x1="4"
-              x2="15"
-              y1="4"
-              y2="15"
-            />
-            <line
-              x1="15"
-              x2="4"
-              y1="4"
-              y2="15"
-            />
-          </svg>
-        }
-        closeWidgets={true}
-        format="y-MM-dd HH:mm"
-        isCalendarOpen={null}
-        isClockOpen={null}
-        maxDetail="minute"
+      <n
+        className=""
+        closeOnClickOutside={true}
+        closeOnSelect={false}
+        closeOnTab={true}
+        dateFormat="y-MM-D"
+        input={true}
+        inputProps={Object {}}
+        isValidDate={[Function]}
+        onBeforeNavigate={[Function]}
+        onCalendarClose={[Function]}
+        onCalendarOpen={[Function]}
         onChange={[MockFunction]}
-        openWidgetsOnFocus={true}
+        onClose={[Function]}
+        onNavigate={[Function]}
+        onNavigateBack={[Function]}
+        onNavigateForward={[Function]}
+        onOpen={[Function]}
+        renderView={[Function]}
+        strictParsing={true}
+        timeConstraints={Object {}}
+        timeFormat="HH:mm"
+        utc={false}
         value="2021-06-29T05:00:00.000Z"
       />
     </div>
@@ -96,71 +54,29 @@ exports[`FilterWidget component should render FilterWidget 1`] = `
       >
         End Date:
       </p>
-      <DateTimePicker
-        ampm={false}
-        calendarIcon={
-          <svg
-            className="react-datetime-picker__calendar-button__icon react-datetime-picker__button__icon"
-            height={19}
-            stroke="black"
-            strokeWidth={2}
-            viewBox="0 0 19 19"
-            width={19}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <rect
-              fill="none"
-              height="15"
-              width="15"
-              x="2"
-              y="2"
-            />
-            <line
-              x1="6"
-              x2="6"
-              y1="0"
-              y2="4"
-            />
-            <line
-              x1="13"
-              x2="13"
-              y1="0"
-              y2="4"
-            />
-          </svg>
-        }
-        className="end-date-picker"
-        clearIcon={
-          <svg
-            className="react-datetime-picker__clear-button__icon react-datetime-picker__button__icon"
-            height={19}
-            stroke="black"
-            strokeWidth={2}
-            viewBox="0 0 19 19"
-            width={19}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <line
-              x1="4"
-              x2="15"
-              y1="4"
-              y2="15"
-            />
-            <line
-              x1="15"
-              x2="4"
-              y1="4"
-              y2="15"
-            />
-          </svg>
-        }
-        closeWidgets={true}
-        format="y-MM-dd HH:mm"
-        isCalendarOpen={null}
-        isClockOpen={null}
-        maxDetail="minute"
+      <n
+        className=""
+        closeOnClickOutside={true}
+        closeOnSelect={false}
+        closeOnTab={true}
+        dateFormat="y-MM-D"
+        input={true}
+        inputProps={Object {}}
+        isValidDate={[Function]}
+        onBeforeNavigate={[Function]}
+        onCalendarClose={[Function]}
+        onCalendarOpen={[Function]}
         onChange={[MockFunction]}
-        openWidgetsOnFocus={true}
+        onClose={[Function]}
+        onNavigate={[Function]}
+        onNavigateBack={[Function]}
+        onNavigateForward={[Function]}
+        onOpen={[Function]}
+        renderView={[Function]}
+        strictParsing={true}
+        timeConstraints={Object {}}
+        timeFormat="HH:mm"
+        utc={false}
         value="2021-08-03T05:00:00.000Z"
       />
     </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/changeLog/changeLog.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/changeLog/changeLog.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
-import DateTimePicker from 'react-datetime-picker';
+import Datetime from 'react-datetime';
 import { useQuery } from 'react-query';
 import stripHtml from "string-strip-html";
 import * as _ from 'underscore';
-;
 
 import { sort } from '../../../../../modules/sortingMethods.js';
 import { ReactTable, Spinner, uniqueValuesArray } from '../../../../Shared/index';
@@ -15,8 +14,8 @@ const ChangeLog = ({ history, match }) => {
   const { activityId, } = params;
   const initialStartDateString = '';
   const initialEndDateString = '';
-  const initialStartDate = initialStartDateString ? new Date(initialStartDateString) : null;
-  const initialEndDate = initialEndDateString ? new Date(initialEndDateString) : null;
+  const initialStartDate = initialStartDateString ? new Date(initialStartDateString) : new Date();
+  const initialEndDate = initialEndDateString ? new Date(initialEndDateString) : new Date();
   const DEFAULT_RULE = 'all'
   const DEFAULT_PROMPT = 'all'
 
@@ -220,17 +219,17 @@ const ChangeLog = ({ history, match }) => {
         </div>
         <div id="bottom-selectors">
           <p className="date-picker-label">Start Date:</p>
-          <DateTimePicker
-            ampm={false}
-            format='y-MM-dd HH:mm'
+          <Datetime
+            dateFormat='y-MM-D'
             onChange={onStartDateChange}
+            timeFormat='HH:mm'
             value={startDate}
           />
           <p className="date-picker-label">End Date (optional):</p>
-          <DateTimePicker
-            ampm={false}
-            format='y-MM-dd HH:mm'
+          <Datetime
+            dateFormat='y-MM-D'
             onChange={onEndDateChange}
+            timeFormat='HH:mm'
             value={endDate}
           />
         </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/shared/filterWidget.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/shared/filterWidget.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import DateTimePicker from 'react-datetime-picker';
+import Datetime from 'react-datetime';
 import { DropdownInput } from "../../../../Shared";
 
 const FilterWidget = ({
@@ -25,22 +25,20 @@ const FilterWidget = ({
         />
         <div className="filter-container">
           <p className="date-picker-label">Start Date:</p>
-          <DateTimePicker
-            ampm={false}
-            className="start-date-picker"
-            format='y-MM-dd HH:mm'
+          <Datetime
+            dateFormat='y-MM-D'
             onChange={onStartDateChange}
-            value={startDate}
+            timeFormat='HH:mm'
+            value={startDate || new Date()}
           />
         </div>
         <div className="filter-container">
           <p className="date-picker-label">End Date:</p>
-          <DateTimePicker
-            ampm={false}
-            className="end-date-picker"
-            format='y-MM-dd HH:mm'
-            onChange={onEndDateChange}
-            value={endDate}
+          <Datetime
+            dateFormat='y-MM-D'
+            onChange={onStartDateChange}
+            timeFormat='HH:mm'
+            value={endDate || new Date()}
           />
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Staff/styles/date_time_selector.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/date_time_selector.scss
@@ -15,30 +15,11 @@
   }
   &.rules-analysis {
     margin-bottom: 24px;
-
-    .react-datetime-picker {
-      input:nth-of-type(2) {
-        width: 32px !important;
-      }
-      input:nth-of-type(3), input:nth-of-type(4), input:nth-of-type(5), input:nth-of-type(6) {
-        width: 16px !important;
-      }
-    }
   }
 }
 
 .date-picker-label {
   margin: 0px 16px 0px 0px;
-}
-.react-datetime-picker {
-  display: inline;
-  margin-right: 24px;
-}
-.react-datetime-picker__inputGroup {
-  padding-top: 2px;
-}
-.react-datetime-picker__inputGroup__input {
-  height: auto;
 }
 
 .error-container {

--- a/services/QuillLMS/client/app/bundles/Staff/styles/styles.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/styles.scss
@@ -7,6 +7,7 @@
 @import '../../../../../app/assets/stylesheets/pages/custom_activity_pack/empty_state.scss';
 @import '../../../../../app/assets/stylesheets/pages/custom_activity_pack/filter_column.scss';
 @import '../../../../../app/assets/stylesheets/pages/custom_activity_pack/mobile_sort_and_filter_menus.scss';
+@import "../../../../node_modules/react-datetime/css/react-datetime";
 
 @import './concept_manager.scss';
 @import './attributes_manager.scss';

--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -3090,14 +3090,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "@types/react-calendar": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@types/react-calendar/-/react-calendar-3.9.0.tgz",
-      "integrity": "sha512-KpAu1MKAGFw5hNwlDnWsHWqI9i/igAB+8jH97YV7QpC2v7rlwNEU5i6VMFb73lGRacuejM/Zd2LklnEzkFV3XA==",
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/react-dom": {
       "version": "16.9.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
@@ -3409,11 +3401,6 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
       "integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw=="
-    },
-    "@wojtekmaj/date-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.1.3.tgz",
-      "integrity": "sha512-rHrDuTl1cx5LYo8F4K4HVauVjwzx4LwrKfEk4br4fj4nK8JjJZ8IG6a6pBHkYmPLBQHCOEDwstb0WNXMGsmdOw=="
     },
     "@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.6",
@@ -6333,11 +6320,6 @@
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true
     },
-    "detect-element-overflow": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/detect-element-overflow/-/detect-element-overflow-1.3.1.tgz",
-      "integrity": "sha512-E29Axx3pyotgg3j5HUbusTTarjPUHsC02p7fZ3/cnUufyK0kx5RzRA9waBvrKFWGc/LWiRj3pD9Y3y+mymMYiQ=="
-    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -7437,14 +7419,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
-      }
-    },
-    "get-user-locale": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-1.5.1.tgz",
-      "integrity": "sha512-WiNpoFRcHn1qxP9VabQljzGwkAQDrcpqUtaP0rNBEkFxJdh4f3tik6MfZsMYZc+UgQJdGCxWEjL9wnCUlRQXag==",
-      "requires": {
-        "lodash.memoize": "^4.1.1"
       }
     },
     "glob": {
@@ -11418,11 +11392,6 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
-    "make-event-props": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.4.2.tgz",
-      "integrity": "sha512-ZOHqRpLn2htnMd9zqhE+wticVr31PdwrJXHcvEEdKgrfjCOuSDn8urG9SDzEIqzP1ayp1uTdDJcOiTlJhqWpEQ=="
-    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -11486,24 +11455,11 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
-    "merge-class-names": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.4.2.tgz",
-      "integrity": "sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw=="
-    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
-    },
-    "merge-refs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.1.3.tgz",
-      "integrity": "sha512-di/iXo7YUDHs38KoIROE2BQvL6xmqiKYpNQSM0NG2jdvikvhJOeihXXyOXXMKkoMxdCXF2SvyxTJ92NuRA5wfA==",
-      "requires": {
-        "@types/react": "*"
-      }
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -13975,28 +13931,6 @@
         }
       }
     },
-    "react-calendar": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-3.9.0.tgz",
-      "integrity": "sha512-g6RJCEaPovHTiV2bMhBUfm0a1YoMj4bOUpL8hQSLmR1Glhc7lgRLtZBd4mcC4jkoGsb+hv9uA/QH4pZcm5l9lQ==",
-      "requires": {
-        "@wojtekmaj/date-utils": "^1.0.2",
-        "get-user-locale": "^1.2.0",
-        "merge-class-names": "^1.1.1",
-        "prop-types": "^15.6.0"
-      }
-    },
-    "react-clock": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-clock/-/react-clock-3.1.0.tgz",
-      "integrity": "sha512-KLV3pDBcETc7lHPPqK6EpRaPS8NA3STAes+zIdfr7IY67vYgYc3brOAnGC9IcgA4X4xNPnLZwwaLJXmHrQ/MnQ==",
-      "requires": {
-        "@wojtekmaj/date-utils": "^1.0.0",
-        "get-user-locale": "^1.4.0",
-        "merge-class-names": "^1.1.1",
-        "prop-types": "^15.6.0"
-      }
-    },
     "react-confetti": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.1.0.tgz",
@@ -14060,23 +13994,6 @@
       "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-1.1.2.tgz",
       "integrity": "sha512-pTOTYntW+gQWzCxyEGfS5ZeOfQw4Mu3B+DJd4jrJKNuAWFQ+EEyF2Earfg0+FVEkPwMr62OLtbYCHmc6vQWj2w=="
     },
-    "react-date-picker": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-8.4.0.tgz",
-      "integrity": "sha512-zocntugDUyiHmV2Nq1qnsk4kDQuhBLUsDTz7akfIEJ0jVX925w0K5Ai5oZzWFNQOzXL/ITxafmDMuSbzlpBt/A==",
-      "requires": {
-        "@types/react-calendar": "^3.0.0",
-        "@wojtekmaj/date-utils": "^1.0.3",
-        "get-user-locale": "^1.2.0",
-        "make-event-props": "^1.1.0",
-        "merge-class-names": "^1.1.1",
-        "merge-refs": "^1.0.0",
-        "prop-types": "^15.6.0",
-        "react-calendar": "^3.3.1",
-        "react-fit": "^1.4.0",
-        "update-input-width": "^1.2.2"
-      }
-    },
     "react-dates": {
       "version": "21.8.0",
       "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-21.8.0.tgz",
@@ -14107,23 +14024,6 @@
         "prop-types": "^15.5.7"
       }
     },
-    "react-datetime-picker": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/react-datetime-picker/-/react-datetime-picker-3.5.0.tgz",
-      "integrity": "sha512-Df5HQbzUmT+a8IlH4veVZylDgHLbUxjTS+Tv1YoWsJ7La/7K/mAycaSC++bV7myVlfMUrMUPPULavakAsiIFAQ==",
-      "requires": {
-        "@wojtekmaj/date-utils": "^1.0.3",
-        "get-user-locale": "^1.2.0",
-        "make-event-props": "^1.1.0",
-        "merge-class-names": "^1.1.1",
-        "prop-types": "^15.6.0",
-        "react-calendar": "^3.3.1",
-        "react-clock": "^3.0.0",
-        "react-date-picker": "^8.4.0",
-        "react-fit": "^1.4.0",
-        "react-time-picker": "^4.5.0"
-      }
-    },
     "react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -14150,18 +14050,6 @@
       "requires": {
         "attr-accept": "^1.1.3",
         "prop-types": "^15.5.7"
-      }
-    },
-    "react-fit": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/react-fit/-/react-fit-1.5.1.tgz",
-      "integrity": "sha512-r86m/6GuJa7j6dLYjC7kENBQRBaDMLTU0mBBoqnh42d/Iil9rmWEeOtdB2KEQEUyDQ8rZXojIx8u+gNFJ+9y1w==",
-      "requires": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "detect-element-overflow": "^1.3.1",
-        "prop-types": "^15.6.0",
-        "tiny-warning": "^1.0.0"
       }
     },
     "react-floater": {
@@ -14533,22 +14421,6 @@
       "integrity": "sha512-9Dt+lVa+adKxl77CfNeo4bMQFlHVJ3RqhKQUbt7SoLQZifVpPdvQ0M3tv3QvhailN7yQML5Zoq2SsKMdwMAaUw==",
       "requires": {
         "prop-types": "^15.5.8"
-      }
-    },
-    "react-time-picker": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/react-time-picker/-/react-time-picker-4.5.0.tgz",
-      "integrity": "sha512-06ViW8t3hGmkrwGvUtaoZ5ud/uSlQwMexn86eL3uoTV6FnIeRhKq0H944L4bA1ne4xIndO4Fro5tGUMmWUA9gw==",
-      "requires": {
-        "@wojtekmaj/date-utils": "^1.0.0",
-        "get-user-locale": "^1.2.0",
-        "make-event-props": "^1.1.0",
-        "merge-class-names": "^1.1.1",
-        "merge-refs": "^1.0.0",
-        "prop-types": "^15.6.0",
-        "react-clock": "^3.0.0",
-        "react-fit": "^1.4.0",
-        "update-input-width": "^1.2.2"
       }
     },
     "react-transition-group": {
@@ -16632,11 +16504,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true
-    },
-    "update-input-width": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/update-input-width/-/update-input-width-1.3.1.tgz",
-      "integrity": "sha512-hV2DGiSn7FKerjIXaI3s0EG/AnmAeoRTV5cvpsFcygzUzKreYj5qSu7rVihzUOEXF/MP2mjJpUzwi14sZdp0nw=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -97,7 +97,6 @@
     "react-csv": "^1.0.8",
     "react-dates": "^21.8.0",
     "react-datetime": "^3.2.0",
-    "react-datetime-picker": "^3.3.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^4.2.8",
     "react-html-parser": "^2.0.2",


### PR DESCRIPTION
## WHAT
Replace `react-datetime-picker` with `react-datetime`, which we use for teacher-facing components.

## WHY
`react-datetime-picker` relies on an older version of React, and rather than update it made sense to just consolidate since we have two libs doing the same thing.

## HOW
Just replace the libraries and update the props to work.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Replace-react-datetime-picker-with-react-datetime-022370e81b664a668636adc59383cacb?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes