### PR TITLE
store feedback session csv on disk instead of in memory (#10603)

### DIFF
--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -164,9 +164,11 @@ class UserMailer < ActionMailer::Base
     mail from: "The Quill Team <hello@quill.org>", to: email, subject: "ELL Starter Diagnostic Next Steps"
   end
 
-  def feedback_history_session_csv_download(email, csv)
-    attachments[FEEDBACK_SESSIONS_CSV_FILENAME] = {mime_type: 'text/csv', content: csv}
+  def feedback_history_session_csv_download(email, csv_file_path)
+    attachments[FEEDBACK_SESSIONS_CSV_FILENAME] = File.read(csv_file_path)
     mail from: "The Quill Team <hello@quill.org>", to: email, subject: FEEDBACK_SESSIONS_CSV_DOWNLOAD
+
+    File.delete(csv_file_path) if File.exist?(csv_file_path)
   end
 
   def approved_admin_email(user, school_name)

--- a/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -20,7 +20,9 @@ class InternalTool::EmailFeedbackHistorySessionDataWorker
     results.sort! { |a,b| b["datetime"] <=> a["datetime"] }
     return if !results
 
-    csv = CSV.generate(headers: true) do |csv_body|
+    csv_file_path = Rails.root.join('public', "feedback_history_#{activity_id}_#{Time.current.to_i}.csv")
+
+    CSV.open(csv_file_path, 'wb') do |csv_body|
       csv_body << FEEDBACK_HISTORY_CSV_HEADERS
       results.each do |row|
         csv_body << [
@@ -37,6 +39,6 @@ class InternalTool::EmailFeedbackHistorySessionDataWorker
       end
     end
 
-    UserMailer.feedback_history_session_csv_download(email, csv).deliver_now!
+    UserMailer.feedback_history_session_csv_download(email, csv_file_path).deliver_now!
   end
 end

--- a/services/QuillLMS/spec/mailers/user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/user_mailer_spec.rb
@@ -177,7 +177,7 @@ describe UserMailer, type: :mailer do
 
   describe 'feedback_history_session_csv_download' do
     # I like to structure specs starting with subject which matches the describe block
-    subject { described_class.feedback_history_session_csv_download(email, csv_body) }
+    subject { described_class.feedback_history_session_csv_download(email, csv_file_path) }
 
     # factor out parameters provided to subject as let variables
     let(:email) { 'team@quill.org' }
@@ -198,6 +198,8 @@ describe UserMailer, type: :mailer do
     end
 
     let(:csv_headers) { InternalTool::EmailFeedbackHistorySessionDataWorker::FEEDBACK_HISTORY_CSV_HEADERS }
+
+    let(:csv_file_path) { Rails.root.join('public', "feedback_history_0_#{Time.now.to_i}.csv") }
 
     let(:csv_body) {
       CSV.generate(headers: true) do |csv|
@@ -222,14 +224,28 @@ describe UserMailer, type: :mailer do
     # Add some constants to UserMailer to make explicit the coupling with the spec:
     let(:csv_attachment) { subject.attachments[described_class::FEEDBACK_SESSIONS_CSV_FILENAME] }
 
+    before do
+      CSV.open(csv_file_path, 'wb') do |csv|
+        rows = CSV.parse(csv_body, headers: true)
+        csv << csv_headers
+        rows.each do |row|
+          csv << row
+        end
+      end
+    end
+
     it 'should set the subject, receiver and the sender' do
 
       expect(subject.to).to eq [email]
 
       # Refer to constants to make coupling with string explicit
       expect(subject.subject).to match(described_class::FEEDBACK_SESSIONS_CSV_DOWNLOAD)
-      expect(csv_attachment.mime_type).to match('text/csv')
       expect(CSV.parse(csv_attachment.body.raw_source)).to eq(CSV.parse(csv_body))
+    end
+
+    it 'should delete the file after the email has been sent' do
+      subject.subject
+      expect(File).not_to exist(csv_file_path)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -17,12 +17,14 @@ describe InternalTool::EmailFeedbackHistorySessionDataWorker, type: :worker do
   let!(:feedback_history5) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-09T20:43:27.698Z', prompt_id: so_prompt.id) }
   let!(:feedback_history6) { create(:feedback_history, feedback_session_uid: activity_session1_uid, created_at: '2021-04-10T20:43:27.698Z', prompt_id: so_prompt.id) }
   let!(:feedback_history7) { create(:feedback_history, feedback_session_uid: activity_session2_uid, created_at: '2021-04-11T20:43:27.698Z', prompt_id: because_prompt.id) }
-
+  let!(:time_current) { Time.current }
+  let!(:csv_file_path) { Rails.root.join('public', "feedback_history_#{activity.id}_#{time_current.to_i}.csv") }
 
   describe 'called with only activity id' do
 
     before do
       allow(UserMailer).to receive(:feedback_history_session_csv_download).and_return(double(:email, deliver_now!: true))
+      allow(Time).to receive(:current).and_return(time_current)
     end
 
     it 'should fetch all feedback history sessions for that activity' do
@@ -31,7 +33,7 @@ describe InternalTool::EmailFeedbackHistorySessionDataWorker, type: :worker do
       feedback_histories.find_each(batch_size: 10_000) { |feedback_history| results << feedback_history.serialize_csv_data }
       results.sort! { |a,b| b["datetime"] <=> a["datetime"] }
 
-      expect(UserMailer).to receive(:feedback_history_session_csv_download).with("test@test.com", csv(results))
+      expect(UserMailer).to receive(:feedback_history_session_csv_download).with("test@test.com", csv_file_path)
       described_class.new.perform(activity.id, nil, nil, nil, nil, "test@test.com")
     end
 
@@ -43,7 +45,7 @@ describe InternalTool::EmailFeedbackHistorySessionDataWorker, type: :worker do
       feedback_histories.find_each(batch_size: 10_000) { |feedback_history| results << feedback_history.serialize_csv_data }
       results.sort! { |a,b| b["datetime"] <=> a["datetime"] }
 
-      expect(UserMailer).to receive(:feedback_history_session_csv_download).with("test@test.com", csv(results))
+      expect(UserMailer).to receive(:feedback_history_session_csv_download).with("test@test.com", csv_file_path)
       described_class.new.perform(activity.id, start_date, end_date, nil, nil, "test@test.com")
     end
 
@@ -53,8 +55,18 @@ describe InternalTool::EmailFeedbackHistorySessionDataWorker, type: :worker do
       feedback_histories.find_each(batch_size: 10_000) { |feedback_history| results << feedback_history.serialize_csv_data }
       results.sort! { |a,b| b["datetime"] <=> a["datetime"] }
 
-      expect(UserMailer).to receive(:feedback_history_session_csv_download).with("test@test.com", csv(results))
+      expect(UserMailer).to receive(:feedback_history_session_csv_download).with("test@test.com", csv_file_path)
       described_class.new.perform(activity.id, nil, nil, nil, true, "test@test.com")
+    end
+
+    it 'should write to a csv with the results data' do
+      feedback_histories = FeedbackHistory.session_data_for_csv({ activity_id: activity.id, responses_for_scoring: true})
+      results = []
+      feedback_histories.find_each(batch_size: 10_000) { |feedback_history| results << feedback_history.serialize_csv_data }
+      results.sort! { |a,b| b["datetime"] <=> a["datetime"] }
+
+      described_class.new.perform(activity.id, nil, nil, nil, true, "test@test.com")
+      expect(File.read(csv_file_path)).to eq(csv(results))
     end
   end
 end


### PR DESCRIPTION
* store feedback session csv on disk instead of in memory

* fix lint

* have usermailer delete the file

* fix lint and test

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
