### PR TITLE
make it possible to set hint_id to nil

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -322,7 +322,7 @@ export const buildRule = ({
     rule_type: ruleType.value,
     suborder: suborder ? suborder : order,
     universal: universal,
-    hint_id: ruleHint?.id,
+    hint_id: ruleHint?.id || null,
     state
   };
 


### PR DESCRIPTION
## WHAT
Make it possible to remove a hint from an evidence rule.

## WHY
We want curriculum team users to have this functionality.

## HOW
Just make sure that, if the user selects no rule, we pass `null` rather than `undefined` to the backend so the param actually comes through and the rule gets updated correctly.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-remove-hint-from-feedback-label-in-Evidence-CMS-20fa8f9c024f4e388fecb3d333f620ac

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A