### PR TITLE
fix tutorial slides regression

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/tutorials/TutorialIndex.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/tutorials/TutorialIndex.jsx
@@ -32,6 +32,12 @@ const TutorialIndex = ({}) => {
     }
   }, [])
 
+  React.useEffect(() => {
+    if (Number(params.slideNumber) === slides.length) {
+      finishTutorial();
+    }
+  }, [params.slideNumber])
+
   function circles() {
     const circles = slides.map((el, index) => {
       const currSlide = slideNumber - 1;


### PR DESCRIPTION
## WHAT
Fix bug where teachers can't get to lessons from tutorial slides.

## WHY
We want this pathway to work correctly.

## HOW
I rewrote this component to be functional last week and missed a critical piece of functionality from the `componentWillReceiveProps`, so I just added it back in as an `effect`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teachers-cannot-get-past-the-onboarding-slides-in-Quill-Lessons-cd3799f397914c9a82015ee6ec7fcf48

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES