### PR TITLE
handle student with no last name in activity analysis

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/class_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/class_report.jsx
@@ -78,7 +78,7 @@ export default class ClassReport extends React.Component {
     return names.sort((a, b) => {
       const aLast = a.split(' ')[1]
       const bLast = b.split(' ')[1]
-      return aLast.localeCompare(bLast)
+      return aLast?.localeCompare(bLast)
     })
   }
 


### PR DESCRIPTION
## WHAT
Fix an edge case where having a student without a last name was causing the proficiency boxes not to render in the activity analysis.

## WHY
We want those boxes to display for all classrooms.

## HOW
Just add a safe operator where the error was happening.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Activity-Analysis-does-not-have-the-summary-numbers-of-students-who-are-in-each-proficiency-range-at-23cac398422040f8a1ea05d90fc22bc6?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES