### PR TITLE
Fix visual bug in Google import modal

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -1026,7 +1026,7 @@
       height: 94px;
       position: relative;
       .unacknowledged {
-        margin-top: 62px;
+        margin-top: 48px;
         z-index: 2;
         .dropdown {
           margin-bottom: 6px;
@@ -1040,16 +1040,6 @@
       .error-text {
         white-space: normal;
       }
-    }
-    .data-table-row.error.checked::after {
-      background-color: white;
-      content: '';
-      position: absolute;
-      top: 47px;
-      left: 0px;
-      right: 0px;
-      height: 46px;
-      z-index: 0;
     }
     .show-overflow {
       overflow: visible;


### PR DESCRIPTION
## WHAT
fix visual bug in Google import modal where classes with no grade selected was causing it to look janky

## WHY
we want this to display cleanly

## HOW
just update some CSS

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1431" alt="Screen Shot 2023-05-24 at 4 44 06 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/b1195042-f582-4ae9-a754-f4fdf62090bb">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Visual-bugs-in-Google-import-modal-d98ba81aab164a248ce7c344bc4d12d1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
