### PR TITLE
BigQuery - district standards report

### DIFF
--- a/services/QuillLMS/app/queries/progress_reports/district_standards_reports.rb
+++ b/services/QuillLMS/app/queries/progress_reports/district_standards_reports.rb
@@ -75,14 +75,14 @@ class ProgressReports::DistrictStandardsReports
           GROUP BY
             final_activity_sessions.standard_id,
             final_activity_sessions.user_id
-          HAVING AVG(percentage) >= 0.8
+          HAVING AVG(percentage) >= #{PROFICIENT_THRESHOLD}
         ) AS avg_score_for_standard_by_user
           ON avg_score_for_standard_by_user.standard_id = standards.id
         GROUP BY
           standards.id,
           standard_levels.name
-        SQL
-      ).to_a
+      SQL
+    )
   end
 
   def user_ids_query(admin_id)

--- a/services/QuillLMS/app/services/quill_big_query/runner.rb
+++ b/services/QuillLMS/app/services/quill_big_query/runner.rb
@@ -15,7 +15,6 @@ module QuillBigQuery
       raise JobNotCompletedError, json_body unless json_body['jobComplete']
 
       json_body.dig('schema','fields').respond_to?(:count) &&
-        json_body['rows'].respond_to?(:count) &&
         json_body['totalRows'].respond_to?(:to_i)
     end
 
@@ -46,7 +45,7 @@ module QuillBigQuery
       rescue => e
         raise ClientExecutionError, "Query: #{query}, wrapped error: #{e}"
       end
-      #binding.pry
+
       body = JSON.parse(result.response.body)
     end
 

--- a/services/QuillLMS/app/services/quill_big_query/runner.rb
+++ b/services/QuillLMS/app/services/quill_big_query/runner.rb
@@ -46,6 +46,7 @@ module QuillBigQuery
       rescue => e
         raise ClientExecutionError, "Query: #{query}, wrapped error: #{e}"
       end
+      #binding.pry
       body = JSON.parse(result.response.body)
     end
 

--- a/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
@@ -92,50 +92,63 @@ describe ProgressReports::DistrictStandardsReports do
       #   )
       # end
       let(:example_json) do
-        {"kind"=>"bigquery#queryResponse",
-        "schema"=>
-         {"fields"=>
-           [{"name"=>"id", "type"=>"INTEGER", "mode"=>"NULLABLE"},
-            {"name"=>"name", "type"=>"STRING", "mode"=>"NULLABLE"},
-            {"name"=>"standard_level_name", "type"=>"STRING", "mode"=>"NULLABLE"},
-            {"name"=>"total_activity_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
-            {"name"=>"total_student_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
-            {"name"=>"proficient_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
-            {"name"=>"timespent", "type"=>"FLOAT", "mode"=>"NULLABLE"}]},
-        "jobReference"=>
-         {"projectId"=>"analytics-data-stores", "jobId"=>"job_kS-b_Iml8O5mCgYv0soGWRXdxP6d", "location"=>"us-central1"},
-        "totalRows"=>"1",
-        "rows"=>
-         [{"f"=>
-            [{"v"=>"7"},
-             {"v"=>"1.1b Use common, proper, and possessive nouns"},
-             {"v"=>"CCSS: Grade 1"},
-             {"v"=>"1"},
-             {"v"=>"82"},
-             {"v"=>"82"},
-             {"v"=>nil}]}],
-        "totalBytesProcessed"=>"7817015634",
-        "jobComplete"=>true,
-        "cacheHit"=>false}
+        {
+          "kind"=>"bigquery#queryResponse",
+          "schema"=>{
+            "fields"=>[
+              {"name"=>"id", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+              {"name"=>"name", "type"=>"STRING", "mode"=>"NULLABLE"},
+              {"name"=>"standard_level_name", "type"=>"STRING", "mode"=>"NULLABLE"},
+              {"name"=>"total_activity_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+              {"name"=>"total_student_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+              {"name"=>"proficient_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+              {"name"=>"timespent", "type"=>"FLOAT", "mode"=>"NULLABLE"}
+            ]
+          },
+          "jobReference"=>{
+            "projectId"=>"analytics-data-stores", "jobId"=>"job_kS-b_Iml8O5mCgYv0soGWRXdxP6d", "location"=>"us-central1"
+          },
+          "totalRows"=>"1",
+          "rows"=>[
+            {
+              "f"=>[
+                {"v"=>"7"},
+                {"v"=>"1.1b Use common, proper, and possessive nouns"},
+                {"v"=>"CCSS: Grade 1"},
+                {"v"=>"1"},
+                {"v"=>"82"},
+                {"v"=>"82"},
+                {"v"=>nil}
+              ]
+            }
+          ],
+          "totalBytesProcessed"=>"7817015634",
+          "jobComplete"=>true,
+          "cacheHit"=>false
+        }
       end
 
-      xit 'should WIP' do
+      it 'should transform stubbed payload correctly' do
+        allow(QuillBigQuery::Runner).to receive(:get_response).and_return(example_json)
+
         report = described_class.new(admin.id)
         query_result = report.standards_report_query(teacher.id, standard1.id)
-        expected =
-          {
-            "name"=>"Standard 1",
-            "standard_level_name"=>"Standard Level 1",
-            "total_activity_count"=>1,
-            "total_student_count"=>2,
-            "proficient_count"=>2,
-            "timespent"=>"30"
-          }
+
+        expected = {
+          "id"=>7,
+          "name"=>"1.1b Use common, proper, and possessive nouns",
+          "standard_level_name"=>"CCSS: Grade 1",
+          "total_activity_count"=>1,
+          "total_student_count"=>82,
+          "proficient_count"=>82,
+          "timespent"=>nil
+        }
+
         expect(query_result.count).to eq 1
-        expect(expected < query_result.first).to be true
         expect(query_result.first.keys).to match_array(
           %w(id name standard_level_name total_activity_count total_student_count proficient_count timespent)
         )
+        expect(query_result.first).to eq expected
       end
     end
   end

--- a/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
@@ -72,7 +72,8 @@ describe ProgressReports::DistrictStandardsReports do
         ]
       },
       "jobReference"=>{
-        "projectId"=>"analytics-data-stores", "jobId"=>"job_hdxcHeTAbIgInJ5nZvPUwryG853s", "location"=>"us-central1"},
+        "projectId"=>"analytics-data-stores", "jobId"=>"job_hdxcHeTAbIgInJ5nZvPUwryG853s", "location"=>"us-central1"
+      },
         "totalRows"=>"1",
         "rows"=>[
           {
@@ -88,8 +89,8 @@ describe ProgressReports::DistrictStandardsReports do
         "totalBytesProcessed"=>"7823614651",
         "jobComplete"=>true,
         "cacheHit"=>false
-      }
-    end
+    }
+  end
 
 
   context '#standards_report_query' do
@@ -103,8 +104,7 @@ describe ProgressReports::DistrictStandardsReports do
       end
 
       it 'tests end to end' do
-        expected =
-        [
+        expected = [
           {
           "id"=>7,
           "name"=>"1.1b Use common, proper, and possessive nouns",
@@ -188,7 +188,7 @@ describe ProgressReports::DistrictStandardsReports do
 
       results = report.results
 
-      expect(results.first.pluck('id')).to match_array [7]
+      expect(results.pluck('id')).to eq [7]
       expect(results.count).to eq 1
     end
 

--- a/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
@@ -37,49 +37,106 @@ describe ProgressReports::DistrictStandardsReports do
   end
 
   context '#standards_report_query' do
-    let(:assigned_student_ids) { [student1.id, student2.id] }
-    let(:activity1) { create(:activity, standard: standard1) }
-    let(:activity2) { create(:activity, standard: standard2) }
+    context 'integration', :external_api do
+      let(:assigned_student_ids) { [] }
+      around do |a_spec|
+        VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
+        a_spec.run
+        VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
+      end
 
-    before do
-      create(
-        :activity_session,
-        :finished,
-        activity: activity1,
-        percentage: percentage1,
-        timespent: timespent1,
-        classroom_unit: classroom_unit,
-        user: student1
-      )
+      it 'tests end to end' do
+        expected =
+        [
+          {
+          "id"=>7,
+          "name"=>"1.1b Use common, proper, and possessive nouns",
+          "standard_level_name"=>"CCSS: Grade 1",
+          "total_activity_count"=>1,
+          "total_student_count"=>82,
+          "proficient_count"=>82,
+          "timespent"=>nil
+          }
+        ]
 
-      create(
-        :activity_session,
-        :finished,
-        activity: activity1,
-        percentage: percentage2,
-        timespent: timespent2,
-        classroom_unit: classroom_unit,
-        user: student2
-      )
+        report = described_class.new(admin.id)
+        query_result = report.standards_report_query(3945512, 7)
+        expect(query_result).to eq expected
+      end
     end
 
-    it 'should WIP' do
-      report = described_class.new(admin.id)
-      query_result = report.standards_report_query(teacher.id, standard1.id)
-      expected =
-        {
-          "name"=>"Standard 1",
-          "standard_level_name"=>"Standard Level 1",
-          "total_activity_count"=>1,
-          "total_student_count"=>2,
-          "proficient_count"=>2,
-          "timespent"=>"30"
-        }
-      expect(query_result.count).to eq 1
-      expect(expected < query_result.first).to be true
-      expect(query_result.first.keys).to match_array(
-        %w(id name standard_level_name total_activity_count total_student_count proficient_count timespent)
-      )
+    context 'stubbed' do
+      let(:assigned_student_ids) { [student1.id, student2.id] }
+      let(:activity1) { create(:activity, standard: standard1) }
+      let(:activity2) { create(:activity, standard: standard2) }
+
+      # before do
+      #   create(
+      #     :activity_session,
+      #     :finished,
+      #     activity: activity1,
+      #     percentage: percentage1,
+      #     timespent: timespent1,
+      #     classroom_unit: classroom_unit,
+      #     user: student1
+      #   )
+
+      #   create(
+      #     :activity_session,
+      #     :finished,
+      #     activity: activity1,
+      #     percentage: percentage2,
+      #     timespent: timespent2,
+      #     classroom_unit: classroom_unit,
+      #     user: student2
+      #   )
+      # end
+      let(:example_json) do
+        {"kind"=>"bigquery#queryResponse",
+        "schema"=>
+         {"fields"=>
+           [{"name"=>"id", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+            {"name"=>"name", "type"=>"STRING", "mode"=>"NULLABLE"},
+            {"name"=>"standard_level_name", "type"=>"STRING", "mode"=>"NULLABLE"},
+            {"name"=>"total_activity_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+            {"name"=>"total_student_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+            {"name"=>"proficient_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+            {"name"=>"timespent", "type"=>"FLOAT", "mode"=>"NULLABLE"}]},
+        "jobReference"=>
+         {"projectId"=>"analytics-data-stores", "jobId"=>"job_kS-b_Iml8O5mCgYv0soGWRXdxP6d", "location"=>"us-central1"},
+        "totalRows"=>"1",
+        "rows"=>
+         [{"f"=>
+            [{"v"=>"7"},
+             {"v"=>"1.1b Use common, proper, and possessive nouns"},
+             {"v"=>"CCSS: Grade 1"},
+             {"v"=>"1"},
+             {"v"=>"82"},
+             {"v"=>"82"},
+             {"v"=>nil}]}],
+        "totalBytesProcessed"=>"7817015634",
+        "jobComplete"=>true,
+        "cacheHit"=>false}
+      end
+
+      xit 'should WIP' do
+        report = described_class.new(admin.id)
+        query_result = report.standards_report_query(teacher.id, standard1.id)
+        expected =
+          {
+            "name"=>"Standard 1",
+            "standard_level_name"=>"Standard Level 1",
+            "total_activity_count"=>1,
+            "total_student_count"=>2,
+            "proficient_count"=>2,
+            "timespent"=>"30"
+          }
+        expect(query_result.count).to eq 1
+        expect(expected < query_result.first).to be true
+        expect(query_result.first.keys).to match_array(
+          %w(id name standard_level_name total_activity_count total_student_count proficient_count timespent)
+        )
+      end
     end
   end
 

--- a/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
@@ -36,6 +36,53 @@ describe ProgressReports::DistrictStandardsReports do
     it { expect(subject).to eq [] }
   end
 
+  context '#standards_report_query' do
+    let(:assigned_student_ids) { [student1.id, student2.id] }
+    let(:activity1) { create(:activity, standard: standard1) }
+    let(:activity2) { create(:activity, standard: standard2) }
+
+    before do
+      create(
+        :activity_session,
+        :finished,
+        activity: activity1,
+        percentage: percentage1,
+        timespent: timespent1,
+        classroom_unit: classroom_unit,
+        user: student1
+      )
+
+      create(
+        :activity_session,
+        :finished,
+        activity: activity1,
+        percentage: percentage2,
+        timespent: timespent2,
+        classroom_unit: classroom_unit,
+        user: student2
+      )
+    end
+
+    it 'should WIP' do
+      report = described_class.new(admin.id)
+      query_result = report.standards_report_query(teacher.id, standard1.id)
+      expected =
+        {
+          "name"=>"Standard 1",
+          "standard_level_name"=>"Standard Level 1",
+          "total_activity_count"=>1,
+          "total_student_count"=>2,
+          "proficient_count"=>2,
+          "timespent"=>"30"
+        }
+      expect(query_result.count).to eq 1
+      expect(expected < query_result.first).to be true
+      expect(query_result.first.keys).to match_array(
+        %w(id name standard_level_name total_activity_count total_student_count proficient_count timespent)
+      )
+    end
+  end
+
   context 'student1 is assigned to classroom_unit' do
     let(:assigned_student_ids) { [student1.id] }
 

--- a/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
@@ -3,42 +3,99 @@
 require 'rails_helper'
 
 describe ProgressReports::DistrictStandardsReports do
-  subject { described_class.new(admin.id).results }
-
-  let!(:school) { create(:school) }
-  let!(:teacher) { create(:teacher) }
   let!(:admin) { create(:admin) }
-  let!(:classroom) { create(:classroom) }
-
-  let!(:schools_admins) { create(:schools_admins, school: school, user: admin) }
-  let!(:schools_users) { create(:schools_users, school: school, user: teacher) }
-  let!(:classrooms_teacher) { create(:classrooms_teacher, user: teacher, role: "owner", classroom: classroom) }
-  let!(:classroom_unit) { create(:classroom_unit, classroom: classroom, assigned_student_ids: assigned_student_ids) }
-
-  let(:proficient_threshold) { described_class::PROFICIENT_THRESHOLD }
-
-  let(:student1) { create(:student) }
-  let(:student2) { create(:student) }
-
-  let(:standard1) { create(:standard) }
-  let(:standard2) { create(:standard) }
-
-  let(:percentage1) { proficient_threshold + 0.1 }
-  let(:percentage2) { proficient_threshold + 0.2 }
-
-  let(:timespent1) { 10 }
-  let(:timespent2) { 20 }
-
-  context 'no assigned students' do
-    let(:assigned_student_ids) { [] }
-
-    it { expects_results }
-    it { expect(subject).to eq [] }
+  let(:payload_keys) do
+    %w(id name standard_level_name total_activity_count total_student_count proficient_count timespent)
   end
 
+  let(:exmaple_null_json) do
+    {
+      "schema" => {
+        "fields" => []
+      },
+      "totalRows" => "0",
+      "jobComplete" => true
+    }
+  end
+
+  # standards_report_query(3945512, 7)
+  let(:example_json) do
+    {
+      "kind"=>"bigquery#queryResponse",
+      "schema"=>{
+        "fields"=>[
+          {"name"=>"id", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+          {"name"=>"name", "type"=>"STRING", "mode"=>"NULLABLE"},
+          {"name"=>"standard_level_name", "type"=>"STRING", "mode"=>"NULLABLE"},
+          {"name"=>"total_activity_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+          {"name"=>"total_student_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+          {"name"=>"proficient_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+          {"name"=>"timespent", "type"=>"FLOAT", "mode"=>"NULLABLE"}
+        ]
+      },
+      "jobReference"=>{
+        "projectId"=>"analytics-data-stores", "jobId"=>"job_kS-b_Iml8O5mCgYv0soGWRXdxP6d", "location"=>"us-central1"
+      },
+      "totalRows"=>"1",
+      "rows"=>[
+        {
+          "f"=>[
+            {"v"=>"7"},
+            {"v"=>"1.1b Use common, proper, and possessive nouns"},
+            {"v"=>"CCSS: Grade 1"},
+            {"v"=>"1"},
+            {"v"=>"82"},
+            {"v"=>"82"},
+            {"v"=>nil}
+          ]
+        }
+      ],
+      "totalBytesProcessed"=>"7817015634",
+      "jobComplete"=>true,
+      "cacheHit"=>false
+    }
+  end
+
+  # standards_report_query(3945512, 6)
+  let(:example_json2) do
+    {
+      "kind"=>"bigquery#queryResponse",
+      "schema"=>{
+        "fields"=>[
+          {"name"=>"id", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+          {"name"=>"name", "type"=>"STRING", "mode"=>"NULLABLE"},
+          {"name"=>"standard_level_name", "type"=>"STRING", "mode"=>"NULLABLE"},
+          {"name"=>"total_activity_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+          {"name"=>"total_student_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+          {"name"=>"proficient_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
+          {"name"=>"timespent", "type"=>"FLOAT", "mode"=>"NULLABLE"}
+        ]
+      },
+      "jobReference"=>{
+        "projectId"=>"analytics-data-stores", "jobId"=>"job_hdxcHeTAbIgInJ5nZvPUwryG853s", "location"=>"us-central1"},
+        "totalRows"=>"1",
+        "rows"=>[
+          {
+            "f"=>[
+              {"v"=>"6"},
+              {"v"=>"1.1i Frequently occurring prepositions"},
+              {"v"=>"CCSS: Grade 1"}, {"v"=>"4"}, {"v"=>"103"},
+              {"v"=>"103"},
+              {"v"=>"51010.0"}
+            ]
+          }
+        ],
+        "totalBytesProcessed"=>"7823614651",
+        "jobComplete"=>true,
+        "cacheHit"=>false
+      }
+    end
+
+
   context '#standards_report_query' do
+    let(:assigned_student_ids) { [] }
+
     context 'integration', :external_api do
-      let(:assigned_student_ids) { [] }
       around do |a_spec|
         VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
         a_spec.run
@@ -66,73 +123,11 @@ describe ProgressReports::DistrictStandardsReports do
     end
 
     context 'stubbed' do
-      let(:assigned_student_ids) { [student1.id, student2.id] }
-      let(:activity1) { create(:activity, standard: standard1) }
-      let(:activity2) { create(:activity, standard: standard2) }
-
-      # before do
-      #   create(
-      #     :activity_session,
-      #     :finished,
-      #     activity: activity1,
-      #     percentage: percentage1,
-      #     timespent: timespent1,
-      #     classroom_unit: classroom_unit,
-      #     user: student1
-      #   )
-
-      #   create(
-      #     :activity_session,
-      #     :finished,
-      #     activity: activity1,
-      #     percentage: percentage2,
-      #     timespent: timespent2,
-      #     classroom_unit: classroom_unit,
-      #     user: student2
-      #   )
-      # end
-      let(:example_json) do
-        {
-          "kind"=>"bigquery#queryResponse",
-          "schema"=>{
-            "fields"=>[
-              {"name"=>"id", "type"=>"INTEGER", "mode"=>"NULLABLE"},
-              {"name"=>"name", "type"=>"STRING", "mode"=>"NULLABLE"},
-              {"name"=>"standard_level_name", "type"=>"STRING", "mode"=>"NULLABLE"},
-              {"name"=>"total_activity_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
-              {"name"=>"total_student_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
-              {"name"=>"proficient_count", "type"=>"INTEGER", "mode"=>"NULLABLE"},
-              {"name"=>"timespent", "type"=>"FLOAT", "mode"=>"NULLABLE"}
-            ]
-          },
-          "jobReference"=>{
-            "projectId"=>"analytics-data-stores", "jobId"=>"job_kS-b_Iml8O5mCgYv0soGWRXdxP6d", "location"=>"us-central1"
-          },
-          "totalRows"=>"1",
-          "rows"=>[
-            {
-              "f"=>[
-                {"v"=>"7"},
-                {"v"=>"1.1b Use common, proper, and possessive nouns"},
-                {"v"=>"CCSS: Grade 1"},
-                {"v"=>"1"},
-                {"v"=>"82"},
-                {"v"=>"82"},
-                {"v"=>nil}
-              ]
-            }
-          ],
-          "totalBytesProcessed"=>"7817015634",
-          "jobComplete"=>true,
-          "cacheHit"=>false
-        }
-      end
-
       it 'should transform stubbed payload correctly' do
         allow(QuillBigQuery::Runner).to receive(:get_response).and_return(example_json)
 
         report = described_class.new(admin.id)
-        query_result = report.standards_report_query(teacher.id, standard1.id)
+        query_result = report.standards_report_query(admin.id, 7)
 
         expected = {
           "id"=>7,
@@ -145,283 +140,57 @@ describe ProgressReports::DistrictStandardsReports do
         }
 
         expect(query_result.count).to eq 1
-        expect(query_result.first.keys).to match_array(
-          %w(id name standard_level_name total_activity_count total_student_count proficient_count timespent)
-        )
+        expect(query_result.first.keys).to match_array(payload_keys)
         expect(query_result.first).to eq expected
       end
     end
   end
 
-  context 'student1 is assigned to classroom_unit' do
-    let(:assigned_student_ids) { [student1.id] }
+  context '#results' do
+    let!(:standard7) { create(:standard, id: 7) }
 
-    it { expects_results }
-    it { expect(subject).to eq [] }
+    it 'should return results in the correct schema' do
+      allow(QuillBigQuery::Runner).to receive(:get_response).and_return(example_json)
+      report = described_class.new(admin.id)
+      allow(report).to receive(:user_ids_query).and_return '3945512'
+      results = report.results
 
-    context 'standard1 is assigned to activity1' do
-      let!(:activity1) { create(:activity, standard: standard1) }
-
-      it { expects_results }
-      it { expect(subject).to eq [] }
-
-      context 'student1 has started activity_session with activity1' do
-        before do
-          create(
-            :activity_session,
-            :started,
-            activity: activity1,
-            classroom_unit: classroom_unit,
-            user: student1
-          )
-        end
-
-        it { expects_results }
-        it { expect(subject).to eq [] }
-
-        context 'student1 has finished activity_session with activity1' do
-          before do
-            create(
-              :activity_session,
-              :finished,
-              activity: activity1,
-              percentage: percentage1,
-              timespent: timespent1,
-              classroom_unit: classroom_unit,
-              user: student1
-            )
-          end
-
-          context 'percentage1 does not meet threshold' do
-            let(:percentage1)  { proficient_threshold - 0.1 }
-
-            it { expects_results }
-            it { expect(subject[0]["proficient_count"]).to eq 0 }
-          end
-
-          context 'percentage1 meets threshold' do
-            let(:percentage1) { proficient_threshold }
-
-            it { expects_results }
-            it { expect(subject[0]["proficient_count"]).to eq 1 }
-          end
-
-          context 'student1 has another finished another activity_session with activity1' do
-            before do
-              create(
-                :activity_session,
-                :finished,
-                activity: activity1,
-                percentage: percentage2,
-                timespent: timespent2,
-                classroom_unit: classroom_unit,
-                user: student1
-              )
-            end
-
-            it { expects_results }
-            it { expect(subject[0]["proficient_count"]).to eq 1 }
-          end
-        end
-      end
+      expect(results.is_a?(Array)).to be true
+      expect(results.count).to eq 1
+      expect(results.first.keys).to match_array(payload_keys)
     end
-  end
 
-  context 'student1, student2 are assigned to classroom_unit' do
-    let(:assigned_student_ids) { [student1.id, student2.id] }
+    it 'should handle multiple standards' do
+      create(:standard, id: 6)
+      stubbed_payload_sequence = [example_json, example_json2]
 
-    context 'two activities with different standards' do
-      let(:activity1) { create(:activity, standard: standard1) }
-      let(:activity2) { create(:activity, standard: standard2) }
+      allow(QuillBigQuery::Runner).to receive(:get_response).and_return(*stubbed_payload_sequence)
 
-      it { expects_results }
-      it { expect(subject).to eq [] }
+      report = described_class.new(admin.id)
+      allow(report).to receive(:user_ids_query).and_return '3945512'
 
-      context 'student1 has finished activity_session with activity1' do
-        before do
-          create(
-            :activity_session,
-            :finished,
-            activity: activity1,
-            percentage: percentage1,
-            timespent: timespent1,
-            classroom_unit: classroom_unit,
-            user: student1
-          )
-        end
+      results = report.results
 
-        context 'student2 has finished activity_sessions with activity1' do
-          before do
-            create(
-              :activity_session,
-              :finished,
-              activity: activity1,
-              percentage: percentage2,
-              timespent: timespent2,
-              classroom_unit: classroom_unit,
-              user: student2
-            )
-          end
-
-          it { expects_results }
-
-          it do
-            expect(subject.size).to eq 1
-            expect(subject[0]["total_student_count"]).to eq 2
-            expect(subject[0]["total_activity_count"]).to eq 1
-          end
-
-          context 'timespent2 is nil' do
-            let(:timespent2) { nil }
-
-            it { expects_results }
-
-            # nil timespent is effectively replaced with average of all non-nil timespent
-            it { expect(subject[0]["timespent"]).to eq (timespent1 + timespent1).to_s }
-          end
-        end
-
-        context 'student2 has finished activity_sessions with activity2' do
-          before do
-            create(
-              :activity_session,
-              :finished,
-              activity: activity2,
-              percentage: percentage2,
-              timespent: timespent2,
-              classroom_unit: classroom_unit,
-              user: student2
-            )
-          end
-
-          it { expects_results }
-
-          it do
-            expect(subject.size).to eq 2
-            expect(subject[0]["total_student_count"]).to eq 1
-            expect(subject[0]["total_activity_count"]).to eq 1
-            expect(subject[1]["total_student_count"]).to eq 1
-            expect(subject[1]["total_activity_count"]).to eq 1
-          end
-        end
+      expect(results.pluck('id')).to match_array [6,7]
+      expect(results.count).to eq 2
+      results.each do |result|
+        expect(result.keys).to match_array(payload_keys)
       end
     end
 
-    context 'two activities with same standard' do
-      let(:activity1) { create(:activity, standard: standard1) }
-      let(:activity2) { create(:activity, standard: standard1) }
+    it 'should handle bigquery responses with null rows' do
+      create(:standard, id: 6)
+      stubbed_payload_sequence = [example_json, exmaple_null_json]
+      allow(QuillBigQuery::Runner).to receive(:get_response).and_return(*stubbed_payload_sequence)
 
-      it { expects_results }
+      report = described_class.new(admin.id)
+      allow(report).to receive(:user_ids_query).and_return '3945512'
 
-      context 'student1 has finished activity_session with activity1' do
-        before do
-          create(
-            :activity_session,
-            :finished,
-            activity: activity1,
-            percentage: percentage1,
-            timespent: timespent1,
-            classroom_unit: classroom_unit,
-            user: student1
-          )
-        end
+      results = report.results
 
-        context 'student2 has finished activity_sessions with activity1' do
-          before do
-            create(
-              :activity_session,
-              :finished,
-              activity: activity1,
-              percentage: percentage2,
-              timespent: timespent2,
-              classroom_unit: classroom_unit,
-              user: student2
-            )
-          end
-
-          it { expects_results }
-
-          it do
-            expect(subject.size).to eq 1
-            expect(subject[0]["total_activity_count"]).to eq 1
-            expect(subject[0]["total_student_count"]).to eq 2
-          end
-        end
-
-        context 'student2 has finished activity_sessions with activity2' do
-          before do
-            create(
-              :activity_session,
-              :finished,
-              activity: activity2,
-              percentage: percentage2,
-              timespent: timespent2,
-              classroom_unit: classroom_unit,
-              user: student2
-            )
-          end
-
-          it { expects_results }
-
-          it do
-            expect(subject.size).to eq 1
-            expect(subject[0]["total_activity_count"]).to eq 2
-            expect(subject[0]["total_student_count"]).to eq 2
-          end
-        end
-      end
+      expect(results.first.pluck('id')).to match_array [7]
+      expect(results.count).to eq 1
     end
-  end
 
-  def finished_activity_sessions
-    ActivitySession.where(is_final_score: true).to_a
-  end
-
-  def finished_standard_activity_sessions(standard)
-    finished_activity_sessions.select { |as| as.activity.standard == standard }
-  end
-
-  def finished_standard_activities(standard)
-    finished_standard_activity_sessions(standard).map(&:activity).uniq
-  end
-
-  def finished_standard_student_ids(standard)
-    finished_standard_activity_sessions(standard).pluck(:user_id).uniq
-  end
-
-  def proficient_standard_student_ids(standard)
-    finished_standard_activity_sessions(standard).select { |as| as.percentage >= 0.80 }.pluck(:user_id).uniq
-  end
-
-  def average_timespent(standard)
-    timespent_values = finished_standard_activity_sessions(standard).pluck(:timespent).compact
-    timespent_values.sum / timespent_values.count
-  end
-
-  def total_timespent_standard(standard)
-    average_timespent(standard) * finished_standard_activity_sessions(standard).pluck(:id).uniq.count
-  end
-
-  def expected_result(standard)
-    {
-      id: standard.id,
-      name: standard.name,
-      standard_level_name: standard.standard_level.name,
-      total_activity_count: finished_standard_activities(standard).count,
-      total_student_count: finished_standard_student_ids(standard).count,
-      proficient_count: proficient_standard_student_ids(standard).count,
-      timespent: total_timespent_standard(standard).to_s
-    }.stringify_keys
-  end
-
-  def finished_standards
-    finished_activity_sessions
-      .map(&:activity)
-      .map(&:standard)
-      .uniq
-  end
-
-  def expects_results
-    expect(subject).to eq(finished_standards.map { |standard| expected_result(standard) })
   end
 end

--- a/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
@@ -8,7 +8,7 @@ describe ProgressReports::DistrictStandardsReports do
     %w(id name standard_level_name total_activity_count total_student_count proficient_count timespent)
   end
 
-  let(:exmaple_null_json) do
+  let(:example_null_json) do
     {
       "schema" => {
         "fields" => []
@@ -180,7 +180,7 @@ describe ProgressReports::DistrictStandardsReports do
 
     it 'should handle bigquery responses with null rows' do
       create(:standard, id: 6)
-      stubbed_payload_sequence = [example_json, exmaple_null_json]
+      stubbed_payload_sequence = [example_json, example_null_json]
       allow(QuillBigQuery::Runner).to receive(:get_response).and_return(*stubbed_payload_sequence)
 
       report = described_class.new(admin.id)


### PR DESCRIPTION
## WHAT
- Migrate another report query from Postgres to BigQuery 
- remove `json_body['rows'].respond_to?(:count)` validation check, since this field is not present in a null response

## WHY
This query is taxing on Postgres' resources. 

## HOW
Follow established pattern from https://github.com/empirical-org/Empirical-Core/pull/10490

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=b06ee1bef5e34e17b4515137e73fedca&pm=c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
