### PR TITLE
Add Google Tags to website header for Google Analytics

### DIFF
--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -1,4 +1,14 @@
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-C0FB3VEGYR"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-C0FB3VEGYR');
+  </script>
+
   <% if Rails.env.development? %>
     <title>[DEV] Quill.org | <%= @title || 'Interactive Writing and Grammar' %></title>
     <%= favicon_link_tag 'favicon-dev.ico' %>

--- a/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
+++ b/services/QuillLMS/app/views/layouts/twenty_seventeen_home.html.erb
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-C0FB3VEGYR"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-C0FB3VEGYR');
+    </script>
+
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -60,7 +60,8 @@ SecureHeaders::Configuration.default do |config|
       "https://*.sentry.io",
       "https://*.heapanalytics.com",
       "https://cdn.jsdelivr.net/npm/vanilla-lazyload@17.8.3/dist/lazyload.min.js",
-      "https://*.salesmate.io"
+      "https://*.salesmate.io",
+      "https://*.googletagmanager.com"
     ],
 
     font_src: [


### PR DESCRIPTION
## WHAT
Embed Google's tracking code in our website head.

## WHY
Google Analytics is migrating to a new version, which requires us to manually embed tracking code in the head of our website. This will send visitor engagement info over to Google Analytics.

## HOW
Add the script that Google Analytics provided to the head of the website. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-Google-Analytics-18ce167192bb41c4b3708f7db00c5bdf?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tested manually by looking at Google Analytics
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
