### PR TITLE
Exclude apple touch icons from blocks.

### DIFF
--- a/services/QuillLMS/config/initializers/rack_attack.rb
+++ b/services/QuillLMS/config/initializers/rack_attack.rb
@@ -26,6 +26,7 @@ class Rack::Attack
       BLOCKLIST_REGEX.present? &&
       req.path != '/404' &&
       req.path != '/500' &&
+      !req.path.start_with?('/apple-touch-icon') &&
       req.path.match?(BLOCKLIST_REGEX)
   end
 


### PR DESCRIPTION
## WHAT
Exclude apple-touch-icons from blocklist so they don't return a `503`.
## WHY
These should return either the image or a `404`. The `503` might cause phones/tablets not to use the proper icon and it muddies our graphs/tracking of `503`-related issues.
## HOW
Regex check in block code.
### Screenshots
![Screenshot 2023-05-16 at 10 42 11 AM](https://github.com/empirical-org/Empirical-Core/assets/1304933/fa1253c2-b4ad-4078-8443-e99b51ee99db)


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, small change, locally tested manually
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
