### PR TITLE
move json iostream out of initializer

### DIFF
--- a/services/QuillLMS/app/services/quill_big_query/client_fetcher.rb
+++ b/services/QuillLMS/app/services/quill_big_query/client_fetcher.rb
@@ -11,9 +11,9 @@ module QuillBigQuery
 
     def run
       client = Google::APIClient.new(application_name: APPLICATION_NAME, user_agent: USER_AGENT_DIRECTIVES)
-
+      json_credential_iostream = StringIO.new(ENV.fetch('BIGQUERY_CREDENTIALS', ''))
       # Auth Service account: https://github.com/googleapis/google-auth-library-ruby#example-service-account
-      authorizer = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: JSON_CREDENTIAL_IOSTREAM, scope: SCOPE)
+      authorizer = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: json_credential_iostream, scope: SCOPE)
 
       client.authorization = authorizer
       client.authorization.fetch_access_token!

--- a/services/QuillLMS/config/initializers/bigquery.rb
+++ b/services/QuillLMS/config/initializers/bigquery.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'stringio'
-
-module QuillBigQuery
-  JSON_CREDENTIAL_IOSTREAM = StringIO.new(ENV.fetch('BIGQUERY_CREDENTIALS', ''))
-end

--- a/services/QuillLMS/spec/services/quill_big_query/client_fetcher_spec.rb
+++ b/services/QuillLMS/spec/services/quill_big_query/client_fetcher_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe QuillBigQuery::ClientFetcher do
+  context 'integration', :external_api do
+    around do |a_spec|
+      VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
+      a_spec.run
+      VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
+    end
+
+    it 'should initializer multiple clients without error' do
+      expect do
+        2.times { QuillBigQuery::ClientFetcher.run }
+      end.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Move json iostream creation out of initializer 

## WHY
Because of the nature of iostreams, a second read of the stream will yield an empty string. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
no - identified during a zoom call

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
