### PR TITLE
Fix meta image urls for social media sharing

### DIFF
--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -14,8 +14,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:type"               content="website" />
-  <meta property="og:title"              content= "<%= @title || "Free tools to make your students better writers." %>" />
-  <meta property="og:image"              content="<%=@image_link || image_url('share/facebook.png') %>"/>
+  <meta property="og:title"              content="<%= @title || "Free tools to make your students better writers." %>" />
+  <meta property="og:image"              content="<%= image_url('share/facebook.png') %>" />
 
   <meta name="description" content="<%= @description || @content %>">
   <meta name="og:description" content="<%= @description || @content %>">

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -16,6 +16,7 @@
   <meta property="og:type"               content="website" />
   <meta property="og:title"              content="<%= @title || "Free tools to make your students better writers." %>" />
   <meta property="og:image"              content="<%= @image_link || "https:#{image_url('share/facebook.png')}" %>" />
+  <meta property="twitter:image"         content="<%= @image_link || "https:#{image_url('share/facebook.png')}" %>" />
 
   <meta name="description" content="<%= @description || @content %>">
   <meta name="og:description" content="<%= @description || @content %>">

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -15,7 +15,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:type"               content="website" />
   <meta property="og:title"              content="<%= @title || "Free tools to make your students better writers." %>" />
-  <meta property="og:image"              content="<%= image_url('share/facebook.png') %>" />
+  <meta property="og:image"              content="<%= @image_link || "https:#{image_url('share/facebook.png')}" %>" />
 
   <meta name="description" content="<%= @description || @content %>">
   <meta name="og:description" content="<%= @description || @content %>">

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -18,7 +18,7 @@
     <meta property="og:type"        content="website" />
     <meta property="og:title"       content="<%= @title %>" />
     <meta property="og:description" content="<%= @description %>" />
-    <meta property="og:image"       content=<%= image_url('share/facebook.png') %> />
+    <meta property="og:image"       content="<%= image_url('share/facebook.png') %>" />
     <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
     <link rel="canonical" href="https://www.quill.org<%= request.path %>">
 

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -18,8 +18,8 @@
     <meta property="og:type"        content="website" />
     <meta property="og:title"       content="<%= @title %>" />
     <meta property="og:description" content="<%= @description %>" />
-    <meta property="og:image"       content="<%= image_url('share/facebook.png') %>" />
-    <meta name="twitter:image"      content="<%= image_url('share/facebook.png') %>" />
+    <meta property="og:image"       content="https:<%= image_url('share/facebook.png') %>" />
+    <meta name="twitter:image"      content="https:<%= image_url('share/facebook.png') %>" />
     <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
     <link rel="canonical" href="https://www.quill.org<%= request.path %>">
 

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -19,6 +19,7 @@
     <meta property="og:title"       content="<%= @title %>" />
     <meta property="og:description" content="<%= @description %>" />
     <meta property="og:image"       content="<%= image_url('share/facebook.png') %>" />
+    <meta name="twitter:image"      content="<%= image_url('share/facebook.png') %>" />
     <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
     <link rel="canonical" href="https://www.quill.org<%= request.path %>">
 

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -19,7 +19,7 @@
     <meta property="og:title"       content="<%= @title %>" />
     <meta property="og:description" content="<%= @description %>" />
     <meta property="og:image"       content="https:<%= image_url('share/facebook.png') %>" />
-    <meta name="twitter:image"      content="https:<%= image_url('share/facebook.png') %>" />
+    <meta property="twitter:image"  content="https:<%= image_url('share/facebook.png') %>" />
     <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
     <link rel="canonical" href="https://www.quill.org<%= request.path %>">
 


### PR DESCRIPTION
## WHAT
Append the "https:" to meta image tags URL because rails is not generating them in its helper method. Also add a twitter image tag for Twitter specific social media shares.

## WHY
To get working images attached to all our Facebook, Twitter, and LinkedIn shares.

## HOW
Append https: to the URL generated by rails image_url helper so that the URL is valid and working. Add a twitter image tag.

### Screenshots
<img width="614" alt="Screen Shot 2023-05-15 at 6 37 25 PM" src="https://github.com/empirical-org/Empirical-Core/assets/57366100/c6d79129-ec97-439a-8940-4525168c9137">

### Notion Card Links
https://www.notion.so/quill/Fix-images-and-metadata-for-public-Quill-pages-2568cf0b75774f2eb4a915c64a196659?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
