### PR TITLE
Make evidence factories visible in LMS for testing

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # require_relative '../quill_scaffold_controller'
-require 'factory_bot_rails'
+require 'factory_bot_rails' unless Rails.env.production?
 
 module Evidence
   class Engine < ::Rails::Engine
@@ -23,8 +23,10 @@ module Evidence
       g.fallbacks[:shoulda] = :test_unit
     end
 
-    initializer "evidence.factories", after: "factory_bot.set_factory_paths" do
-      FactoryBot.definition_file_paths << File.expand_path('../../../spec/factories/evidence', __FILE__) if defined?(FactoryBot)
+    unless Rails.env.production?
+      initializer "evidence.factories", after: "factory_bot.set_factory_paths" do
+        FactoryBot.definition_file_paths << File.expand_path('../../../spec/factories/evidence', __FILE__)
+      end
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 # require_relative '../quill_scaffold_controller'
+require 'factory_bot_rails'
+
 module Evidence
   class Engine < ::Rails::Engine
     config.eager_load_paths += %W{#{config.root}/lib/evidence}
@@ -19,6 +21,10 @@ module Evidence
       g.template_engine nil
 
       g.fallbacks[:shoulda] = :test_unit
+    end
+
+    initializer "evidence.factories", after: "factory_bot.set_factory_paths" do
+      FactoryBot.definition_file_paths << File.expand_path('../../../spec/factories/evidence', __FILE__) if defined?(FactoryBot)
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/rails_helper.rb
+++ b/services/QuillLMS/engines/evidence/spec/rails_helper.rb
@@ -58,10 +58,6 @@ RSpec.configure do |config|
   config.filter_run_excluding benchmarking: true
 end
 
-factory_files = Dir.glob('spec/factories/evidence/*')
-
-factory_files.each {|f| require File.expand_path(File.join(Rails.root, '..', '..', f))}
-
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec

--- a/services/QuillLMS/engines/evidence/spec/spec_helper.rb
+++ b/services/QuillLMS/engines/evidence/spec/spec_helper.rb
@@ -3,7 +3,6 @@
 require 'simplecov'
 require 'simplecov-json'
 require 'webmock/rspec'
-require 'factory_bot_rails'
 WebMock.disable_net_connect!
 
 

--- a/services/QuillLMS/spec/controllers/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activities_controller_spec.rb
@@ -182,10 +182,10 @@ describe ActivitiesController, type: :controller, redis: true do
   end
 
   describe '#suggested_activities' do
-    let!(:production_activity1) { create(:evidence_activity, flags: [Flags::PRODUCTION])}
-    let!(:production_activity2) { create(:evidence_activity, flags: [Flags::PRODUCTION])}
-    let!(:beta2_activity) { create(:evidence_activity, flags: [Flags::EVIDENCE_BETA2])}
-    let!(:beta1_activity) { create(:evidence_activity, flags: [Flags::EVIDENCE_BETA1])}
+    let!(:production_activity1) { create(:evidence_lms_activity, flags: [Flags::PRODUCTION])}
+    let!(:production_activity2) { create(:evidence_lms_activity, flags: [Flags::PRODUCTION])}
+    let!(:beta2_activity) { create(:evidence_lms_activity, flags: [Flags::EVIDENCE_BETA2])}
+    let!(:beta1_activity) { create(:evidence_lms_activity, flags: [Flags::EVIDENCE_BETA1])}
     let(:teacher_info) { create(:teacher_info, minimum_grade_level: 9, maximum_grade_level: 12)}
     let(:user) { create(:user, flagset: Flags::PRODUCTION, teacher_info: teacher_info)}
 
@@ -193,7 +193,7 @@ describe ActivitiesController, type: :controller, redis: true do
       Evidence::Activity.create(parent_activity_id: production_activity1.id, notes: "notes", title: "title")
       Evidence::Activity.create(parent_activity_id: production_activity2.id, notes: "notes", title: "title")
       Evidence::Activity.create(parent_activity_id: beta1_activity.id, notes: "notes", title: "title")
-      Evidence::Activity.create(parent_activity_id: beta2_activity.id, notes: "notes", title: "title")
+      create(:evidence_activity, parent_activity_id: beta2_activity.id, notes: "notes", title: "title")
       allow(controller).to receive(:current_user) { user }
     end
 

--- a/services/QuillLMS/spec/controllers/api/v1/evidence_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/evidence_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Evidence::ActivitiesController, :type => :controller do
   routes { Evidence::Engine.routes }
 
   it "hits the correct engine endpoint and renders json" do
-    activity = Evidence::Activity.create(notes: "some notes", title: "some title", target_level: 5, parent_activity_id: 1)
+    activity = create(:evidence_activity, notes: "some notes", title: "some title", target_level: 5, parent_activity_id: 1)
 
     get :show, params: { id: activity.id }, as: :json
     expect(response.status).to eq(200)

--- a/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
@@ -93,8 +93,8 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     end
 
     it "should set prompt_type to Evidence::Prompt if prompt_id is provided" do
-      activity = Evidence::Activity.create(target_level: 1, title: 'Test Activity Title')
-      prompt = Evidence::Prompt.create(activity: activity, text: 'Test prompt text', conjunction: 'but')
+      activity = create(:evidence_activity, target_level: 1, title: 'Test Activity Title')
+      prompt = create(:evidence_prompt, activity: activity, text: 'Test prompt text', conjunction: 'but')
       post :create,
         params: {
           feedback_history: {
@@ -151,8 +151,8 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
     end
 
     it "should attach include prompt model if attached" do
-      activity = Evidence::Activity.create(target_level: 1, title: 'Test Activity Title')
-      prompt = Evidence::Prompt.create(activity: activity, text: 'Test prompt text', conjunction: 'but')
+      activity = create(:evidence_activity, target_level: 1, title: 'Test Activity Title')
+      prompt = create(:evidence_prompt, activity: activity, text: 'Test prompt text', conjunction: 'but')
       feedback_history = build(:feedback_history)
       feedback_history.prompt = prompt
       feedback_history.save

--- a/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
@@ -62,7 +62,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
       it 'should return successfully' do
         main_activity = create(:activity)
 
-        prompt = Evidence::Prompt.create!(
+        prompt = create(:evidence_prompt,
           text: 'foobarbazbat',
           conjunction: 'so',
           activity: main_activity,
@@ -94,7 +94,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
       it 'should return successfully' do
         main_activity = create(:activity)
 
-        prompt = Evidence::Prompt.create!(
+        prompt = create(:evidence_prompt,
           text: 'foobarbazbat',
           conjunction: 'so',
           activity: main_activity,

--- a/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
@@ -58,8 +58,8 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
 
       context 'activity_id' do
         before do
-          @activity = Evidence::Activity.create!(notes: 'Title 1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
-          @prompt = Evidence::Prompt.create!(activity: @activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+          @activity = create(:evidence_activity, notes: 'Title 1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
+          @prompt = create(:evidence_prompt, activity: @activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
           create_list(:feedback_history, 10, prompt: @prompt)
           create_list(:feedback_history, 10)
         end
@@ -177,10 +177,10 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
         end
 
         it 'should retrieve only complete sessions when filter_type is complete' do
-          activity = Evidence::Activity.create!(notes: 'Title 1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
-          because_prompt = Evidence::Prompt.create!(activity: activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-          but_prompt = Evidence::Prompt.create!(activity: activity, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-          so_prompt = Evidence::Prompt.create!(activity: activity, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+          activity = create(:evidence_activity, notes: 'Title 1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
+          because_prompt = create(:evidence_prompt, activity: activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+          but_prompt = create(:evidence_prompt, activity: activity, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+          so_prompt = create(:evidence_prompt, activity: activity, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
           activity_session = create(:activity_session)
           feedback_history3 = create(:feedback_history, feedback_session_uid: activity_session.uid, prompt: because_prompt, optimal: true)
           feedback_history4 = create(:feedback_history, feedback_session_uid: activity_session.uid, prompt: but_prompt, optimal: true)
@@ -218,7 +218,7 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
 
   context "email_csv_data" do
     let!(:user) { create(:user)}
-    let!(:activity) { create(:evidence_activity) }
+    let!(:activity) { create(:evidence_lms_activity) }
 
     before { allow(controller).to receive(:current_user) { user } }
 

--- a/services/QuillLMS/spec/controllers/cms/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/activities_controller_spec.rb
@@ -135,7 +135,7 @@ describe Cms::ActivitiesController, type: :controller do
 
     it 'should create a change log record if the activity is an evidence activity and the flag was updated' do
       parent_activity = create(:activity, activity_classification_id: ActivityClassification.find_by_key("evidence").id, flags: ["beta"])
-      evidence_activity = Evidence::Activity.create!(parent_activity_id: parent_activity.id, title: "This is a test evidence activity", notes: "notes")
+      evidence_activity = create(:evidence_activity, parent_activity_id: parent_activity.id, title: "This is a test evidence activity", notes: "notes")
       put :update, params: { id: parent_activity.id, activity_classification_id: parent_activity.activity_classification_id, activity: {flags: ["alpha"]} }
 
       change_log = Evidence.change_log_class.last

--- a/services/QuillLMS/spec/factories/activities.rb
+++ b/services/QuillLMS/spec/factories/activities.rb
@@ -87,10 +87,10 @@ FactoryBot.define do
       end
     end
 
-    factory :evidence_activity do
-      classification { ActivityClassification.find_by_key(attributes_for(:evidence)[:key]) || create(:evidence) }
-      activity_classification_id { ActivityClassification.find_by_key(attributes_for(:evidence)[:key])&.id || create(:evidence).id }
-    end
+    # factory :evidence_activity do
+    #   classification { ActivityClassification.find_by_key(attributes_for(:evidence)[:key]) || create(:evidence) }
+    #   activity_classification_id { ActivityClassification.find_by_key(attributes_for(:evidence)[:key])&.id || create(:evidence).id }
+    # end
 
     trait :production do
       flags ['production']

--- a/services/QuillLMS/spec/factories/activities.rb
+++ b/services/QuillLMS/spec/factories/activities.rb
@@ -87,10 +87,10 @@ FactoryBot.define do
       end
     end
 
-    # factory :evidence_activity do
-    #   classification { ActivityClassification.find_by_key(attributes_for(:evidence)[:key]) || create(:evidence) }
-    #   activity_classification_id { ActivityClassification.find_by_key(attributes_for(:evidence)[:key])&.id || create(:evidence).id }
-    # end
+    factory :evidence_lms_activity do
+      classification { ActivityClassification.find_by_key(attributes_for(:evidence)[:key]) || create(:evidence) }
+      activity_classification_id { ActivityClassification.find_by_key(attributes_for(:evidence)[:key])&.id || create(:evidence).id }
+    end
 
     trait :production do
       flags ['production']

--- a/services/QuillLMS/spec/factories/activity_sessions.rb
+++ b/services/QuillLMS/spec/factories/activity_sessions.rb
@@ -105,7 +105,7 @@ FactoryBot.define do
     end
 
     factory :evidence_activity_session do
-      activity { create(:evidence_activity) }
+      activity { create(:evidence_lms_activity) }
       # We explicitly don't record percentages for Evidence sessions
       percentage { nil }
     end

--- a/services/QuillLMS/spec/factories/unit_activities.rb
+++ b/services/QuillLMS/spec/factories/unit_activities.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
     end
 
     trait :evidence_unit_activity do
-      activity { create(:evidence_activity, :production) }
+      activity { create(:evidence_lms_activity, :production) }
     end
   end
 end

--- a/services/QuillLMS/spec/lib/universal_rule_loader_spec.rb
+++ b/services/QuillLMS/spec/lib/universal_rule_loader_spec.rb
@@ -4,32 +4,6 @@ require 'rails_helper'
 
 RSpec.describe UniversalRuleLoader do
 
-  def rule_factory(&hash_block)
-    Evidence::Rule.create!(
-      {
-        uid: SecureRandom.uuid,
-        name: 'name',
-        universal: true,
-        suborder: 1,
-        rule_type: Evidence::Rule::TYPES.first,
-        optimal: true,
-        concept_uid: SecureRandom.uuid,
-        state: Evidence::Rule::STATES.first
-      }.merge(yield)
-    )
-  end
-
-  def feedback_factory(&hash_block)
-    Evidence::Feedback.create!(
-      {
-        rule: rule_factory { {} },
-        text: 'Feedback string',
-        description: 'Internal description of feedback',
-        order: 1
-      }.merge(yield)
-    )
-  end
-
   describe '#update_from_csv' do
     context 'grammar rules' do
       let(:rule_type) { 'grammar' }
@@ -69,7 +43,7 @@ RSpec.describe UniversalRuleLoader do
       end
 
       it 'should not create a rule when a rule exists that is not universal or grammar' do
-        rule = rule_factory { { uid: 'abc6a', rule_type: rule_type, universal: false } }
+        rule = create(:evidence_rule, uid: 'abc6a', rule_type: rule_type, universal: false)
         expect do
           UniversalRuleLoader.update_from_csv(type: rule_type, iostream: csv3)
         end.to change { Evidence::Rule.count }.by(0)
@@ -78,8 +52,8 @@ RSpec.describe UniversalRuleLoader do
 
 
       it 'should update existing rule and update feedback' do
-        rule = rule_factory { { uid: '1d66a', rule_type: rule_type, universal: true } }
-        feedback_factory { { rule: rule, order: 0 } }
+        rule = create(:evidence_rule, uid: '1d66a', rule_type: rule_type, universal: true)
+        create(:evidence_feedback, rule: rule, order: 0)
 
         expect do
           UniversalRuleLoader.update_from_csv(type: rule_type, iostream: csv1)

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -113,8 +113,8 @@ describe Activity, type: :model, redis: true do
       end
 
       describe 'activity is evidence and the flag is being changed' do
-        let!(:evidence_activity) { create(:evidence_activity, flag: 'alpha') }
-        let!(:child_activity) { Evidence::Activity.create(title: "this is a child activity", notes: "note", parent_activity_id: evidence_activity.id)}
+        let!(:evidence_activity) { create(:evidence_lms_activity, flag: 'alpha') }
+        let!(:child_activity) { create(:evidence_activity, title: "this is a child activity", notes: "note", parent_activity_id: evidence_activity.id)}
         let!(:staff_user) { create(:user, role: 'staff') }
 
         before do
@@ -249,7 +249,7 @@ describe Activity, type: :model, redis: true do
       classification = build(:activity_classification, key: 'evidence')
       classified_activity = create(:activity, classification: classification)
       activity_session = build(:activity_session)
-      comp_activity = Evidence::Activity.create!(parent_activity_id: classified_activity.id,
+      comp_activity = create(:evidence_activity, parent_activity_id: classified_activity.id,
         target_level: 12,
         title: 'Test Evidence Activity',
         notes: 'Test Evidence Activity')
@@ -284,7 +284,7 @@ describe Activity, type: :model, redis: true do
     it "must use the evidence_url_helper when the classification.key is 'evidence'" do
       classification = build(:activity_classification, key: 'evidence')
       classified_activity = create(:activity, classification: classification)
-      comp_activity = Evidence::Activity.create!(parent_activity_id: classified_activity.id,
+      comp_activity = create(:evidence_activity, parent_activity_id: classified_activity.id,
         target_level: 12,
         title: 'Test Evidence Activity',
         notes: 'Test Evidence Activity')
@@ -645,7 +645,7 @@ describe Activity, type: :model, redis: true do
     end
 
     it 'should return a Evidence::Activity if one has the LMS Activity.id as its parent_activity_id' do
-      comp_activity = Evidence::Activity.create!(title: 'Old Title', notes: 'Some notes', target_level: 1, parent_activity_id: activity.id)
+      comp_activity = create(:evidence_activity, title: 'Old Title', notes: 'Some notes', target_level: 1, parent_activity_id: activity.id)
       expect(activity.child_activity).to eq(comp_activity)
     end
   end
@@ -656,7 +656,7 @@ describe Activity, type: :model, redis: true do
 
     it 'should update the child activity title to the name value' do
       new_name = 'A new name'
-      comp_activity = Evidence::Activity.create!(title: 'Old Title', notes: 'Some notes', target_level: 1, parent_activity_id: activity.id)
+      comp_activity = create(:evidence_activity, title: 'Old Title', notes: 'Some notes', target_level: 1, parent_activity_id: activity.id)
       activity.update(name: new_name)
       comp_activity.reload
       expect(comp_activity.title).to eq(new_name)
@@ -670,7 +670,7 @@ describe Activity, type: :model, redis: true do
   context 'a test that belongs in Comprehension that we need here because the engine stubs the LMS Activity model, and we need them both to behave as if real' do
     describe '#Evidence::Activity.update_parent_activity_name' do
       let(:activity) { create(:activity) }
-      let(:comp_activity) { Evidence::Activity.create!(title: 'Old Title', notes: 'Some notes', target_level: 1, parent_activity_id: activity.id) }
+      let(:comp_activity) {create(:evidence_activity, title: 'Old Title', notes: 'Some notes', target_level: 1, parent_activity_id: activity.id) }
 
       it 'should update the parent_activity.name when the comprehension activity.title is updated' do
         new_title = 'New Title'
@@ -737,8 +737,8 @@ describe Activity, type: :model, redis: true do
   describe '#publication_date' do
     context 'when the activity has no associated flag change log' do
       it 'returns the created_at date of that activity' do
-        activity = create(:evidence_activity, created_at: Time.zone.today - 10.days)
-        Evidence::Activity.create(parent_activity: activity, title: "title", notes: "notes")
+        activity = create(:evidence_lms_activity, created_at: Time.zone.today - 10.days)
+        create(:evidence_activity, parent_activity: activity, title: "title", notes: "notes")
 
         expect(activity.publication_date).to eq(activity.created_at.strftime("%m/%d/%Y"))
       end
@@ -746,8 +746,8 @@ describe Activity, type: :model, redis: true do
 
     context 'when the activity has an associated flag change log' do
       it 'returns the created_at date of the last flag change' do
-        activity = create(:evidence_activity)
-        evidence_activity = Evidence::Activity.create(parent_activity: activity, title: "title", notes: "notes")
+        activity = create(:evidence_lms_activity)
+        evidence_activity = create(:evidence_activity, parent_activity: activity, title: "title", notes: "notes")
         change_log = create(:change_log, created_at: Time.zone.today - 20.days, changed_attribute: Activity::FLAGS_ATTRIBUTE, changed_record: evidence_activity)
 
         expect(activity.publication_date).to eq(change_log.created_at.strftime("%m/%d/%Y"))
@@ -758,8 +758,8 @@ describe Activity, type: :model, redis: true do
   describe '#serialize_with_topics_and_publication_date' do
     it 'returns the serialized activity hash with topics genealogy and publication date added' do
       topic = create(:topic, level: 1)
-      activity = create(:evidence_activity, topics: [topic])
-      evidence_activity = Evidence::Activity.create(parent_activity: activity, title: "title", notes: "notes")
+      activity = create(:evidence_lms_activity, topics: [topic])
+      evidence_activity = create(:evidence_activity, parent_activity: activity, title: "title", notes: "notes")
       change_log = create(:change_log, created_at: Time.zone.today - 20.days, changed_attribute: Activity::FLAGS_ATTRIBUTE, changed_record: evidence_activity)
 
       serialized_hash = activity.serialize_with_topics_and_publication_date

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -13,7 +13,7 @@ describe PublicProgressReports, type: :model do
   end
 
   describe '#results_by_question' do
-    let!(:activity) { create(:evidence_activity) }
+    let!(:activity) { create(:evidence_lms_activity) }
 
     it 'should return an empty array when questions array is empty' do
       report = FakeReports.new
@@ -24,7 +24,7 @@ describe PublicProgressReports, type: :model do
 
   describe '#results_for_classroom' do
     let!(:classroom) { create(:classroom) }
-    let!(:activity) { create(:evidence_activity) }
+    let!(:activity) { create(:evidence_lms_activity) }
     let!(:classroom_unit) { create(:classroom_unit, classroom: classroom, assign_on_join: true) }
     let!(:students_classrooms1) { create(:students_classrooms, classroom: classroom)}
     let!(:students_classrooms2) { create(:students_classrooms, classroom: classroom)}
@@ -62,9 +62,9 @@ describe PublicProgressReports, type: :model do
 
     it 'populates feedback for an evidence activity' do
       activity_session_two = create(:activity_session_without_concept_results, classroom_unit_id: classroom_unit.id, activity_id: activity.id, user: students_classrooms1.student)
-      prompt = Evidence::Prompt.create(text: "prompt text", conjunction: "but")
+      prompt = create(:evidence_prompt, text: "prompt text", conjunction: "but")
       feedback = "This is the current feedback the student is receiving."
-      evidence_child_activity = Evidence::Activity.create(parent_activity_id: activity.id, prompts: [prompt], target_level: 1, title: "test activity", notes: "note")
+      evidence_child_activity = create(:evidence_activity, parent_activity_id: activity.id, prompts: [prompt], target_level: 1, title: "test activity", notes: "note")
       feedback_history = create(:feedback_history, feedback_session_uid: activity_session_two.uid, attempt: 2, prompt: prompt, feedback_text: feedback)
 
       last_feedback = "This is the last feedback the student received."

--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe FeedbackHistory, type: :model do
 
   context 'concept results hash' do
     before do
-      @prompt = Evidence::Prompt.create(text: 'Test test test text')
-      @activity = create(:evidence_activity)
+      @prompt = create(:evidence_prompt, text: 'Test test test text')
+      @activity = create(:evidence_lms_activity)
       @activity_session = create(:activity_session, activity_id: @activity.id)
       @concept = create(:concept)
       @feedback_history = create(:feedback_history, feedback_session_uid: @activity_session.uid, concept: @concept, prompt: @prompt)
@@ -114,7 +114,7 @@ RSpec.describe FeedbackHistory, type: :model do
 
   context 'serializable_hash' do
     before do
-      @prompt = Evidence::Prompt.create(text: 'Test text')
+      @prompt = create(:evidence_prompt)
       @feedback_history = create(:feedback_history, prompt: @prompt)
     end
 
@@ -414,14 +414,14 @@ RSpec.describe FeedbackHistory, type: :model do
 
   context 'Session-aggregate FeedbackHistories' do
     before do
-      @activity1 = Evidence::Activity.create!(notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
-      @activity2 = Evidence::Activity.create!(notes: 'Title_2', title: 'Title 2', parent_activity_id: 2, target_level: 1)
-      @because_prompt1 = Evidence::Prompt.create!(activity: @activity1, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-      @because_prompt2 = Evidence::Prompt.create!(activity: @activity2, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-      @but_prompt1 = Evidence::Prompt.create!(activity: @activity1, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-      @but_prompt2 = Evidence::Prompt.create!(activity: @activity2, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-      @so_prompt1 = Evidence::Prompt.create!(activity: @activity1, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-      @so_prompt2 = Evidence::Prompt.create!(activity: @activity2, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+      @activity1 = create(:evidence_activity, parent_activity_id: 1)
+      @activity2 = create(:evidence_activity, parent_activity_id: 2)
+      @because_prompt1 = create(:evidence_prompt, activity: @activity1, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+      @because_prompt2 = create(:evidence_prompt, activity: @activity2, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+      @but_prompt1 = create(:evidence_prompt, activity: @activity1, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+      @but_prompt2 = create(:evidence_prompt, activity: @activity2, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+      @so_prompt1 = create(:evidence_prompt, activity: @activity1, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+      @so_prompt2 = create(:evidence_prompt, activity: @activity2, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
 
       @activity_session1_uid = SecureRandom.uuid
       @feedback_session1_uid = FeedbackSession.get_uid_for_activity_session(@activity_session1_uid)
@@ -643,7 +643,7 @@ RSpec.describe FeedbackHistory, type: :model do
 
     context '#most_recent_rating' do
       before do
-        @prompt = Evidence::Prompt.create(text: 'Test text')
+        @prompt = create(:evidence_prompt)
         @feedback_history = create(:feedback_history, prompt: @prompt)
         @user1 = create(:user)
         @user2 = create(:user)

--- a/services/QuillLMS/spec/queries/activity_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/queries/activity_feedback_history_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe ActivityFeedbackHistory, type: :model do
 
   before do
-    @main_activity = Evidence::Activity.create!(notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
-    @prompt1 = Evidence::Prompt.create!(activity: @main_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+    @main_activity = create(:evidence_activity, notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
+    @prompt1 = create(:evidence_prompt, activity: @main_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
   end
 
   describe '#activity_stats_query' do

--- a/services/QuillLMS/spec/queries/prompt_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/queries/prompt_feedback_history_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe PromptFeedbackHistory, type: :model do
   # rubocop:enable Metrics/ParameterLists
 
   before do
-    @main_activity = Evidence::Activity.create!(notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
-    @unused_activity = Evidence::Activity.create!(notes: 'Title_2', title: 'Title 2', parent_activity_id: 2, target_level: 1)
+    @main_activity = create(:evidence_activity, notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
+    @unused_activity = create(:evidence_activity, notes: 'Title_2', title: 'Title 2', parent_activity_id: 2, target_level: 1)
 
-    @prompt1 = Evidence::Prompt.create!(activity: @main_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-    @prompt2 = Evidence::Prompt.create!(activity: @main_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-    @prompt3 = Evidence::Prompt.create!(activity: @unused_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+    @prompt1 = create(:evidence_prompt, activity: @main_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+    @prompt2 = create(:evidence_prompt, activity: @main_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+    @prompt3 = create(:evidence_prompt, activity: @unused_activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
 
     generate_feedback_history(@prompt3.id)
   end

--- a/services/QuillLMS/spec/services/serialize_evidence_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_evidence_activity_health_spec.rb
@@ -5,14 +5,14 @@ require 'rails_helper'
 describe 'SerializeEvidenceActivityHealth' do
 
   before do
-    @activity = Evidence::Activity.create!(notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
+    @activity = create(:evidence_activity, notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
     @activity.update(flag: "production")
     @previous_version = @activity.version
     @activity.increment_version!
 
-    @because_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'because', text: 'Some feedback text because', max_attempts_feedback: 'Feedback')
-    @but_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'but', text: 'Some feedback text but', max_attempts_feedback: 'Feedback')
-    @so_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'so', text: 'Some feedback text so', max_attempts_feedback: 'Feedback')
+    @because_prompt1 = create(:evidence_prompt, activity: @activity, conjunction: 'because', text: 'Some feedback text because', max_attempts_feedback: 'Feedback')
+    @but_prompt1 = create(:evidence_prompt, activity: @activity, conjunction: 'but', text: 'Some feedback text but', max_attempts_feedback: 'Feedback')
+    @so_prompt1 = create(:evidence_prompt, activity: @activity, conjunction: 'so', text: 'Some feedback text so', max_attempts_feedback: 'Feedback')
 
     @activity_session1 = create(:activity_session, state: "finished", timespent: 600)
     @activity_session2 = create(:activity_session, state: "finished", timespent: 300)

--- a/services/QuillLMS/spec/services/serialize_evidence_prompt_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_evidence_prompt_health_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 describe 'SerializeEvidencePromptHealth' do
 
   before do
-    @activity = Evidence::Activity.create!(notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
+    @activity = create(:evidence_activity, notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
     @activity.update(flag: "production")
     @previous_version = @activity.version
     @activity.increment_version!
 
-    @because_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'because', text: 'Some feedback text because', max_attempts_feedback: 'Feedback')
+    @because_prompt1 = create(:evidence_prompt, activity: @activity, conjunction: 'because', text: 'Some feedback text because', max_attempts_feedback: 'Feedback')
     @activity_session1 = create(:activity_session, state: "finished", data: {time_tracking: {because: 600}})
     @activity_session2 = create(:activity_session, state: "finished", data: {time_tracking: {because: 250}})
     @activity_session3 = create(:activity_session, state: "started", data: {time_tracking: {because: 200}})
@@ -28,16 +28,16 @@ describe 'SerializeEvidencePromptHealth' do
     @feedback_session5_uid = FeedbackSession.get_uid_for_activity_session(@activity_session5_uid)
     @comprehension_turking_round = create(:comprehension_turking_round_activity_session, activity_session_uid: @activity_session1_uid)
 
-    @automl_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_AUTOML)
-    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @automl_rule)
-    @plagiarism_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_PLAGIARISM)
-    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @plagiarism_rule)
-    @opinion_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_OPINION)
-    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @opinion_rule)
-    @grammar_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_GRAMMAR)
-    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @grammar_rule)
-    @spelling_rule = Evidence::Rule.create!(name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_SPELLING)
-    Evidence::PromptsRule.create!(prompt: @because_prompt1, rule: @spelling_rule)
+    @automl_rule = create(:evidence_rule, name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_AUTOML)
+    create(:evidence_prompts_rule, prompt: @because_prompt1, rule: @automl_rule)
+    @plagiarism_rule = create(:evidence_rule, name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_PLAGIARISM)
+    create(:evidence_prompts_rule, prompt: @because_prompt1, rule: @plagiarism_rule)
+    @opinion_rule = create(:evidence_rule, name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_OPINION)
+    create(:evidence_prompts_rule, prompt: @because_prompt1, rule: @opinion_rule)
+    @grammar_rule = create(:evidence_rule, name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_GRAMMAR)
+    create(:evidence_prompts_rule, prompt: @because_prompt1, rule: @grammar_rule)
+    @spelling_rule = create(:evidence_rule, name: "rule", universal: false, state: "active", optimal: false, rule_type: Evidence::Rule::TYPE_SPELLING)
+    create(:evidence_prompts_rule, prompt: @because_prompt1, rule: @spelling_rule)
 
     @user = create(:user)
     @first_session_feedback1 = create(:feedback_history, feedback_session_uid: @activity_session1_uid, prompt_id: @because_prompt1.id, optimal: false, activity_version: @activity.version, metadata: {api: {confidence: 0.99}}, rule_uid: @automl_rule.uid)

--- a/services/QuillLMS/spec/services/vitally_integration/previous_year_teacher_datum_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/previous_year_teacher_datum_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PreviousYearTeacherDatum, type: :model do
     let!(:classroom_unit4) { create(:classroom_unit, classroom: current_classroom, unit: unit4, created_at: Date.new(year, 10, 1), assigned_student_ids: [student4.id])}
     let!(:diagnostic) { create(:diagnostic_activity)}
     let!(:connect) { create(:connect_activity)}
-    let!(:evidence) { create(:evidence_activity)}
+    let!(:evidence) { create(:evidence_lms_activity)}
     let!(:unit_activity) { create(:unit_activity, unit: unit, activity: diagnostic, created_at: Date.new(year, 10, 1)) }
     let!(:unit_activity2) { create(:unit_activity, unit: unit2, activity: diagnostic, created_at: Date.new(2021, 10, 1)) }
     let!(:unit_activity3) { create(:unit_activity, unit: unit3, activity: connect, created_at: Date.new(year, 10, 1)) }

--- a/services/QuillLMS/spec/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 describe InternalTool::EmailFeedbackHistorySessionDataWorker, type: :worker do
   let!(:user) { create(:user)}
-  let!(:activity) { create(:evidence_activity) }
-  let!(:because_prompt) { Evidence::Prompt.create!(activity: activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
-  let!(:but_prompt) { Evidence::Prompt.create!(activity: activity, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
-  let!(:so_prompt) { Evidence::Prompt.create!(activity: activity, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
+  let!(:activity) { create(:evidence_lms_activity) }
+  let!(:because_prompt) { create(:evidence_prompt, activity: activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
+  let!(:but_prompt) { create(:evidence_prompt, activity: activity, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
+  let!(:so_prompt) { create(:evidence_prompt, activity: activity, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback') }
   let!(:activity_session1_uid) { SecureRandom.uuid }
   let!(:activity_session2_uid) { SecureRandom.uuid }
   let!(:feedback_history1) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-05T20:43:27.698Z', prompt_id: because_prompt.id) }

--- a/services/QuillLMS/spec/workers/populate_aggregated_evidence_activity_healths_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_aggregated_evidence_activity_healths_worker_spec.rb
@@ -11,10 +11,10 @@ describe PopulateAggregatedEvidenceActivityHealthsWorker do
 
   let(:connect) { create(:activity_classification, key: "connect") }
   let(:connect_activity) { create(:activity, activity_classification_id: connect.id) }
-  let(:evidence_activity) { Evidence::Activity.create!(notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1) }
-  let(:evidence_activity_two) { Evidence::Activity.create!(notes: 'Title_2', title: 'Title 2', parent_activity_id: 1, target_level: 1) }
+  let(:evidence_activity) { create(:evidence_activity, notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1) }
+  let(:evidence_activity_two) { create(:evidence_activity, notes: 'Title_2', title: 'Title 2', parent_activity_id: 1, target_level: 1) }
   let(:parent_archived_activity) { create(:activity, flag: "archived")}
-  let(:archived_evidence_activity) { Evidence::Activity.create!(notes: 'Title_3', title: 'Title 3', parent_activity_id: parent_archived_activity.id, target_level: 1) }
+  let(:archived_evidence_activity) { create(:evidence_activity, notes: 'Title_3', title: 'Title 3', parent_activity_id: parent_archived_activity.id, target_level: 1) }
 
   it 'should kick off populate activity health worker jobs spread out by interval' do
     stub_const("PopulateEvidenceActivityHealthsWorker::INTERVAL", 5)
@@ -34,7 +34,7 @@ describe PopulateAggregatedEvidenceActivityHealthsWorker do
   end
 
   it 'should truncate the table each time the job is run' do
-    Evidence::ActivityHealth.create(name: "title1", activity_id: 1, flag: "alpha", version: 1, version_plays: 0, total_plays: 0)
+    create(:evidence_activity_health)
     expect(Evidence::ActivityHealth.count).to eq(1)
 
     subject.perform

--- a/services/QuillLMS/spec/workers/populate_evidence_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_evidence_activity_health_worker_spec.rb
@@ -6,14 +6,14 @@ describe PopulateEvidenceActivityHealthWorker do
   subject { described_class.new }
 
   before do
-    @activity = Evidence::Activity.create!(notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
+    @activity = create(:evidence_activity, notes: 'Title_1', title: 'Title 1', parent_activity_id: 1, target_level: 1)
     @activity.update(flag: "production")
     @previous_version = @activity.version
     @activity.increment_version!
 
-    @because_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-    @but_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
-    @so_prompt1 = Evidence::Prompt.create!(activity: @activity, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+    @because_prompt1 = create(:evidence_prompt, activity: @activity, conjunction: 'because', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+    @but_prompt1 = create(:evidence_prompt, activity: @activity, conjunction: 'but', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
+    @so_prompt1 = create(:evidence_prompt, activity: @activity, conjunction: 'so', text: 'Some feedback text', max_attempts_feedback: 'Feedback')
 
     @activity_session1 = create(:activity_session, state: "finished", timespent: 600)
     @activity_session2 = create(:activity_session, state: "finished", timespent: 300)


### PR DESCRIPTION
## WHAT
Tweak configurations to make all evidence engine factories (Activity, Prompt, Rule, Feedback, etc.) usable in LMS specs. 

## WHY
This makes it much easier for us to write tests in the LMS because we no longer have to manually create objects (with a lot of manually configured required fields) when we want to test things related to the Evidence Engine.

## HOW
Tweak the configs in the engine to add the Evidence Engine factories to the FactoryBot directory whenever the Evidence Engine is loaded. Previously, this code was only running inside the spec setup code for Evidence Engine. 
Then change the code inside all previously written LMS specs to start using the evidence engine factories instead of manually creating records. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Import-factories-from-engine-to-LMS-08495475acd54cfb979f1bc987ab2f0d?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
