### PR TITLE
Catch error and flash message when Activity Pack is archived

### DIFF
--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -74,7 +74,11 @@ class ActivitiesController < ApplicationController
   def activity_session
     return redirect_to profile_path unless current_user.student?
 
-    if classroom_unit.unit.closed?
+    if classroom_unit.unit.blank?
+      flash[:error] = t('activity_link.errors.activity_belongs_to_archived_pack')
+      flash.keep(:error)
+      redirect_to classes_path
+    elsif classroom_unit.unit.closed?
       flash[:error] = t('activity_link.errors.activity_belongs_to_closed_pack')
       flash.keep(:error)
       redirect_to classes_path

--- a/services/QuillLMS/config/locales/en.yml
+++ b/services/QuillLMS/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
   activity_link:
     errors:
       activity_belongs_to_closed_pack: 'Sorry, you do not have access to this activity because it belongs to an activity pack that has been closed. Please contact your teacher.'
+      activity_belongs_to_archived_pack: 'Sorry, you do not have access to this activity because it belongs to an activity pack that has been archived. Please contact your teacher.'
       activity_pack_closed: 'Sorry, you do not have access to this activity pack because it has been closed. Please contact your teacher.'
       activity_not_assigned: 'Sorry, you do not have access to this activity because it has not been assigned to you. Please contact your teacher.'
       activity_pack_not_assigned: 'Sorry, you do not have access to this activity pack because it has not been assigned to you. Please contact your teacher.'

--- a/services/QuillLMS/spec/controllers/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activities_controller_spec.rb
@@ -152,6 +152,15 @@ describe ActivitiesController, type: :controller, redis: true do
       end
     end
 
+    context 'unit is archived' do
+      it 'redirects and raises an error' do
+        classroom_unit.unit.update(visible: false)
+        subject
+        expect(response).to redirect_to classes_path
+        expect(flash[:error]).to match I18n.t('activity_link.errors.activity_belongs_to_archived_pack')
+      end
+    end
+
     context 'non-student user attempts to access link' do
       before { session[:user_id] = create(:teacher).id }
 


### PR DESCRIPTION
## WHAT
Occasionally a student runs into a nil error where their activity pack has been archived. (This started about four months ago when we deployed code that checks `classroom_unit.unit.closed` when a student accesses an activity). We want to show them a message when this happens, similar to the message when the Activity Pack has been closed.

## WHY
If we don't catch and show this error, the student will be unable to access their activity and it will seem like the website is broken because there is no visible response.

## HOW
Catch when a Unit is nil (this been it's been archived because of the visible scope on Unit) and flash an error.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-NoMethodError-ActivitiesController-activity_session-fe44cb9d8cfb450d8ee669162f3a2c2f?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
