### PR TITLE
update react-textarea-autosize

### DIFF
--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/listBlanks.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/listBlanks.test.jsx.snap
@@ -123,18 +123,15 @@ exports[`ListBlanks component projector view inactive renders 1`] = `
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -147,14 +144,9 @@ exports[`ListBlanks component projector view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -173,18 +165,15 @@ exports[`ListBlanks component projector view inactive renders 1`] = `
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -197,14 +186,9 @@ exports[`ListBlanks component projector view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -223,18 +207,15 @@ exports[`ListBlanks component projector view inactive renders 1`] = `
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -247,14 +228,9 @@ exports[`ListBlanks component projector view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -433,18 +409,15 @@ exports[`ListBlanks component projector view when an answer is being displayed r
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -457,14 +430,9 @@ exports[`ListBlanks component projector view when an answer is being displayed r
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -483,18 +451,15 @@ exports[`ListBlanks component projector view when an answer is being displayed r
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -507,14 +472,9 @@ exports[`ListBlanks component projector view when an answer is being displayed r
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -533,18 +493,15 @@ exports[`ListBlanks component projector view when an answer is being displayed r
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -557,14 +514,9 @@ exports[`ListBlanks component projector view when an answer is being displayed r
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -685,17 +637,14 @@ exports[`ListBlanks component student view inactive renders 1`] = `
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -706,13 +655,8 @@ exports[`ListBlanks component student view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -729,17 +673,14 @@ exports[`ListBlanks component student view inactive renders 1`] = `
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -750,13 +691,8 @@ exports[`ListBlanks component student view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -773,17 +709,14 @@ exports[`ListBlanks component student view inactive renders 1`] = `
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -794,13 +727,8 @@ exports[`ListBlanks component student view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -940,17 +868,14 @@ exports[`ListBlanks component student view when an answer is being displayed ren
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -961,13 +886,8 @@ exports[`ListBlanks component student view when an answer is being displayed ren
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -984,17 +904,14 @@ exports[`ListBlanks component student view when an answer is being displayed ren
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -1005,13 +922,8 @@ exports[`ListBlanks component student view when an answer is being displayed ren
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1028,17 +940,14 @@ exports[`ListBlanks component student view when an answer is being displayed ren
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -1049,13 +958,8 @@ exports[`ListBlanks component student view when an answer is being displayed ren
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -1187,17 +1091,14 @@ exports[`ListBlanks component student view when the student has submitted an ans
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -1208,13 +1109,8 @@ exports[`ListBlanks component student view when the student has submitted an ans
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1231,17 +1127,14 @@ exports[`ListBlanks component student view when the student has submitted an ans
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -1252,13 +1145,8 @@ exports[`ListBlanks component student view when the student has submitted an ans
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1275,17 +1163,14 @@ exports[`ListBlanks component student view when the student has submitted an ans
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -1296,13 +1181,8 @@ exports[`ListBlanks component student view when the student has submitted an ans
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -1434,17 +1314,14 @@ exports[`ListBlanks component student view when the student has submitted an ans
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -1455,13 +1332,8 @@ exports[`ListBlanks component student view when the student has submitted an ans
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1478,17 +1350,14 @@ exports[`ListBlanks component student view when the student has submitted an ans
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -1499,13 +1368,8 @@ exports[`ListBlanks component student view when the student has submitted an ans
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1522,17 +1386,14 @@ exports[`ListBlanks component student view when the student has submitted an ans
             handleChange={[Function]}
             placeholder="Type your response here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
             >
               <textarea
                 autoCapitalize="off"
@@ -1543,13 +1404,8 @@ exports[`ListBlanks component student view when the student has submitted an ans
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/multistep.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/multistep.test.jsx.snap
@@ -111,18 +111,15 @@ exports[`Multistep component projector view inactive renders 1`] = `
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -135,14 +132,9 @@ exports[`Multistep component projector view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -161,18 +153,15 @@ exports[`Multistep component projector view inactive renders 1`] = `
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -185,14 +174,9 @@ exports[`Multistep component projector view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -211,18 +195,15 @@ exports[`Multistep component projector view inactive renders 1`] = `
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -235,14 +216,9 @@ exports[`Multistep component projector view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -413,18 +389,15 @@ exports[`Multistep component projector view when an answer is being displayed re
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -437,14 +410,9 @@ exports[`Multistep component projector view when an answer is being displayed re
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -463,18 +431,15 @@ exports[`Multistep component projector view when an answer is being displayed re
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -487,14 +452,9 @@ exports[`Multistep component projector view when an answer is being displayed re
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -513,18 +473,15 @@ exports[`Multistep component projector view when an answer is being displayed re
             placeholder="Type your response here"
             value="Students type responses here"
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth disabled-editor"
               disabled={true}
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value="Students type responses here"
             >
               <textarea
@@ -537,14 +494,9 @@ exports[`Multistep component projector view when an answer is being displayed re
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value="Students type responses here"
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -654,17 +606,14 @@ exports[`Multistep component student view inactive renders 1`] = `
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -676,14 +625,9 @@ exports[`Multistep component student view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -701,17 +645,14 @@ exports[`Multistep component student view inactive renders 1`] = `
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -723,14 +664,9 @@ exports[`Multistep component student view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -748,17 +684,14 @@ exports[`Multistep component student view inactive renders 1`] = `
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -770,14 +703,9 @@ exports[`Multistep component student view inactive renders 1`] = `
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -909,17 +837,14 @@ exports[`Multistep component student view when an answer is being displayed rend
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -931,14 +856,9 @@ exports[`Multistep component student view when an answer is being displayed rend
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -956,17 +876,14 @@ exports[`Multistep component student view when an answer is being displayed rend
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -978,14 +895,9 @@ exports[`Multistep component student view when an answer is being displayed rend
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1003,17 +915,14 @@ exports[`Multistep component student view when an answer is being displayed rend
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -1025,14 +934,9 @@ exports[`Multistep component student view when an answer is being displayed rend
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -1154,17 +1058,14 @@ exports[`Multistep component student view when the student has submitted an answ
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -1176,14 +1077,9 @@ exports[`Multistep component student view when the student has submitted an answ
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1201,17 +1097,14 @@ exports[`Multistep component student view when the student has submitted an answ
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -1223,14 +1116,9 @@ exports[`Multistep component student view when the student has submitted an answ
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1248,17 +1136,14 @@ exports[`Multistep component student view when the student has submitted an answ
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -1270,14 +1155,9 @@ exports[`Multistep component student view when the student has submitted an answ
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>
@@ -1398,17 +1278,14 @@ exports[`Multistep component student view when the student has submitted an answ
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -1420,14 +1297,9 @@ exports[`Multistep component student view when the student has submitted an answ
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1445,17 +1317,14 @@ exports[`Multistep component student view when the student has submitted an answ
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -1467,14 +1336,9 @@ exports[`Multistep component student view when the student has submitted an answ
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
         <div
@@ -1492,17 +1356,14 @@ exports[`Multistep component student view when the student has submitted an answ
             placeholder="Type your response here"
             value=""
           >
-            <TextareaAutosize
+            <ForwardRef(TextareaAutosize)
               autoCapitalize="off"
               autoCorrect="off"
               className="student text-editor card is-fullwidth null"
-              onChange={[Function]}
-              onHeightChange={[Function]}
               onInput={[Function]}
               onKeyDown={[Function]}
               placeholder="Type your response here"
               spellCheck={false}
-              useCacheForDOMMeasurements={false}
               value=""
             >
               <textarea
@@ -1514,14 +1375,9 @@ exports[`Multistep component student view when the student has submitted an answ
                 onKeyDown={[Function]}
                 placeholder="Type your response here"
                 spellCheck={false}
-                style={
-                  Object {
-                    "height": 0,
-                  }
-                }
                 value=""
               />
-            </TextareaAutosize>
+            </ForwardRef(TextareaAutosize)>
           </RenderTextEditor>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/singleAnswer.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/play/__tests__/__snapshots__/singleAnswer.test.jsx.snap
@@ -160,18 +160,15 @@ exports[`SingleAnswer component projector view inactive renders 1`] = `
         placeholder="Type your response here"
         value="Students type responses here"
       >
-        <TextareaAutosize
+        <ForwardRef(TextareaAutosize)
           autoCapitalize="off"
           autoCorrect="off"
           className="student text-editor card is-fullwidth disabled-editor"
           disabled={true}
-          onChange={[Function]}
-          onHeightChange={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
           placeholder="Type your response here"
           spellCheck={false}
-          useCacheForDOMMeasurements={false}
           value="Students type responses here"
         >
           <textarea
@@ -184,14 +181,9 @@ exports[`SingleAnswer component projector view inactive renders 1`] = `
             onKeyDown={[Function]}
             placeholder="Type your response here"
             spellCheck={false}
-            style={
-              Object {
-                "height": 0,
-              }
-            }
             value="Students type responses here"
           />
-        </TextareaAutosize>
+        </ForwardRef(TextareaAutosize)>
       </RenderTextEditor>
       <SubmitButton
         disabled={true}
@@ -395,18 +387,15 @@ exports[`SingleAnswer component projector view when an answer is being displayed
         placeholder="Type your response here"
         value="Students type responses here"
       >
-        <TextareaAutosize
+        <ForwardRef(TextareaAutosize)
           autoCapitalize="off"
           autoCorrect="off"
           className="student text-editor card is-fullwidth disabled-editor"
           disabled={true}
-          onChange={[Function]}
-          onHeightChange={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
           placeholder="Type your response here"
           spellCheck={false}
-          useCacheForDOMMeasurements={false}
           value="Students type responses here"
         >
           <textarea
@@ -419,14 +408,9 @@ exports[`SingleAnswer component projector view when an answer is being displayed
             onKeyDown={[Function]}
             placeholder="Type your response here"
             spellCheck={false}
-            style={
-              Object {
-                "height": 0,
-              }
-            }
             value="Students type responses here"
           />
-        </TextareaAutosize>
+        </ForwardRef(TextareaAutosize)>
       </RenderTextEditor>
       <SubmitButton
         disabled={true}
@@ -582,17 +566,14 @@ exports[`SingleAnswer component student view inactive renders 1`] = `
         handleChange={[Function]}
         placeholder="Type your response here"
       >
-        <TextareaAutosize
+        <ForwardRef(TextareaAutosize)
           autoCapitalize="off"
           autoCorrect="off"
           className="student text-editor card is-fullwidth null"
-          onChange={[Function]}
-          onHeightChange={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
           placeholder="Type your response here"
           spellCheck={false}
-          useCacheForDOMMeasurements={false}
         >
           <textarea
             autoCapitalize="off"
@@ -603,13 +584,8 @@ exports[`SingleAnswer component student view inactive renders 1`] = `
             onKeyDown={[Function]}
             placeholder="Type your response here"
             spellCheck={false}
-            style={
-              Object {
-                "height": 0,
-              }
-            }
           />
-        </TextareaAutosize>
+        </ForwardRef(TextareaAutosize)>
       </RenderTextEditor>
       <SubmitButton
         disabled={true}
@@ -778,17 +754,14 @@ exports[`SingleAnswer component student view when an answer is being displayed r
         handleChange={[Function]}
         placeholder="Type your response here"
       >
-        <TextareaAutosize
+        <ForwardRef(TextareaAutosize)
           autoCapitalize="off"
           autoCorrect="off"
           className="student text-editor card is-fullwidth null"
-          onChange={[Function]}
-          onHeightChange={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
           placeholder="Type your response here"
           spellCheck={false}
-          useCacheForDOMMeasurements={false}
         >
           <textarea
             autoCapitalize="off"
@@ -799,13 +772,8 @@ exports[`SingleAnswer component student view when an answer is being displayed r
             onKeyDown={[Function]}
             placeholder="Type your response here"
             spellCheck={false}
-            style={
-              Object {
-                "height": 0,
-              }
-            }
           />
-        </TextareaAutosize>
+        </ForwardRef(TextareaAutosize)>
       </RenderTextEditor>
       <SubmitButton
         disabled={true}
@@ -968,17 +936,14 @@ exports[`SingleAnswer component student view when the student has submitted an a
         handleChange={[Function]}
         placeholder="Type your response here"
       >
-        <TextareaAutosize
+        <ForwardRef(TextareaAutosize)
           autoCapitalize="off"
           autoCorrect="off"
           className="student text-editor card is-fullwidth null"
-          onChange={[Function]}
-          onHeightChange={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
           placeholder="Type your response here"
           spellCheck={false}
-          useCacheForDOMMeasurements={false}
         >
           <textarea
             autoCapitalize="off"
@@ -989,13 +954,8 @@ exports[`SingleAnswer component student view when the student has submitted an a
             onKeyDown={[Function]}
             placeholder="Type your response here"
             spellCheck={false}
-            style={
-              Object {
-                "height": 0,
-              }
-            }
           />
-        </TextareaAutosize>
+        </ForwardRef(TextareaAutosize)>
       </RenderTextEditor>
       <SubmitButton
         disabled={true}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/__tests__/__snapshots__/create_or_edit_blog_post.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/__tests__/__snapshots__/create_or_edit_blog_post.test.jsx.snap
@@ -8197,15 +8197,12 @@ exports[`CreateOrEditBlogPost component renders for a new blog post 1`] = `
             </strong>
             )
           </p>
-          <TextareaAutosize
+          <ForwardRef(TextareaAutosize)
             autoCapitalize="off"
             autoCorrect="off"
             className="footer-content-text-editor"
-            onChange={[Function]}
-            onHeightChange={[Function]}
             onInput={[Function]}
             spellCheck={false}
-            useCacheForDOMMeasurements={false}
           >
             <textarea
               autoCapitalize="off"
@@ -8214,13 +8211,8 @@ exports[`CreateOrEditBlogPost component renders for a new blog post 1`] = `
               onChange={[Function]}
               onInput={[Function]}
               spellCheck={false}
-              style={
-                Object {
-                  "height": 0,
-                }
-              }
             />
-          </TextareaAutosize>
+          </ForwardRef(TextareaAutosize)>
         </div>
         <div
           className="save-buttons"
@@ -16572,15 +16564,12 @@ exports[`CreateOrEditBlogPost component renders for an existing blog post 1`] = 
             </strong>
             )
           </p>
-          <TextareaAutosize
+          <ForwardRef(TextareaAutosize)
             autoCapitalize="off"
             autoCorrect="off"
             className="footer-content-text-editor"
-            onChange={[Function]}
-            onHeightChange={[Function]}
             onInput={[Function]}
             spellCheck={false}
-            useCacheForDOMMeasurements={false}
           >
             <textarea
               autoCapitalize="off"
@@ -16589,13 +16578,8 @@ exports[`CreateOrEditBlogPost component renders for an existing blog post 1`] = 
               onChange={[Function]}
               onInput={[Function]}
               spellCheck={false}
-              style={
-                Object {
-                  "height": 0,
-                }
-              }
             />
-          </TextareaAutosize>
+          </ForwardRef(TextareaAutosize)>
         </div>
         <div
           className="save-buttons"

--- a/services/QuillLMS/client/package-lock.json
+++ b/services/QuillLMS/client/package-lock.json
@@ -14528,11 +14528,28 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-4.3.2.tgz",
-      "integrity": "sha512-9Dt+lVa+adKxl77CfNeo4bMQFlHVJ3RqhKQUbt7SoLQZifVpPdvQ0M3tv3QvhailN7yQML5Zoq2SsKMdwMAaUw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
+      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
       "requires": {
-        "prop-types": "^15.5.8"
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.21.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+          "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.11"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.11",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+        }
       }
     },
     "react-time-picker": {
@@ -16702,6 +16719,24 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+    },
+    "use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.1.1"
       }
     },
     "use-sync-external-store": {

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -117,7 +117,7 @@
     "react-simple-pie-chart": "^0.5.0",
     "react-sortable-hoc": "^2.0.0",
     "react-table": "^7.8.0",
-    "react-textarea-autosize": "^4.3.2",
+    "react-textarea-autosize": "^8.4.1",
     "redux": "^3.3.1",
     "redux-devtools-extension": "^2.13.8",
     "redux-persist": "^4.10.2",

--- a/services/QuillLMS/client/setupTests.ts
+++ b/services/QuillLMS/client/setupTests.ts
@@ -3,3 +3,7 @@ import { configure } from 'enzyme';
 import 'whatwg-fetch';
 
 configure({ adapter: new Adapter() });
+
+Object.defineProperty(document, 'fonts', {
+  value: { addEventListener: jest.fn(), removeEventListener: jest.fn() },
+});


### PR DESCRIPTION
## WHAT
Update the `react-textarea-autosize`, adding a test stub to make sure our jest tests still pass.

## WHY
This is follow-up to the React upgrade project.

## HOW
Just bump the version and look at the github repo for the lib to see how they were stubbing this behavior in their own tests, then effectively copy that solution.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Upgrade-react-textarea-autosize-fe76ccd5369e4727bef9e6e01016b0cb?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A