### PR TITLE
Lms/rake task to set default notification frequency

### DIFF
--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -54,4 +54,18 @@ namespace :users do
       user.verify_email(verification_method)
     end
   end
+
+  task set_default_notification_frequency: :environment do
+    # First make sure all teachers and admins have a TeacherInfo record with
+    # notification_email_frequency set to "never"
+    User.left_outer_joins(:teacher_info)
+      .where(role: [User::TEACHER, User::ADMIN])
+      .where(teacher_info: {id: nil})
+      .each do |user|
+        user.create_teacher_info(notification_email_frequency: TeacherInfo::NEVER_EMAIL)
+    end
+
+    # Now find any existing TeacherInfo records without notification_email_frequency set, and set it to "never"
+    TeacherInfo.where(notification_email_frequency: nil).update_all(notification_email_frequency: TeacherInfo::NEVER)
+  end
 end

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -61,8 +61,7 @@ namespace :users do
     User.left_outer_joins(:teacher_info)
       .where(role: [User::TEACHER, User::ADMIN])
       .where(teacher_info: {id: nil})
-      .all
-      .each do |user|
+      .find_each do |user|
         puts "Creating TeacherInfo record for user #{user.id}"
         user.create_teacher_info(notification_email_frequency: TeacherInfo::NEVER_EMAIL)
     end

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -62,6 +62,7 @@ namespace :users do
       .where(role: [User::TEACHER, User::ADMIN])
       .where(teacher_info: {id: nil})
       .each do |user|
+        puts "Creating TeacherInfo record for user #{user.id}"
         user.create_teacher_info(notification_email_frequency: TeacherInfo::NEVER_EMAIL)
     end
 

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -61,6 +61,7 @@ namespace :users do
     User.left_outer_joins(:teacher_info)
       .where(role: [User::TEACHER, User::ADMIN])
       .where(teacher_info: {id: nil})
+      .all
       .each do |user|
         puts "Creating TeacherInfo record for user #{user.id}"
         user.create_teacher_info(notification_email_frequency: TeacherInfo::NEVER_EMAIL)

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -67,6 +67,6 @@ namespace :users do
     end
 
     # Now find any existing TeacherInfo records without notification_email_frequency set, and set it to "never"
-    TeacherInfo.where(notification_email_frequency: nil).update_all(notification_email_frequency: TeacherInfo::NEVER)
+    TeacherInfo.where(notification_email_frequency: nil).update_all(notification_email_frequency: TeacherInfo::NEVER_EMAIL)
   end
 end

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -62,8 +62,8 @@ namespace :users do
       .where(role: [User::TEACHER, User::ADMIN])
       .where(teacher_info: {id: nil})
       .find_each do |user|
-        puts "Creating TeacherInfo record for user #{user.id}"
-        user.create_teacher_info(notification_email_frequency: TeacherInfo::NEVER_EMAIL)
+      puts "Creating TeacherInfo record for user #{user.id}"
+      user.create_teacher_info(notification_email_frequency: TeacherInfo::NEVER_EMAIL)
     end
 
     # Now find any existing TeacherInfo records without notification_email_frequency set, and set it to "never"


### PR DESCRIPTION
## WHAT
Create a rake task to set all teachers and admin users to have a `TeacherInfo.notification_email_frequency` of `never` if they don't have one set already.
## WHY
This fixes a minor issue in the "My Account" UI that needs a value set for that value.
## HOW
Find all Teacher and Admin users who have no `TeacherInfo` record and create one with `notification_email_frequency` set to `never`.  Then find any `TeacherInfo` records that have `notification_email_frequency` set to `nil` and update the value to `never`.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on rake tasks
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A