### PR TITLE
Convert Rack::Attack throttle to pure block for bad urls.

### DIFF
--- a/services/QuillLMS/config/initializers/rack_attack.rb
+++ b/services/QuillLMS/config/initializers/rack_attack.rb
@@ -8,8 +8,8 @@ class Rack::Attack
   BLOCKLIST_REGEX = BLOCKLIST_REGEX_STRING.present? ? Regexp.new(BLOCKLIST_REGEX_STRING) : nil
   # Using 503 because it may make attacker think that they have successfully
   # DOSed the site. Rack::Attack returns 429 for throttling by default
-  BLOCKLIST_RESPONSE = [503, {}, [{ message: 'Too many attempts. Please try again later.'}.to_json]].freeze
-  THROTTLE_RESPONSE = [503, {}, [{ message: 'Too many attempts. Please try again later.', type: 'password' }.to_json]].freeze
+  BLOCKLIST_RESPONSE = [503, {}, [{ message: 'Too many attempts. Please try again later.'}.to_json]]
+  THROTTLE_RESPONSE = [503, {}, [{ message: 'Too many attempts. Please try again later.', type: 'password' }.to_json]]
 
   Rack::Attack.throttle('limit logins per email', limit: 20, period: 10.minutes) do |req|
     if req.path == '/session/login_through_ajax' && req.post?


### PR DESCRIPTION
## WHAT
This is essentially `maxretry: 0` for the current blocking implementation. Instead of throttling by ip for some number of requests, just block any request of this form.
## WHY
This is the strongest version of a block of this form that is worth trying.
## HOW
Use blocklist instead of throttle.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, this is outside of our testing setup.
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
