### PR TITLE
Remove logging for LongTimeTrackingError

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -106,25 +106,11 @@ class Api::V1::ActivitySessionsController < Api::ApiController
     time_tracking = clean_data&.fetch(ActivitySession::TIME_TRACKING_KEY, nil)
     timespent = ActivitySession.calculate_timespent(@activity_session, time_tracking)
 
-    record_long_timespent(timespent, @activity_session&.user_id, @activity_session&.id)
-
     params
       .permit(activity_session_permitted_params)
       .merge(data: clean_data&.permit!)
       .reject { |_, v| v.nil? }
       .merge(timespent: timespent)
-  end
-
-  private def record_long_timespent(timespent, user_id, activity_session_id)
-    return if timespent.nil?
-    return if timespent <= 3600
-
-    ErrorNotifier.report(
-      ActivitySession::LongTimeTrackingError.new,
-      activity_session_id: activity_session_id,
-      timespent: timespent,
-      user_id: user_id
-    )
   end
 
   private def transform_incoming_request

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -43,7 +43,6 @@ class ActivitySession < ApplicationRecord
 
   class ConceptResultSubmittedWithoutActivitySessionError < StandardError; end
   class StudentNotAssignedActivityError < StandardError; end
-  class LongTimeTrackingError < StandardError; end
 
   include Uid
   include Concepts

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -190,23 +190,6 @@ describe Api::V1::ActivitySessionsController, type: :controller do
         expect(activity_session.data['time_tracking']).to include(modified_data['time_tracking'])
         expect(activity_session.data['time_tracking_edits']).to include(modified_data['time_tracking_edits'])
       end
-
-      it 'should log long session' do
-        # lots of keys to hit Tracking error but avoid time_tracking cleaner
-        data = {
-          'time_tracking' => ('a'..'z').to_h {|k| [k,600]}
-        }
-
-        reporting_params = {
-          activity_session_id: activity_session.id,
-          timespent: 15600,
-          user_id: activity_session.user_id
-        }
-
-        expect(ErrorNotifier).to receive(:report).with(ActivitySession::LongTimeTrackingError, reporting_params).once
-
-        put :update, params: { id: activity_session.uid, data: data }, as: :json
-      end
     end
 
     context 'a finished session' do


### PR DESCRIPTION
## WHAT
Remove this error class, all error logging and tests for this error.

## WHY
This was a temporary debugging error that we no longer need to track or log in Sentry.

## HOW
Remove the error class and all related code.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Remove-the-long-sessions-logging-from-app-and-related-code-31718e399f524af996fb30e39e5bdb38?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
