### PR TITLE
allow teachers to select alt schools on settings page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_general.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_general.jsx
@@ -90,9 +90,12 @@ export default class TeacherGeneralAccountInfo extends React.Component {
   };
 
   handleSchoolTypeChange = schoolType => {
+    const { alternativeSchools, alternativeSchoolsNameMap, } = this.props
     // we don't want teachers to set their school as "not-listed" if they already have a school selected
     if (schoolType.value !== US_K12_SCHOOL || this.state.schoolType !== US_K12_SCHOOL) {
-      this.setState({ schoolType: schoolType.value, school: schoolType, changedSchools: true});
+      const alternativeSchoolName = Object.keys(alternativeSchoolsNameMap).find(key => alternativeSchoolsNameMap[key] === schoolType.value)
+      const school = alternativeSchools.find(school => school.name === alternativeSchoolName)
+      this.setState({ schoolType: schoolType.value, school, changedSchools: true});
     }
   };
 


### PR DESCRIPTION
## WHAT
Fix bug that prevented teachers from selecting alternative schools on settings page.

## WHY
We want teachers to be able to perform this action.

## HOW
I couldn't identify when this broke, but the problem was that the way we were storing these alt schools on the frontend and then sending them to the controller didn't match what the controller expected, so I updated the code to store the correct school on the frontend.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Unable-to-persist-non-U-S-K-12-Schools-options-in-teacher-My-Account-section-4973b9bf6aa2432caa715fa0459286a5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A