### PR TITLE
Fix styling on class summary post diagnostic

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_growth_results_summary.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_growth_results_summary.scss
@@ -1,8 +1,5 @@
 .results-summary-container.growth-results-summary-container {
   .skill-group-summary-card {
-    &:nth-of-type(3n+3) {
-      margin-right: 0px;
-    }
     .percentage-circles {
       display: flex;
       justify-content: space-between;


### PR DESCRIPTION
## WHAT
Fix margin padding on Class Summary for Post diagnostic.  (This does not appear to be an issue with pre-diagnostic)

## WHY
The activity pack spacing on the third item is zero.

## HOW
Since this rule only exists for Growth diagnostic and not baseline, I decided to remove the class styling for the 3n+3 item since we want the padding to remain.

### Screenshots
![Screenshot 2023-05-22 at 2 37 08 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/438c91a8-4195-4e86-b191-8ec8048dfb6f)

### Notion Card Links
https://www.notion.so/quill/Styling-issue-on-the-Class-summary-tab-of-the-post-test-diagnostic-report-8841aa04f1ff4c979ef244bc52b44d87?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manual check
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES