### PR TITLE
evidence/add-annotate-gem

### DIFF
--- a/services/QuillLMS/engines/evidence/Gemfile
+++ b/services/QuillLMS/engines/evidence/Gemfile
@@ -28,6 +28,7 @@ group :test do
 end
 
 group :test, :development do
+  gem 'annotate'
   gem 'factory_bot_rails', '~> 4.8.2', require: false
   gem 'pry'
   gem 'rspec-rails', '~> 5.0'

--- a/services/QuillLMS/engines/evidence/Gemfile.lock
+++ b/services/QuillLMS/engines/evidence/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -332,6 +335,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   byebug
   evidence!
   factory_bot_rails (~> 4.8.2)

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_activities
+#
+#  id                 :integer          not null, primary key
+#  title              :string(100)
+#  parent_activity_id :integer
+#  target_level       :integer
+#  scored_level       :string(100)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  notes              :string
+#  version            :integer          default(1), not null
+#
 module Evidence
 
   class Activity < ApplicationRecord

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity_health.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_activity_healths
+#
+#  id                    :bigint           not null, primary key
+#  name                  :string           not null
+#  flag                  :string           not null
+#  activity_id           :integer          not null
+#  version               :integer          not null
+#  version_plays         :integer          not null
+#  total_plays           :integer          not null
+#  completion_rate       :integer
+#  because_final_optimal :integer
+#  but_final_optimal     :integer
+#  so_final_optimal      :integer
+#  avg_completion_time   :integer
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
 module Evidence
   class ActivityHealth < ApplicationRecord
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_automl_models
+#
+#  id              :integer          not null, primary key
+#  automl_model_id :string           not null
+#  name            :string           not null
+#  labels          :string           default([]), is an Array
+#  prompt_id       :integer
+#  state           :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  notes           :text             default("")
+#
 require "google/cloud/automl"
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/feedback.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_feedbacks
+#
+#  id          :integer          not null, primary key
+#  rule_id     :integer          not null
+#  text        :string           not null
+#  description :string
+#  order       :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module Evidence
   class Feedback < ApplicationRecord
     self.table_name = 'comprehension_feedbacks'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_highlights
+#
+#  id             :integer          not null, primary key
+#  feedback_id    :integer          not null
+#  text           :string           not null
+#  highlight_type :string           not null
+#  starting_index :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 module Evidence
   class Highlight < ApplicationRecord
     self.table_name = 'comprehension_highlights'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/hint.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/hint.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_hints
+#
+#  id             :bigint           not null, primary key
+#  explanation    :string           not null
+#  image_link     :string           not null
+#  image_alt_text :string           not null
+#  rule_id        :bigint
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  name           :text
+#
 module Evidence
   class Hint < ApplicationRecord
     has_many :rules, inverse_of: :hint

--- a/services/QuillLMS/engines/evidence/app/models/evidence/label.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/label.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_labels
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  rule_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 module Evidence
   class Label < ApplicationRecord
     self.table_name = 'comprehension_labels'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/passage.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/passage.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_passages
+#
+#  id                       :integer          not null, primary key
+#  activity_id              :integer
+#  text                     :text
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  image_link               :string
+#  image_alt_text           :string           default("")
+#  highlight_prompt         :string
+#  image_caption            :text             default("")
+#  image_attribution        :text             default("")
+#  essential_knowledge_text :string           default("")
+#
 module Evidence
   class Passage < ApplicationRecord
     self.table_name = 'comprehension_passages'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_plagiarism_texts
+#
+#  id         :integer          not null, primary key
+#  rule_id    :integer          not null
+#  text       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 module Evidence
   class PlagiarismText < ApplicationRecord
     self.table_name = 'comprehension_plagiarism_texts'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_prompts
+#
+#  id                    :integer          not null, primary key
+#  activity_id           :integer
+#  max_attempts          :integer
+#  conjunction           :string(20)
+#  text                  :string
+#  max_attempts_feedback :text
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  first_strong_example  :string           default("")
+#  second_strong_example :string           default("")
+#
 module Evidence
   class Prompt < ApplicationRecord
     self.table_name = 'comprehension_prompts'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_prompt_healths
+#
+#  id                                  :bigint           not null, primary key
+#  prompt_id                           :integer          not null
+#  activity_short_name                 :string           not null
+#  text                                :string           not null
+#  current_version                     :integer          not null
+#  version_responses                   :integer          not null
+#  first_attempt_optimal               :integer
+#  final_attempt_optimal               :integer
+#  avg_attempts                        :float
+#  confidence                          :float
+#  percent_automl_consecutive_repeated :integer
+#  percent_automl                      :integer
+#  percent_plagiarism                  :integer
+#  percent_opinion                     :integer
+#  percent_grammar                     :integer
+#  percent_spelling                    :integer
+#  avg_time_spent_per_prompt           :integer
+#  evidence_activity_health_id         :bigint
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
+#
 module Evidence
   class PromptHealth < ApplicationRecord
     FIRST_ATTEMPT_OPTIMAL_CUTOFF = 25

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_text.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_prompt_texts
+#
+#  id                   :bigint           not null, primary key
+#  prompt_text_batch_id :integer          not null
+#  text_generation_id   :integer          not null
+#  text                 :string           not null
+#  label                :string
+#  ml_type              :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
 module Evidence
   class PromptText < ApplicationRecord
     belongs_to :prompt_text_batch

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_text_batch.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_text_batch.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_prompt_text_batches
+#
+#  id         :bigint           not null, primary key
+#  type       :string           not null
+#  prompt_id  :integer          not null
+#  config     :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 module Evidence
   class PromptTextBatch < ApplicationRecord
     # TODO, use STI for this in the future

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompts_rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompts_rule.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_prompts_rules
+#
+#  id         :integer          not null, primary key
+#  prompt_id  :integer          not null
+#  rule_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 module Evidence
   class PromptsRule < ApplicationRecord
     self.table_name = 'comprehension_prompts_rules'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_regex_rules
+#
+#  id             :integer          not null, primary key
+#  regex_text     :string(200)      not null
+#  case_sensitive :boolean          not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  rule_id        :integer
+#  sequence_type  :text             default("incorrect"), not null
+#  conditional    :boolean          default(FALSE)
+#
 module Evidence
   class RegexRule < ApplicationRecord
     self.table_name = 'comprehension_regex_rules'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/rule.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_rules
+#
+#  id          :integer          not null, primary key
+#  uid         :string           not null
+#  name        :string           not null
+#  note        :string
+#  universal   :boolean          not null
+#  rule_type   :string           not null
+#  optimal     :boolean          not null
+#  suborder    :integer
+#  concept_uid :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  state       :string           not null
+#  hint_id     :bigint
+#
 module Evidence
   class Rule < ApplicationRecord
     self.table_name = 'comprehension_rules'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/text_generation.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/text_generation.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_text_generations
+#
+#  id         :bigint           not null, primary key
+#  type       :string           not null
+#  config     :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 module Evidence
   class TextGeneration < ApplicationRecord
     # TODO, use STI for this in the future

--- a/services/QuillLMS/engines/evidence/app/models/evidence/turking_round.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/turking_round.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_turking_rounds
+#
+#  id          :integer          not null, primary key
+#  activity_id :integer
+#  uuid        :uuid
+#  expires_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module Evidence
   class TurkingRound < ApplicationRecord
     self.table_name = 'comprehension_turking_rounds'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/turking_round_activity_session.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/turking_round_activity_session.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_turking_round_activity_sessions
+#
+#  id                   :integer          not null, primary key
+#  turking_round_id     :integer
+#  activity_session_uid :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
 module Evidence
   class TurkingRoundActivitySession < ApplicationRecord
     self.table_name = 'comprehension_turking_round_activity_sessions'

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
@@ -233,7 +233,7 @@ ActiveRecord::Schema.define(version: 2023_03_06_215624) do
   create_table "evidence_prompt_text_batches", force: :cascade do |t|
     t.string "type", null: false
     t.integer "prompt_id", null: false
-    t.jsonb "data"
+    t.jsonb "config"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -246,6 +246,15 @@ ActiveRecord::Schema.define(version: 2023_03_06_215624) do
     t.string "ml_type"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "evidence_rule_hints", force: :cascade do |t|
+    t.bigint "rule_id", null: false
+    t.bigint "hint_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["hint_id"], name: "index_evidence_rule_hints_on_hint_id"
+    t.index ["rule_id"], name: "index_evidence_rule_hints_on_rule_id"
   end
 
   create_table "evidence_text_generations", force: :cascade do |t|
@@ -265,4 +274,6 @@ ActiveRecord::Schema.define(version: 2023_03_06_215624) do
   add_foreign_key "comprehension_plagiarism_texts", "comprehension_rules", column: "rule_id", on_delete: :cascade
   add_foreign_key "comprehension_regex_rules", "comprehension_rules", column: "rule_id", on_delete: :cascade
   add_foreign_key "evidence_prompt_healths", "evidence_activity_healths", on_delete: :cascade
+  add_foreign_key "evidence_rule_hints", "comprehension_rules", column: "rule_id", on_delete: :cascade
+  add_foreign_key "evidence_rule_hints", "evidence_hints", column: "hint_id", on_delete: :cascade
 end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/activities.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/activities.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_activities
+#
+#  id                 :integer          not null, primary key
+#  title              :string(100)
+#  parent_activity_id :integer
+#  target_level       :integer
+#  scored_level       :string(100)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  notes              :string
+#  version            :integer          default(1), not null
+#
 FactoryBot.define do
   factory :evidence_activity, class: 'Evidence::Activity' do
     sequence(:title) {|n| "MyString #{n}" }

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/activity_healths.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/activity_healths.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_activity_healths
+#
+#  id                    :bigint           not null, primary key
+#  name                  :string           not null
+#  flag                  :string           not null
+#  activity_id           :integer          not null
+#  version               :integer          not null
+#  version_plays         :integer          not null
+#  total_plays           :integer          not null
+#  completion_rate       :integer
+#  because_final_optimal :integer
+#  but_final_optimal     :integer
+#  so_final_optimal      :integer
+#  avg_completion_time   :integer
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_activity_health, class: 'Evidence::ActivityHealth' do
     name { "test name" }

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/automl_models.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/automl_models.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_automl_models
+#
+#  id              :integer          not null, primary key
+#  automl_model_id :string           not null
+#  name            :string           not null
+#  labels          :string           default([]), is an Array
+#  prompt_id       :integer
+#  state           :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  notes           :text             default("")
+#
 FactoryBot.define do
   factory :evidence_automl_model, class: 'Evidence::AutomlModel' do
     sequence(:automl_model_id) { |n| "MODEL-ID-#{n}" }

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/feedbacks.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_feedbacks
+#
+#  id          :integer          not null, primary key
+#  rule_id     :integer          not null
+#  text        :string           not null
+#  description :string
+#  order       :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_feedback, class: 'Evidence::Feedback' do
     association :rule, factory: :evidence_rule

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/highlights.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/highlights.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_highlights
+#
+#  id             :integer          not null, primary key
+#  feedback_id    :integer          not null
+#  text           :string           not null
+#  highlight_type :string           not null
+#  starting_index :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_highlight, class: 'Evidence::Highlight' do
     association :feedback, factory: :evidence_feedback

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/hints.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/hints.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_hints
+#
+#  id             :bigint           not null, primary key
+#  explanation    :string           not null
+#  image_link     :string           not null
+#  image_alt_text :string           not null
+#  rule_id        :bigint
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  name           :text
+#
 FactoryBot.define do
   factory :evidence_hint, class: 'Evidence::Hint' do
     name { "Hint Name" }

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/labels.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/labels.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_labels
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  rule_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_label, class: 'Evidence::Label' do
     name { "some label name" }

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/passages.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/passages.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_passages
+#
+#  id                       :integer          not null, primary key
+#  activity_id              :integer
+#  text                     :text
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  image_link               :string
+#  image_alt_text           :string           default("")
+#  highlight_prompt         :string
+#  image_caption            :text             default("")
+#  image_attribution        :text             default("")
+#  essential_knowledge_text :string           default("")
+#
 FactoryBot.define do
   factory :evidence_passage, class: 'Evidence::Passage' do
     association :activity, factory: :evidence_activity

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_healths.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_healths.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_prompt_healths
+#
+#  id                                  :bigint           not null, primary key
+#  prompt_id                           :integer          not null
+#  activity_short_name                 :string           not null
+#  text                                :string           not null
+#  current_version                     :integer          not null
+#  version_responses                   :integer          not null
+#  first_attempt_optimal               :integer
+#  final_attempt_optimal               :integer
+#  avg_attempts                        :float
+#  confidence                          :float
+#  percent_automl_consecutive_repeated :integer
+#  percent_automl                      :integer
+#  percent_plagiarism                  :integer
+#  percent_opinion                     :integer
+#  percent_grammar                     :integer
+#  percent_spelling                    :integer
+#  avg_time_spent_per_prompt           :integer
+#  evidence_activity_health_id         :bigint
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_prompt_health, class: 'Evidence::PromptHealth' do
     prompt_id { 1 }

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_text_batches.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_text_batches.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_prompt_text_batches
+#
+#  id         :bigint           not null, primary key
+#  type       :string           not null
+#  prompt_id  :integer          not null
+#  config     :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_prompt_text_batch, class: 'Evidence::PromptTextBatch' do
     association :prompt, factory: :evidence_prompt

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/prompts.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/prompts.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_prompts
+#
+#  id                    :integer          not null, primary key
+#  activity_id           :integer
+#  max_attempts          :integer
+#  conjunction           :string(20)
+#  text                  :string
+#  max_attempts_feedback :text
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  first_strong_example  :string           default("")
+#  second_strong_example :string           default("")
+#
 FactoryBot.define do
   factory :evidence_prompt, class: 'Evidence::Prompt' do
     association :activity, factory: :evidence_activity

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/prompts_rules.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/prompts_rules.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_prompts_rules
+#
+#  id         :integer          not null, primary key
+#  prompt_id  :integer          not null
+#  rule_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_prompts_rule, class: 'Evidence::PromptsRule' do
     association :prompt, factory: :evidence_prompt

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/regex_rules.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/regex_rules.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_regex_rules
+#
+#  id             :integer          not null, primary key
+#  regex_text     :string(200)      not null
+#  case_sensitive :boolean          not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  rule_id        :integer
+#  sequence_type  :text             default("incorrect"), not null
+#  conditional    :boolean          default(FALSE)
+#
 FactoryBot.define do
   factory :evidence_regex_rule, class: 'Evidence::RegexRule' do
     association :rule, factory: :evidence_rule

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/rules.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/rules.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_rules
+#
+#  id          :integer          not null, primary key
+#  uid         :string           not null
+#  name        :string           not null
+#  note        :string
+#  universal   :boolean          not null
+#  rule_type   :string           not null
+#  optimal     :boolean          not null
+#  suborder    :integer
+#  concept_uid :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  state       :string           not null
+#  hint_id     :bigint
+#
 FactoryBot.define do
   factory :evidence_rule, class: 'Evidence::Rule' do
     uid { SecureRandom.uuid }

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/text_generations.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/text_generations.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_text_generations
+#
+#  id         :bigint           not null, primary key
+#  type       :string           not null
+#  config     :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_text_generation, class: 'Evidence::TextGeneration' do
     type  Evidence::TextGeneration::TYPE_ORIGINAL

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/turking_round_activity_sessions.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/turking_round_activity_sessions.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_turking_round_activity_sessions
+#
+#  id                   :integer          not null, primary key
+#  turking_round_id     :integer
+#  activity_session_uid :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_turking_round_activity_session, class: 'Evidence::TurkingRoundActivitySession' do
     association :turking_round, factory: :evidence_turking_round

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/turking_rounds.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/turking_rounds.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_turking_rounds
+#
+#  id          :integer          not null, primary key
+#  activity_id :integer
+#  uuid        :uuid
+#  expires_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
   factory :evidence_turking_round, class: 'Evidence::TurkingRound' do
     association :activity, factory: :evidence_activity

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_health_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_health_spec.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_activity_healths
+#
+#  id                    :bigint           not null, primary key
+#  name                  :string           not null
+#  flag                  :string           not null
+#  activity_id           :integer          not null
+#  version               :integer          not null
+#  version_plays         :integer          not null
+#  total_plays           :integer          not null
+#  completion_rate       :integer
+#  because_final_optimal :integer
+#  but_final_optimal     :integer
+#  so_final_optimal      :integer
+#  avg_completion_time   :integer
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_activities
+#
+#  id                 :integer          not null, primary key
+#  title              :string(100)
+#  parent_activity_id :integer
+#  target_level       :integer
+#  scored_level       :string(100)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  notes              :string
+#  version            :integer          default(1), not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_automl_models
+#
+#  id              :integer          not null, primary key
+#  automl_model_id :string           not null
+#  name            :string           not null
+#  labels          :string           default([]), is an Array
+#  prompt_id       :integer
+#  state           :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  notes           :text             default("")
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/feedback_spec.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_feedbacks
+#
+#  id          :integer          not null, primary key
+#  rule_id     :integer          not null
+#  text        :string           not null
+#  description :string
+#  order       :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/highlight_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/highlight_spec.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_highlights
+#
+#  id             :integer          not null, primary key
+#  feedback_id    :integer          not null
+#  text           :string           not null
+#  highlight_type :string           not null
+#  starting_index :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/hint_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/hint_spec.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_hints
+#
+#  id             :bigint           not null, primary key
+#  explanation    :string           not null
+#  image_link     :string           not null
+#  image_alt_text :string           not null
+#  rule_id        :bigint
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  name           :text
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/label_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/label_spec.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_labels
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  rule_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/passage_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/passage_spec.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_passages
+#
+#  id                       :integer          not null, primary key
+#  activity_id              :integer
+#  text                     :text
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  image_link               :string
+#  image_alt_text           :string           default("")
+#  highlight_prompt         :string
+#  image_caption            :text             default("")
+#  image_attribution        :text             default("")
+#  essential_knowledge_text :string           default("")
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/plagiarism_text_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/plagiarism_text_spec.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_plagiarism_texts
+#
+#  id         :integer          not null, primary key
+#  rule_id    :integer          not null
+#  text       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_health_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_health_spec.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_prompt_healths
+#
+#  id                                  :bigint           not null, primary key
+#  prompt_id                           :integer          not null
+#  activity_short_name                 :string           not null
+#  text                                :string           not null
+#  current_version                     :integer          not null
+#  version_responses                   :integer          not null
+#  first_attempt_optimal               :integer
+#  final_attempt_optimal               :integer
+#  avg_attempts                        :float
+#  confidence                          :float
+#  percent_automl_consecutive_repeated :integer
+#  percent_automl                      :integer
+#  percent_plagiarism                  :integer
+#  percent_opinion                     :integer
+#  percent_grammar                     :integer
+#  percent_spelling                    :integer
+#  avg_time_spent_per_prompt           :integer
+#  evidence_activity_health_id         :bigint
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_spec.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_prompts
+#
+#  id                    :integer          not null, primary key
+#  activity_id           :integer
+#  max_attempts          :integer
+#  conjunction           :string(20)
+#  text                  :string
+#  max_attempts_feedback :text
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  first_strong_example  :string           default("")
+#  second_strong_example :string           default("")
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_text_batch_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_text_batch_spec.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_prompt_text_batches
+#
+#  id         :bigint           not null, primary key
+#  type       :string           not null
+#  prompt_id  :integer          not null
+#  config     :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_text_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_text_spec.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_prompt_texts
+#
+#  id                   :bigint           not null, primary key
+#  prompt_text_batch_id :integer          not null
+#  text_generation_id   :integer          not null
+#  text                 :string           not null
+#  label                :string
+#  ml_type              :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompts_rule_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompts_rule_spec.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_prompts_rules
+#
+#  id         :integer          not null, primary key
+#  prompt_id  :integer          not null
+#  rule_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/regex_rule_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/regex_rule_spec.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_regex_rules
+#
+#  id             :integer          not null, primary key
+#  regex_text     :string(200)      not null
+#  case_sensitive :boolean          not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  rule_id        :integer
+#  sequence_type  :text             default("incorrect"), not null
+#  conditional    :boolean          default(FALSE)
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_rules
+#
+#  id          :integer          not null, primary key
+#  uid         :string           not null
+#  name        :string           not null
+#  note        :string
+#  universal   :boolean          not null
+#  rule_type   :string           not null
+#  optimal     :boolean          not null
+#  suborder    :integer
+#  concept_uid :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  state       :string           not null
+#  hint_id     :bigint
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/text_generation_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/text_generation_spec.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_text_generations
+#
+#  id         :bigint           not null, primary key
+#  type       :string           not null
+#  config     :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/turking_round_activity_session_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/turking_round_activity_session_spec.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_turking_round_activity_sessions
+#
+#  id                   :integer          not null, primary key
+#  turking_round_id     :integer
+#  activity_session_uid :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/turking_round_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/turking_round_spec.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: comprehension_turking_rounds
+#
+#  id          :integer          not null, primary key
+#  activity_id :integer
+#  uuid        :uuid
+#  expires_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'rails_helper'
 
 module Evidence


### PR DESCRIPTION
## WHAT
Add Annotate gem to Evidence
## WHY
It's been so nice in the LMS that we might as well get the same niceness in Evidence
## HOW
- Add `annotate` to our Gemfile for `develop`
- Run `bundle exec annotate --models --exclude fixtures` to add annotations to files

### Notion Card Links
https://www.notion.so/quill/Add-annotation-gem-to-Evidence-04cf183c62dd45afa6a3d1d6b53a6329?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests
Have you deployed to Staging? | No code change, just comments
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
