### PR TITLE
MERGE PR: rake task for activity session backfill (#10551)

### DIFF
--- a/services/QuillLMS/lib/tasks/activity_sessions.rake
+++ b/services/QuillLMS/lib/tasks/activity_sessions.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :activity_sessions do
+  namespace :backfill do
+    desc 'backfills updated_at so null values do not exist'
+    task :updated_at => :environment do
+      sessions = ActivitySession.unscoped.where(updated_at: nil)
+      sessions.each do |session|
+        backfill_value = session.completed_at || session.created_at || DateTime.new(2014,4,1)
+        puts "updating ActivitySession with id #{session.id}"
+        session.update_columns(
+          updated_at: backfill_value,
+          created_at: DateTime.new(2014,4,1)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
* rake task for activity session backfill

* ignore default scopes

* add join to query, so that validations pass

* don't run validations, remove joins

---------

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
