### PR TITLE
fix several bugs with feedback sessions internal tool

### DIFF
--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -22,8 +22,6 @@ class UserMailer < ActionMailer::Base
   before_action { @constants = CONSTANTS }
 
   COTEACHER_SUPPORT_ARTICLE = 'http://support.quill.org/getting-started-for-teachers/manage-classes/how-do-i-share-a-class-with-my-co-teacher'
-  DEFAULT_MAX_ATTEMPTS = 5
-  FEEDBACK_HISTORY_CSV_HEADERS = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
   FEEDBACK_SESSIONS_CSV_DOWNLOAD = "Feedback Sessions CSV Download"
   FEEDBACK_SESSIONS_CSV_FILENAME = "feedback_sessions.csv"
 
@@ -166,24 +164,7 @@ class UserMailer < ActionMailer::Base
     mail from: "The Quill Team <hello@quill.org>", to: email, subject: "ELL Starter Diagnostic Next Steps"
   end
 
-  def feedback_history_session_csv_download(email, data)
-    csv = CSV.generate(headers: true) do |csv_body|
-      csv_body << FEEDBACK_HISTORY_CSV_HEADERS
-      data.each do |row|
-        csv_body << [
-          row["datetime"],
-          row["session_uid"],
-          row["conjunction"],
-          row["attempt"],
-          row["optimal"],
-          row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS,
-          row["response"],
-          row["feedback"],
-          "#{row['feedback_type']}: #{row['name']}"
-        ]
-      end
-    end
-
+  def feedback_history_session_csv_download(email, csv)
     attachments[FEEDBACK_SESSIONS_CSV_FILENAME] = {mime_type: 'text/csv', content: csv}
     mail from: "The Quill Team <hello@quill.org>", to: email, subject: FEEDBACK_SESSIONS_CSV_DOWNLOAD
   end

--- a/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -4,6 +4,9 @@ class InternalTool::EmailFeedbackHistorySessionDataWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 
+  FEEDBACK_HISTORY_CSV_HEADERS = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
+  DEFAULT_MAX_ATTEMPTS = 5
+
   def perform(activity_id, start_date, end_date, filter_type, responses_for_scoring, email)
     feedback_histories = FeedbackHistory.session_data_for_csv(
         activity_id: activity_id,
@@ -17,6 +20,23 @@ class InternalTool::EmailFeedbackHistorySessionDataWorker
     results.sort! { |a,b| b["datetime"] <=> a["datetime"] }
     return if !results
 
-    UserMailer.feedback_history_session_csv_download(email, results).deliver_now!
+    csv = CSV.generate(headers: true) do |csv_body|
+      csv_body << FEEDBACK_HISTORY_CSV_HEADERS
+      results.each do |row|
+        csv_body << [
+          row["datetime"],
+          row["session_uid"],
+          row["conjunction"],
+          row["attempt"],
+          row["optimal"],
+          row['optimal'] || row['attempt'] == DEFAULT_MAX_ATTEMPTS,
+          row["response"],
+          row["feedback"],
+          "#{row['feedback_type']}: #{row['name']}"
+        ]
+      end
+    end
+
+    UserMailer.feedback_history_session_csv_download(email, csv).deliver_now!
   end
 end

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
@@ -188,7 +188,7 @@ const SessionsIndex = ({ match }) => {
 
   const { activitySessions } = sessionsData;
   const { total_activity_sessions, activity_sessions } = activitySessions;
-  const metabaseLink = `https://data.quill.org/question/615?activity_id=${activityId}`
+  const metabaseLink = `https://data.quill.org/question/1048?activity_id=${activityId}`
 
   return(
     <div className="sessions-index-container">

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/activity_sessions.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/activity_sessions.scss
@@ -171,13 +171,9 @@
         .data-table-row {
           height: auto;
           padding: 10px 16px;
-          span {
-            div {
-              .entry {
-                margin-bottom: 0px;
-                white-space: break-spaces !important;
-              }
-            }
+          .entry {
+            margin-bottom: 0px;
+            white-space: break-spaces !important;
           }
         }
       }

--- a/services/QuillLMS/spec/mailers/user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/user_mailer_spec.rb
@@ -177,7 +177,7 @@ describe UserMailer, type: :mailer do
 
   describe 'feedback_history_session_csv_download' do
     # I like to structure specs starting with subject which matches the describe block
-    subject { described_class.feedback_history_session_csv_download(email, data) }
+    subject { described_class.feedback_history_session_csv_download(email, csv_body) }
 
     # factor out parameters provided to subject as let variables
     let(:email) { 'team@quill.org' }
@@ -197,12 +197,10 @@ describe UserMailer, type: :mailer do
       ]
     end
 
-    # Add some constants to UserMailer to make explicit the coupling with the spec:
-    let(:csv_headers) { described_class::FEEDBACK_HISTORY_CSV_HEADERS }
-    let(:csv_attachment) { subject.attachments[described_class::FEEDBACK_SESSIONS_CSV_FILENAME] }
+    let(:csv_headers) { InternalTool::EmailFeedbackHistorySessionDataWorker::FEEDBACK_HISTORY_CSV_HEADERS }
 
-    it 'should set the subject, receiver and the sender' do
-      csv_body = CSV.generate(headers: true) do |csv|
+    let(:csv_body) {
+      CSV.generate(headers: true) do |csv|
         csv << csv_headers
         data.each do |row|
           #  break up multiple parameter method into multiple lines for readability
@@ -212,13 +210,19 @@ describe UserMailer, type: :mailer do
             row["conjunction"],
             row["attempt"],
             row["optimal"],
-            row['optimal'] || row['attempt'] == described_class::DEFAULT_MAX_ATTEMPTS,
+            row['optimal'] || row['attempt'] == InternalTool::EmailFeedbackHistorySessionDataWorker::DEFAULT_MAX_ATTEMPTS,
             row["response"],
             row["feedback"],
             "#{row['feedback_type']}: #{row['name']}"
           ]
         end
       end
+    }
+
+    # Add some constants to UserMailer to make explicit the coupling with the spec:
+    let(:csv_attachment) { subject.attachments[described_class::FEEDBACK_SESSIONS_CSV_FILENAME] }
+
+    it 'should set the subject, receiver and the sender' do
 
       expect(subject.to).to eq [email]
 


### PR DESCRIPTION
## WHAT
Fix two frontend bugs (bad metabase link and text getting cutoff) and move feedback sessions CSV generation from UserMailer action to worker in order to avoid [an intermittent error](https://quillorg-5s.sentry.io/issues/4207013568/?environment=production&project=11238&query=is%3Aunresolved&referrer=issue-stream&stream_index=10).

## WHY
We want this internal tool to function well for the curriculum team.

## HOW
See "What".

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Student-responses-cut-off-in-Individual-Sessions-view-220d57e5a2fe4cabbc7ff75abf36473c?pvs=4
https://www.notion.so/quill/Can-t-remove-hint-from-feedback-label-in-Evidence-CMS-20fa8f9c024f4e388fecb3d333f620ac?pvs=4
https://www.notion.so/quill/Email-Me-CSV-Data-button-not-working-on-View-Sessions-page-86ad7b0514a64c32beb37cee28f4ca41?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny changes, tested locally
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A