### PR TITLE
Recalculate staggered release locks on login

### DIFF
--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -63,7 +63,7 @@ module QuillAuthentication
 
     unless staff_impersonating_user?(user) || admin_impersonating_user?(user)
       user.update(ip_address: request&.remote_ip, last_sign_in: Time.current)
-      user.save_user_pack_sequence_items
+      user.save_user_pack_sequence_items if user.student?
       UserLoginWorker.perform_async(user.id)
     end
 

--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -63,6 +63,7 @@ module QuillAuthentication
 
     unless staff_impersonating_user?(user) || admin_impersonating_user?(user)
       user.update(ip_address: request&.remote_ip, last_sign_in: Time.current)
+      user.save_user_pack_sequence_items
       UserLoginWorker.perform_async(user.id)
     end
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -810,6 +810,10 @@ class User < ApplicationRecord
     school_premium? || district_premium?
   end
 
+  def save_user_pack_sequence_items
+    classrooms.each { |classroom| SaveUserPackSequenceItemsWorker.perform_async(classroom.id, id) }
+  end
+
   private def validate_flags
     invalid_flags = flags - VALID_FLAGS
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1835,5 +1835,21 @@ describe User, type: :model do
       end.to change(TeacherNotificationSetting, :count).by(TeacherNotificationSetting::DEFAULT_FOR_NEW_USERS.length)
     end
   end
+
+  context 'save_user_pack_sequence_items' do
+    subject { user.save_user_pack_sequence_items}
+
+    context 'user has no classrooms' do
+      it { expect { subject }.not_to change { SaveUserPackSequenceItemsWorker.jobs.size } }
+    end
+
+    context 'user belongs to a classroom' do
+      let(:classroom) { double(:classroom, id: 1) }
+
+      before { allow(user).to receive(:classrooms).and_return([classroom]) }
+
+      it { expect { subject }.to change { SaveUserPackSequenceItemsWorker.jobs.size }.by(1) }
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## WHAT
Some staggered release are sporadically not finishing (~5 reports / week).

## WHY
Some of the intercom messages report teachers having their student logout/login as a troubleshooting technique.  We could trigger a recalculation in this case.

## HOW
Add a call to recalculate locks after within the sign_in method.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
