### PR TITLE
Send LearnWorlds data to Vitally Sync

### DIFF
--- a/services/QuillLMS/app/controllers/auth/learn_worlds_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/learn_worlds_controller.rb
@@ -9,6 +9,7 @@ module Auth
     def courses
       if learn_worlds_access? && sso_success?
         create_learn_worlds_user
+        update_last_login
         redirect_to learn_worlds_courses_endpoint
       else
         redirect_to root_path
@@ -35,6 +36,10 @@ module Auth
 
     private def sso_success?
       sso_response["success"] == true
+    end
+
+    private def update_last_login
+      current_user.learn_worlds_account.update(last_login: DateTime.current)
     end
   end
 end

--- a/services/QuillLMS/app/controllers/learn_worlds_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/learn_worlds_integration/webhooks_controller.rb
@@ -6,7 +6,7 @@ module LearnWorldsIntegration
     class InvalidSignatureError < Error; end
     class UnknownEventTypeError < Error; end
 
-    EVENT_TYPE_HANDLER_MAPPING = {
+    HANDLER_MAPPING = {
       'enrolledFreeCourse' => LearnWorldsIntegration::Webhooks::EnrolledFreeCourseEventHandler,
       'courseCompleted' => LearnWorldsIntegration::Webhooks::CourseCompletedEventHandler,
       'awardedCertificate' => LearnWorldsIntegration::Webhooks::EarnedCertificateEventHandler
@@ -34,7 +34,7 @@ module LearnWorldsIntegration
     end
 
     private def payload
-      @payload ||= JSON.parse(request.body.read)
+      @payload ||= JSON.parse(request.body.string)
     end
 
     private def signature_header

--- a/services/QuillLMS/app/controllers/learn_worlds_integration/webhooks_controller.rb
+++ b/services/QuillLMS/app/controllers/learn_worlds_integration/webhooks_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module LearnWorldsIntegration
+  class WebhooksController < ApplicationController
+    class Error < StandardError; end
+    class InvalidSignatureError < Error; end
+    class UnknownEventTypeError < Error; end
+
+    SIGNATURE_HEADER_KEY = 'HTTP_LEARNWORLDS_WEBHOOK_SIGNATURE'
+
+    protect_from_forgery except: :create
+
+    def create
+      verify_signature
+      webhook_handler_class.run(data)
+      head 200
+    rescue => e
+      ErrorNotifier.report(e)
+      head 400
+    end
+
+    private def event_type
+      payload['type']
+    end
+
+    private def data
+      payload['data']
+    end
+
+    private def payload
+      @payload ||= JSON.parse(request.body.read)
+    end
+
+    private def signature_header
+      request.env[SIGNATURE_HEADER_KEY]
+    end
+
+    private def verify_signature
+      raise InvalidSignatureError unless signature_header.split('=').last == Auth::LearnWorlds::WEBHOOK_SIGNATURE
+    end
+
+    private def webhook_handler_class
+      case event_type
+      when 'enrolledFreeCourse' then Webhooks::EnrolledFreeCourseEventHandler
+      when 'courseCompleted' then Webhooks::CourseCompletedEventHandler
+      when 'awardedCertificate' then Webhooks::EarnedCertificateEventHandler
+      else raise UnknownEventTypeError, "Unknown event type: #{event_type}"
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/models/app_setting.rb
+++ b/services/QuillLMS/app/models/app_setting.rb
@@ -22,6 +22,7 @@ require 'zlib'
 class AppSetting < ApplicationRecord
 
   COMPREHENSION = 'comprehension'
+  LEARN_WORLDS_ACCESS_OVERRIDE = 'learn_worlds_access_override'
 
   validates :percent_active, numericality: {
     only_integer: true,

--- a/services/QuillLMS/app/models/learn_worlds_account.rb
+++ b/services/QuillLMS/app/models/learn_worlds_account.rb
@@ -5,6 +5,7 @@
 # Table name: learn_worlds_accounts
 #
 #  id          :bigint           not null, primary key
+#  last_login  :datetime
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  external_id :string           not null
@@ -12,7 +13,8 @@
 #
 # Indexes
 #
-#  index_learn_worlds_accounts_on_user_id  (user_id)
+#  index_learn_worlds_accounts_on_external_id  (external_id) UNIQUE
+#  index_learn_worlds_accounts_on_user_id      (user_id)
 #
 # Foreign Keys
 #
@@ -20,4 +22,33 @@
 #
 class LearnWorldsAccount < ApplicationRecord
   belongs_to :user
+
+  validates :external_id, presence: true, uniqueness: true
+
+  has_many :learn_worlds_account_enrolled_course_events,
+    -> { enrolled },
+    class_name: 'LearnWorldsAccountCourseEvent',
+    dependent: :destroy
+
+  has_many :enrolled_courses,
+    through: :learn_worlds_account_enrolled_course_events,
+    source: :learn_worlds_course
+
+  has_many :learn_worlds_account_completed_course_events,
+    -> { completed },
+    class_name: 'LearnWorldsAccountCourseEvent',
+    dependent: :destroy
+
+  has_many :completed_courses,
+    through: :learn_worlds_account_completed_course_events,
+    source: :learn_worlds_course
+
+  has_many :learn_worlds_account_earned_certificate_course_events,
+    -> { earned_certificate },
+    class_name: 'LearnWorldsAccountCourseEvent',
+    dependent: :destroy
+
+  has_many :earned_certificate_courses,
+    through: :learn_worlds_account_earned_certificate_course_events,
+    source: :learn_worlds_course
 end

--- a/services/QuillLMS/app/models/learn_worlds_account_course_event.rb
+++ b/services/QuillLMS/app/models/learn_worlds_account_course_event.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: learn_worlds_account_course_events
+#
+#  id                      :bigint           not null, primary key
+#  event_type              :string           not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  learn_worlds_account_id :bigint           not null
+#  learn_worlds_course_id  :bigint           not null
+#
+# Indexes
+#
+#  learn_worlds_account_course_events_on_account_id  (learn_worlds_account_id)
+#  learn_worlds_account_course_events_on_course_id   (learn_worlds_course_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (learn_worlds_account_id => learn_worlds_accounts.id)
+#  fk_rails_...  (learn_worlds_course_id => learn_worlds_courses.id)
+#
+class LearnWorldsAccountCourseEvent < ApplicationRecord
+  EVENT_TYPES = [
+    ENROLLED = 'enrolled',
+    COMPLETED = 'completed',
+    EARNED_CERTIFICATE = 'earned_certificate'
+  ]
+
+  belongs_to :learn_worlds_account
+  belongs_to :learn_worlds_course
+
+  validates :event_type, inclusion: { in: EVENT_TYPES}
+  validates :learn_worlds_account_id, presence: true
+  validates :learn_worlds_course_id, presence: true
+
+  scope :enrolled, -> { where(event_type: ENROLLED) }
+  scope :completed, -> { where(event_type: COMPLETED) }
+  scope :earned_certificate, -> { where(event_type: EARNED_CERTIFICATE) }
+end

--- a/services/QuillLMS/app/models/learn_worlds_course.rb
+++ b/services/QuillLMS/app/models/learn_worlds_course.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: learn_worlds_courses
+#
+#  id          :bigint           not null, primary key
+#  title       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  external_id :string           not null
+#
+# Indexes
+#
+#  index_learn_worlds_courses_on_external_id  (external_id) UNIQUE
+#
+class LearnWorldsCourse < ApplicationRecord
+  has_many :learn_worlds_account_course_events, dependent: :destroy
+
+  validates :title, presence: true
+  validates :external_id, presence: true, uniqueness: true
+end

--- a/services/QuillLMS/app/models/learn_worlds_course.rb
+++ b/services/QuillLMS/app/models/learn_worlds_course.rb
@@ -19,4 +19,8 @@ class LearnWorldsCourse < ApplicationRecord
 
   validates :title, presence: true
   validates :external_id, presence: true, uniqueness: true
+
+  def self.titles_string
+    pluck(:title).join(',')
+  end
 end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -109,6 +109,8 @@ class User < ApplicationRecord
 
   SCHOOL_CHANGELOG_ATTRIBUTE = 'school_id'
 
+  LEARN_WORLDS_ACCESS_OVERRIDE = 'learn_worlds_access_override'
+
   attr_accessor :validate_username, :require_password_confirmation_when_password_present, :newsletter
 
   has_secure_password validations: false
@@ -793,7 +795,11 @@ class User < ApplicationRecord
   end
 
   def learn_worlds_access?
-    school_premium? || district_premium?
+    school_premium? || district_premium? || learn_worlds_access_override?
+  end
+
+  def learn_worlds_access_override?
+    AppSetting.enabled?(name: LEARN_WORLDS_ACCESS_OVERRIDE, user: self)
   end
 
   def school_premium?

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -109,8 +109,6 @@ class User < ApplicationRecord
 
   SCHOOL_CHANGELOG_ATTRIBUTE = 'school_id'
 
-  LEARN_WORLDS_ACCESS_OVERRIDE = 'learn_worlds_access_override'
-
   attr_accessor :validate_username, :require_password_confirmation_when_password_present, :newsletter
 
   has_secure_password validations: false
@@ -799,7 +797,7 @@ class User < ApplicationRecord
   end
 
   def learn_worlds_access_override?
-    AppSetting.enabled?(name: LEARN_WORLDS_ACCESS_OVERRIDE, user: self)
+    AppSetting.enabled?(name: AppSetting::LEARN_WORLDS_ACCESS_OVERRIDE, user: self)
   end
 
   def school_premium?

--- a/services/QuillLMS/app/services/learn_worlds_integration/webhooks/account_course_event_handler.rb
+++ b/services/QuillLMS/app/services/learn_worlds_integration/webhooks/account_course_event_handler.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module LearnWorldsIntegration
+  module Webhooks
+    class AccountCourseEventHandler < ApplicationService
+      attr_reader :data
+
+      def initialize(data)
+        @data = data
+      end
+
+      def run
+        LearnWorldsAccountCourseEvent.find_or_create_by!(
+          learn_worlds_account: learn_worlds_account,
+          learn_worlds_course: learn_worlds_course,
+          event_type: event_type
+        )
+      end
+
+      private def account_external_id
+        data.dig('user', 'id')
+      end
+
+      private def learn_worlds_account
+        LearnWorldsAccount.find_by!(external_id: account_external_id)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/learn_worlds_integration/webhooks/course_completed_event_handler.rb
+++ b/services/QuillLMS/app/services/learn_worlds_integration/webhooks/course_completed_event_handler.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module LearnWorldsIntegration
+  module Webhooks
+    class CourseCompletedEventHandler < AccountCourseEventHandler
+      private def course_external_id
+        data.dig('course', 'id')
+      end
+
+      private def event_type
+        LearnWorldsAccountCourseEvent::COMPLETED
+      end
+
+      private def learn_worlds_course
+        LearnWorldsCourse.find_by!(external_id: course_external_id)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/learn_worlds_integration/webhooks/earned_certificate_event_handler.rb
+++ b/services/QuillLMS/app/services/learn_worlds_integration/webhooks/earned_certificate_event_handler.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module LearnWorldsIntegration
+  module Webhooks
+    class EarnedCertificateEventHandler < AccountCourseEventHandler
+      private def event_type
+        LearnWorldsAccountCourseEvent::EARNED_CERTIFICATE
+      end
+
+      private def course_external_id
+        data.dig('certificate', 'course_id')
+      end
+
+      private def learn_worlds_course
+        LearnWorldsCourse.find_by!(external_id: course_external_id)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/learn_worlds_integration/webhooks/enrolled_free_course_event_handler.rb
+++ b/services/QuillLMS/app/services/learn_worlds_integration/webhooks/enrolled_free_course_event_handler.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module LearnWorldsIntegration
+  module Webhooks
+    class EnrolledFreeCourseEventHandler < AccountCourseEventHandler
+      private def course_external_id
+        data.dig('course', 'id')
+      end
+
+      private def course_title
+        data.dig('course', 'title')
+      end
+
+      private def event_type
+        LearnWorldsAccountCourseEvent::ENROLLED
+      end
+
+      private def learn_worlds_course
+        LearnWorldsCourse.find_or_create_by!(external_id: course_external_id, title: course_title)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -28,6 +28,11 @@ class SerializeVitallySalesUser
     evidence_activities_assigned_this_year = evidence_assigned_in_year_count(@user, school_year_start, school_year_end)
     evidence_activities_completed_this_year = evidence_completed_in_year_count(@user, school_year_start, school_year_end)
     date_of_last_completed_evidence_activity = evidence_finished(@user).order("activity_sessions.completed_at DESC").select("activity_sessions.completed_at").first&.completed_at&.strftime("%F") || 'N/A'
+    learn_worlds_account = @user.learn_worlds_account
+    learn_worlds_enrolled_courses = learn_worlds_account&.enrolled_courses&.pluck(:title)
+    learn_worlds_completed_courses = learn_worlds_account&.completed_courses&.pluck(:title)
+    learn_worlds_earned_certificate_courses = learn_worlds_account&.earned_certificate_courses&.pluck(:title)
+
     {
       accountId: @user.school&.id&.to_s,
       userId: @user.id.to_s,
@@ -100,7 +105,14 @@ class SerializeVitallySalesUser
         email_verification_status: @user.email_verification_status,
         admin_approval_status: @user.admin_approval_status,
         number_of_schools_administered: number_of_schools_administered,
-        number_of_districts_administered: number_of_districts_administered
+        number_of_districts_administered: number_of_districts_administered,
+        learn_worlds_last_login: learn_worlds_account&.last_login,
+        learn_worlds_num_enrolled_courses: learn_worlds_enrolled_courses,
+        learn_worlds_enrolled_courses: learn_worlds_enrolled_courses&.count,
+        learn_worlds_num_completed_courses: learn_worlds_completed_courses,
+        learn_worlds_completed_courses: learn_worlds_completed_courses&.count,
+        learn_worlds_num_earned_certificate_courses: learn_worlds_earned_certificate_courses&.count,
+        learn_worlds_earned_certificate_courses: learn_worlds_earned_certificate_courses
       }.merge(account_data_params)
     }
   end

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -29,9 +29,9 @@ class SerializeVitallySalesUser
     evidence_activities_completed_this_year = evidence_completed_in_year_count(@user, school_year_start, school_year_end)
     date_of_last_completed_evidence_activity = evidence_finished(@user).order("activity_sessions.completed_at DESC").select("activity_sessions.completed_at").first&.completed_at&.strftime("%F") || 'N/A'
     learn_worlds_account = @user.learn_worlds_account
-    learn_worlds_enrolled_courses = learn_worlds_account&.enrolled_courses&.pluck(:title)
-    learn_worlds_completed_courses = learn_worlds_account&.completed_courses&.pluck(:title)
-    learn_worlds_earned_certificate_courses = learn_worlds_account&.earned_certificate_courses&.pluck(:title)
+    learn_worlds_enrolled_courses = learn_worlds_account&.enrolled_courses&.pluck(:title)&.join(',')
+    learn_worlds_completed_courses = learn_worlds_account&.completed_courses&.pluck(:title)&.join(',')
+    learn_worlds_earned_certificate_courses = learn_worlds_account&.earned_certificate_courses&.pluck(:title)&.join(',')
 
     {
       accountId: @user.school&.id&.to_s,

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -29,9 +29,9 @@ class SerializeVitallySalesUser
     evidence_activities_completed_this_year = evidence_completed_in_year_count(@user, school_year_start, school_year_end)
     date_of_last_completed_evidence_activity = evidence_finished(@user).order("activity_sessions.completed_at DESC").select("activity_sessions.completed_at").first&.completed_at&.strftime("%F") || 'N/A'
     learn_worlds_account = @user.learn_worlds_account
-    learn_worlds_enrolled_courses = learn_worlds_account&.enrolled_courses&.pluck(:title)&.join(',')
-    learn_worlds_completed_courses = learn_worlds_account&.completed_courses&.pluck(:title)&.join(',')
-    learn_worlds_earned_certificate_courses = learn_worlds_account&.earned_certificate_courses&.pluck(:title)&.join(',')
+    learn_worlds_enrolled_courses = learn_worlds_account&.enrolled_courses
+    learn_worlds_completed_courses = learn_worlds_account&.completed_courses
+    learn_worlds_earned_certificate_courses = learn_worlds_account&.earned_certificate_courses
 
     {
       accountId: @user.school&.id&.to_s,
@@ -106,13 +106,13 @@ class SerializeVitallySalesUser
         admin_approval_status: @user.admin_approval_status,
         number_of_schools_administered: number_of_schools_administered,
         number_of_districts_administered: number_of_districts_administered,
-        learn_worlds_last_login: learn_worlds_account&.last_login,
-        learn_worlds_num_enrolled_courses: learn_worlds_enrolled_courses,
-        learn_worlds_enrolled_courses: learn_worlds_enrolled_courses&.count,
-        learn_worlds_num_completed_courses: learn_worlds_completed_courses,
-        learn_worlds_completed_courses: learn_worlds_completed_courses&.count,
+        learn_worlds_num_enrolled_courses: learn_worlds_enrolled_courses&.count,
+        learn_worlds_enrolled_courses: learn_worlds_enrolled_courses&.titles_string,
+        learn_worlds_num_completed_courses: learn_worlds_completed_courses&.count,
+        learn_worlds_completed_courses: learn_worlds_completed_courses&.titles_string,
         learn_worlds_num_earned_certificate_courses: learn_worlds_earned_certificate_courses&.count,
-        learn_worlds_earned_certificate_courses: learn_worlds_earned_certificate_courses
+        learn_worlds_earned_certificate_courses: learn_worlds_earned_certificate_courses&.titles_string,
+        learn_worlds_last_login: learn_worlds_account&.last_login&.to_date
       }.merge(account_data_params)
     }
   end

--- a/services/QuillLMS/config/environments/development.rb
+++ b/services/QuillLMS/config/environments/development.rb
@@ -77,5 +77,5 @@ EmpiricalGrammar::Application.configure do
   config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  config.hosts << ENV.fetch("NGROK_HOST") if ENV.fetch("NGROK_HOST")
+  config.hosts << ENV.fetch("NGROK_HOST") if ENV.fetch("NGROK_HOST", false)
 end

--- a/services/QuillLMS/config/environments/development.rb
+++ b/services/QuillLMS/config/environments/development.rb
@@ -76,4 +76,6 @@ EmpiricalGrammar::Application.configure do
   config.active_record.database_selector = { delay: 0.seconds }
   config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.hosts << ENV.fetch("NGROK_HOST") if ENV.fetch("NGROK_HOST")
 end

--- a/services/QuillLMS/config/initializers/auth/learn_worlds.rb
+++ b/services/QuillLMS/config/initializers/auth/learn_worlds.rb
@@ -8,5 +8,7 @@ module Auth
 
     SSO_ENDPOINT = "#{BASE_URI}/admin/api/sso"
     COURSES_ENDPOINT = "#{BASE_URI}/courses"
+
+    WEBHOOK_SIGNATURE = ENV.fetch('LEARN_WORLDS_WEBHOOK_SIGNATURE', '')
   end
 end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -91,6 +91,10 @@ EmpiricalGrammar::Application.routes.draw do
     post '/webhooks', to: 'webhooks#create'
   end
 
+  namespace :learn_worlds_integration do
+    post '/webhooks', to: 'webhooks#create', format: :json
+  end
+
   namespace :intercom_integration do
     post '/webhooks', to: 'webhooks#create'
   end

--- a/services/QuillLMS/db/migrate/20230523191206_create_learn_worlds_courses.rb
+++ b/services/QuillLMS/db/migrate/20230523191206_create_learn_worlds_courses.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateLearnWorldsCourses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learn_worlds_courses do |t|
+      t.string :title, null: false
+      t.string :external_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20230523191347_create_learn_worlds_account_course_events.rb
+++ b/services/QuillLMS/db/migrate/20230523191347_create_learn_worlds_account_course_events.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateLearnWorldsAccountCourseEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learn_worlds_account_course_events do |t|
+      t.references :learn_worlds_account,
+        foreign_key: true,
+        null: false,
+        index: { name: 'learn_worlds_account_course_events_on_account_id' }
+
+      t.references :learn_worlds_course,
+        foreign_key: true,
+        null: false,
+        index: { name: 'learn_worlds_account_course_events_on_course_id'}
+
+      t.string :event_type, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20230523192828_add_last_login_to_learn_worlds_account.rb
+++ b/services/QuillLMS/db/migrate/20230523192828_add_last_login_to_learn_worlds_account.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastLoginToLearnWorldsAccount < ActiveRecord::Migration[6.1]
+  def change
+    add_column :learn_worlds_accounts, :last_login, :datetime
+  end
+end

--- a/services/QuillLMS/db/migrate/20230524142914_add_uniqueness_to_external_id_in_learn_worlds_account.rb
+++ b/services/QuillLMS/db/migrate/20230524142914_add_uniqueness_to_external_id_in_learn_worlds_account.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniquenessToExternalIdInLearnWorldsAccount < ActiveRecord::Migration[6.1]
+  def change
+    add_index :learn_worlds_accounts, :external_id, unique: true
+  end
+end

--- a/services/QuillLMS/db/migrate/20230524143000_add_uniqueness_to_external_id_in_learn_worlds_course.rb
+++ b/services/QuillLMS/db/migrate/20230524143000_add_uniqueness_to_external_id_in_learn_worlds_course.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniquenessToExternalIdInLearnWorldsCourse < ActiveRecord::Migration[6.1]
+  def change
+    add_index :learn_worlds_courses, :external_id, unique: true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2589,6 +2589,106 @@ ALTER SEQUENCE public.evidence_prompt_healths_id_seq OWNED BY public.evidence_pr
 
 
 --
+-- Name: evidence_prompt_text_batches; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_prompt_text_batches (
+    id bigint NOT NULL,
+    type character varying NOT NULL,
+    prompt_id integer NOT NULL,
+    config jsonb,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_prompt_text_batches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_prompt_text_batches_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_prompt_text_batches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_prompt_text_batches_id_seq OWNED BY public.evidence_prompt_text_batches.id;
+
+
+--
+-- Name: evidence_prompt_texts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_prompt_texts (
+    id bigint NOT NULL,
+    prompt_text_batch_id integer NOT NULL,
+    text_generation_id integer NOT NULL,
+    text character varying NOT NULL,
+    label character varying,
+    ml_type character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_prompt_texts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_prompt_texts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_prompt_texts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_prompt_texts_id_seq OWNED BY public.evidence_prompt_texts.id;
+
+
+--
+-- Name: evidence_text_generations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_text_generations (
+    id bigint NOT NULL,
+    type character varying NOT NULL,
+    config jsonb,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_text_generations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_text_generations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_text_generations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_text_generations_id_seq OWNED BY public.evidence_text_generations.id;
+
+
+--
 -- Name: feedback_histories; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2916,6 +3016,39 @@ ALTER SEQUENCE public.ip_locations_id_seq OWNED BY public.ip_locations.id;
 
 
 --
+-- Name: learn_worlds_account_course_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.learn_worlds_account_course_events (
+    id bigint NOT NULL,
+    learn_worlds_account_id bigint NOT NULL,
+    learn_worlds_course_id bigint NOT NULL,
+    event_type character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: learn_worlds_account_course_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.learn_worlds_account_course_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: learn_worlds_account_course_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.learn_worlds_account_course_events_id_seq OWNED BY public.learn_worlds_account_course_events.id;
+
+
+--
 -- Name: learn_worlds_accounts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2924,7 +3057,8 @@ CREATE TABLE public.learn_worlds_accounts (
     user_id bigint,
     external_id character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    last_login timestamp without time zone
 );
 
 
@@ -2945,6 +3079,38 @@ CREATE SEQUENCE public.learn_worlds_accounts_id_seq
 --
 
 ALTER SEQUENCE public.learn_worlds_accounts_id_seq OWNED BY public.learn_worlds_accounts.id;
+
+
+--
+-- Name: learn_worlds_courses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.learn_worlds_courses (
+    id bigint NOT NULL,
+    title character varying NOT NULL,
+    external_id character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: learn_worlds_courses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.learn_worlds_courses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: learn_worlds_courses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.learn_worlds_courses_id_seq OWNED BY public.learn_worlds_courses.id;
 
 
 --
@@ -4400,7 +4566,8 @@ CREATE TABLE public.teacher_infos (
     user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    role_selected_at_signup character varying DEFAULT ''::character varying
+    role_selected_at_signup character varying DEFAULT ''::character varying,
+    notification_email_frequency text
 );
 
 
@@ -4421,6 +4588,72 @@ CREATE SEQUENCE public.teacher_infos_id_seq
 --
 
 ALTER SEQUENCE public.teacher_infos_id_seq OWNED BY public.teacher_infos.id;
+
+
+--
+-- Name: teacher_notification_settings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.teacher_notification_settings (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    notification_type text NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: teacher_notification_settings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.teacher_notification_settings_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: teacher_notification_settings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.teacher_notification_settings_id_seq OWNED BY public.teacher_notification_settings.id;
+
+
+--
+-- Name: teacher_notifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.teacher_notifications (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    type text,
+    email_sent timestamp without time zone,
+    message_attrs jsonb,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: teacher_notifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.teacher_notifications_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: teacher_notifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.teacher_notifications_id_seq OWNED BY public.teacher_notifications.id;
 
 
 --
@@ -5425,6 +5658,27 @@ ALTER TABLE ONLY public.evidence_prompt_healths ALTER COLUMN id SET DEFAULT next
 
 
 --
+-- Name: evidence_prompt_text_batches id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_text_batches ALTER COLUMN id SET DEFAULT nextval('public.evidence_prompt_text_batches_id_seq'::regclass);
+
+
+--
+-- Name: evidence_prompt_texts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_texts ALTER COLUMN id SET DEFAULT nextval('public.evidence_prompt_texts_id_seq'::regclass);
+
+
+--
+-- Name: evidence_text_generations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_text_generations ALTER COLUMN id SET DEFAULT nextval('public.evidence_text_generations_id_seq'::regclass);
+
+
+--
 -- Name: feedback_histories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5488,10 +5742,24 @@ ALTER TABLE ONLY public.ip_locations ALTER COLUMN id SET DEFAULT nextval('public
 
 
 --
+-- Name: learn_worlds_account_course_events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_account_course_events ALTER COLUMN id SET DEFAULT nextval('public.learn_worlds_account_course_events_id_seq'::regclass);
+
+
+--
 -- Name: learn_worlds_accounts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.learn_worlds_accounts ALTER COLUMN id SET DEFAULT nextval('public.learn_worlds_accounts_id_seq'::regclass);
+
+
+--
+-- Name: learn_worlds_courses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_courses ALTER COLUMN id SET DEFAULT nextval('public.learn_worlds_courses_id_seq'::regclass);
 
 
 --
@@ -5786,6 +6054,20 @@ ALTER TABLE ONLY public.teacher_info_subject_areas ALTER COLUMN id SET DEFAULT n
 --
 
 ALTER TABLE ONLY public.teacher_infos ALTER COLUMN id SET DEFAULT nextval('public.teacher_infos_id_seq'::regclass);
+
+
+--
+-- Name: teacher_notification_settings id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teacher_notification_settings ALTER COLUMN id SET DEFAULT nextval('public.teacher_notification_settings_id_seq'::regclass);
+
+
+--
+-- Name: teacher_notifications id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teacher_notifications ALTER COLUMN id SET DEFAULT nextval('public.teacher_notifications_id_seq'::regclass);
 
 
 --
@@ -6430,6 +6712,30 @@ ALTER TABLE ONLY public.evidence_prompt_healths
 
 
 --
+-- Name: evidence_prompt_text_batches evidence_prompt_text_batches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_text_batches
+    ADD CONSTRAINT evidence_prompt_text_batches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_prompt_texts evidence_prompt_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_texts
+    ADD CONSTRAINT evidence_prompt_texts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_text_generations evidence_text_generations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_text_generations
+    ADD CONSTRAINT evidence_text_generations_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: feedback_histories feedback_histories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6502,11 +6808,27 @@ ALTER TABLE ONLY public.ip_locations
 
 
 --
+-- Name: learn_worlds_account_course_events learn_worlds_account_course_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_account_course_events
+    ADD CONSTRAINT learn_worlds_account_course_events_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: learn_worlds_accounts learn_worlds_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.learn_worlds_accounts
     ADD CONSTRAINT learn_worlds_accounts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: learn_worlds_courses learn_worlds_courses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_courses
+    ADD CONSTRAINT learn_worlds_courses_pkey PRIMARY KEY (id);
 
 
 --
@@ -6851,6 +7173,22 @@ ALTER TABLE ONLY public.teacher_info_subject_areas
 
 ALTER TABLE ONLY public.teacher_infos
     ADD CONSTRAINT teacher_infos_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: teacher_notification_settings teacher_notification_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teacher_notification_settings
+    ADD CONSTRAINT teacher_notification_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: teacher_notifications teacher_notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teacher_notifications
+    ADD CONSTRAINT teacher_notifications_pkey PRIMARY KEY (id);
 
 
 --
@@ -7807,10 +8145,24 @@ CREATE INDEX index_ip_locations_on_zip ON public.ip_locations USING btree (zip);
 
 
 --
+-- Name: index_learn_worlds_accounts_on_external_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_learn_worlds_accounts_on_external_id ON public.learn_worlds_accounts USING btree (external_id);
+
+
+--
 -- Name: index_learn_worlds_accounts_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_learn_worlds_accounts_on_user_id ON public.learn_worlds_accounts USING btree (user_id);
+
+
+--
+-- Name: index_learn_worlds_courses_on_external_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_learn_worlds_courses_on_external_id ON public.learn_worlds_courses USING btree (external_id);
 
 
 --
@@ -8262,6 +8614,27 @@ CREATE INDEX index_teacher_infos_on_user_id ON public.teacher_infos USING btree 
 
 
 --
+-- Name: index_teacher_notification_settings_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_teacher_notification_settings_on_user_id ON public.teacher_notification_settings USING btree (user_id);
+
+
+--
+-- Name: index_teacher_notification_settings_on_user_id_and_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_teacher_notification_settings_on_user_id_and_type ON public.teacher_notification_settings USING btree (user_id, notification_type);
+
+
+--
+-- Name: index_teacher_notifications_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_teacher_notifications_on_user_id ON public.teacher_notifications USING btree (user_id);
+
+
+--
 -- Name: index_teacher_saved_activities_on_activity_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8514,6 +8887,20 @@ CREATE UNIQUE INDEX index_zipcode_infos_on_zipcode ON public.zipcode_infos USING
 
 
 --
+-- Name: learn_worlds_account_course_events_on_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX learn_worlds_account_course_events_on_account_id ON public.learn_worlds_account_course_events USING btree (learn_worlds_account_id);
+
+
+--
+-- Name: learn_worlds_account_course_events_on_course_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX learn_worlds_account_course_events_on_course_id ON public.learn_worlds_account_course_events USING btree (learn_worlds_course_id);
+
+
+--
 -- Name: name_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8718,6 +9105,14 @@ ALTER TABLE ONLY public.evidence_prompt_healths
 
 
 --
+-- Name: teacher_notification_settings fk_rails_3291865e04; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teacher_notification_settings
+    ADD CONSTRAINT fk_rails_3291865e04 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: comprehension_automl_models fk_rails_35c32f80fc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8918,6 +9313,14 @@ ALTER TABLE ONLY public.user_pack_sequence_items
 
 
 --
+-- Name: teacher_notifications fk_rails_81552fbc91; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teacher_notifications
+    ADD CONSTRAINT fk_rails_81552fbc91 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: activities fk_rails_8b159cf902; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9086,6 +9489,14 @@ ALTER TABLE ONLY public.teacher_saved_activities
 
 
 --
+-- Name: learn_worlds_account_course_events fk_rails_d14877312a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_account_course_events
+    ADD CONSTRAINT fk_rails_d14877312a FOREIGN KEY (learn_worlds_account_id) REFERENCES public.learn_worlds_accounts(id);
+
+
+--
 -- Name: skill_group_activities fk_rails_d286b719ca; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9187,6 +9598,14 @@ ALTER TABLE ONLY public.content_partner_activities
 
 ALTER TABLE ONLY public.auth_credentials
     ADD CONSTRAINT fk_rails_f92a275310 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: learn_worlds_account_course_events fk_rails_f9564aaf30; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_account_course_events
+    ADD CONSTRAINT fk_rails_f9564aaf30 FOREIGN KEY (learn_worlds_course_id) REFERENCES public.learn_worlds_courses(id);
 
 
 --
@@ -9629,7 +10048,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211019143514'),
 ('20211026160939'),
 ('20211108171529'),
-('20211202235402'),
 ('20220105145446'),
 ('20220106193721'),
 ('20220128175405'),
@@ -9699,12 +10117,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230206203447'),
 ('20230301151808'),
 ('20230301160642'),
-('20230306220015'),
-('20230306220016'),
-('20230306220017'),
-('20230317151920'),
-('20230317151921'),
-('20230317151922'),
 ('20230323114351'),
 ('20230328155819'),
 ('20230405140349'),
@@ -9717,6 +10129,11 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230414164818'),
 ('20230420141952'),
 ('20230421172858'),
-('20230428190706');
+('20230428190706'),
+('20230523191206'),
+('20230523191347'),
+('20230523192828'),
+('20230524142914'),
+('20230524143000');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2916,6 +2916,39 @@ ALTER SEQUENCE public.ip_locations_id_seq OWNED BY public.ip_locations.id;
 
 
 --
+-- Name: learn_worlds_account_course_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.learn_worlds_account_course_events (
+    id bigint NOT NULL,
+    learn_worlds_account_id bigint NOT NULL,
+    learn_worlds_course_id bigint NOT NULL,
+    event_type character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: learn_worlds_account_course_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.learn_worlds_account_course_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: learn_worlds_account_course_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.learn_worlds_account_course_events_id_seq OWNED BY public.learn_worlds_account_course_events.id;
+
+
+--
 -- Name: learn_worlds_accounts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2924,7 +2957,8 @@ CREATE TABLE public.learn_worlds_accounts (
     user_id bigint,
     external_id character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    last_login timestamp without time zone
 );
 
 
@@ -2945,6 +2979,38 @@ CREATE SEQUENCE public.learn_worlds_accounts_id_seq
 --
 
 ALTER SEQUENCE public.learn_worlds_accounts_id_seq OWNED BY public.learn_worlds_accounts.id;
+
+
+--
+-- Name: learn_worlds_courses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.learn_worlds_courses (
+    id bigint NOT NULL,
+    title character varying NOT NULL,
+    external_id character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: learn_worlds_courses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.learn_worlds_courses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: learn_worlds_courses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.learn_worlds_courses_id_seq OWNED BY public.learn_worlds_courses.id;
 
 
 --
@@ -5488,10 +5554,24 @@ ALTER TABLE ONLY public.ip_locations ALTER COLUMN id SET DEFAULT nextval('public
 
 
 --
+-- Name: learn_worlds_account_course_events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_account_course_events ALTER COLUMN id SET DEFAULT nextval('public.learn_worlds_account_course_events_id_seq'::regclass);
+
+
+--
 -- Name: learn_worlds_accounts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.learn_worlds_accounts ALTER COLUMN id SET DEFAULT nextval('public.learn_worlds_accounts_id_seq'::regclass);
+
+
+--
+-- Name: learn_worlds_courses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_courses ALTER COLUMN id SET DEFAULT nextval('public.learn_worlds_courses_id_seq'::regclass);
 
 
 --
@@ -6502,11 +6582,27 @@ ALTER TABLE ONLY public.ip_locations
 
 
 --
+-- Name: learn_worlds_account_course_events learn_worlds_account_course_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_account_course_events
+    ADD CONSTRAINT learn_worlds_account_course_events_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: learn_worlds_accounts learn_worlds_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.learn_worlds_accounts
     ADD CONSTRAINT learn_worlds_accounts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: learn_worlds_courses learn_worlds_courses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_courses
+    ADD CONSTRAINT learn_worlds_courses_pkey PRIMARY KEY (id);
 
 
 --
@@ -7807,10 +7903,24 @@ CREATE INDEX index_ip_locations_on_zip ON public.ip_locations USING btree (zip);
 
 
 --
+-- Name: index_learn_worlds_accounts_on_external_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_learn_worlds_accounts_on_external_id ON public.learn_worlds_accounts USING btree (external_id);
+
+
+--
 -- Name: index_learn_worlds_accounts_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_learn_worlds_accounts_on_user_id ON public.learn_worlds_accounts USING btree (user_id);
+
+
+--
+-- Name: index_learn_worlds_courses_on_external_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_learn_worlds_courses_on_external_id ON public.learn_worlds_courses USING btree (external_id);
 
 
 --
@@ -8514,6 +8624,20 @@ CREATE UNIQUE INDEX index_zipcode_infos_on_zipcode ON public.zipcode_infos USING
 
 
 --
+-- Name: learn_worlds_account_course_events_on_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX learn_worlds_account_course_events_on_account_id ON public.learn_worlds_account_course_events USING btree (learn_worlds_account_id);
+
+
+--
+-- Name: learn_worlds_account_course_events_on_course_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX learn_worlds_account_course_events_on_course_id ON public.learn_worlds_account_course_events USING btree (learn_worlds_course_id);
+
+
+--
 -- Name: name_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9086,6 +9210,14 @@ ALTER TABLE ONLY public.teacher_saved_activities
 
 
 --
+-- Name: learn_worlds_account_course_events fk_rails_d14877312a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_account_course_events
+    ADD CONSTRAINT fk_rails_d14877312a FOREIGN KEY (learn_worlds_account_id) REFERENCES public.learn_worlds_accounts(id);
+
+
+--
 -- Name: skill_group_activities fk_rails_d286b719ca; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9187,6 +9319,14 @@ ALTER TABLE ONLY public.content_partner_activities
 
 ALTER TABLE ONLY public.auth_credentials
     ADD CONSTRAINT fk_rails_f92a275310 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: learn_worlds_account_course_events fk_rails_f9564aaf30; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learn_worlds_account_course_events
+    ADD CONSTRAINT fk_rails_f9564aaf30 FOREIGN KEY (learn_worlds_course_id) REFERENCES public.learn_worlds_courses(id);
 
 
 --
@@ -9704,6 +9844,17 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230411145111'),
 ('20230411145241'),
 ('20230413140558'),
-('20230414164818');
+('20230413215936'),
+('20230413215937'),
+('20230413215938'),
+('20230414164818'),
+('20230420141952'),
+('20230421172858'),
+('20230428190706'),
+('20230523191206'),
+('20230523191347'),
+('20230523192828'),
+('20230524142914'),
+('20230524143000');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2916,39 +2916,6 @@ ALTER SEQUENCE public.ip_locations_id_seq OWNED BY public.ip_locations.id;
 
 
 --
--- Name: learn_worlds_account_course_events; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.learn_worlds_account_course_events (
-    id bigint NOT NULL,
-    learn_worlds_account_id bigint NOT NULL,
-    learn_worlds_course_id bigint NOT NULL,
-    event_type character varying NOT NULL,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: learn_worlds_account_course_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.learn_worlds_account_course_events_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: learn_worlds_account_course_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.learn_worlds_account_course_events_id_seq OWNED BY public.learn_worlds_account_course_events.id;
-
-
---
 -- Name: learn_worlds_accounts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2957,8 +2924,7 @@ CREATE TABLE public.learn_worlds_accounts (
     user_id bigint,
     external_id character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    last_login timestamp without time zone
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -2979,38 +2945,6 @@ CREATE SEQUENCE public.learn_worlds_accounts_id_seq
 --
 
 ALTER SEQUENCE public.learn_worlds_accounts_id_seq OWNED BY public.learn_worlds_accounts.id;
-
-
---
--- Name: learn_worlds_courses; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.learn_worlds_courses (
-    id bigint NOT NULL,
-    title character varying NOT NULL,
-    external_id character varying NOT NULL,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: learn_worlds_courses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.learn_worlds_courses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: learn_worlds_courses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.learn_worlds_courses_id_seq OWNED BY public.learn_worlds_courses.id;
 
 
 --
@@ -5554,24 +5488,10 @@ ALTER TABLE ONLY public.ip_locations ALTER COLUMN id SET DEFAULT nextval('public
 
 
 --
--- Name: learn_worlds_account_course_events id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.learn_worlds_account_course_events ALTER COLUMN id SET DEFAULT nextval('public.learn_worlds_account_course_events_id_seq'::regclass);
-
-
---
 -- Name: learn_worlds_accounts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.learn_worlds_accounts ALTER COLUMN id SET DEFAULT nextval('public.learn_worlds_accounts_id_seq'::regclass);
-
-
---
--- Name: learn_worlds_courses id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.learn_worlds_courses ALTER COLUMN id SET DEFAULT nextval('public.learn_worlds_courses_id_seq'::regclass);
 
 
 --
@@ -6582,27 +6502,11 @@ ALTER TABLE ONLY public.ip_locations
 
 
 --
--- Name: learn_worlds_account_course_events learn_worlds_account_course_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.learn_worlds_account_course_events
-    ADD CONSTRAINT learn_worlds_account_course_events_pkey PRIMARY KEY (id);
-
-
---
 -- Name: learn_worlds_accounts learn_worlds_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.learn_worlds_accounts
     ADD CONSTRAINT learn_worlds_accounts_pkey PRIMARY KEY (id);
-
-
---
--- Name: learn_worlds_courses learn_worlds_courses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.learn_worlds_courses
-    ADD CONSTRAINT learn_worlds_courses_pkey PRIMARY KEY (id);
 
 
 --
@@ -7903,24 +7807,10 @@ CREATE INDEX index_ip_locations_on_zip ON public.ip_locations USING btree (zip);
 
 
 --
--- Name: index_learn_worlds_accounts_on_external_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_learn_worlds_accounts_on_external_id ON public.learn_worlds_accounts USING btree (external_id);
-
-
---
 -- Name: index_learn_worlds_accounts_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_learn_worlds_accounts_on_user_id ON public.learn_worlds_accounts USING btree (user_id);
-
-
---
--- Name: index_learn_worlds_courses_on_external_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_learn_worlds_courses_on_external_id ON public.learn_worlds_courses USING btree (external_id);
 
 
 --
@@ -8624,20 +8514,6 @@ CREATE UNIQUE INDEX index_zipcode_infos_on_zipcode ON public.zipcode_infos USING
 
 
 --
--- Name: learn_worlds_account_course_events_on_account_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX learn_worlds_account_course_events_on_account_id ON public.learn_worlds_account_course_events USING btree (learn_worlds_account_id);
-
-
---
--- Name: learn_worlds_account_course_events_on_course_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX learn_worlds_account_course_events_on_course_id ON public.learn_worlds_account_course_events USING btree (learn_worlds_course_id);
-
-
---
 -- Name: name_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9210,14 +9086,6 @@ ALTER TABLE ONLY public.teacher_saved_activities
 
 
 --
--- Name: learn_worlds_account_course_events fk_rails_d14877312a; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.learn_worlds_account_course_events
-    ADD CONSTRAINT fk_rails_d14877312a FOREIGN KEY (learn_worlds_account_id) REFERENCES public.learn_worlds_accounts(id);
-
-
---
 -- Name: skill_group_activities fk_rails_d286b719ca; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9319,14 +9187,6 @@ ALTER TABLE ONLY public.content_partner_activities
 
 ALTER TABLE ONLY public.auth_credentials
     ADD CONSTRAINT fk_rails_f92a275310 FOREIGN KEY (user_id) REFERENCES public.users(id);
-
-
---
--- Name: learn_worlds_account_course_events fk_rails_f9564aaf30; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.learn_worlds_account_course_events
-    ADD CONSTRAINT fk_rails_f9564aaf30 FOREIGN KEY (learn_worlds_course_id) REFERENCES public.learn_worlds_courses(id);
 
 
 --
@@ -9769,6 +9629,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211019143514'),
 ('20211026160939'),
 ('20211108171529'),
+('20211202235402'),
 ('20220105145446'),
 ('20220106193721'),
 ('20220128175405'),
@@ -9838,6 +9699,12 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230206203447'),
 ('20230301151808'),
 ('20230301160642'),
+('20230306220015'),
+('20230306220016'),
+('20230306220017'),
+('20230317151920'),
+('20230317151921'),
+('20230317151922'),
 ('20230323114351'),
 ('20230328155819'),
 ('20230405140349'),
@@ -9850,11 +9717,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230414164818'),
 ('20230420141952'),
 ('20230421172858'),
-('20230428190706'),
-('20230523191206'),
-('20230523191347'),
-('20230523192828'),
-('20230524142914'),
-('20230524143000');
+('20230428190706');
 
 

--- a/services/QuillLMS/lib/tasks/local_data.rake
+++ b/services/QuillLMS/lib/tasks/local_data.rake
@@ -20,6 +20,7 @@ namespace :local_data do
   # PROD_FOLLOWER_DB_HOST
   # PROD_FOLLOWER_DB_USER
   # You will be prompted for the password in the console when run
+  # If starting from a new database, run `bundle exec rake db:structure:load` first
   # To Run: bundle exec rake local_data:reset_nonuser_data_from_follower
   desc "import non-user tables"
   task reset_nonuser_data_from_follower: :environment do

--- a/services/QuillLMS/spec/controllers/learn_worlds_integration/webhooks_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/learn_worlds_integration/webhooks_controller_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LearnWorldsIntegration::WebhooksController, type: :controller do
+  include_context 'LearnWorlds Enrolled Free Course Event'
+  include_context 'LearnWorlds Course Completed Event'
+  include_context 'LearnWorlds Earned Certificate Event'
+
+  subject { post :create, params: params, as: :json }
+
+  let(:webhook_signature) { SecureRandom.hex(12) }
+
+  before { stub_const("Auth::LearnWorlds::WEBHOOK_SIGNATURE", webhook_signature) }
+
+  context '#create' do
+    before { allow(request).to receive(:env).and_return({described_class::SIGNATURE_HEADER_KEY => signature_header}) }
+
+    context 'invalid signature' do
+      let(:params) { {} }
+      let(:signature_header) { 'v2=invalid-signature' }
+      let(:error) { LearnWorldsIntegration::WebhooksController::InvalidSignatureError }
+
+      it 'handles the signature error and reports to new relic' do
+        expect(ErrorNotifier).to receive(:report).with(error)
+        subject
+        expect(response.status).to eq 400
+      end
+    end
+
+    context 'valid signature' do
+      let(:signature_header) { "v2=#{webhook_signature}" }
+
+      context 'enrolled_free_course_event' do
+        let(:params) {  enrolled_free_course_event }
+
+        it { should_call_event_handler(LearnWorldsIntegration::Webhooks::EnrolledFreeCourseEventHandler)}
+      end
+
+      context 'course_completed_event' do
+        let(:params) { course_completed_event }
+
+        it { should_call_event_handler(LearnWorldsIntegration::Webhooks::CourseCompletedEventHandler)}
+      end
+
+      context 'earned_certificate_event' do
+        let(:params) { earned_certificate_event }
+
+        it { should_call_event_handler(LearnWorldsIntegration::Webhooks::EarnedCertificateEventHandler) }
+      end
+
+      context 'unknown event type' do
+        let(:error) { LearnWorldsIntegration::WebhooksController::UnknownEventTypeError }
+        let(:params) { { 'type' => 'anUnknownEventType', 'data' => {}} }
+
+        it 'handles the unknown event error and reports to new relic' do
+          expect(ErrorNotifier).to receive(:report).with(error)
+          subject
+          expect(response.status).to eq 400
+        end
+      end
+    end
+  end
+
+  def should_call_event_handler(event_handler)
+    expect(event_handler).to receive(:run).with(params['data'])
+    subject
+    expect(response.status).to eq 200
+  end
+end

--- a/services/QuillLMS/spec/factories/learn_worlds_account_course_events.rb
+++ b/services/QuillLMS/spec/factories/learn_worlds_account_course_events.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: learn_worlds_account_course_events
+#
+#  id                      :bigint           not null, primary key
+#  event_type              :string           not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  learn_worlds_account_id :bigint           not null
+#  learn_worlds_course_id  :bigint           not null
+#
+# Indexes
+#
+#  learn_worlds_account_course_events_on_account_id  (learn_worlds_account_id)
+#  learn_worlds_account_course_events_on_course_id   (learn_worlds_course_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (learn_worlds_account_id => learn_worlds_accounts.id)
+#  fk_rails_...  (learn_worlds_course_id => learn_worlds_courses.id)
+#
+FactoryBot.define do
+  factory :learn_worlds_account_course_event, aliases: [:learn_worlds_account_enrolled_course_event] do
+    learn_worlds_account
+    learn_worlds_course
+    event_type { LearnWorldsAccountCourseEvent::ENROLLED }
+
+    factory :learn_worlds_account_completed_course_event do
+      event_type { LearnWorldsAccountCourseEvent::COMPLETED }
+    end
+
+    factory :learn_worlds_account_earned_certificate_course_event do
+      event_type { LearnWorldsAccountCourseEvent::EARNED_CERTIFICATE }
+    end
+  end
+end

--- a/services/QuillLMS/spec/factories/learn_worlds_accounts.rb
+++ b/services/QuillLMS/spec/factories/learn_worlds_accounts.rb
@@ -5,6 +5,7 @@
 # Table name: learn_worlds_accounts
 #
 #  id          :bigint           not null, primary key
+#  last_login  :datetime
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  external_id :string           not null
@@ -12,7 +13,8 @@
 #
 # Indexes
 #
-#  index_learn_worlds_accounts_on_user_id  (user_id)
+#  index_learn_worlds_accounts_on_external_id  (external_id) UNIQUE
+#  index_learn_worlds_accounts_on_user_id      (user_id)
 #
 # Foreign Keys
 #
@@ -22,5 +24,6 @@ FactoryBot.define do
   factory :learn_worlds_account do
     user
     external_id { SecureRandom.hex(12) }
+    last_login { DateTime.current }
   end
 end

--- a/services/QuillLMS/spec/factories/learn_worlds_courses.rb
+++ b/services/QuillLMS/spec/factories/learn_worlds_courses.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: learn_worlds_courses
+#
+#  id          :bigint           not null, primary key
+#  title       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  external_id :string           not null
+#
+# Indexes
+#
+#  index_learn_worlds_courses_on_external_id  (external_id) UNIQUE
+#
+FactoryBot.define do
+  factory :learn_worlds_course do
+    external_id { SecureRandom.hex(12) }
+    title { Faker::Book.title }
+  end
+end

--- a/services/QuillLMS/spec/models/learn_worlds_account_course_event_spec.rb
+++ b/services/QuillLMS/spec/models/learn_worlds_account_course_event_spec.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: learn_worlds_account_course_events
+#
+#  id                      :bigint           not null, primary key
+#  event_type              :string           not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  learn_worlds_account_id :bigint           not null
+#  learn_worlds_course_id  :bigint           not null
+#
+# Indexes
+#
+#  learn_worlds_account_course_events_on_account_id  (learn_worlds_account_id)
+#  learn_worlds_account_course_events_on_course_id   (learn_worlds_course_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (learn_worlds_account_id => learn_worlds_accounts.id)
+#  fk_rails_...  (learn_worlds_course_id => learn_worlds_courses.id)
+#
+require 'rails_helper'
+
+RSpec.describe LearnWorldsAccountCourseEvent, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/services/QuillLMS/spec/models/learn_worlds_account_course_event_spec.rb
+++ b/services/QuillLMS/spec/models/learn_worlds_account_course_event_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe LearnWorldsAccountCourseEvent, type: :model do
   it { should belong_to(:learn_worlds_account) }
   it { should belong_to(:learn_worlds_course) }
 
-  it { should validate_presence_of(:event_type) }
   it { should validate_inclusion_of(:event_type).in_array(LearnWorldsAccountCourseEvent::EVENT_TYPES) }
 
   it { expect(subject).to be_valid }

--- a/services/QuillLMS/spec/models/learn_worlds_account_course_event_spec.rb
+++ b/services/QuillLMS/spec/models/learn_worlds_account_course_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: learn_worlds_account_course_events
@@ -22,5 +24,13 @@
 require 'rails_helper'
 
 RSpec.describe LearnWorldsAccountCourseEvent, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject { create(:learn_worlds_account_course_event) }
+
+  it { should belong_to(:learn_worlds_account) }
+  it { should belong_to(:learn_worlds_course) }
+
+  it { should validate_presence_of(:event_type) }
+  it { should validate_inclusion_of(:event_type).in_array(LearnWorldsAccountCourseEvent::EVENT_TYPES) }
+
+  it { expect(subject).to be_valid }
 end

--- a/services/QuillLMS/spec/models/learn_worlds_account_spec.rb
+++ b/services/QuillLMS/spec/models/learn_worlds_account_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe LearnWorldsAccount, type: :model do
   subject { create(:learn_worlds_account) }
 
   it { should belong_to(:user) }
-  it { should validate_uniqueness_of(:external_id).case_insensitive }
+  it { should validate_uniqueness_of(:external_id) }
 
   it { expect(subject).to be_valid }
 

--- a/services/QuillLMS/spec/models/learn_worlds_account_spec.rb
+++ b/services/QuillLMS/spec/models/learn_worlds_account_spec.rb
@@ -5,6 +5,7 @@
 # Table name: learn_worlds_accounts
 #
 #  id          :bigint           not null, primary key
+#  last_login  :datetime
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  external_id :string           not null
@@ -12,7 +13,8 @@
 #
 # Indexes
 #
-#  index_learn_worlds_accounts_on_user_id  (user_id)
+#  index_learn_worlds_accounts_on_external_id  (external_id) UNIQUE
+#  index_learn_worlds_accounts_on_user_id      (user_id)
 #
 # Foreign Keys
 #
@@ -21,5 +23,31 @@
 require 'rails_helper'
 
 RSpec.describe LearnWorldsAccount, type: :model do
+  subject { create(:learn_worlds_account) }
+
   it { should belong_to(:user) }
+  it { should validate_uniqueness_of(:external_id).case_insensitive }
+
+  it { expect(subject).to be_valid }
+
+  context 'scopes' do
+
+    context 'enrolled courses' do
+      before { create(:learn_worlds_account_enrolled_course_event, learn_worlds_account: subject) }
+
+      it { expect(subject.enrolled_courses.count).to eq(1) }
+    end
+
+    context 'completed courses' do
+      before { create(:learn_worlds_account_completed_course_event, learn_worlds_account: subject) }
+
+      it { expect(subject.completed_courses.count).to eq(1) }
+    end
+
+    context 'earned certificate courses' do
+      before { create(:learn_worlds_account_earned_certificate_course_event, learn_worlds_account: subject) }
+
+      it { expect(subject.earned_certificate_courses.count).to eq(1) }
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/learn_worlds_course_spec.rb
+++ b/services/QuillLMS/spec/models/learn_worlds_course_spec.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: learn_worlds_courses
+#
+#  id          :bigint           not null, primary key
+#  title       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  external_id :string           not null
+#
+# Indexes
+#
+#  index_learn_worlds_courses_on_external_id  (external_id) UNIQUE
+#
+require 'rails_helper'
+
+RSpec.describe LearnWorldsCourse, type: :model do
+  subject { create(:learn_worlds_course) }
+
+  it { should validate_uniqueness_of(:external_id).case_insensitive }
+
+  it { expect(subject).to be_valid }
+end

--- a/services/QuillLMS/spec/models/learn_worlds_course_spec.rb
+++ b/services/QuillLMS/spec/models/learn_worlds_course_spec.rb
@@ -19,7 +19,7 @@ require 'rails_helper'
 RSpec.describe LearnWorldsCourse, type: :model do
   subject { create(:learn_worlds_course) }
 
-  it { should validate_uniqueness_of(:external_id).case_insensitive }
+  it { should validate_uniqueness_of(:external_id) }
 
   it { expect(subject).to be_valid }
 end

--- a/services/QuillLMS/spec/models/learn_worlds_course_spec.rb
+++ b/services/QuillLMS/spec/models/learn_worlds_course_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: learn_worlds_courses

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1782,6 +1782,31 @@ describe User, type: :model do
 
       it { expect(subject).to be_truthy }
     end
+
+    context 'learn_worlds_access override? is true' do
+      before { allow(user).to receive(:learn_worlds_access_override?).and_return(true) }
+
+      it { expect(subject).to be_truthy }
+    end
+  end
+
+  describe '#learn_worlds_access_override?' do
+    subject { user.learn_worlds_access_override? }
+
+    it { expect(subject).to be_falsey }
+
+    context 'override exists' do
+      before do
+        create(
+          :app_setting,
+          name: User::LEARN_WORLDS_ACCESS_OVERRIDE,
+          enabled: true,
+          user_ids_allow_list: [user.id]
+        )
+      end
+
+      it { expect(subject).to be_truthy }
+    end
   end
 
   describe '#generate_default_notification_email_frequency' do

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1799,7 +1799,7 @@ describe User, type: :model do
       before do
         create(
           :app_setting,
-          name: User::LEARN_WORLDS_ACCESS_OVERRIDE,
+          name: AppSetting::LEARN_WORLDS_ACCESS_OVERRIDE,
           enabled: true,
           user_ids_allow_list: [user.id]
         )

--- a/services/QuillLMS/spec/requests/auth/learn_worlds_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/auth/learn_worlds_controller_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Auth::LearnWorldsController do
           before { create(:learn_worlds_account, user: user, external_id: learn_worlds_account_external_id) }
 
           it { expect { subject }.not_to change(user, :learn_worlds_account) }
+          it { expect { subject }.to change { user.learn_worlds_account.last_login } }
         end
       end
     end

--- a/services/QuillLMS/spec/services/learn_worlds_integration/webhooks/course_completed_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/learn_worlds_integration/webhooks/course_completed_event_handler_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LearnWorldsIntegration::Webhooks::CourseCompletedEventHandler do
+  include_context 'LearnWorlds Course Completed Event Data'
+
+  subject { described_class.run(course_completed_event_data) }
+
+  it { expect { subject }.to change { LearnWorldsAccountCourseEvent.completed.count }.by(1) }
+end

--- a/services/QuillLMS/spec/services/learn_worlds_integration/webhooks/earned_certificate_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/learn_worlds_integration/webhooks/earned_certificate_event_handler_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LearnWorldsIntegration::Webhooks::EarnedCertificateEventHandler do
+  include_context 'LearnWorlds Earned Certificate Event Data'
+
+  subject { described_class.run(earned_certificate_event_data) }
+
+  it { expect { subject }.to change { LearnWorldsAccountCourseEvent.earned_certificate.count }.by(1) }
+end

--- a/services/QuillLMS/spec/services/learn_worlds_integration/webhooks/enrolled_free_course_event_handler_spec.rb
+++ b/services/QuillLMS/spec/services/learn_worlds_integration/webhooks/enrolled_free_course_event_handler_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LearnWorldsIntegration::Webhooks::EnrolledFreeCourseEventHandler do
+  include_context 'LearnWorlds Enrolled Free Course Event Data'
+
+  subject { described_class.run(enrolled_free_course_event_data) }
+
+  it { expect { subject }.to change { LearnWorldsAccountCourseEvent.enrolled.count }.by(1) }
+end

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -21,8 +21,6 @@ describe 'SerializeVitallySalesUser' do
   let!(:old_unit_activity) { create(:unit_activity, unit: old_unit, created_at: current_time - 1.year) }
   let!(:student) { create(:user, role: 'student') }
   let!(:old_student) { create(:user, role: 'student') }
-  let!(:learn_worlds_account) { create(:learn_worlds_account, user: teacher) }
-  let!(:learn_worlds_account_course_event) { create(:learn_worlds_account_course_event, learn_worlds_account: learn_worlds_account) }
 
   before do
     create(:activity_classification, key: 'diagnostic')
@@ -394,6 +392,37 @@ describe 'SerializeVitallySalesUser' do
 
     it 'handles nil record #sum_students' do
       expect(vitally_user.send(:sum_students, records)).to eq 3
+    end
+  end
+
+  context 'learnworlds' do
+    subject { SerializeVitallySalesUser.new(teacher).data[:traits] }
+
+    before { create(:learn_worlds_account, user: teacher) }
+
+    let(:learn_worlds_account) { teacher.learn_worlds_account }
+
+    it { expect(subject[:learn_worlds_last_login]).to eq learn_worlds_account.last_login.to_date }
+
+    context 'enrolled courses' do
+      before { create(:learn_worlds_account_enrolled_course_event, learn_worlds_account: learn_worlds_account) }
+
+      it { expect(subject[:learn_worlds_enrolled_courses]).to eq learn_worlds_account.enrolled_courses.titles_string}
+      it { expect(subject[:learn_worlds_num_enrolled_courses]).to eq 1 }
+    end
+
+    context 'completed courses' do
+      before { create(:learn_worlds_account_completed_course_event, learn_worlds_account: learn_worlds_account) }
+
+      it { expect(subject[:learn_worlds_completed_courses]).to eq learn_worlds_account.completed_courses.titles_string }
+      it { expect(subject[:learn_worlds_num_completed_courses]).to eq 1 }
+    end
+
+    context 'earned certificate courses' do
+      before { create(:learn_worlds_account_earned_certificate_course_event, learn_worlds_account: learn_worlds_account) }
+
+      it { expect(subject[:learn_worlds_earned_certificate_courses]).to eq learn_worlds_account.earned_certificate_courses.titles_string }
+      it { expect(subject[:learn_worlds_num_earned_certificate_courses]).to eq 1 }
     end
   end
 end

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -21,6 +21,8 @@ describe 'SerializeVitallySalesUser' do
   let!(:old_unit_activity) { create(:unit_activity, unit: old_unit, created_at: current_time - 1.year) }
   let!(:student) { create(:user, role: 'student') }
   let!(:old_student) { create(:user, role: 'student') }
+  let!(:learn_worlds_account) { create(:learn_worlds_account, user: teacher) }
+  let!(:learn_worlds_account_course_event) { create(:learn_worlds_account_course_event, learn_worlds_account: learn_worlds_account) }
 
   before do
     create(:activity_classification, key: 'diagnostic')

--- a/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/account_course_event_data.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/account_course_event_data.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'LearnWorlds Account Course Event Data' do
+  let(:learn_worlds_course) { create(:learn_worlds_course) }
+  let(:learn_worlds_account) { create(:learn_worlds_account) }
+end

--- a/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/course_completed_event.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/course_completed_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'LearnWorlds Course Completed Event' do
+  include_context 'LearnWorlds Course Completed Event Data'
+
+  let(:course_completed_event) do
+    {
+      "version" => 2,
+      "type" => "courseCompleted",
+      "trigger" => "course_completed",
+      "school_id" => "60004a6de11ac0798538ccc2",
+      "data" => course_completed_event_data
+    }
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/course_completed_event_data.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/course_completed_event_data.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'LearnWorlds Course Completed Event Data' do
+  include_context 'LearnWorlds Account Course Event Data'
+
+  let(:course_completed_event_data) do
+    {
+      "completed_at" => 1637232384.736462,
+      "ip_address" => nil,
+      "manually_completed" => false,
+      "course" => {
+        "access" => "free",
+        "afterPurchase" => nil,
+        "author" => nil,
+        "categories" => [],
+        "courseImage" => nil,
+        "created" => 1637232215.057839,
+        "description" => nil,
+        "discount_price" => 0,
+        "dripFeed" => "none",
+        "expires" => nil,
+        "expiresType" => "weeks",
+        "final_price" => 0,
+        "id" => learn_worlds_course.external_id,
+        "label" => nil,
+        "modified" => 1637232244.922408,
+        "original_price" => 0,
+        "title" => "sample course",
+        "identifiers" => {
+          "google_store_id" => "sample_course",
+          "apple_store_id" => "sample_course"
+        }
+      },
+      "user" => {
+        "created" => 1636463631.488376,
+        "email" => "john@doe.com",
+        "eu_customer" => false,
+        "fields" => {
+          "address" => nil,
+          "behance" => nil,
+          "bio" => "my story",
+          "birthday" => nil,
+          "cf_checkboxtest" => nil,
+          "cf_drop" => nil,
+          "cf_mycustom" => nil,
+          "cf_test" => "123",
+          "company" => nil,
+          "company_size" => nil,
+          "country" => nil,
+          "dribbble" => nil,
+          "fb" => "htttps =>//www.fb.com",
+          "github" => nil,
+          "graduation_year" => "2000",
+          "instagram" => nil,
+          "linkedin" => nil,
+          "location" => "Athens",
+          "phone" => nil,
+          "skype" => nil,
+          "twitter" => "htttps =>//www.twitter.com",
+          "university" => nil,
+          "url" => "https =>//test.com"
+        },
+        "id" => learn_worlds_account.external_id,
+        "is_admin" => false,
+        "is_instructor" => false,
+        "is_reporter" => false,
+        "role" => {
+          "level" => "user",
+          "name" => "User"
+        },
+        "is_affiliate" => true,
+        "last_login" => 1637233550.657523,
+        "signup_approval_status" => "passed",
+        "email_verification_status" => "verified",
+        "referrer_id" => nil,
+        "subscribed_for_marketing_emails" => nil,
+        "tags" => [
+          "testgeo",
+          "hi"
+        ],
+        "username" => "johndoe",
+        "utms" => {
+          "fc_landing" => "/",
+          "lc_landing" => "/"
+        },
+        "billing_info" => {
+          "bf_name" => "Sherlock Holmes",
+          "bf_address" => "Baker Street 221B",
+          "bf_city" => "London",
+          "bf_postalcode" => "NW1",
+          "bf_country" => "UK",
+          "bf_taxid" => nil
+        },
+        "nps_score" => 9,
+        "nps_comment" => "Fantastic learning resources."
+      }
+    }
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/earned_certificate_event.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/earned_certificate_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'LearnWorlds Earned Certificate Event' do
+  include_context 'LearnWorlds Earned Certificate Event Data'
+
+  let(:earned_certificate_event) do
+    {
+      "version" => 2,
+      "type" => "awardedCertificate",
+      "trigger" => "certificate_awarded",
+      "school_id" => "60004a6de11ac0798538ccc2",
+      "data" => earned_certificate_event_data
+    }
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/earned_certificate_event_data.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/earned_certificate_event_data.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'LearnWorlds Earned Certificate Event Data' do
+  include_context 'LearnWorlds Account Course Event Data'
+
+  let(:earned_certificate_event_data) do
+    {
+      "certificate" => {
+        "attempts" => 0,
+        "course_id" => learn_worlds_course.external_id,
+        "form" => {
+          "firstname" => "John",
+          "lastname" => "Doe",
+          "ptin" => "123456"
+        },
+        "id" => "619600bfec57735ec64a6b39",
+        "issued" => 1637220543.671415,
+        "score" => "OK",
+        "short_url" => false,
+        "status" => "active",
+        "title" => "Cert of Completion",
+        "type" => "completion",
+        "user" => {
+          "email" => "john@doe.com",
+          "id" => "618e6db9cfb2226fe229d927"
+        }
+      },
+      "ip_address" => nil,
+      "user" => {
+        "created" => 1644228530.45123,
+        "email" => "john@doe.com",
+        "eu_customer" => false,
+        "fields" => {
+          "address" => nil,
+          "behance" => nil,
+          "bio" => nil,
+          "birthday" => nil,
+          "company" => nil,
+          "company_size" => nil,
+          "country" => nil,
+          "dribbble" => nil,
+          "fb" => nil,
+          "github" => nil,
+          "graduation_year" => nil,
+          "instagram" => nil,
+          "linkedin" => nil,
+          "location" => nil,
+          "phone" => nil,
+          "skype" => nil,
+          "twitter" => nil,
+          "university" => nil,
+          "url" => nil
+        },
+        "id" => learn_worlds_account.external_id,
+        "is_admin" => false,
+        "is_affiliate" => false,
+        "is_instructor" => false,
+        "is_reporter" => false,
+        "role" => {
+          "level" => "user",
+          "name" => "User"
+        },
+        "last_login" => 1646146990.079593,
+        "signup_approval_status" => "passed",
+        "email_verification_status" => "verified",
+        "referrer_id" => nil,
+        "subscribed_for_marketing_emails" => nil,
+        "tags" => [],
+        "username" => "JohnDoe",
+        "utms" => {
+          "fc_landing" => "/",
+          "lc_landing" => "/"
+        },
+        "billing_info" => {
+          "bf_name" => "Sherlock Holmes",
+          "bf_address" => "Baker Street 221B",
+          "bf_city" => "London",
+          "bf_postalcode" => "NW1",
+          "bf_country" => "UK",
+          "bf_taxid" => nil
+        },
+        "nps_score" => 9,
+        "nps_comment" => "Fantastic learning resources."
+      }
+    }
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/enrolled_free_course_event.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/enrolled_free_course_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'LearnWorlds Enrolled Free Course Event' do
+  include_context 'LearnWorlds Enrolled Free Course Event Data'
+
+  let(:enrolled_free_course_event) do
+    {
+      "version" => 2,
+      "type" => "enrolledFreeCourse",
+      "trigger" => "enrolled_free",
+      "school_id" => "60004a6de11ac0798538ccc2",
+      "data" => enrolled_free_course_event_data
+    }
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/enrolled_free_course_event_data.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/enrolled_free_course_event_data.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'LearnWorlds Enrolled Free Course Event Data' do
+  include_context 'LearnWorlds Account Course Event Data'
+
+  let(:enrolled_free_course_event_data) do
+    {
+      "ip_address" => nil,
+      "date" => 1638190255,
+      "course" => {
+        "access" => "free",
+        "afterPurchase" => nil,
+        "author" => nil,
+        "categories" => [],
+        "courseImage" => nil,
+        "created" => 1637232215.057839,
+        "description" => nil,
+        "discount_price" => 0,
+        "dripFeed" => "none",
+        "expires" => nil,
+        "expiresType" => "weeks",
+        "final_price" => 0,
+        "id" => learn_worlds_course.external_id,
+        "label" => nil,
+        "modified" => 1637232244.922408,
+        "original_price" => 0,
+        "title" => "sample course",
+        "identifiers" => {
+          "google_store_id" => "sample_course",
+          "apple_store_id" => "sample_course"
+        }
+      },
+      "user" => {
+        "created" => 1636724153.189269,
+        "email" => "john@doe.com",
+        "eu_customer" => false,
+        "fields" => {
+          "address" => nil,
+          "behance" => nil,
+          "bio" => "my story",
+          "birthday" => nil,
+          "company" => nil,
+          "company_size" => nil,
+          "country" => nil,
+          "dribbble" => nil,
+          "fb" => nil,
+          "github" => nil,
+          "graduation_year" => "2000-10-10",
+          "instagram" => nil,
+          "linkedin" => nil,
+          "location" => "Athens",
+          "phone" => nil,
+          "skype" => nil,
+          "twitter" => "htttps =>//www.twitter.com",
+          "university" => nil,
+          "url" => "https =>//test.com"
+        },
+        "id" => learn_worlds_account.external_id,
+        "is_admin" => false,
+        "is_instructor" => false,
+        "is_reporter" => false,
+        "role" => {
+          "level" => "user",
+          "name" => "User"
+        },
+        "is_affiliate" => true,
+        "last_login" => 1637222305.3564,
+        "signup_approval_status" => "passed",
+        "email_verification_status" => "verified",
+        "referrer_id" => nil,
+        "subscribed_for_marketing_emails" => nil,
+        "tags" => [
+          "testgeo",
+          "test2geo"
+        ],
+        "username" => "johndoe",
+        "utms" => {
+          "fc_campaign" => "WOW campaign",
+          "fc_content" => nil,
+          "fc_country" => nil,
+          "fc_landing" => "/",
+          "fc_medium" => "FB",
+          "fc_referrer" => nil,
+          "fc_source" => "Facebook",
+          "fc_term" => nil,
+          "lc_campaign" => nil,
+          "lc_content" => nil,
+          "lc_country" => nil,
+          "lc_landing" => "/",
+          "lc_medium" => nil,
+          "lc_referrer" => nil,
+          "lc_source" => nil,
+          "lc_term" => nil
+        },
+        "billing_info" => {
+          "bf_name" => "Sherlock Holmes",
+          "bf_address" => "Baker Street 221B",
+          "bf_city" => "London",
+          "bf_postalcode" => "NW1",
+          "bf_country" => "UK",
+          "bf_taxid" => nil
+        },
+        "nps_score" => 9,
+        "nps_comment" => "Fantastic learning resources."
+      }
+    }
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/enrolled_free_course_event_data.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/learn_worlds_integration/enrolled_free_course_event_data.rb
@@ -24,7 +24,7 @@ RSpec.shared_context 'LearnWorlds Enrolled Free Course Event Data' do
         "label" => nil,
         "modified" => 1637232244.922408,
         "original_price" => 0,
-        "title" => "sample course",
+        "title" => learn_worlds_course.title,
         "identifiers" => {
           "google_store_id" => "sample_course",
           "apple_store_id" => "sample_course"


### PR DESCRIPTION
## WHAT
1. Persist LearnWorlds data on Quill
2. Handle LearnWorlds webhooks for various course events
3. Sync data with Vitally

## WHY
Sales/Partnerships team is interested how LearnWorlds is being used

## HOW
1.  Create LearnWorldsCourse: stores the course title and LearnWorldsAccountCourseEvent: links LearnWorldsAccount with LearnWorlds course along with the event type
2.  Add Webhooks handler that for each of the three types: enrolled, completed and earned certificate
3.  Add user info about the enrolled, completed and earned certificate courses to the vitally sync

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Send-data-from-Learnworlds-Quill-via-API-Vitally-5fd55ec9ed1b43a0a43108790ef6445c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
