### PR TITLE
lms/fix-unlink-job-bug

### DIFF
--- a/services/QuillLMS/app/workers/sync_vitally_unlinks_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_unlinks_worker.rb
@@ -7,7 +7,8 @@ class SyncVitallyUnlinksWorker
     api = VitallyApi.new
     api.unlink({
       userId: user_id,
-      accountId: school_id
+      accountId: school_id,
+      timestamp: DateTime.current
     })
   end
 end

--- a/services/QuillLMS/spec/workers/sync_vitally_unlinks_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/sync_vitally_unlinks_worker_spec.rb
@@ -8,16 +8,19 @@ describe SyncVitallyUnlinksWorker do
   let(:school) { create(:school) }
   let(:user) { create(:teacher, school: school) }
   let(:vitally_api_double) { double }
+  let(:now) { DateTime.current }
 
   before do
     allow(VitallyApi).to receive(:new).and_return(vitally_api_double)
+    allow(DateTime).to receive(:current).and_return(now)
   end
 
   describe '#perform' do
     it 'constructs an Unlink API payload and passes it to the vitally API' do
       expect(vitally_api_double).to receive(:unlink).with({
         userId: user.id,
-        accountId: school.id
+        accountId: school.id,
+        timestamp: now
       })
 
       subject.perform(user.id, school.id)


### PR DESCRIPTION
## WHAT
Pass a "timestamp" value through to the Unlink API
## WHY
Because that's required in this endpoint even though it's not required for other endpoints
## HOW
Just add an extra param to the API call in the job

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
