### PR TITLE
fix function signature-based regression on staggered release teacher fix

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/teacher_fix/recalculate_staggered_release_locks.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/teacher_fix/recalculate_staggered_release_locks.jsx
@@ -23,7 +23,7 @@ const RecalculateStaggeredReleaseLocks = () => {
     )
   }
 
-  function handleTeacherIdentifierUpdate() {
+  function handleTeacherIdentifierUpdate(e) {
     setTeacherIdentifier(e.target.value)
   };
 


### PR DESCRIPTION
## WHAT
Fixes regression which removed param from a callback function. 

## WHY
Bug fix

## HOW
Reinstante original function isgnature 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Cannot-type-in-email-field-on-Recalculate-Staggered-Release-Locks-teacher-fix-6fdc1953a99c4d9293c0542772676510

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - reverting regression
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
