### PR TITLE
rake task for activity session backfill

### DIFF
--- a/services/QuillLMS/lib/tasks/activity_sessions.rake
+++ b/services/QuillLMS/lib/tasks/activity_sessions.rake
@@ -4,7 +4,7 @@ namespace :activity_sessions do
   namespace :backfill do
     desc 'backfills updated_at so null values do not exist'
     task :updated_at => :environment do
-      sessions = ActivitySession.where(updated_at: nil)
+      sessions = ActivitySession.unscoped.where(updated_at: nil)
       sessions.each do |session|
         backfill_value = session.completed_at || session.created_at || DateTime.new(2014,4,1)
         puts "updating ActivitySession with id #{session.id}"

--- a/services/QuillLMS/lib/tasks/activity_sessions.rake
+++ b/services/QuillLMS/lib/tasks/activity_sessions.rake
@@ -4,11 +4,11 @@ namespace :activity_sessions do
   namespace :backfill do
     desc 'backfills updated_at so null values do not exist'
     task :updated_at => :environment do
-      sessions = ActivitySession.unscoped.joins(:activity).where(updated_at: nil)
+      sessions = ActivitySession.unscoped.where(updated_at: nil)
       sessions.each do |session|
         backfill_value = session.completed_at || session.created_at || DateTime.new(2014,4,1)
         puts "updating ActivitySession with id #{session.id}"
-        session.update(
+        session.update_columns(
           updated_at: backfill_value,
           created_at: DateTime.new(2014,4,1)
         )

--- a/services/QuillLMS/lib/tasks/activity_sessions.rake
+++ b/services/QuillLMS/lib/tasks/activity_sessions.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :activity_sessions do
+  namespace :backfill do
+    desc 'backfills updated_at so null values do not exist'
+    task :updated_at => :environment do
+      sessions = ActivitySession.where(updated_at: nil)
+      sessions.each do |session|
+        backfill_value = session.completed_at || session.created_at || DateTime.new(2014,4,1)
+        puts "updating ActivitySession with id #{session.id}"
+        session.update(
+          updated_at: backfill_value,
+          created_at: DateTime.new(2014,4,1)
+        )
+      end
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/activity_sessions.rake
+++ b/services/QuillLMS/lib/tasks/activity_sessions.rake
@@ -4,7 +4,7 @@ namespace :activity_sessions do
   namespace :backfill do
     desc 'backfills updated_at so null values do not exist'
     task :updated_at => :environment do
-      sessions = ActivitySession.unscoped.where(updated_at: nil)
+      sessions = ActivitySession.unscoped.joins(:activity).where(updated_at: nil)
       sessions.each do |session|
         backfill_value = session.completed_at || session.created_at || DateTime.new(2014,4,1)
         puts "updating ActivitySession with id #{session.id}"


### PR DESCRIPTION
## WHAT
Some ActivitySessions have null values for updated_at. We want all rows to be non null, so that Airbyte can use this field as a cursor.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=b9015bdad7c5444cbd7ad11f9f92beba&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
