### PR TITLE
Add learn_worlds_access_override for test account

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -109,6 +109,8 @@ class User < ApplicationRecord
 
   SCHOOL_CHANGELOG_ATTRIBUTE = 'school_id'
 
+  LEARN_WORLDS_ACCESS_OVERRIDE = 'learn_worlds_access_override'
+
   attr_accessor :validate_username, :require_password_confirmation_when_password_present, :newsletter
 
   has_secure_password validations: false
@@ -793,7 +795,11 @@ class User < ApplicationRecord
   end
 
   def learn_worlds_access?
-    school_premium? || district_premium?
+    school_premium? || district_premium? || learn_worlds_access_override?
+  end
+
+  def learn_worlds_access_override?
+    AppSetting.enabled?(name: LEARN_WORLDS_ACCESS_OVERRIDE, user: self)
   end
 
   def school_premium?

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1782,6 +1782,30 @@ describe User, type: :model do
 
       it { expect(subject).to be_truthy }
     end
+
+    context 'learn_worlds_access override? is true' do
+      before { allow(user).to receive(:learn_worlds_access_override?).and_return(true) }
+      it { expect(subject).to be_truthy }
+    end
+  end
+
+  describe '#learn_worlds_access_override?' do
+    subject { user.learn_worlds_access_override? }
+
+    it { expect(subject).to be_falsey }
+
+    context 'override exists' do
+      before do
+        create(
+          :app_setting,
+          name: User::LEARN_WORLDS_ACCESS_OVERRIDE,
+          enabled: true,
+          user_ids_allow_list: [user.id]
+        )
+      end
+
+      it { expect(subject).to be_truthy }
+    end
   end
 
   describe '#generate_default_notification_email_frequency' do

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1785,6 +1785,7 @@ describe User, type: :model do
 
     context 'learn_worlds_access override? is true' do
       before { allow(user).to receive(:learn_worlds_access_override?).and_return(true) }
+
       it { expect(subject).to be_truthy }
     end
   end


### PR DESCRIPTION
## WHAT
Add an override app setting for learn_worlds_access to be used with a test account

## WHY
This allows us to get around the check for school or district premium access that is required for learn worlds

# HOW
Create the app setting: `rake app_settings:create[learn_worlds_access_override,true,true,0,[#insert-test-account-id-here]` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
