### PR TITLE
Fix bug with teacher_admin_subscriptions_url

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_checkout_sessions_controller.rb
@@ -78,7 +78,7 @@ module StripeIntegration
       if schools.empty? || !customer.admin?
         "#{subscriptions_url}?checkout_session_id={CHECKOUT_SESSION_ID}"
       else
-        "#{teacher_admin_subscriptions_url(school_id: school_ids.first)}&checkout_session_id={CHECKOUT_SESSION_ID}"
+        "#{premium_hub_school_subscriptions_url(school_id: school_ids.first)}&checkout_session_id={CHECKOUT_SESSION_ID}"
       end
     end
 

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -208,6 +208,7 @@ EmpiricalGrammar::Application.routes.draw do
   put 'students/update_password' => 'students#update_password'
   get 'join/:classcode' => 'students#join_classroom'
   get 'teachers/premium_hub' => 'teachers#premium_hub'
+  get 'teachers/premium_hub/school_subscriptions' => 'teachers#premium_hub', as: :premium_hub_school_subscriptions
   get 'teachers/premium_hub/:tab' => 'teachers#premium_hub'
   get 'teachers/admin_dashboard', to: redirect('teachers/premium_hub')
   get 'teachers/admin_dashboard/:tab', to: redirect('teachers/premium_hub/%{tab}')

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_checkout_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_checkout_sessions_controller_spec.rb
@@ -9,26 +9,30 @@ RSpec.describe StripeIntegration::SubscriptionCheckoutSessionsController, type: 
   describe '#create' do
     let(:stripe_checkout_session) { create(:stripe_checkout_session) }
     let(:redirect_url) { stripe_checkout_session.url }
-    let(:params) { { customer_email: customer_email, stripe_price_id: stripe_price_id } }
+    let(:params) { { customer_email: customer_email, stripe_price_id: stripe_price_id, school_ids: school_ids } }
     let(:url) { '/stripe_integration/subscription_checkout_sessions' }
+    let(:school_ids) { nil }
 
     subject { post url, params: params, as: :json }
 
     context 'happy path' do
-      before { allow(StripeCheckoutSession).to receive(:custom_find_or_create_by!).and_return(stripe_checkout_session) }
+      before { allow(Stripe::Checkout::Session).to receive(:create).and_return(stripe_checkout_session) }
 
-      it 'creates a stripe checkout session and provides a redirect' do
-        subject
-        expect(response.body).to eq({ redirect_url: redirect_url }.to_json)
-      end
+      it { should_create_stripe_checkout_session_and_provide_redirect }
 
       context 'customer already has stripe_customer_id attached' do
         before { customer.update(stripe_customer_id: stripe_customer_id) }
 
-        it 'creates a stripe checkout session and provides a redirect' do
-          subject
-          expect(response.body).to eq({ redirect_url: redirect_url }.to_json)
-        end
+        it { should_create_stripe_checkout_session_and_provide_redirect }
+      end
+
+      context 'school ids are provided and customer is an admin' do
+        let(:school) { create(:school) }
+        let(:school_ids) { [school.id].to_json }
+
+        before { customer.update(role: 'admin') }
+
+        it { should_create_stripe_checkout_session_and_provide_redirect }
       end
     end
 
@@ -37,5 +41,10 @@ RSpec.describe StripeIntegration::SubscriptionCheckoutSessionsController, type: 
 
       it { expect { subject }.to raise_error described_class::CustomerNotFoundError }
     end
+  end
+
+  def should_create_stripe_checkout_session_and_provide_redirect
+    subject
+    expect(response.body).to eq({ redirect_url: redirect_url }.to_json)
   end
 end


### PR DESCRIPTION
## WHAT
Fix a regression involving a the teacher_admin_subscriptions_url

## WHY
After the premium hub rollout, the aforementioned URL no longer exists.

## HOW
Update the routes.rb with a new named helper.
Also, add a test case to ensure that the named helper actually works.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
