### PR TITLE
Fix user_ids_allow_list setting for rake task

### DIFF
--- a/services/QuillLMS/lib/tasks/app_settings.rake
+++ b/services/QuillLMS/lib/tasks/app_settings.rake
@@ -3,13 +3,15 @@
 namespace :app_settings do
   desc 'Creates a new AppSetting.'
   # Example usage: rake 'app_settings:create[theName,true,true,50,[]]'
+  # To pass user_ids to the allow list, separate ids with spaces instead of commas
+  # Example usage: rake 'app_settings:create[theName,true,true,50,[1 5]]'
   task :create, [:name, :enabled, :enabled_for_staff, :percent_active, :user_ids_allow_list] => :environment do |t, args|
     app_setting = AppSetting.create!(
       name: args[:name],
       enabled: args[:enabled],
       enabled_for_staff: args[:enabled_for_staff],
       percent_active: args[:percent_active],
-      user_ids_allow_list: args[:user_ids_allow_list]
+      user_ids_allow_list: JSON.parse(args[:user_ids_allow_list].tr(' ',','))
     )
     puts "AppSetting with name #{app_setting.name} created."
   end


### PR DESCRIPTION
## WHAT
Allow for setting of  user_ids_allow_list with the `app_setting:create` rake task

## WHY
Rake has [trouble](https://groups.google.com/g/boston-rubygroup/c/wDfsKR7aEgo/m/1YmJzv5fnCQJ) parsing array arguments containing commas.

## HOW
Instruct users to use spaces instead of commas and then replace spaces with commas and do JSON.parse to deserialize the array.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | No.
Self-Review: Have you done an initial self-review of the code below on Github? | No.
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
