### PR TITLE
Add testing for snapshots queries on BigQuery 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,72 @@ jobs:
             bin/rspec ${TESTFILES}
       - store_artifacts:
           path: /home/circleci/Empirical-Core/services/QuillLMS/tmp/screenshots
+  lms_big_query_build:
+    working_directory: ~/Empirical-Core
+    parallelism: 1
+    docker:
+      - image: cimg/ruby:2.7.8
+        environment:
+          PG_DB: quill_test_db
+          PG_USER: ubuntu
+          RAILS_ENV: test
+          RACK_ENV: test
+      - image: postgres:13.7-alpine
+        environment:
+          POSTGRES_DB: quill_test_db
+          POSTGRES_USER: ubuntu
+          POSTGRES_PASSWORD: password
+      - image: postgres:13.7-alpine
+        name: test_replica
+        environment:
+          POSTGRES_DB: quill_test_db
+          POSTGRES_USER: ubuntu
+          POSTGRES_PASSWORD: password
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - bundle-cache-lms-v2-{{ checksum "services/QuillLMS/Gemfile.lock" }}
+            - bundle-cache-lms-v2
+      - run:
+          name: Bundle Install if cache isn't present.
+          command: |
+            cd services/QuillLMS
+            gem install bundler:2.2.33
+            # BUNDLE_GEMS__CONTRIBSYS__COM defined in https://circleci.com/gh/empirical-org/Empirical-Core/edit#env-vars
+            bundle config --local gems.contribsys.com ${BUNDLE_GEMS__CONTRIBSYS__COM}
+            bundle check || bundle install --path vendor/bundle
+      - save_cache:
+          key: bundle-cache-lms-v2-{{ checksum "services/QuillLMS/Gemfile.lock" }}
+          paths:
+            - services/QuillLMS/vendor/bundle
+      - run:
+          name: Install postgres dependencies
+          command: |
+            sudo apt update
+            sudo apt-cache search postgres
+            sudo apt install -y postgresql-client
+      - run:
+          name: Copy Config files
+          command: |
+            cd services/QuillLMS
+            cp .env-sample .env
+            cp config/database.yml.circle config/database.yml
+      - run:
+          name: Set up DB
+          command: |
+            cd services/QuillLMS
+            bundle exec rake db:structure:load
+            bundle exec rake db:migrate
+          environment:
+            DATABASE_URL: "postgres://ubuntu@localhost:5432/quill_test_db"
+      - run:
+          name: Run tests
+          command: |
+            cd services/QuillLMS
+            bin/rspec --tag big_query_snapshot
+          environment:
+            SUPPRESS_PUTS: "true"
   lms_node_build:
     working_directory: ~/Empirical-Core
     parallelism: 3
@@ -334,6 +400,8 @@ workflows:
             branches:
               ignore: /^deploy-.*/
       - lms_integration_build:
+          <<: *default_filter
+      - lms_big_query_build:
           <<: *default_filter
       - lms_node_build:
           <<: *default_filter

--- a/services/QuillLMS/app/queries/quill_big_query/query.rb
+++ b/services/QuillLMS/app/queries/quill_big_query/query.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module QuillBigQuery
+  class Query < ::ApplicationService
+    attr_reader :runner
+
+    def initialize(runner: QuillBigQuery::Runner)
+      @runner = runner
+    end
+
+    def run
+      raise NotImplementedError
+    end
+
+    def run_query
+      runner.execute(query)
+    end
+
+    def query
+      <<-SQL
+        #{select_clause}
+          #{from_and_join_clauses}
+          #{where_clause}
+          #{group_by_clause}
+          #{order_by_clause}
+          #{limit_clause}
+      SQL
+    end
+
+    def group_by_clause
+      ""
+    end
+
+    def order_by_clause
+      ""
+    end
+
+    def limit_clause
+      ""
+    end
+  end
+end

--- a/services/QuillLMS/app/queries/snapshots/active_classrooms_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/active_classrooms_query.rb
@@ -5,16 +5,5 @@ module Snapshots
     def select_clause
       "SELECT COUNT(DISTINCT classrooms.id) AS count"
     end
-
-    def query
-      <<-SQL
-        SELECT
-          COUNT(DISTINCT classrooms.id) AS classrooms_count,
-          COUNT(DISTINCT classrooms_teachers.id) AS classrooms_teachers_count,
-        FROM lms.classrooms
-        JOIN lms.classrooms_teachers
-          ON classrooms.id = classrooms_teachers.classroom_id
-      SQL
-    end
   end
 end

--- a/services/QuillLMS/app/queries/snapshots/active_classrooms_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/active_classrooms_query.rb
@@ -5,5 +5,16 @@ module Snapshots
     def select_clause
       "SELECT COUNT(DISTINCT classrooms.id) AS count"
     end
+
+    def query
+      <<-SQL
+        SELECT
+          COUNT(DISTINCT classrooms.id) AS classrooms_count,
+          COUNT(DISTINCT classrooms_teachers.id) AS classrooms_teachers_count,
+        FROM lms.classrooms
+        JOIN lms.classrooms_teachers
+          ON classrooms.id = classrooms_teachers.classroom_id
+      SQL
+    end
   end
 end

--- a/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
@@ -2,7 +2,7 @@
 
 module Snapshots
   class ActivitiesAssignedQuery < CountQuery
-    def query_to_run
+    def final_query
       utilizing_subquery
     end
 
@@ -12,7 +12,7 @@ module Snapshots
           FROM (
             SELECT (sub_sub_query.students_assigned_count *
               COUNT(unit_activities.unit_id)) AS activities_assigned
-            FROM (#{query}) AS sub_sub_query
+            FROM (#{core_query}) AS sub_sub_query
             JOIN lms.unit_activities
               ON sub_sub_query.unit_id = unit_activities.unit_id
             GROUP BY sub_sub_query.id,

--- a/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
@@ -2,8 +2,8 @@
 
 module Snapshots
   class ActivitiesAssignedQuery < CountQuery
-    def run_query
-      QuillBigQuery::Runner.execute(utilizing_subquery)
+    def query_to_run
+      utilizing_subquery
     end
 
     def utilizing_subquery

--- a/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
@@ -2,17 +2,12 @@
 
 module Snapshots
   class ActivitiesAssignedQuery < CountQuery
-    def final_query
-      utilizing_subquery
-    end
-
-    def utilizing_subquery
+    def query
       <<-SQL
         SELECT SUM(sub_query.activities_assigned) AS count
           FROM (
-            SELECT (sub_sub_query.students_assigned_count *
-              COUNT(unit_activities.unit_id)) AS activities_assigned
-            FROM (#{core_query}) AS sub_sub_query
+            SELECT (sub_sub_query.students_assigned_count * COUNT(unit_activities.unit_id)) AS activities_assigned
+            FROM (#{super}) AS sub_sub_query
             JOIN lms.unit_activities
               ON sub_sub_query.unit_id = unit_activities.unit_id
             GROUP BY sub_sub_query.id,

--- a/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
@@ -23,7 +23,12 @@ module Snapshots
     end
 
     def select_clause
-      "SELECT DISTINCT classroom_units.id, classroom_units.unit_id, array_length(classroom_units.assigned_student_ids) AS students_assigned_count"
+      <<-SQL
+        SELECT
+          DISTINCT classroom_units.id,
+          classroom_units.unit_id,
+          array_length(classroom_units.assigned_student_ids) AS students_assigned_count
+      SQL
     end
 
     def relevant_date_column

--- a/services/QuillLMS/app/queries/snapshots/options_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/options_query.rb
@@ -9,14 +9,10 @@ module Snapshots
     end
 
     def run
-      run_query
+      QuillBigQuery::Runner.execute(final_query)
     end
 
-    def run_query
-      QuillBigQuery::Runner.execute(query_to_run)
-    end
-
-    def query_to_run
+    def final_query
       query
     end
 

--- a/services/QuillLMS/app/queries/snapshots/options_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/options_query.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
 module Snapshots
-  class OptionsQuery
+  class OptionsQuery < ::ApplicationService
     attr_accessor :admin_id
-
-    def self.run(*args)
-      new(*args).run
-    end
 
     def initialize(admin_id)
       @admin_id = admin_id

--- a/services/QuillLMS/app/queries/snapshots/options_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/options_query.rb
@@ -1,26 +1,16 @@
 # frozen_string_literal: true
 
 module Snapshots
-  class OptionsQuery < ::ApplicationService
+  class OptionsQuery < ::QuillBigQuery::Query
     attr_accessor :admin_id
 
-    def initialize(admin_id)
+    def initialize(admin_id, options = {})
       @admin_id = admin_id
+      super(options)
     end
 
     def run
-      QuillBigQuery::Runner.execute(query)
-    end
-
-    def query
-      <<-SQL
-        #{select_clause}
-          #{from_and_join_clauses}
-          #{where_clause}
-          #{group_by_clause}
-          #{order_by_clause}
-          #{limit_clause}
-      SQL
+      run_query
     end
 
     def select_clause
@@ -43,18 +33,6 @@ module Snapshots
 
     def where_clause
       "WHERE admins.id = #{admin_id}"
-    end
-
-    def group_by_clause
-      ""
-    end
-
-    def order_by_clause
-      ""
-    end
-
-    def limit_clause
-      ""
     end
   end
 end

--- a/services/QuillLMS/app/queries/snapshots/options_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/options_query.rb
@@ -9,11 +9,7 @@ module Snapshots
     end
 
     def run
-      QuillBigQuery::Runner.execute(final_query)
-    end
-
-    def final_query
-      query
+      QuillBigQuery::Runner.execute(query)
     end
 
     def query

--- a/services/QuillLMS/app/queries/snapshots/options_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/options_query.rb
@@ -13,7 +13,11 @@ module Snapshots
     end
 
     def run_query
-      QuillBigQuery::Runner.execute(query)
+      QuillBigQuery::Runner.execute(query_to_run)
+    end
+
+    def query_to_run
+      query
     end
 
     def query

--- a/services/QuillLMS/app/queries/snapshots/period_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/period_query.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
 module Snapshots
-  class PeriodQuery < ApplicationService
+  class PeriodQuery < ::ApplicationService
     attr_accessor :timeframe_start, :timeframe_end, :school_ids, :grades
-
-    def self.run(*args)
-      new(*args).run
-    end
 
     def initialize(timeframe_start, timeframe_end, school_ids, grades = nil)
       @timeframe_start = timeframe_start
@@ -20,7 +16,11 @@ module Snapshots
     end
 
     def run_query
-      QuillBigQuery::Runner.execute(query)
+      QuillBigQuery::Runner.execute(query_to_run)
+    end
+
+    def query_to_run
+      query
     end
 
     def query

--- a/services/QuillLMS/app/queries/snapshots/period_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/period_query.rb
@@ -16,14 +16,14 @@ module Snapshots
     end
 
     def run_query
-      QuillBigQuery::Runner.execute(query_to_run)
+      QuillBigQuery::Runner.execute(final_query)
     end
 
-    def query_to_run
-      query
+    def final_query
+      core_query
     end
 
-    def query
+    def core_query
       <<-SQL
         #{select_clause}
           #{from_and_join_clauses}

--- a/services/QuillLMS/app/queries/snapshots/period_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/period_query.rb
@@ -16,14 +16,10 @@ module Snapshots
     end
 
     def run_query
-      QuillBigQuery::Runner.execute(final_query)
+      QuillBigQuery::Runner.execute(query)
     end
 
-    def final_query
-      core_query
-    end
-
-    def core_query
+    def query
       <<-SQL
         #{select_clause}
           #{from_and_join_clauses}

--- a/services/QuillLMS/app/queries/snapshots/period_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/period_query.rb
@@ -1,22 +1,16 @@
 # frozen_string_literal: true
 
 module Snapshots
-  class PeriodQuery < ::ApplicationService
+  class PeriodQuery < ::QuillBigQuery::Query
     attr_accessor :timeframe_start, :timeframe_end, :school_ids, :grades
 
-    def initialize(timeframe_start, timeframe_end, school_ids, grades = nil)
+    def initialize(timeframe_start, timeframe_end, school_ids, grades = nil, options = {})
       @timeframe_start = timeframe_start
       @timeframe_end = timeframe_end
       @school_ids = school_ids
       @grades = grades
-    end
 
-    def run
-      raise NotImplementedError
-    end
-
-    def run_query
-      QuillBigQuery::Runner.execute(query)
+      super(options)
     end
 
     def query
@@ -67,18 +61,6 @@ module Snapshots
       return "" unless grades
 
       "AND classrooms.grade IN (#{grades.map { |g| "'#{g}'" }.join(',')})"
-    end
-
-    def group_by_clause
-      ""
-    end
-
-    def order_by_clause
-      ""
-    end
-
-    def limit_clause
-      ""
     end
   end
 end

--- a/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
@@ -2,14 +2,10 @@
 
 module Snapshots
   class SentencesWrittenQuery < CountQuery
-    def final_query
-      utilizing_subquery
-    end
-
-    def utilizing_subquery
+    def query
       <<-SQL
         SELECT COUNT(*) AS count
-          FROM (#{core_query})
+          FROM (#{super})
       SQL
     end
 

--- a/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
@@ -2,8 +2,8 @@
 
 module Snapshots
   class SentencesWrittenQuery < CountQuery
-    def run_query
-      QuillBigQuery::Runner.execute(utilizing_subquery)
+    def query_to_run
+      utilizing_subquery
     end
 
     def utilizing_subquery

--- a/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
@@ -2,14 +2,14 @@
 
 module Snapshots
   class SentencesWrittenQuery < CountQuery
-    def query_to_run
+    def final_query
       utilizing_subquery
     end
 
     def utilizing_subquery
       <<-SQL
         SELECT COUNT(*) AS count
-          FROM (#{query})
+          FROM (#{core_query})
       SQL
     end
 

--- a/services/QuillLMS/spec/factories/schools.rb
+++ b/services/QuillLMS/spec/factories/schools.rb
@@ -79,12 +79,6 @@ FactoryBot.define do
       fte_classroom_teacher { 100 }
       ppin { "A1234567" }
     end
-
-    factory :school_with_three_teachers do
-      after(:create) do |school|
-        activities = create_list(:schools_users, 2, school: school)
-      end
-    end
   end
 
   factory :simple_school, class: 'School'

--- a/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_concept_reports_spec.rb
@@ -101,12 +101,6 @@ describe ProgressReports::DistrictConceptReports do
       %w(school_name teacher_name classroom_name student_name correct incorrect percentage)
     end
 
-    around do |a_spec|
-      VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
-      a_spec.run
-      VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
-    end
-
     it 'tests end to end' do
       results = ProgressReports::DistrictConceptReports.new(sample_prod_admin_id).results
       sample_row = results.first

--- a/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/district_standards_reports_spec.rb
@@ -97,12 +97,6 @@ describe ProgressReports::DistrictStandardsReports do
     let(:assigned_student_ids) { [] }
 
     context 'integration', :external_api do
-      around do |a_spec|
-        VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
-        a_spec.run
-        VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
-      end
-
       it 'tests end to end' do
         expected = [
           {

--- a/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
@@ -6,10 +6,16 @@ module Snapshots
   describe ActiveClassroomsQuery do
     include_context 'Snapshot Query Params'
 
-    context 'external_api', :external_api do
+    around do |example|
+      VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
+      example.run
+      VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
+    end
+
+    context 'external_api' do
       let(:big_query_runner) { QuillBigQuery::Runner }
 
-      # BigQuery doesn't support CTE aliases with period in the name, so we need to remove the `lms.` prefix
+      # BigQuery doesn't support CTE aliases with period in the name, so we need to remove the `lms.` prefix from 'FROM' and 'JOIN' clauses
       let(:query) { ActiveClassroomsQuery.new("", "", []).query.gsub(/(FROM|JOIN) lms\.(\w+)/, '\1 \2') }
 
       let(:num_classrooms) { 2 }

--- a/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
@@ -7,7 +7,7 @@ module Snapshots
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 
-      it { expect(results).to eq [{'count' => num_classrooms}] }
+      it { expect(results).to eq(count: num_classrooms) }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
@@ -39,7 +39,8 @@ module Snapshots
 
       let(:expected_results) do
         [
-          { 'classrooms_count' => classrooms.count,
+          {
+            'classrooms_count' => classrooms.count,
             'classrooms_teachers_count' => classrooms_teachers.count
           }
         ]
@@ -54,7 +55,7 @@ module Snapshots
     def data_helper(records)
       records
         .map { |record| record.attributes.except('order') }
-        .map { |attrs| [:SELECT, attrs.map { |k, v| "'#{v}' AS #{k}" }.join(', ') ].join(' ') }
+        .map { |attrs| [:SELECT, attrs.map { |k, v| "'#{v}' AS #{k}" }.join(', ')].join(' ') }
         .join(" UNION ALL \n")
     end
   end

--- a/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
@@ -10,13 +10,6 @@ module Snapshots
       include_context 'Snapshots Count CTE'
 
       it { expect(results).to eq [{'count' => num_classrooms}] }
-
-      context 'filters' do
-        it_behaves_like 'snapshots period query with a timeframe', 1.day.ago, 1.hour.ago, [{'count' => 0}]
-        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.from_now, [{'count' => 0}]
-        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.ago, [{'count' => 0}]
-        it_behaves_like 'snapshots period query with a different school id', [{'count' => 0 }]
-      end
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
@@ -36,6 +36,7 @@ module Snapshots
       end
 
       let(:actual_results) { big_query_runner.execute(cte_query) }
+
       let(:expected_results) do
         [
           { 'classrooms_count' => classrooms.count,
@@ -45,14 +46,15 @@ module Snapshots
       end
 
       it 'should successfully get data' do
+        puts cte_query
         expect(actual_results).to eq expected_results
       end
     end
 
     def data_helper(records)
       records
-        .map { |record| record.attributes }
-        .map { |attrs| "SELECT " + attrs.map { |k, v| "'#{v}' AS #{k}" }.join(', ') }
+        .map { |record| record.attributes.except('order') }
+        .map { |attrs| [:SELECT, attrs.map { |k, v| "'#{v}' AS #{k}" }.join(', ') ].join(' ') }
         .join(" UNION ALL \n")
     end
   end

--- a/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
@@ -6,57 +6,17 @@ module Snapshots
   describe ActiveClassroomsQuery do
     include_context 'Snapshot Query Params'
 
-    around do |example|
-      VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
-      example.run
-      VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
-    end
+    context 'external_api', :big_query_snapshot do
+      include_context 'Snapshots Count CTE'
 
-    context 'external_api' do
-      let(:big_query_runner) { QuillBigQuery::Runner }
+      it { expect(results).to eq [{'count' => num_classrooms}] }
 
-      # BigQuery doesn't support CTE aliases with period in the name, so we need to remove the `lms.` prefix from 'FROM' and 'JOIN' clauses
-      let(:query) { ActiveClassroomsQuery.new("", "", []).query.gsub(/(FROM|JOIN) lms\.(\w+)/, '\1 \2') }
-
-      let(:num_classrooms) { 2 }
-      let!(:classrooms) { create_list(:classroom, num_classrooms) }
-      let(:classrooms_teachers) { classrooms.map(&:reload).map(&:classrooms_teachers).flatten }
-
-      let!(:classrooms_data) { data_helper(classrooms) }
-
-      let!(:classrooms_teachers_data) { data_helper(ClassroomsTeacher.all) }
-
-      let(:cte_query) do
-        <<-SQL
-          WITH
-            classrooms AS ( #{classrooms_data} ),
-            classrooms_teachers AS ( #{classrooms_teachers_data} )
-          #{query}
-        SQL
+      context 'filters' do
+        it_behaves_like 'snapshots period query with a timeframe', 1.day.ago, 1.hour.ago, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.from_now, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.ago, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a different school id', [{'count' => 0 }]
       end
-
-      let(:actual_results) { big_query_runner.execute(cte_query) }
-
-      let(:expected_results) do
-        [
-          {
-            'classrooms_count' => classrooms.count,
-            'classrooms_teachers_count' => classrooms_teachers.count
-          }
-        ]
-      end
-
-      it 'should successfully get data' do
-        puts cte_query
-        expect(actual_results).to eq expected_results
-      end
-    end
-
-    def data_helper(records)
-      records
-        .map { |record| record.attributes.except('order') }
-        .map { |attrs| [:SELECT, attrs.map { |k, v| "'#{v}' AS #{k}" }.join(', ')].join(' ') }
-        .join(" UNION ALL \n")
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_classrooms_query_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 module Snapshots
   describe ActiveClassroomsQuery do
-    include_context 'Snapshot Query Params'
-
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 

--- a/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+u# frozen_string_literal: true
 
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
@@ -9,7 +9,9 @@ module Snapshots
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 
-      it { expect(results).to eq [{'count' => num_activity_sessions}] }
+      let(:num_active_students) { activity_sessions.map(&:user_id).uniq.count }
+
+      it { expect(results).to eq [{'count' => num_active_students }] }
 
       context 'filters' do
         it_behaves_like 'snapshots period query with a timeframe', 1.day.ago, 1.hour.ago, [{'count' => 0}]

--- a/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
@@ -1,4 +1,4 @@
-u# frozen_string_literal: true
+# frozen_string_literal: true
 
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 module Snapshots
   describe ActiveStudentsQuery do
-    include_context 'Snapshot Query Params'
-
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 

--- a/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
@@ -14,9 +14,7 @@ module Snapshots
       it { expect(results).to eq [{'count' => num_active_students }] }
 
       context 'filters' do
-        it_behaves_like 'snapshots period query with a timeframe', 1.day.ago, 1.hour.ago, [{'count' => 0}]
-        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.from_now, [{'count' => 0}]
-        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.ago, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a timeframe', 1.day.ago.to_date, 1.hour.ago.to_date, [{'count' => 0}]
         it_behaves_like 'snapshots period query with a different school id', [{'count' => 0 }]
       end
     end

--- a/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
@@ -6,11 +6,16 @@ module Snapshots
   describe ActiveStudentsQuery do
     include_context 'Snapshot Query Params'
 
-    context 'external_api', :external_api do
-      it 'should successfully get data' do
-        result = described_class.run(timeframe_start, timeframe_end, school_ids, grades)
+    context 'external_api', :big_query_snapshot do
+      include_context 'Snapshots Count CTE'
 
-        expect(result[:count]).to eq(797)
+      it { expect(results).to eq [{'count' => num_activity_sessions}] }
+
+      context 'filters' do
+        it_behaves_like 'snapshots period query with a timeframe', 1.day.ago, 1.hour.ago, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.from_now, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.ago, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a different school id', [{'count' => 0 }]
       end
     end
   end

--- a/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_students_query_spec.rb
@@ -9,11 +9,11 @@ module Snapshots
 
       let(:num_active_students) { activity_sessions.map(&:user_id).uniq.count }
 
-      it { expect(results).to eq [{'count' => num_active_students }] }
+      it { expect(results).to eq(count: num_active_students) }
 
       context 'filters' do
-        it_behaves_like 'snapshots period query with a timeframe', 1.day.ago.to_date, 1.hour.ago.to_date, [{'count' => 0}]
-        it_behaves_like 'snapshots period query with a different school id', [{'count' => 0 }]
+        it_behaves_like 'snapshots period query with a timeframe', 1.day.ago.to_date, 1.hour.ago.to_date, count: 0
+        it_behaves_like 'snapshots period query with a different school id', count: 0
       end
     end
   end

--- a/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 module Snapshots
   describe ActivitiesAssignedQuery do
-    include_context 'Snapshot Query Params'
-
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 

--- a/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
@@ -12,7 +12,7 @@ module Snapshots
 
       let(:num_activities_assigned) { unit_activities.count }
 
-      it { expect(results).to eq [{'count' => num_activities_assigned }] }
+      it { expect(results).to eq(count: num_activities_assigned) }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
@@ -6,12 +6,19 @@ module Snapshots
   describe ActivitiesAssignedQuery do
     include_context 'Snapshot Query Params'
 
-    context 'external_api', :external_api do
-      it 'should successfully get data' do
-        result = described_class.run(timeframe_start, timeframe_end, school_ids, grades)
+    context 'external_api', :big_query_snapshot do
+      include_context 'Snapshots Count CTE'
 
-        expect(result[:count]).to eq(46522)
-      end
+      let(:num_activities_assigned) { 0 }
+
+      it { puts bq_query; expect(results).to eq [{'count' => num_activities_assigned }] }
+
+      # context 'filters' do
+      #   it_behaves_like 'snapshots period query with a timeframe', 1.day.ago, 1.hour.ago, [{'count' => 0}]
+      #   it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.from_now, [{'count' => 0}]
+      #   it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.ago, [{'count' => 0}]
+      #   it_behaves_like 'snapshots period query with a different school id', [{'count' => 0 }]
+      # end
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
@@ -9,16 +9,12 @@ module Snapshots
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 
-      let(:num_activities_assigned) { 0 }
+      let(:unit_activities) { classroom_units.map { |classroom_unit| create(:unit_activity, unit: classroom_unit.unit) } }
+      let(:cte_table_collections) { count_query_cte_table_collections << unit_activities }
 
-      it { puts bq_query; expect(results).to eq [{'count' => num_activities_assigned }] }
+      let(:num_activities_assigned) { unit_activities.count }
 
-      # context 'filters' do
-      #   it_behaves_like 'snapshots period query with a timeframe', 1.day.ago, 1.hour.ago, [{'count' => 0}]
-      #   it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.from_now, [{'count' => 0}]
-      #   it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.ago, [{'count' => 0}]
-      #   it_behaves_like 'snapshots period query with a different school id', [{'count' => 0 }]
-      # end
+      it { expect(results).to eq [{'count' => num_activities_assigned }] }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_assigned_query_spec.rb
@@ -8,7 +8,7 @@ module Snapshots
       include_context 'Snapshots Count CTE'
 
       let(:unit_activities) { classroom_units.map { |classroom_unit| create(:unit_activity, unit: classroom_unit.unit) } }
-      let(:cte_table_collections) { count_query_cte_table_collections << unit_activities }
+      let(:cte_records) { count_query_cte_records << unit_activities }
 
       let(:num_activities_assigned) { unit_activities.count }
 

--- a/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
@@ -9,7 +9,6 @@ module Snapshots
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 
-      let(:activity_session_trait) { :finished }
       let(:num_completed_activities) { activity_sessions.count }
 
       it { expect(results).to eq [{'count' => num_completed_activities }] }

--- a/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 module Snapshots
   describe ActivitiesCompletedQuery do
-    include_context 'Snapshot Query Params'
-
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 

--- a/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
@@ -9,7 +9,7 @@ module Snapshots
 
       let(:num_completed_activities) { activity_sessions.count }
 
-      it { expect(results).to eq [{'count' => num_completed_activities }] }
+      it { expect(results).to eq(count: num_completed_activities) }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
@@ -6,11 +6,24 @@ module Snapshots
   describe ActivitiesCompletedQuery do
     include_context 'Snapshot Query Params'
 
-    context 'external_api', :external_api do
-      it 'should successfully get data' do
-        result = described_class.run(timeframe_start, timeframe_end, school_ids, grades)
+    context 'external_api', :big_query_snapshot do
+      include_context 'Snapshots Count CTE'
 
-        expect(result[:count]).to eq(30320)
+      let(:num_completed_activities) { activity_sessions.count }
+
+      it { expect(results).to eq [{'count' => num_completed_activities }] }
+
+      context 'unfinished activity sessions' do
+        let(:activity_sessions) { classroom_units.map { |cu| create(:activity_session, :started, classroom_unit: cu) } }
+
+        it { expect(results).to eq [{'count' => 0 }] }
+      end
+
+      context 'filters' do
+        it_behaves_like 'snapshots period query with a timeframe', 1.day.ago, 1.hour.ago, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.from_now, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.ago, [{'count' => 0}]
+        it_behaves_like 'snapshots period query with a different school id', [{'count' => 0 }]
       end
     end
   end

--- a/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/activities_completed_query_spec.rb
@@ -9,22 +9,10 @@ module Snapshots
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 
+      let(:activity_session_trait) { :finished }
       let(:num_completed_activities) { activity_sessions.count }
 
       it { expect(results).to eq [{'count' => num_completed_activities }] }
-
-      context 'unfinished activity sessions' do
-        let(:activity_sessions) { classroom_units.map { |cu| create(:activity_session, :started, classroom_unit: cu) } }
-
-        it { expect(results).to eq [{'count' => 0 }] }
-      end
-
-      context 'filters' do
-        it_behaves_like 'snapshots period query with a timeframe', 1.day.ago, 1.hour.ago, [{'count' => 0}]
-        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.from_now, [{'count' => 0}]
-        it_behaves_like 'snapshots period query with a timeframe', 1.hour.from_now, 1.day.ago, [{'count' => 0}]
-        it_behaves_like 'snapshots period query with a different school id', [{'count' => 0 }]
-      end
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/average_activities_completed_per_student_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/average_activities_completed_per_student_query_spec.rb
@@ -6,12 +6,12 @@ module Snapshots
   describe AverageActivitiesCompletedPerStudentQuery do
     include_context 'Snapshot Query Params'
 
-    context 'external_api', :external_api do
-      it 'should successfully get data' do
-        result = described_class.run(timeframe_start, timeframe_end, school_ids, grades)
+    context 'external_api', :big_query_snapshot do
+      include_context 'Snapshots Count CTE'
 
-        expect(result[:count]).to eq(41.534246575342465)
-      end
+      let(:average_activities_completed_per_student) { activity_sessions.count / activity_sessions.map(&:user_id).uniq.count.to_f }
+
+      it { expect(results).to eq [{'count' => average_activities_completed_per_student }] }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/average_activities_completed_per_student_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/average_activities_completed_per_student_query_spec.rb
@@ -9,7 +9,7 @@ module Snapshots
 
       let(:average_activities_completed_per_student) { activity_sessions.count / activity_sessions.map(&:user_id).uniq.count.to_f }
 
-      it { expect(results).to eq [{'count' => average_activities_completed_per_student }] }
+      it { expect(results).to eq(count: average_activities_completed_per_student) }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/average_activities_completed_per_student_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/average_activities_completed_per_student_query_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 module Snapshots
   describe AverageActivitiesCompletedPerStudentQuery do
-    include_context 'Snapshot Query Params'
-
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 

--- a/services/QuillLMS/spec/queries/snapshots/schools_option_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/schools_option_query_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Snapshots
+  describe SchoolsOptionsQuery do
+    context 'external_api', :big_query_snapshot do
+      include_context 'Snapshots Option CTE'
+
+      let(:schools) { School.where(id: schools_users.pluck(:school_id)) }
+      let(:cte_table_collections) { option_query_cte_table_collections << schools }
+
+      let(:school) { schools.first }
+
+      it { expect(results).to eq [{ "id" => school.id, "name" => school.name }] }
+    end
+  end
+end

--- a/services/QuillLMS/spec/queries/snapshots/schools_option_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/schools_option_query_spec.rb
@@ -8,7 +8,7 @@ module Snapshots
       include_context 'Snapshots Option CTE'
 
       let(:schools) { School.where(id: schools_users.pluck(:school_id)) }
-      let(:cte_table_collections) { option_query_cte_table_collections << schools }
+      let(:cte_records) { option_query_cte_records << schools }
 
       let(:school) { schools.first }
 

--- a/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
@@ -8,7 +8,7 @@ module Snapshots
       include_context 'Snapshots Count CTE'
 
       let(:concept_results) { activity_sessions.map { |activity_session| create(:concept_result, activity_session: activity_session) } }
-      let(:cte_table_collections) { count_query_cte_table_collections << concept_results }
+      let(:cte_records) { count_query_cte_records << concept_results }
 
       it { expect(results).to eq [{'count' => concept_results.count }] }
     end

--- a/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
@@ -9,14 +9,10 @@ module Snapshots
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 
-      let(:cte) do
-        <<-SQL
-          #{snapshots_count_cte},
-          concept_results AS ( #{concept_results_cte_query} )
-        SQL
-      end
+      let(:concept_results) { activity_sessions.map { |activity_session| create(:concept_result, activity_session: activity_session) } }
+      let(:cte_table_collections) { count_query_cte_table_collections << concept_results }
 
-      it { p concept_results; expect(results).to eq [{'count' => concept_results.count }] }
+      it { expect(results).to eq [{'count' => concept_results.count }] }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 module Snapshots
   describe SentencesWrittenQuery do
-    include_context 'Snapshot Query Params'
-
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 

--- a/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
@@ -6,12 +6,17 @@ module Snapshots
   describe SentencesWrittenQuery do
     include_context 'Snapshot Query Params'
 
-    context 'external_api', :external_api do
-      it 'should successfully get data' do
-        result = described_class.run(timeframe_start, timeframe_end, school_ids, grades)
+    context 'external_api', :big_query_snapshot do
+      include_context 'Snapshots Count CTE'
 
-        expect(result[:count]).to eq(245835)
+      let(:cte) do
+        <<-SQL
+          #{snapshots_count_cte},
+          concept_results AS ( #{concept_results_cte_query} )
+        SQL
       end
+
+      it { p concept_results; expect(results).to eq [{'count' => concept_results.count }] }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
@@ -10,7 +10,7 @@ module Snapshots
       let(:concept_results) { activity_sessions.map { |activity_session| create(:concept_result, activity_session: activity_session) } }
       let(:cte_records) { count_query_cte_records << concept_results }
 
-      it { expect(results).to eq [{'count' => concept_results.count }] }
+      it { expect(results).to eq(count: concept_results.count) }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
@@ -6,12 +6,13 @@ module Snapshots
   describe StudentLearningHoursQuery do
     include_context 'Snapshot Query Params'
 
-    context 'external_api', :external_api do
-      it 'should successfully get data' do
-        result = described_class.run(timeframe_start, timeframe_end, school_ids, grades)
+    context 'external_api', :big_query_snapshot do
+      include_context 'Snapshots Count CTE'
 
-        expect(result[:count]).to eq(4418.901944444445)
-      end
+      let(:total_timespent) { activity_sessions.sum(&:timespent) / 3600.0 }
+
+      it { binding.pry;
+        expect(results).to eq [{'count' => total_timespent }] }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
@@ -11,8 +11,7 @@ module Snapshots
 
       let(:total_timespent) { activity_sessions.sum(&:timespent) / 3600.0 }
 
-      it { binding.pry;
-        expect(results).to eq [{'count' => total_timespent }] }
+      it { expect(results).to eq [{'count' => total_timespent }] }
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 module Snapshots
   describe StudentLearningHoursQuery do
-    include_context 'Snapshot Query Params'
-
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Count CTE'
 

--- a/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
@@ -9,7 +9,7 @@ module Snapshots
 
       let(:total_timespent) { activity_sessions.sum(&:timespent) / 3600.0 }
 
-      it { expect(results).to eq [{'count' => total_timespent }] }
+      it { expect(results).to eq(count: total_timespent) }
     end
   end
 end

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -96,11 +96,8 @@ RSpec.configure do |config|
     ActionController::Base.perform_caching = caching
   end
 
-  config.around(:each, :external_api) do |example|
-    VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
-    example.run
-    VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
-  end
+  config.around(:each, :external_api) { |example| with_vcr_disabled { example.run } }
+  config.around(:each, :big_query_snapshot) { |example| with_vcr_disabled { example.run } }
 
   if ENV.fetch('SUPPRESS_PUTS', false) == 'true'
     config.before do
@@ -110,6 +107,8 @@ RSpec.configure do |config|
   end
 end
 
-def vcr_ignores_localhost
-  VCR.configuration.ignore_localhost = true
+private def with_vcr_disabled
+  VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
+  yield
+  VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
 end

--- a/services/QuillLMS/spec/services/quill_big_query/client_fetcher_spec.rb
+++ b/services/QuillLMS/spec/services/quill_big_query/client_fetcher_spec.rb
@@ -4,12 +4,6 @@ require 'rails_helper'
 
 describe QuillBigQuery::ClientFetcher do
   context 'integration', :external_api do
-    around do |a_spec|
-      VCR.configure { |c| c.allow_http_connections_when_no_cassette = true }
-      a_spec.run
-      VCR.configure { |c| c.allow_http_connections_when_no_cassette = false }
-    end
-
     it 'should initializer multiple clients without error' do
       expect do
         2.times { QuillBigQuery::ClientFetcher.run }

--- a/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
+++ b/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module QuillBigQuery
+  class TestRunner < ::ApplicationService
+    attr_reader :cte_records, :query
+
+    def initialize(query, cte_records)
+      @query = query
+      @cte_records = cte_records
+    end
+
+    def run
+      QuillBigQuery::Runner.execute(bq_query)
+    end
+
+    private def bq_query
+      <<-SQL
+        WITH
+          #{cte}
+        #{table_namespaces_removed_query}
+      SQL
+    end
+
+    # BigQuery doesn't support CTE aliases with period in the name.
+    # So, we need to remove the 'lms.' and 'special.' prefixes from 'FROM' and 'JOIN' clauses
+    private def table_namespaces_removed_query
+      query.gsub(/(FROM|JOIN)\s+(?:lms|special)\.(\w+)/, '\1 \2')
+    end
+
+    private def cte
+      cte_records
+        .flatten
+        .group_by { |record| record.class.table_name }
+        .reject { |table_name, records| records.empty? }
+        .map { |table_name, records| "#{table_name} AS ( #{cte_query(records)} )" }
+        .join(",\n\t")
+    end
+
+    private def cte_query(records)
+      records
+        .map { |record| [:SELECT, cte_select_clause(record)].join(' ') }
+        .join(" UNION ALL \n")
+    end
+
+    private def cte_select_clause(record)
+      record
+        .attributes
+        .except('order')
+        .map { |attr, value| "#{convert_type(record, attr, value)} AS #{attr}" }
+        .join(', ')
+    end
+
+    private def convert_type(record, attr, value)
+      attr_type = record.class.column_for_attribute(attr).type
+
+      if value.nil?
+        "''"
+      elsif value.is_a?(Array)
+        value.map { |v| attr_type_value(attr_type, v) }
+      else
+        attr_type_value(attr_type, value)
+      end
+    end
+
+    private def attr_type_value(attr_type, value)
+      case attr_type
+      when :boolean, :decimal, :float, :integer then value
+      when :inet, :jsonb, :string then "'#{value}'"
+      when :datetime then "'#{value&.iso8601}'"
+      else
+        raise "Error: value:'#{value}' type #{attr_type} not found"
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
+++ b/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
@@ -1,29 +1,28 @@
 # frozen_string_literal: true
 
 module QuillBigQuery
-  class TestRunner < ::ApplicationService
-    attr_reader :cte_records, :query
+  class TestRunner
+    attr_reader :cte_records
 
-    def initialize(query, cte_records)
-      @query = query
+    def initialize(cte_records)
       @cte_records = cte_records
     end
 
-    def run
-      QuillBigQuery::Runner.execute(bq_query)
+    def execute(query)
+      QuillBigQuery::Runner.execute(translate_to_big_query_with_cte(query))
     end
 
-    private def bq_query
+    private def translate_to_big_query_with_cte(query)
       <<-SQL
         WITH
           #{cte}
-        #{table_namespaces_removed_query}
+        #{table_namespaces_removed_query(query)}
       SQL
     end
 
     # BigQuery doesn't support CTE aliases with period in the name.
     # So, we need to remove the 'lms.' and 'special.' prefixes from 'FROM' and 'JOIN' clauses
-    private def table_namespaces_removed_query
+    private def table_namespaces_removed_query(query)
       query.gsub(/(FROM|JOIN)\s+(?:lms|special)\.(\w+)/, '\1 \2')
     end
 

--- a/services/QuillLMS/spec/support/shared_contexts/quill_big_query_test_runner_setup.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/quill_big_query_test_runner_setup.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'QuillBigQuery TestRunner Setup' do
+  # Create before running the query, otherwise, some parameters (e.g. school_ids) will be nil
+  before { cte_records }
+
+  let(:runner) { QuillBigQuery::TestRunner.new(cte_records) }
+  let(:results) {described_class.run(*params, runner: runner) }
+end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'Snapshots Count CTE' do
+  include_context 'Snapshots Period CTE'
+
+  let(:classroom_units) { classrooms.map { |classroom| create(:classroom_unit, classroom: classroom) } }
+  let(:classroom_units_cte_query) { cte_query(classroom_units) }
+
+  let(:num_activity_sessions) { activity_sessions.count }
+  let(:activity_sessions) { classroom_units.map { |classroom_unit| create(:activity_session, classroom_unit: classroom_unit) } }
+  let(:activity_sessions_cte_query) { cte_query(activity_sessions) }
+
+  let(:snapshots_count_cte_query) do
+    <<-SQL
+      #{snapshots_period_cte},
+      classroom_units AS ( #{classroom_units_cte_query} ),
+      activity_sessions AS ( #{activity_sessions_cte_query} )
+    SQL
+  end
+
+  let(:cte) { snapshots_count_cte_query }
+end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
@@ -9,7 +9,10 @@ RSpec.shared_context 'Snapshots Count CTE' do
   let(:activity_sessions) { classroom_units.map { |classroom_unit| create(:activity_session, classroom_unit: classroom_unit) } }
   let(:activity_sessions_cte_query) { cte_query(activity_sessions) }
 
-  let(:snapshots_count_cte_query) do
+  let(:concept_results) { activity_sessions.map { |activity_session| create(:concept_result, activity_session: activity_session) } }
+  let(:concept_results_cte_query)  { cte_query(concept_results) }
+
+  let(:snapshots_count_cte) do
     <<-SQL
       #{snapshots_period_cte},
       classroom_units AS ( #{classroom_units_cte_query} ),
@@ -17,5 +20,5 @@ RSpec.shared_context 'Snapshots Count CTE' do
     SQL
   end
 
-  let(:cte) { snapshots_count_cte_query }
+  let(:cte) { snapshots_count_cte }
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
@@ -4,21 +4,15 @@ RSpec.shared_context 'Snapshots Count CTE' do
   include_context 'Snapshots Period CTE'
 
   let(:classroom_units) { classrooms.map { |classroom| create(:classroom_unit, classroom: classroom) } }
-  let(:classroom_units_cte_query) { cte_query(classroom_units) }
 
-  let(:activity_sessions) { classroom_units.map { |classroom_unit| create(:activity_session, classroom_unit: classroom_unit) } }
-  let(:activity_sessions_cte_query) { cte_query(activity_sessions) }
-
-  let(:concept_results) { activity_sessions.map { |activity_session| create(:concept_result, activity_session: activity_session) } }
-  let(:concept_results_cte_query)  { cte_query(concept_results) }
-
-  let(:snapshots_count_cte) do
-    <<-SQL
-      #{snapshots_period_cte},
-      classroom_units AS ( #{classroom_units_cte_query} ),
-      activity_sessions AS ( #{activity_sessions_cte_query} )
-    SQL
+  let(:activity_sessions) do
+    classroom_units.map do |classroom_unit|
+      create(:activity_session, activity_session_trait, classroom_unit: classroom_unit, timespent: rand(1..100))
+    end
   end
 
-  let(:cte) { snapshots_count_cte }
+  let(:activity_session_trait) { :started }
+
+  let(:count_query_cte_table_collections) { period_query_cte_table_collections << classroom_units << activity_sessions }
+  let(:cte_table_collections) { count_query_cte_table_collections }
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
@@ -11,6 +11,6 @@ RSpec.shared_context 'Snapshots Count CTE' do
     end
   end
 
-  let(:count_query_cte_table_collections) { period_query_cte_table_collections << classroom_units << activity_sessions }
-  let(:cte_table_collections) { count_query_cte_table_collections }
+  let(:count_query_cte_records) { period_query_cte_records << classroom_units << activity_sessions }
+  let(:cte_records) { count_query_cte_records }
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
@@ -7,11 +7,9 @@ RSpec.shared_context 'Snapshots Count CTE' do
 
   let(:activity_sessions) do
     classroom_units.map do |classroom_unit|
-      create(:activity_session, activity_session_trait, classroom_unit: classroom_unit, timespent: rand(1..100))
+      create(:activity_session, classroom_unit: classroom_unit, timespent: rand(1..100))
     end
   end
-
-  let(:activity_session_trait) { :started }
 
   let(:count_query_cte_table_collections) { period_query_cte_table_collections << classroom_units << activity_sessions }
   let(:cte_table_collections) { count_query_cte_table_collections }

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_count_cte.rb
@@ -6,7 +6,6 @@ RSpec.shared_context 'Snapshots Count CTE' do
   let(:classroom_units) { classrooms.map { |classroom| create(:classroom_unit, classroom: classroom) } }
   let(:classroom_units_cte_query) { cte_query(classroom_units) }
 
-  let(:num_activity_sessions) { activity_sessions.count }
   let(:activity_sessions) { classroom_units.map { |classroom_unit| create(:activity_session, classroom_unit: classroom_unit) } }
   let(:activity_sessions_cte_query) { cte_query(activity_sessions) }
 

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
@@ -40,7 +40,7 @@ RSpec.shared_context 'Snapshots CTE' do
     attr_type = record.class.column_for_attribute(attr).type
 
     if value.nil?
-      'NULL'
+      "''"
     elsif value.is_a?(Array)
       value.map { |v| attr_type_value(attr_type, v) }
     else
@@ -52,7 +52,7 @@ RSpec.shared_context 'Snapshots CTE' do
     case attr_type
     when :boolean, :decimal, :float, :integer then value
     when :jsonb, :string then "'#{value}'"
-    when :datetime then "'#{value.iso8601}'"
+    when :datetime then "'#{value&.iso8601}'"
     else
       raise "Error: type #{attr_type} not found" # "'#{value}'"
     end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
@@ -1,60 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'Snapshots CTE' do
-  # BigQuery doesn't support CTE aliases with period in the name.
-  # So, we need to remove the 'lms.' and 'special.' prefixes from 'FROM' and 'JOIN' clauses
-  let(:query) { pg_query.gsub(/(FROM|JOIN)\s+(?:lms|special)\.(\w+)/, '\1 \2') }
+  # Create before running the query, otherwise, some parameters (e.g. school_ids) will be nil
+  before { cte_records }
 
-  let(:bq_query) do
-    <<-SQL
-      WITH
-        #{cte}
-      #{query}
-    SQL
-  end
-
-  let(:results) { QuillBigQuery::Runner.execute(bq_query) }
-
-  def cte
-    cte_table_collections
-      .reject { |collection| collection.empty? }
-      .map { |collection| "#{cte_alias(collection)} AS ( #{cte_query(collection)} )" }
-      .join(",\n\t")
-  end
-
-  def cte_alias(collection)
-    collection.first.class.table_name
-  end
-
-  def cte_query(records)
-    records
-      .map { |record| [:SELECT, cte_select_clause(record)].join(' ') }
-      .join(" UNION ALL \n")
-  end
-
-  def cte_select_clause(record)
-    record.attributes.except('order').map { |attr, value| "#{convert_type(record, attr, value)} AS #{attr}" }.join(', ')
-  end
-
-  def convert_type(record, attr, value)
-    attr_type = record.class.column_for_attribute(attr).type
-
-    if value.nil?
-      "''"
-    elsif value.is_a?(Array)
-      value.map { |v| attr_type_value(attr_type, v) }
-    else
-      attr_type_value(attr_type, value)
-    end
-  end
-
-  def attr_type_value(attr_type, value)
-    case attr_type
-    when :boolean, :decimal, :float, :integer then value
-    when :inet, :jsonb, :string then "'#{value}'"
-    when :datetime then "'#{value&.iso8601}'"
-    else
-      raise "Error: value:'#{value}' type #{attr_type} not found"
-    end
-  end
+  let(:results) { QuillBigQuery::TestRunner.run(described_class.new(*params).final_query, cte_records) }
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
@@ -4,17 +4,57 @@ RSpec.shared_context 'Snapshots CTE' do
   # BigQuery doesn't support CTE aliases with period in the name.
   # So, we need to remove the 'lms.' and 'special.' prefixes from 'FROM' and 'JOIN' clauses
   let(:query) { pg_query.gsub(/(FROM|JOIN)\s+(?:lms|special)\.(\w+)/, '\1 \2') }
-  let(:bq_query) { "WITH #{cte} #{query}" }
+
+  let(:bq_query) do
+    <<-SQL
+      WITH
+        #{cte}
+      #{query}
+    SQL
+  end
+
   let(:results) { QuillBigQuery::Runner.execute(bq_query) }
+
+  def cte
+    cte_table_collections
+      .reject { |collection| collection.empty? }
+      .map { |collection| "#{cte_alias(collection)} AS ( #{cte_query(collection)} )" }
+      .join(",\n\t")
+  end
+
+  def cte_alias(collection)
+    collection.first.class.table_name
+  end
 
   def cte_query(records)
     records
-      .map { |record| record.attributes.except('order') }
-      .map { |attrs| [:SELECT, attrs.map { |k, v| "#{quote_unless_numeric(v)} AS #{k}" }.join(', ')].join(' ') }
+      .map { |record| [:SELECT, cte_select_clause(record)].join(' ') }
       .join(" UNION ALL \n")
   end
 
-  def quote_unless_numeric(value)
-    value.is_a?(Numeric) ? value : "'#{value}'"
+  def cte_select_clause(record)
+    record.attributes.except('order').map { |attr, value| "#{convert_type(record, attr, value)} AS #{attr}" }.join(', ')
+  end
+
+  def convert_type(record, attr, value)
+    attr_type = record.class.column_for_attribute(attr).type
+
+    if value.nil?
+      'NULL'
+    elsif value.is_a?(Array)
+      value.map { |v| attr_type_value(attr_type, v) }
+    else
+      attr_type_value(attr_type, value)
+    end
+  end
+
+  def attr_type_value(attr_type, value)
+    case attr_type
+    when :boolean, :decimal, :float, :integer then value
+    when :jsonb, :string then "'#{value}'"
+    when :datetime then "'#{value.iso8601}'"
+    else
+      raise "Error: type #{attr_type} not found" # "'#{value}'"
+    end
   end
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
@@ -2,11 +2,10 @@
 
 RSpec.shared_context 'Snapshots CTE' do
   # BigQuery doesn't support CTE aliases with period in the name.
-  # So, we need to remove the `lms.` prefix from 'FROM' and 'JOIN' clauses
-  let(:query) { pg_query.gsub(/(FROM|JOIN) lms\.(\w+)/, '\1 \2') }
-
-  let(:results) { QuillBigQuery::Runner.execute(bg_query) }
+  # So, we need to remove the 'lms.' and 'special.' prefixes from 'FROM' and 'JOIN' clauses
+  let(:query) { pg_query.gsub(/(FROM|JOIN)\s+(?:lms|special)\.(\w+)/, '\1 \2') }
   let(:bq_query) { "WITH #{cte} #{query}" }
+  let(:results) { QuillBigQuery::Runner.execute(bq_query) }
 
   def cte_query(records)
     records

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
@@ -4,5 +4,5 @@ RSpec.shared_context 'Snapshots CTE' do
   # Create before running the query, otherwise, some parameters (e.g. school_ids) will be nil
   before { cte_records }
 
-  let(:results) { QuillBigQuery::TestRunner.run(described_class.new(*params).final_query, cte_records) }
+  let(:results) { QuillBigQuery::TestRunner.run(described_class.new(*params).query, cte_records) }
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
@@ -51,10 +51,10 @@ RSpec.shared_context 'Snapshots CTE' do
   def attr_type_value(attr_type, value)
     case attr_type
     when :boolean, :decimal, :float, :integer then value
-    when :jsonb, :string then "'#{value}'"
+    when :inet, :jsonb, :string then "'#{value}'"
     when :datetime then "'#{value&.iso8601}'"
     else
-      raise "Error: type #{attr_type} not found" # "'#{value}'"
+      raise "Error: value:'#{value}' type #{attr_type} not found"
     end
   end
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'Snapshots CTE' do
+  # BigQuery doesn't support CTE aliases with period in the name.
+  # So, we need to remove the `lms.` prefix from 'FROM' and 'JOIN' clauses
+  let(:query) { pg_query.gsub(/(FROM|JOIN) lms\.(\w+)/, '\1 \2') }
+
+  let(:results) { QuillBigQuery::Runner.execute(bg_query) }
+  let(:bq_query) { "WITH #{cte} #{query}" }
+
+  def cte_query(records)
+    records
+      .map { |record| record.attributes.except('order') }
+      .map { |attrs| [:SELECT, attrs.map { |k, v| "#{quote_unless_numeric(v)} AS #{k}" }.join(', ')].join(' ') }
+      .join(" UNION ALL \n")
+  end
+
+  def quote_unless_numeric(value)
+    value.is_a?(Numeric) ? value : "'#{value}'"
+  end
+end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.shared_context 'Snapshots CTE' do
-  # Create before running the query, otherwise, some parameters (e.g. school_ids) will be nil
-  before { cte_records }
-
-  let(:results) { QuillBigQuery::TestRunner.run(described_class.new(*params).query, cte_records) }
-end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_option_query_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_option_query_cte.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'Snapshots Option CTE' do
-  include_context 'Snapshots CTE'
+  include_context 'QuillBigQuery TestRunner Setup'
 
   let(:params) { [admin.id] }
 

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_option_query_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_option_query_cte.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'Snapshots Option CTE' do
+  include_context 'Snapshots CTE'
+
+  let(:pg_query) { described_class.new(admin.id).query_to_run }
+
+  let(:num_classrooms) { 2 }
+  let(:classrooms) { create_list(:classroom, num_classrooms) }
+  let(:classrooms_teachers) { ClassroomsTeacher.where(classroom_id: classrooms.pluck(:id)) }
+  let(:schools_users) { User.teacher.map { |teacher| create(:schools_users, user: teacher)} }
+  let(:schools_admins) { schools_users.map { |schools_user| create(:schools_admins, school: schools_user.school) } }
+  let(:users) { User.all }
+  let(:admin) { users.admin.first }
+
+  let(:option_query_cte_table_collections) { [classrooms, classrooms_teachers, schools_users, schools_admins, users] }
+  let(:cte_table_collections) { option_query_cte_table_collections }
+end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_option_query_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_option_query_cte.rb
@@ -3,7 +3,7 @@
 RSpec.shared_context 'Snapshots Option CTE' do
   include_context 'Snapshots CTE'
 
-  let(:pg_query) { described_class.new(admin.id).query_to_run }
+  let(:params) { [admin.id] }
 
   let(:num_classrooms) { 2 }
   let(:classrooms) { create_list(:classroom, num_classrooms) }
@@ -13,6 +13,7 @@ RSpec.shared_context 'Snapshots Option CTE' do
   let(:users) { User.all }
   let(:admin) { users.admin.first }
 
-  let(:option_query_cte_table_collections) { [classrooms, classrooms_teachers, schools_users, schools_admins, users] }
-  let(:cte_table_collections) { option_query_cte_table_collections }
+  let(:option_query_cte_records) { [classrooms, classrooms_teachers, schools_users, schools_admins, users] }
+
+  let(:cte_records) { option_query_cte_records }
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
@@ -8,8 +8,6 @@ RSpec.shared_context 'Snapshots Period CTE' do
   let(:timeframe_start) { 1.day.ago }
   let(:timeframe_end) { 1.day.from_now }
 
-  let(:results) { QuillBigQuery::Runner.execute(bq_query) }
-
   let(:num_classrooms) { 2 }
   let(:classrooms) { create_list(:classroom, num_classrooms) }
   let(:classrooms_cte_query) { cte_query(classrooms) }

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
@@ -3,7 +3,7 @@
 RSpec.shared_context 'Snapshots Period CTE' do
   include_context 'Snapshots CTE'
 
-  let(:pg_query) { described_class.new(timeframe_start, timeframe_end, [school_ids]).query_to_run }
+  let(:params) { [timeframe_start, timeframe_end, school_ids] }
 
   let(:timeframe_start) { 1.week.ago.to_date }
   let(:timeframe_end) { 1.week.from_now.to_date }
@@ -15,6 +15,6 @@ RSpec.shared_context 'Snapshots Period CTE' do
   let(:schools) { School.where(id: schools_users.pluck(:school_id)) }
   let(:school_ids) { schools.pluck(:id) }
 
-  let(:period_query_cte_table_collections) { [classrooms, classrooms_teachers, schools_users, schools] }
-  let(:cte_table_collections) { period_query_cte_table_collections }
+  let(:period_query_cte_records) { [classrooms, classrooms_teachers, schools_users, schools] }
+  let(:cte_records) { period_query_cte_records }
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
@@ -3,33 +3,18 @@
 RSpec.shared_context 'Snapshots Period CTE' do
   include_context 'Snapshots CTE'
 
-  let(:pg_query) { described_class.new(timeframe_start, timeframe_end, [school_ids]).query }
+  let(:pg_query) { described_class.new(timeframe_start, timeframe_end, [school_ids]).query_to_run }
 
-  let(:timeframe_start) { 1.day.ago }
-  let(:timeframe_end) { 1.day.from_now }
+  let(:timeframe_start) { 1.week.ago.to_date }
+  let(:timeframe_end) { 1.week.from_now.to_date }
 
   let(:num_classrooms) { 2 }
   let(:classrooms) { create_list(:classroom, num_classrooms) }
-  let(:classrooms_cte_query) { cte_query(classrooms) }
-
   let(:classrooms_teachers) { ClassroomsTeacher.where(classroom_id: classrooms.pluck(:id)) }
-  let(:classrooms_teachers_cte_query) { cte_query(classrooms_teachers) }
-
   let(:schools_users) { User.teacher.map { |teacher| create(:schools_users, user: teacher)} }
-  let(:schools_users_cte_query) { cte_query(schools_users) }
-
   let(:schools) { School.where(id: schools_users.pluck(:school_id)) }
-  let(:schools_cte_query) { cte_query(School.all) }
   let(:school_ids) { schools.pluck(:id) }
 
-  let(:snapshots_period_cte) do
-    <<-SQL
-      classrooms AS ( #{classrooms_cte_query} ),
-      classrooms_teachers AS ( #{classrooms_teachers_cte_query} ),
-      schools_users AS ( #{schools_users_cte_query} ),
-      schools AS ( #{schools_cte_query} )
-    SQL
-  end
-
-  let(:cte) { snapshots_period_cte }
+  let(:period_query_cte_table_collections) { [classrooms, classrooms_teachers, schools_users, schools] }
+  let(:cte_table_collections) { period_query_cte_table_collections }
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'Snapshots Period CTE' do
+  include_context 'Snapshots CTE'
+
+  let(:pg_query) { described_class.new(timeframe_start, timeframe_end, [school_ids]).query }
+
+  let(:timeframe_start) { 1.day.ago }
+  let(:timeframe_end) { 1.day.from_now }
+
+  let(:results) { QuillBigQuery::Runner.execute(bq_query) }
+
+  let(:num_classrooms) { 2 }
+  let(:classrooms) { create_list(:classroom, num_classrooms) }
+  let(:classrooms_cte_query) { cte_query(classrooms) }
+
+  let(:classrooms_teachers) { ClassroomsTeacher.where(classroom_id: classrooms.pluck(:id)) }
+  let(:classrooms_teachers_cte_query) { cte_query(classrooms_teachers) }
+
+  let(:schools_users) { User.teacher.map { |teacher| create(:schools_users, user: teacher)} }
+  let(:schools_users_cte_query) { cte_query(schools_users) }
+
+  let(:schools) { School.where(id: schools_users.pluck(:school_id)) }
+  let(:schools_cte_query) { cte_query(School.all) }
+  let(:school_ids) { schools.pluck(:id) }
+
+  let(:snapshots_period_cte) do
+    <<-SQL
+      classrooms AS ( #{classrooms_cte_query} ),
+      classrooms_teachers AS ( #{classrooms_teachers_cte_query} ),
+      schools_users AS ( #{schools_users_cte_query} ),
+      schools AS ( #{schools_cte_query} )
+    SQL
+  end
+
+  let(:cte) { snapshots_period_cte }
+end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_period_query_cte.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'Snapshots Period CTE' do
-  include_context 'Snapshots CTE'
+  include_context 'QuillBigQuery TestRunner Setup'
 
-  let(:params) { [timeframe_start, timeframe_end, school_ids] }
+  let(:params) { [timeframe_start, timeframe_end, school_ids, grades] }
 
   let(:timeframe_start) { 1.week.ago.to_date }
   let(:timeframe_end) { 1.week.from_now.to_date }
+  let(:grades) { nil }
 
   let(:num_classrooms) { 2 }
   let(:classrooms) { create_list(:classroom, num_classrooms) }

--- a/services/QuillLMS/spec/support/shared_examples/snapshots/snapshots_period_query_school_ids_rspec.rb
+++ b/services/QuillLMS/spec/support/shared_examples/snapshots/snapshots_period_query_school_ids_rspec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'snapshots period query with a different school id' do |expected_results|
+  let(:school_ids) { [create(:school).id] }
+
+  it { expect(results).to eq expected_results }
+end

--- a/services/QuillLMS/spec/support/shared_examples/snapshots/snapshots_period_query_timeframe_rspec.rb
+++ b/services/QuillLMS/spec/support/shared_examples/snapshots/snapshots_period_query_timeframe_rspec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'snapshots period query with a timeframe' do |timeframe_start, timeframe_end, expected_results|
+  context "timeframe_start #{timeframe_start}, timeframe_end #{timeframe_end}" do
+    let(:timeframe_start) { timeframe_start }
+    let(:timeframe_end) { timeframe_end }
+
+    it { expect(results).to eq expected_results }
+  end
+end
+


### PR DESCRIPTION
## WHAT
Add testing for snapshot queries on BigQuery using CTEs.

## WHY
Tests will give us transparency but also confidence that the queries are doing what we expect them to be doing.

## HOW

The QuillBigQuery::TestRunner [class](https://github.com/empirical-org/Empirical-Core/pull/10605/files#diff-96d2459e3ee946dd97d582a62b96aa844aa76cb61b3fba2e2afaf4df37fc722eR7) takes in some records, creates a CTE from those records, and then runs the query on that CTE.  It takes a couple of arguments: 
1) `query`:  populated with `described_class.new(*params).final_query` in this [file](https://github.com/empirical-org/Empirical-Core/blob/cea5d1a01c5dc7552eb0d84ccee3de8a37739649/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_cte.rb#L7)
2) `cte_records`:  populated from the parent_class' shared_context cte which is one of:
  * snapshots_period_cte 
  * snapshots_count_cte 
  * snapshots_option_cte 

One can override this by specifying a different `cte_records`. (e.g. we override [here](https://github.com/empirical-org/Empirical-Core/blob/e25b1d95dffa531d1c9e65f641f00de97da3c3bb/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb#L11) because the query has additional tables in the [from_and_join_clauses](https://github.com/empirical-org/Empirical-Core/blob/e25b1d95dffa531d1c9e65f641f00de97da3c3bb/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb#L20))


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Just tests
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
