### PR TITLE
bigquery: improve error reporting, handle null rows edge case

### DIFF
--- a/services/QuillLMS/app/services/quill_big_query/runner.rb
+++ b/services/QuillLMS/app/services/quill_big_query/runner.rb
@@ -12,11 +12,11 @@ module QuillBigQuery
     class JobNotCompletedError < StandardError; end
 
     def self.valid_schema?(json_body)
-      raise JobNotCompletedError, json_body unless json_body.dig('jobComplete')
+      raise JobNotCompletedError, json_body unless json_body['jobComplete']
 
       json_body.dig('schema','fields').respond_to?(:count) &&
-        json_body.dig('rows').respond_to?(:count) &&
-        json_body.dig('totalRows').respond_to?(:to_i)
+        json_body['rows'].respond_to?(:count) &&
+        json_body['totalRows'].respond_to?(:to_i)
     end
 
     def self.transform_response(json_body)

--- a/services/QuillLMS/spec/services/quill_big_query/runner_spec.rb
+++ b/services/QuillLMS/spec/services/quill_big_query/runner_spec.rb
@@ -33,6 +33,7 @@ describe QuillBigQuery::Runner do
 
     context 'BigQuery response contains no rows' do
       let(:no_rows_bigquery_response) { bigquery_response.merge({ 'totalRows' => "0" }) }
+
       it 'should return early' do
         allow(QuillBigQuery::Transformer).to receive(:new).exactly(0).times
         QuillBigQuery::Runner.transform_response(no_rows_bigquery_response)
@@ -42,6 +43,7 @@ describe QuillBigQuery::Runner do
     context 'inoperable BigQuey response schema' do
       context 'job is not completed' do
         let(:job_not_completed_response) { {'jobComplete' => false } }
+
         it 'should raise JobNotCompleted' do
           expect do
             QuillBigQuery::Runner.transform_response(job_not_completed_response)
@@ -51,6 +53,7 @@ describe QuillBigQuery::Runner do
 
       context 'jobComplete field is missing' do
         let(:jobcomplete_missing_bigquery_response) { {} }
+
         it 'should raise JobNotCompleted' do
           expect do
             QuillBigQuery::Runner.transform_response(jobcomplete_missing_bigquery_response)


### PR DESCRIPTION
## WHAT / HOW
- the case where a query returns 0 rows was not handled well by our code, because the API shape changes. This PR addresses this case.
- handled new edge case, where `jobCompleted` is false.
- added JobNotCompleted error class, which is easier to understand vs. `undefined method `[]' for nil:NilClass`

## WHY
So that error analysis and organization is improved 


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/BigQuery-call-results-in-invalid-schema-exception-46332a1ec17c4db28f25a911048c082f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? | n/a
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
