### PR TITLE
Add a model to track teacher logins when we send Segment events

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -124,6 +124,7 @@ class User < ApplicationRecord
   has_many :invitations, foreign_key: 'inviter_id'
   has_many :objectives, through: :checkboxes
   has_many :user_activity_classifications, dependent: :destroy
+  has_many :user_logins, dependent: :destroy
   has_many :user_subscriptions
   has_many :subscriptions, through: :user_subscriptions
   has_many :activity_sessions

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -825,6 +825,10 @@ class User < ApplicationRecord
     classrooms.each { |classroom| SaveUserPackSequenceItemsWorker.perform_async(classroom.id, id) }
   end
 
+  def record_login
+    user_logins.create
+  end
+
   private def validate_flags
     invalid_flags = flags - VALID_FLAGS
 

--- a/services/QuillLMS/app/models/user_login.rb
+++ b/services/QuillLMS/app/models/user_login.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_logins
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_user_logins_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class UserLogin < ApplicationRecord
+  belongs_to :user
+
+  def readonly?
+    !new_record?
+  end
+end

--- a/services/QuillLMS/app/workers/user_login_worker.rb
+++ b/services/QuillLMS/app/workers/user_login_worker.rb
@@ -33,6 +33,6 @@ class UserLoginWorker
   end
 
   def record_user_login
-    UserLogin.create(user: @user)
+    @user.record_login
   end
 end

--- a/services/QuillLMS/app/workers/user_login_worker.rb
+++ b/services/QuillLMS/app/workers/user_login_worker.rb
@@ -16,6 +16,7 @@ class UserLoginWorker
         SegmentIo::BackgroundEvents::TEACHER_SIGNIN,
         properties: @user&.segment_user&.common_params
       )
+      record_user_login
     when User::STUDENT
       # keep these in the following order so the student is the last one identified
       teacher = @user.teacher_of_student
@@ -29,5 +30,9 @@ class UserLoginWorker
         )
       end
     end
+  end
+
+  def record_user_login
+    UserLogin.create(user: @user)
   end
 end

--- a/services/QuillLMS/db/migrate/20230601210338_create_user_login.rb
+++ b/services/QuillLMS/db/migrate/20230601210338_create_user_login.rb
@@ -1,0 +1,9 @@
+class CreateUserLogin < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_logins do |t|
+      t.references :user, index: true, foreign_key: true, null: false
+
+      t.datetime :created_at, null: false
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20230601210338_create_user_login.rb
+++ b/services/QuillLMS/db/migrate/20230601210338_create_user_login.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUserLogin < ActiveRecord::Migration[6.1]
   def change
     create_table :user_logins do |t|

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -5004,6 +5004,36 @@ ALTER SEQUENCE public.user_email_verifications_id_seq OWNED BY public.user_email
 
 
 --
+-- Name: user_logins; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_logins (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: user_logins_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_logins_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_logins_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_logins_id_seq OWNED BY public.user_logins.id;
+
+
+--
 -- Name: user_milestones; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6141,6 +6171,13 @@ ALTER TABLE ONLY public.user_email_verifications ALTER COLUMN id SET DEFAULT nex
 
 
 --
+-- Name: user_logins id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_logins ALTER COLUMN id SET DEFAULT nextval('public.user_logins_id_seq'::regclass);
+
+
+--
 -- Name: user_milestones id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7269,6 +7306,14 @@ ALTER TABLE ONLY public.user_activity_classifications
 
 ALTER TABLE ONLY public.user_email_verifications
     ADD CONSTRAINT user_email_verifications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_logins user_logins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_logins
+    ADD CONSTRAINT user_logins_pkey PRIMARY KEY (id);
 
 
 --
@@ -8754,6 +8799,13 @@ CREATE UNIQUE INDEX index_user_email_verifications_on_user_id ON public.user_ema
 
 
 --
+-- Name: index_user_logins_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_logins_on_user_id ON public.user_logins USING btree (user_id);
+
+
+--
 -- Name: index_user_milestones_on_milestone_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9166,6 +9218,14 @@ ALTER TABLE ONLY public.pack_sequences
 
 ALTER TABLE ONLY public.stripe_checkout_sessions
     ADD CONSTRAINT fk_rails_428a7d5f1b FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: user_logins fk_rails_43d9929204; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_logins
+    ADD CONSTRAINT fk_rails_43d9929204 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -10134,6 +10194,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230523191347'),
 ('20230523192828'),
 ('20230524142914'),
-('20230524143000');
+('20230524143000'),
+('20230601210338');
 
 

--- a/services/QuillLMS/spec/models/user_login_spec.rb
+++ b/services/QuillLMS/spec/models/user_login_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_logins
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_user_logins_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe UserLogin, type: :model do
+  context 'should relations' do
+    it { should belong_to(:user) }
+  end
+end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -82,6 +82,7 @@ describe User, type: :model do
   it { should have_and_belong_to_many(:districts) }
   it { should have_one(:ip_location) }
   it { should have_many(:user_activity_classifications).dependent(:destroy) }
+  it { should have_many(:user_logins).dependent(:destroy) }
   it { should have_many(:user_milestones) }
   it { should have_many(:milestones).through(:user_milestones) }
   it { should have_many(:admin_approval_requests).with_foreign_key('requestee_id') }

--- a/services/QuillLMS/spec/workers/user_login_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/user_login_worker_spec.rb
@@ -16,6 +16,14 @@ describe UserLoginWorker, type: :worker do
       expect(analyzer).to receive(:track_with_attributes).with(teacher, SegmentIo::BackgroundEvents::TEACHER_SIGNIN, properties: teacher.segment_user.common_params)
       worker.perform(teacher.id)
     end
+
+    it 'creates a UserLogin' do
+      allow(analyzer).to receive(:track_with_attributes)
+
+      expect do
+        worker.perform(teacher.id)
+      end.to change(UserLogin, :count).by(1)
+    end
   end
 
   context 'when student with teacher logs in' do


### PR DESCRIPTION
## WHAT
Begin tracking each Teacher login
## WHY
We want access to similar time-series data for teacher logins as we have in Segment and Ortto.  Specifically, we want to be able report how many "active teachers" a given school has during arbitrary time periods.  While we acknowledge that teachers who haven't been force-logged-out can be active without signing in for significant periods of time, we want to start with a simple copy of what we're doing in Segment already.
## HOW
- Add a new read-only `UserLogin` model that with a `created_at` timestamp
- Write a new `UserLogin` record for any user who triggers a `Teacher signed in` event in Segment (note that we're not recording for students at this time to reduce volume of events being stored)

### Notion Card Links
https://www.notion.so/quill/Backend-for-Admin-Snapshot-Report-a90a9996669a4c60b8a242ce2306cb12?pvs=4#e9d3b1f40ff84e8abf0a26791a844f58

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A