### PR TITLE
Fix bug with resume_link calculation

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -140,7 +140,7 @@ export default class StudentProfileUnit extends React.Component {
 
     if (finished) {
       linkText = `Replay`;
-    } else if (resume_link === 1) {
+    } else if (resume_link > 0) {
       linkText = `Resume`;
     }
 


### PR DESCRIPTION
## WHAT
Fix a bug with the 'resume' button.

## WHY
'Start' button is being displayed for some activities that have already been started.

## HOW
In some cases the user profile [query](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/models/unit_activity.rb#L163) the `resume_link` field returns values higher than 1 (e.g. a student is assigned the same pre-diagnostic assigned to different activity packs as well as the corresponding post diagnostic.  In this case, the post diagnostic can have resume_link > 1)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)
](https://www.notion.so/quill/Student-cannot-submit-Starter-Growth-Diagnostic-Post-48a5b83eadf74208a00cf8202fba8cd5?pvs=4)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
