### PR TITLE
Lms/detach users from vitally schools

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -9,6 +9,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
+  TargetRubyVersion: 2.7.6
   Exclude:
     - "QuillLMS/engines/evidence/spec/dummy/**/*"
     - "QuillLMS/engines/evidence/lib/generators/**/*"

--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -9,7 +9,6 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 2.7.6
   Exclude:
     - "QuillLMS/engines/evidence/spec/dummy/**/*"
     - "QuillLMS/engines/evidence/lib/generators/**/*"

--- a/services/QuillLMS/app/models/schools_users.rb
+++ b/services/QuillLMS/app/models/schools_users.rb
@@ -20,8 +20,25 @@ class SchoolsUsers < ApplicationRecord
 
   # When a teacher sets their school, we make sure they they have the appropriate subscription type.
   after_save :update_subscriptions
+  after_save :school_changed_change_log, if: :should_write_change_log?
 
   def update_subscriptions
     user&.updated_school(school_id)
+  end
+
+  private def should_write_change_log?
+    saved_change_to_attribute?(:school_id) &&
+      attribute_before_last_save(:school_id)
+  end
+
+  private def school_changed_change_log
+    ChangeLog.create({
+      action: ChangeLog::USER_ACTIONS[:update],
+      changed_record_type: 'User',
+      changed_record_id: user_id,
+      changed_attribute: 'school',
+      previous_value: attribute_before_last_save(:school_id),
+      new_value: attribute_in_database(:school_id)
+    })
   end
 end

--- a/services/QuillLMS/app/models/schools_users.rb
+++ b/services/QuillLMS/app/models/schools_users.rb
@@ -27,8 +27,8 @@ class SchoolsUsers < ApplicationRecord
   end
 
   private def should_write_change_log?
-    saved_change_to_attribute?(:school_id) &&
-      attribute_before_last_save(:school_id)
+    (saved_change_to_attribute?(:school_id) &&
+      attribute_before_last_save(:school_id))
   end
 
   private def school_changed_change_log

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -107,6 +107,8 @@ class User < ApplicationRecord
   GOOGLE_CLASSROOM_ACCOUNT = 'Google Classroom'
   CLEVER_ACCOUNT = 'Clever'
 
+  SCHOOL_CHANGELOG_ATTRIBUTE = 'school_id'
+
   attr_accessor :validate_username, :require_password_confirmation_when_password_present, :newsletter
 
   has_secure_password validations: false

--- a/services/QuillLMS/app/workers/sync_vitally_unlinks_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_unlinks_worker.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SyncVitallyUnlinksWorker
+  include Sidekiq::Worker
+
+  def perform(user_id, school_id)
+    api = VitallyApi.new
+    api.unlink({
+      userId: user_id,
+      accountId: school_id
+    })
+  end
+end

--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -49,7 +49,7 @@ class SyncVitallyWorker
   private def unlinks_to_run
     ChangeLog.where(changed_record_type: 'User')
       .where(changed_attribute: 'school')
-      .where(created_at: (DateTime.current - 25.hours)..)
+      .where(created_at: (DateTime.current - 25.hours)..Float::INFINITY)
   end
 
   private def schools_to_sync

--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -47,8 +47,8 @@ class SyncVitallyWorker
   end
 
   private def unlinks_to_run
-    ChangeLog.where(changed_record_type: 'User')
-      .where(changed_attribute: 'school')
+    ChangeLog.where(changed_record_type: User.name)
+      .where(changed_attribute: User::SCHOOL_CHANGELOG_ATTRIBUTE)
       .where(created_at: (DateTime.current - 25.hours)..Float::INFINITY)
   end
 

--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -16,6 +16,13 @@ class SyncVitallyWorker
     queue_district_syncs
     queue_school_syncs
     queue_user_syncs
+    queue_unlink_syncs
+  end
+
+  private def queue_unlink_syncs
+    unlinks_to_run.each do |change_log|
+      SyncVitallyUnlinksWorker.perform_async(change_log.changed_record_id, change_log.new_value.to_i)
+    end
   end
 
   private def queue_district_syncs
@@ -37,6 +44,12 @@ class SyncVitallyWorker
     users_to_sync.find_in_batches(batch_size: BATCH_SIZE).with_index do |users, index|
       SyncVitallyUsersWorker.perform_in(index.seconds, users.map(&:id))
     end
+  end
+
+  private def unlinks_to_run
+    ChangeLog.where(changed_record_type: 'User')
+      .where(changed_attribute: 'school')
+      .where(created_at: (DateTime.current - 25.hours)..)
   end
 
   private def schools_to_sync

--- a/services/QuillLMS/spec/models/schools_users_spec.rb
+++ b/services/QuillLMS/spec/models/schools_users_spec.rb
@@ -32,4 +32,31 @@ describe SchoolsUsers, type: :model, redis: true do
       schools_user.update_subscriptions
     end
   end
+
+  describe '#school_changed_change_log' do
+    let!(:school1) { create(:school) }
+    let!(:school2) { create(:school) }
+    let(:schools_user) { create(:schools_users, school: school1) }
+
+    it 'should do nothing if school_id does not change' do
+      expect do
+        schools_user.save
+      end.to not_change(ChangeLog, :count)
+    end
+
+    it 'should create a new ChangeLog record when school_id changes' do
+      expect do
+        schools_user.school_id = school2.id
+        schools_user.save
+      end.to change(ChangeLog, :count).by(1)
+    end
+
+    it 'should have an old and new school_id in the ChangeLog created' do
+      schools_user.school_id = school2.id
+      schools_user.save
+
+      expect(ChangeLog.last.previous_value).to eq(school1.id.to_s)
+      expect(ChangeLog.last.new_value).to eq(school2.id.to_s)
+    end
+  end
 end

--- a/services/QuillLMS/spec/workers/sync_vitally_unlinks_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_vitally_unlinks_worker_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SyncVitallyUnlinksWorker do
+  subject { described_class.new }
+
+  let(:school) { create(:school) }
+  let(:user) { create(:teacher, school: school) }
+  let(:vitally_api_double) { double }
+
+  before do
+    allow(VitallyApi).to receive(:new).and_return(vitally_api_double)
+  end
+
+  describe '#perform' do
+    it 'constructs an Unlink API payload and passes it to the vitally API' do
+      expect(vitally_api_double).to receive(:unlink).with({
+        userId: user.id,
+        accountId: school.id
+      })
+
+      subject.perform(user.id, school.id)
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/sync_vitally_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_vitally_worker_spec.rb
@@ -17,9 +17,9 @@ describe SyncVitallyWorker, type: :worker do
       user = create(:user, role: 'teacher')
       schools_user = create(:schools_users, school: school, user: user)
       create(:change_log,
-        changed_record_type: 'User',
+        changed_record_type: User.name,
         changed_record_id: user.id,
-        changed_attribute: 'school',
+        changed_attribute: User::SCHOOL_CHANGELOG_ATTRIBUTE,
         new_value: school.id)
 
       expect(SyncVitallyUnlinksWorker).to receive(:perform_async).with(user.id, school.id)


### PR DESCRIPTION
## WHAT
Add code to record when a Teacher changes which school they're in, and then modify nightly Vitally Sync code to `unlink` users from their old schools
## WHY
Vitally changed the way that they read our batch updates of users so that when a user has a different `accountId` than the last time we synced.  It used to be the case that the new value would override the old value, but the new handling attaches the user to both `accountId`s.  Having a user attached to two different accounts makes some uses Partnerships has harder to use.  Also, we just want Vitally to accurately reflect our actual data.
## HOW
- Begin recording `ChangeLog` records when a user changes what school they're assigned to
- During the nightly Vitally sync process, find ChangeLogs of User school values from the past 25 hours and unlink them in Vitally.

### Notion Card Links
https://www.notion.so/quill/Update-Vitally-Analytics-API-Rule-to-Unlink-Endpoint-only-show-users-at-their-current-school-asso-d875631f26fb456283c2c1eaaa2bfa5d?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
