### PR TITLE
Add ‘antisemitic’ to spelling exceptions

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -16,6 +16,7 @@ module Evidence
 
     # TODO: replace with better exception code
     EXCEPTIONS = [
+      'antisemitic',
       'solartogether',
       'jerom',
       'espana',


### PR DESCRIPTION
## WHAT
Another spelling exception from a passage, "antisemitic"

## WHY
"antisemitic" is being caught as incorrect (spellcheck wants a hyphen), but the preferred spelling from Jewish organizations & the spelling used in the text is "antisemitic"

## HOW
Update exception list.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
N/A

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO', tiny config change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
