### PR TITLE
Update remaining admin dashboard references to Premium Hub

### DIFF
--- a/services/QuillLMS/app/queries/teachers_data.rb
+++ b/services/QuillLMS/app/queries/teachers_data.rb
@@ -9,7 +9,7 @@ module TeachersData
   # num_questions_completd
   # num_time_spent
 
-  # use Outer Joins to account for the fact that some of the teachers shown in the admin dashboard
+  # use Outer Joins to account for the fact that some of the teachers shown in the Premium Hub dashboard
   # will have no classrooms, etc.
 
   def self.run(teacher_ids)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
@@ -63,7 +63,7 @@ const PremiumHubContainer = ({ id, location, children, }) => {
     if (accessType() === LIMITED) {
       return (
         <Banner
-          bodyText="Subscribe to School or District Premium to unlock all admin dashboard features. Manage teacher accounts, access teacher reports, and view school-wide student data."
+          bodyText="Subscribe to School or District Premium to unlock all Premium Hub features. Manage teacher accounts, access teacher reports, and view school-wide student data."
           buttons={(
             <div className="banner-buttons">
               <a className={BANNER_BUTTON_CLASS_NAME} href="https://calendly.com/alex-quill" rel="noopener noreferrer" target="_blank">Talk to sales</a>
@@ -78,7 +78,7 @@ const PremiumHubContainer = ({ id, location, children, }) => {
     if (!associated_school || [NOT_LISTED, NO_SCHOOL_SELECTED].includes(associated_school.name)) {
       return (
         <Banner
-          bodyText="Please select a school to use the admin dashboard."
+          bodyText="Please select a school to use the Premium Hub."
           buttons={<a className={BANNER_BUTTON_CLASS_NAME} href="/teachers/my_account">Select school</a>}
           headerText="Action required"
         />
@@ -98,7 +98,7 @@ const PremiumHubContainer = ({ id, location, children, }) => {
     if (admin_approval_status === PENDING) {
       return (
         <Banner
-          bodyText="Your verification request is pending approval. Once approved, you will be able to use the admin dashboard. If you need help in the meantime, contact us."
+          bodyText="Your verification request is pending approval. Once approved, you will be able to use the Premium Hub. If you need help in the meantime, contact us."
           buttons={<a className={BANNER_BUTTON_CLASS_NAME} href="mailto:hello@quill.org">Contact us</a>}
           headerText="We’re reviewing your request"
         />
@@ -108,7 +108,7 @@ const PremiumHubContainer = ({ id, location, children, }) => {
     if (admin_approval_status === SKIPPED) {
       return (
         <Banner
-          bodyText={`Please verify your connection to ${associated_school?.name} to use the admin dashboard.`}
+          bodyText={`Please verify your connection to ${associated_school?.name} to use the Premium Hub.`}
           buttons={<a className={BANNER_BUTTON_CLASS_NAME} href="/sign-up/verify-school">Begin verification</a>}
           headerText="Action required"
         />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
@@ -26,7 +26,7 @@ const SchoolPricingMini = ({ plan, premiumFeatureData, showBadges, handleClickPu
       </div>
       {showBadges && <div className="school-premium-badge-container">
         <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Quill Academy</div>
-        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Admin dashboard</div>
+        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Premium Hub</div>
         <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Custom reports</div>
       </div>}
     </section>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_premium.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_premium.jsx
@@ -49,9 +49,9 @@ const actionableFeaturesAndSupport = (
       />
       <PremiumFeature
         header="School administrator dashboard"
-        imageAlt="Example admin dashboard showing multiple teacher dashboards with student results"
+        imageAlt="Example PremiumHub showing multiple teacher dashboards with student results"
         imageSrc={schoolDashboardSrc}
-        text="Access each teacher’s Premium account to assign activities, manage rosters and view data. Access school-level reports to see rolled up data at the school level."
+        text="Access each teacher's Premium account to assign activities, manage rosters and view data. Access school-level reports to see rolled up data at the school level."
       />
       <PremiumFeature
         header="School-wide educator support"

--- a/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/progress_reports_controller_spec.rb
@@ -124,7 +124,7 @@ describe Api::V1::ProgressReportsController, type: :controller do
       expect(response.body).to eq({id: teacher.id}.to_json)
     end
 
-    it 'should return the district activities scores progress reports for the freemium section of the admin dashboard' do
+    it 'should return the district activities scores progress reports for the freemium section of the Premium Hub dashboard' do
       # expect(Rails.cache).to receive(:fetch).with("#{SchoolsAdmins::FREEMIUM_DISTRICT_STANDARD_REPORTS_CACHE_KEY_STEM}#{teacher.id}").and_return(nil)
       expect(FindDistrictStandardsReportsWorker).to receive(:perform_async).with(teacher.id, true)
       get :district_standards_reports, params: { freemium: true }, as: :json

--- a/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
@@ -18,7 +18,7 @@ describe TeachersController, type: :controller do
         expect(response).to redirect_to profile_path
       end
 
-      it 'render admin dashboard' do
+      it 'render Premium Hub dashboard' do
         user = create(:admin)
         allow(controller).to receive(:current_user) { user }
         get :premium_hub

--- a/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/navigation_helper_spec.rb
@@ -76,7 +76,7 @@ describe NavigationHelper do
   describe '#admin_page_active?' do
     before { allow(helper).to receive(:action_name) { "premium_hub" } }
 
-    it 'should return true on admin dashboard action' do
+    it 'should return true on premium hub action' do
       expect(helper.admin_page_active?).to eq true
     end
   end


### PR DESCRIPTION
## WHAT
update remaining admin dashboard references to Premium Hub

## WHY
we want to have the correct labeling for this section

## HOW
just update copy across various files (this task specifically highlighted updating references in the banners but I also update a few other references I found in test files, comments, etc)

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1309" alt="Screen Shot 2023-05-23 at 4 33 20 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/103c6f6c-17be-439e-83fd-ed31f3ec711f">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Update-admin-banner-copy-to-refer-to-Premium-Hub-instead-of-admin-dashboard-62f793467cde4851a07b467436c0f77c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
