### PR TITLE
get grammar working on vite

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -477,7 +477,7 @@ class PagesController < ApplicationController
 
   def grammar
     allow_iframe
-    @style_file = ApplicationController::GRAMMAR
+    @style_file = "#{ApplicationController::GRAMMAR}.scss"
   end
 
   def lessons

--- a/services/QuillLMS/client/app/bundles/Connect/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/questions.ts
@@ -229,7 +229,7 @@ function searchResponses(qid) {
     const requestNumber = getState().filters.requestCount
     // check for request number in state, save as const
     requestPost(
-      `${import.meta.env.QUILL_CMS}/questions/${qid}/responses/search`,
+      `${import.meta.env.VITE_CMS_URL}/questions/${qid}/responses/search`,
       { search: getFormattedSearchData(getState()), },
       (data) => {
         // check again for number in state

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/massEditContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/massEditContainer.jsx
@@ -40,7 +40,7 @@ class MassEditContainer extends React.Component {
 
   getResponses = () => {
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/mass_edit/show_many`,
+      `${import.meta.env.VITE_CMS_URL}/responses/mass_edit/show_many`,
       { responses: this.props.massEdit.selectedResponses, },
       (data) => {
         const parsedResponses = _.indexBy(data.responses, 'id');

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/responseComponent.jsx
@@ -118,7 +118,7 @@ class ResponseComponent extends React.Component {
 
   getGradeBreakdown = () => {
     requestGet(
-      `${import.meta.env.QUILL_CMS}/questions/${this.props.questionID}/grade_breakdown`,
+      `${import.meta.env.VITE_CMS_URL}/questions/${this.props.questionID}/grade_breakdown`,
       (body) => {
         this.setState({
           gradeBreakdown: body,
@@ -129,7 +129,7 @@ class ResponseComponent extends React.Component {
 
   getHealth = () => {
     requestGet(
-      `${import.meta.env.QUILL_CMS}/questions/${this.props.questionID}/health`,
+      `${import.meta.env.VITE_CMS_URL}/questions/${this.props.questionID}/health`,
       (body) => {
         this.setState({
           health: body,

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -25,7 +25,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
     const qid = this.props.questionID
     const newSeqs = this.state.itemText.split(/\|{3}(?!\|)/)
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/${qid}/focus_point_affected_count`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${qid}/focus_point_affected_count`,
       {data: {selected_sequences: newSeqs}},
       (body) => {
         this.setState({matchedCount: body.matchedCount})

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -31,7 +31,7 @@ export default class extends React.Component {
     const newSeqs = this.state.itemText.split(/\|{3}(?!\|)/)
 
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/${qid}/incorrect_sequence_affected_count`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${qid}/incorrect_sequence_affected_count`,
       {data: {used_sequences: usedSeqs, selected_sequences: newSeqs}},
       (body) => {
         this.setState({matchedCount: body.matchedCount})

--- a/services/QuillLMS/client/app/bundles/Connect/libs/grading/rematching.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/grading/rematching.ts
@@ -61,7 +61,7 @@ export function rematchAll(mode: string, questionID: string, callback:Function) 
     type = 'fillInBlankQuestions';
   }
 
-  const rematchAllUrl = `${import.meta.env.QUILL_CMS}/responses/rematch_all`;
+  const rematchAllUrl = `${import.meta.env.VITE_CMS_URL}/responses/rematch_all`;
   fetch(rematchAllUrl, {
     method: 'POST',
     body: JSON.stringify({type, uid: questionID}),
@@ -96,7 +96,7 @@ export function rematchOne(response: string, mode: string, question: Question, q
 
 export function paginatedNonHumanResponses(matcher, matcherFields, qid, page, callback) {
   requestPost(
-    `${import.meta.env.QUILL_CMS}/questions/${qid}/responses/search`,
+    `${import.meta.env.VITE_CMS_URL}/questions/${qid}/responses/search`,
     getResponseBody(page),
     (data) => {
       const parsedResponses = _.indexBy(data.results, 'id');
@@ -175,7 +175,7 @@ function deleteRematchedResponse(response) {
 function updateResponse(rid, content) {
   const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content, false);
   return requestPut(
-    `${import.meta.env.QUILL_CMS}/responses/${rid}`,
+    `${import.meta.env.VITE_CMS_URL}/responses/${rid}`,
     { response: rubyConvertedResponse, }
   )
 }
@@ -260,7 +260,7 @@ function getResponseBody(pageNumber) {
 }
 
 function getGradedResponses(questionID) {
-  return requestGet(`${import.meta.env.QUILL_CMS}/questions/${questionID}/responses`);
+  return requestGet(`${import.meta.env.VITE_CMS_URL}/questions/${questionID}/responses`);
 }
 
 function formatGradedResponses(jsonString):{[key:string]: Response} {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/questions.ts
@@ -222,7 +222,7 @@ function searchResponses(qid) {
     const requestNumber = getState().filters.requestCount
     // check for request number in state, save as const
     requestPost(
-      `${import.meta.env.QUILL_CMS}/questions/${qid}/responses/search`,
+      `${import.meta.env.VITE_CMS_URL}/questions/${qid}/responses/search`,
       { search: getFormattedSearchData(getState()), },
       (body) => {
         // check again for number in state

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/massEditContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/massEditContainer.jsx
@@ -41,7 +41,7 @@ class MassEditContainer extends React.Component {
 
   getResponses() {
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/mass_edit/show_many`,
+      `${import.meta.env.VITE_CMS_URL}/responses/mass_edit/show_many`,
       { responses: this.props.massEdit.selectedResponses, },
       (body) => {
         const parsedResponses = _.indexBy(body.responses, 'id');

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
@@ -82,7 +82,7 @@ class ResponseComponent extends React.Component {
 
   getHealth = () => {
     requestGet(
-      `${import.meta.env.QUILL_CMS}/questions/${this.props.questionID}/health`,
+      `${import.meta.env.VITE_CMS_URL}/questions/${this.props.questionID}/health`,
       (body) => {
         this.setState({
           health: body,
@@ -93,7 +93,7 @@ class ResponseComponent extends React.Component {
 
   getGradeBreakdown = () => {
     requestGet(
-      `${import.meta.env.QUILL_CMS}/questions/${this.props.questionID}/grade_breakdown`,
+      `${import.meta.env.VITE_CMS_URL}/questions/${this.props.questionID}/grade_breakdown`,
       (body) => {
         this.setState({
           gradeBreakdown: body,

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -30,7 +30,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
     const qid = this.props.questionID
     const newSeqs = this.state.itemText.split(/\|{3}(?!\|)/)
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/${qid}/focus_point_affected_count`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${qid}/focus_point_affected_count`,
       {data: {selected_sequences: newSeqs}},
       (body) => {
         this.setState({matchedCount: body.matchedCount})

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -32,7 +32,7 @@ export default class extends React.Component {
     const usedSeqs = this.props.usedSequences
     const newSeqs = this.state.itemText.split(/\|{3}(?!\|)/)
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/${qid}/incorrect_sequence_affected_count`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${qid}/incorrect_sequence_affected_count`,
       {data: {used_sequences: usedSeqs, selected_sequences: newSeqs}},
       (body) => {
         this.setState({matchedCount: body.matchedCount})

--- a/services/QuillLMS/client/app/bundles/Diagnostic/libs/grading/rematching.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/libs/grading/rematching.ts
@@ -57,7 +57,7 @@ export function rematchAll(mode: string, question: Question, questionID: string,
     type = 'diagnostic_fillInBlankQuestions';
   }
 
-  const rematchAllUrl = `${import.meta.env.QUILL_CMS}/responses/rematch_all`;
+  const rematchAllUrl = `${import.meta.env.VITE_CMS_URL}/responses/rematch_all`;
   fetch(rematchAllUrl, {
     method: 'POST',
     body: JSON.stringify({type, uid: questionID}),
@@ -91,7 +91,7 @@ export function rematchOne(response: string, mode: string, question: Question, q
 
 export function paginatedNonHumanResponses(matcher, matcherFields, qid, page, callback) {
   requestPost(
-    `${import.meta.env.QUILL_CMS}/questions/${qid}/responses/search`,
+    `${import.meta.env.VITE_CMS_URL}/questions/${qid}/responses/search`,
     getResponseBody(page),
     (data) => {
       const parsedResponses = _.indexBy(data.results, 'id');
@@ -170,7 +170,7 @@ function deleteRematchedResponse(response) {
 function updateResponse(rid, content) {
   const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content, false);
   return requestPut(
-    `${import.meta.env.QUILL_CMS}/responses/${rid}`,
+    `${import.meta.env.VITE_CMS_URL}/responses/${rid}`,
     { response: rubyConvertedResponse, }
   )
 }
@@ -253,7 +253,7 @@ function getResponseBody(pageNumber) {
 }
 
 function getGradedResponses(questionID) {
-  return requestGet(`${import.meta.env.QUILL_CMS}/questions/${questionID}/responses`);
+  return requestGet(`${import.meta.env.VITE_CMS_URL}/questions/${questionID}/responses`);
 }
 
 function formatGradedResponses(jsonString):{[key:string]: Response} {

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -41,7 +41,7 @@ export const getQuestion = (questionID: string) => {
 }
 
 export const getGradedResponsesWithCallback = (questionID: string, callback: Function) => {
-  requestGet(`${import.meta.env.QUILL_CMS}/questions/${questionID}/responses`, (body) => {
+  requestGet(`${import.meta.env.VITE_CMS_URL}/questions/${questionID}/responses`, (body) => {
     const bodyToObj: {[key: string]: Response} = {};
     body.forEach((resp: Response) => {
       bodyToObj[resp.id] = resp;
@@ -84,7 +84,7 @@ export const searchResponses = (qid: string) => {
     const requestNumber = getState().filters.requestCount
     // check for request number in state, save as const
     requestPost(
-      `${import.meta.env.QUILL_CMS}/questions/${qid}/responses/search`,
+      `${import.meta.env.VITE_CMS_URL}/questions/${qid}/responses/search`,
       { search: getFormattedSearchData(getState()), },
       (data) => {
         // check again for number in state

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/responses.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/responses.ts
@@ -1,5 +1,5 @@
 /* eslint-env browser*/
-import * as moment from 'moment';
+import moment from 'moment';
 import { ConceptResult, Response } from 'quill-marking-logic';
 
 import { ActionTypes } from './actionTypes';
@@ -28,7 +28,7 @@ export function submitResponse(content: Response, prid: string, isFirstAttempt: 
   rubyConvertedResponse.is_first_attempt = isFirstAttempt;
   return (dispatch: Function) => {
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/create_or_increment`,
+      `${import.meta.env.VITE_CMS_URL}/responses/create_or_increment`,
       { response: rubyConvertedResponse, },
       (body) => {
         dispatch({ type: ActionTypes.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
@@ -44,7 +44,7 @@ export function submitMassEditFeedback(ids: string[], properties, qid: string) {
   return (dispatch: Function) => {
     const updatedAttribute = properties;
     requestPut(
-      `${import.meta.env.QUILL_CMS}/responses/mass_edit/edit_many`,
+      `${import.meta.env.VITE_CMS_URL}/responses/mass_edit/edit_many`,
       { ids, updated_attribute: updatedAttribute, },
       (body) => {
         dispatch({ type: ActionTypes.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
@@ -63,7 +63,7 @@ export function submitMassEditConceptResults(ids: string[], conceptResults: Conc
       concept_results: conceptResults,
     };
     requestPut(
-      `${import.meta.env.QUILL_CMS}/responses/mass_edit/edit_many`,
+      `${import.meta.env.VITE_CMS_URL}/responses/mass_edit/edit_many`,
       { ids, updated_attribute: updatedAttribute, },
       (body) => {
         dispatch({ type: ActionTypes.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
@@ -79,7 +79,7 @@ export function submitMassEditConceptResults(ids: string[], conceptResults: Conc
 export function massEditDeleteResponses(ids: string[], qid: string) {
   return (dispatch: Function) => {
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/mass_edit/delete_many`,
+      `${import.meta.env.VITE_CMS_URL}/responses/mass_edit/delete_many`,
       { ids, },
       (body) => {
         dispatch({ type: ActionTypes.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
@@ -96,7 +96,7 @@ export function submitResponseEdit(rid: string, content: Response & { concept_re
   const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content);
   return (dispatch: Function) => {
     requestPut(
-      `${import.meta.env.QUILL_CMS}/responses/${rid}`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${rid}`,
       { response: rubyConvertedResponse, },
       (body) => {
         dispatch({ type: ActionTypes.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
@@ -113,7 +113,7 @@ export function updateConceptResults(rid, content, qid) {
   const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content, false);
   return (dispatch) => {
     requestPut(
-      `${import.meta.env.QUILL_CMS}/responses/${rid}`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${rid}`,
       { response: rubyConvertedResponse, },
       (body) => {
         dispatch({ type: ActionTypes.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
@@ -132,7 +132,7 @@ export function deleteConceptResult(rid, content, qid) {
   const updatedResponse = objectWithSnakeKeysFromCamel(content, false);
   return (dispatch) => {
     requestPut(
-      `${import.meta.env.QUILL_CMS}/responses/${rid}`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${rid}`,
       { response: updatedResponse, },
       (body) => {
         dispatch({ type: ActionTypes.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
@@ -149,7 +149,7 @@ export function deleteConceptResult(rid, content, qid) {
 export function deleteResponse(qid, rid) {
   return (dispatch) => {
     requestDelete(
-      `${import.meta.env.QUILL_CMS}/responses/${rid}`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${rid}`,
       null,
       (body) => {
         dispatch({ type: ActionTypes.DISPLAY_MESSAGE, message: 'Submission successfully saved!', });
@@ -175,7 +175,7 @@ function makeIterator(array) {
 }
 
 export function getGradedResponsesWithCallback(questionID, callback) {
-  requestGet(`${import.meta.env.QUILL_CMS}/questions/${questionID}/responses`,
+  requestGet(`${import.meta.env.VITE_CMS_URL}/questions/${questionID}/responses`,
     (body) => {
       const bodyToObj = {};
       body.forEach((resp) => {
@@ -199,7 +199,7 @@ export function getGradedResponsesWithCallback(questionID, callback) {
 
 export function getGradedResponsesWithoutCallback(questionID) {
   requestGet(
-    `${import.meta.env.QUILL_CMS}/questions/${questionID}/responses`,
+    `${import.meta.env.VITE_CMS_URL}/questions/${questionID}/responses`,
     (body) => {
       const bodyToObj = {};
       body.forEach((resp) => {

--- a/services/QuillLMS/client/app/bundles/Grammar/clientRegistration.js
+++ b/services/QuillLMS/client/app/bundles/Grammar/clientRegistration.js
@@ -1,5 +1,4 @@
 import ReactOnRails from 'react-on-rails';
 import App from './App.tsx';
-import './styles/style.scss';
 
 ReactOnRails.register({ App, });

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/__tests__/question.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/__tests__/question.test.tsx
@@ -28,7 +28,7 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 import.meta.env.VITE_DEFAULT_URL = 'https://staging.quill.org'
-import.meta.env.QUILL_CMS = 'https://cms.quill.org'
+import.meta.env.VITE_CMS_URL = 'https://cms.quill.org'
 
 const componentDidMount = QuestionComponent.prototype.componentDidMount = jest.fn();
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/massEditContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/massEditContainer.tsx
@@ -62,7 +62,7 @@ class MassEditContainer extends React.Component<MassEditProps, MassEditState> {
 
   getResponses = () => {
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/mass_edit/show_many`,
+      `${import.meta.env.VITE_CMS_URL}/responses/mass_edit/show_many`,
       { responses: this.props.massEdit.selectedResponses, },
       (body) => {
         const parsedResponses = _.indexBy(body.responses, 'id');

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
@@ -365,7 +365,7 @@ export default class extends React.Component<ResponseProps, ResponseState> {
   }
 
   renderResponseFooter = (isEditing, response) => {
-    const { readOnly, expanded, response } = this.props
+    const { readOnly, expanded, } = this.props
     if (!readOnly || !expanded) {
       return;
     }

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
@@ -123,7 +123,7 @@ class ResponseComponent extends React.Component {
 
   getHealth() {
     requestGet(
-      `${import.meta.env.QUILL_CMS}/questions/${this.props.questionID}/health`,
+      `${import.meta.env.VITE_CMS_URL}/questions/${this.props.questionID}/health`,
       (body) => {
         this.setState({
           health: body,
@@ -134,7 +134,7 @@ class ResponseComponent extends React.Component {
 
   getGradeBreakdown() {
     requestGet(
-      `${import.meta.env.QUILL_CMS}/questions/${this.props.questionID}/grade_breakdown`,
+      `${import.meta.env.VITE_CMS_URL}/questions/${this.props.questionID}/grade_breakdown`,
       (body) => {
         this.setState({
           gradeBreakdown: body,

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
@@ -36,7 +36,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
     const qid = this.props.questionID
     const newSeqs = this.state.itemText.split(/\|{3}(?!\|)/)
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/${qid}/focus_point_affected_count`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${qid}/focus_point_affected_count`,
       {data: {selected_sequences: newSeqs}},
       (body) => {
         this.setState({matchedCount: body.matchedCount})

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
@@ -34,7 +34,7 @@ export default class IncorrectSequencesInputAndConceptSelectorForm extends React
     const usedSeqs = this.props.usedSequences
     const newSeqs = this.state.itemText.split(/\|{3}(?!\|)/)
     requestPost(
-      `${import.meta.env.QUILL_CMS}/responses/${qid}/incorrect_sequence_affected_count`,
+      `${import.meta.env.VITE_CMS_URL}/responses/${qid}/incorrect_sequence_affected_count`,
       {data: {used_sequences: usedSeqs, selected_sequences: newSeqs}},
       (body) => {
         this.setState({matchedCount: body.matchedCount})

--- a/services/QuillLMS/client/app/bundles/Grammar/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/index.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import App from "./App";
-import './styles/style.scss';
 
 ReactDOM.render(
   <App />,

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/grading/rematching.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/grading/rematching.ts
@@ -47,7 +47,7 @@ interface ConceptResults {
 // }
 
 export function rematchAll(mode: string, questionID: string, callback:Function) {
-  const rematchAllUrl = `${import.meta.env.QUILL_CMS}/responses/rematch_all`;
+  const rematchAllUrl = `${import.meta.env.VITE_CMS_URL}/responses/rematch_all`;
   fetch(rematchAllUrl, {
     method: 'POST',
     body: JSON.stringify({ type: 'grammar_questions', uid: questionID}),
@@ -81,7 +81,7 @@ export function rematchOne(response: string, mode: string, question: Question, q
 
 export function paginatedNonHumanResponses(matcher, matcherFields, qid, page, callback) {
   requestPost(
-    `${import.meta.env.QUILL_CMS}/questions/${qid}/responses/search`,
+    `${import.meta.env.VITE_CMS_URL}/questions/${qid}/responses/search`,
     getResponseBody(page),
     (data) => {
       const parsedResponses = _.indexBy(data.results, 'id');
@@ -160,7 +160,7 @@ function deleteRematchedResponse(response: any) {
 function updateResponse(rid, content) {
   const rubyConvertedResponse = objectWithSnakeKeysFromCamel(content, false);
   return requestPut(
-    `${import.meta.env.QUILL_CMS}/responses/${rid}`,
+    `${import.meta.env.VITE_CMS_URL}/responses/${rid}`,
     { response: rubyConvertedResponse, }
   )
 }
@@ -216,7 +216,7 @@ function getResponseBody(pageNumber: number) {
 }
 
 function getGradedResponses(questionID) {
-  return requestGet(`${import.meta.env.QUILL_CMS}/questions/${questionID}/responses`);
+  return requestGet(`${import.meta.env.VITE_CMS_URL}/questions/${questionID}/responses`);
 }
 
 function formatGradedResponses(jsonString: string): {[key: string]: Response} {

--- a/services/QuillLMS/client/app/bundles/Grammar/styles/style.scss
+++ b/services/QuillLMS/client/app/bundles/Grammar/styles/style.scss
@@ -1,6 +1,6 @@
 @import './question.scss';
 @import './spinner.scss';
-@import "./node_modules/bulma/bulma.sass";
+@import "bulma/bulma.sass";
 @import './admin.scss';
 @import "./admin-regex-rules.scss";
 @import './dashboards.scss';

--- a/services/QuillLMS/client/app/bundles/Proofreader/tests/proofreaderActivities/container.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/tests/proofreaderActivities/container.test.tsx
@@ -4,7 +4,7 @@ import { PlayProofreaderContainer } from "../../components/proofreaderActivities
 import { ProofreaderActivityReducer } from './data';
 
 import.meta.env.VITE_DEFAULT_URL = 'https://staging.quill.org'
-import.meta.env.QUILL_CMS = 'https://cms.quill.org'
+import.meta.env.VITE_CMS_URL = 'https://cms.quill.org'
 
 describe("<PlayProofreaderContainer />", () => {
   const wrapper = mount(<PlayProofreaderContainer

--- a/services/QuillLMS/client/app/entrypoints/grammar.scss
+++ b/services/QuillLMS/client/app/entrypoints/grammar.scss
@@ -1,0 +1,1 @@
+@import '../bundles/Grammar/styles/style.scss';

--- a/services/QuillLMS/client/app/entrypoints/grammar.ts
+++ b/services/QuillLMS/client/app/entrypoints/grammar.ts
@@ -1,0 +1,3 @@
+console.log('grammar.ts Vite ⚡️ Rails')
+
+import '../bundles/Grammar/clientRegistration';


### PR DESCRIPTION
## WHAT
Get Grammar working on Vite.

## WHY
Plugging away at getting all our apps running on Vite instead of Webpack.

## HOW
Following the same steps I did for Connect and Diagnostic - I did find in testing this that we were using two different env variables for the CMS_URL, so I consolidated those everywhere.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Vite-Grammar-5b8da490b22543259b2a70f7477f2c7a?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | Not possible yet
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A