### PR TITLE
update nces import to use nces id instead of name

### DIFF
--- a/services/QuillLMS/lib/tasks/nces_sync.rake
+++ b/services/QuillLMS/lib/tasks/nces_sync.rake
@@ -36,7 +36,7 @@ namespace :nces_sync do
           grade_range: "#{row['Lowest Grade Offered']} - #{row['Highest Grade Offered']}"
         }
 
-        district = District.where("lower(name) = ?", attributes_hash[:name].downcase).first
+        district = District.where("nces_id = ?", attributes_hash[:nces_id]).first
         if district.present?
           district.update!(attributes_hash)
         else


### PR DESCRIPTION
## WHAT
Update the NCES import script to find existing districts based on NCES id and not name.

## WHY
We were inaccurately combining different district records into one in our system.

## HOW
Just update the `where` clause here.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/NCES-District-Import-Fix-noting-for-future-imports-not-urgent-07d4a61c8cf64d81ad43352daa447216

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tested locally
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES