### PR TITLE
compress csvs before emailing them

### DIFF
--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -23,7 +23,7 @@ class UserMailer < ActionMailer::Base
 
   COTEACHER_SUPPORT_ARTICLE = 'http://support.quill.org/getting-started-for-teachers/manage-classes/how-do-i-share-a-class-with-my-co-teacher'
   FEEDBACK_SESSIONS_CSV_DOWNLOAD = "Feedback Sessions CSV Download"
-  FEEDBACK_SESSIONS_CSV_FILENAME = "feedback_sessions.csv"
+  FEEDBACK_SESSIONS_CSV_FILENAME = "feedback_sessions.csv.zip"
 
   def invitation_to_non_existing_user invitation_email_hash
     @email_hash = invitation_email_hash.merge(support_article_link: COTEACHER_SUPPORT_ARTICLE, join_link: new_account_url).stringify_keys

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -165,7 +165,7 @@ class UserMailer < ActionMailer::Base
   end
 
   def feedback_history_session_csv_download(email, csv_file_path)
-    attachments[FEEDBACK_SESSIONS_CSV_FILENAME] = File.read(csv_file_path)
+    attachments[FEEDBACK_SESSIONS_CSV_FILENAME] = ActiveSupport::Gzip.compress(File.read(csv_file_path))
     mail from: "The Quill Team <hello@quill.org>", to: email, subject: FEEDBACK_SESSIONS_CSV_DOWNLOAD
 
     File.delete(csv_file_path) if File.exist?(csv_file_path)

--- a/services/QuillLMS/spec/mailers/user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/user_mailer_spec.rb
@@ -240,7 +240,7 @@ describe UserMailer, type: :mailer do
 
       # Refer to constants to make coupling with string explicit
       expect(subject.subject).to match(described_class::FEEDBACK_SESSIONS_CSV_DOWNLOAD)
-      expect(ActiveSupport::Gzip.decompress(CSV.parse(csv_attachment.body.raw_source))).to eq(CSV.parse(csv_body))
+      expect(CSV.parse(ActiveSupport::Gzip.decompress(csv_attachment.body.raw_source))).to eq(CSV.parse(csv_body))
     end
 
     it 'should delete the file after the email has been sent' do

--- a/services/QuillLMS/spec/mailers/user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/user_mailer_spec.rb
@@ -240,7 +240,7 @@ describe UserMailer, type: :mailer do
 
       # Refer to constants to make coupling with string explicit
       expect(subject.subject).to match(described_class::FEEDBACK_SESSIONS_CSV_DOWNLOAD)
-      expect(CSV.parse(csv_attachment.body.raw_source)).to eq(CSV.parse(csv_body))
+      expect(ActiveSupport::Gzip.decompress(CSV.parse(csv_attachment.body.raw_source))).to eq(CSV.parse(csv_body))
     end
 
     it 'should delete the file after the email has been sent' do


### PR DESCRIPTION
## WHAT
Compress feedback session CSVs before mailing them.

## WHY
This is another attempt to fix the bugs mentioned [in this PR](https://github.com/empirical-org/Empirical-Core/pull/10603). It turns out [Sendgrid has a hard 30mb limit](https://docs.sendgrid.com/api-reference/mail-send/limitations#:~:text=The%20total%20size%20of%20your,must%20no%20more%20than%201000.), and our CSVs are definitely exceeding that - I tested locally and one 7k-ish response file was 19.2mb, and the example queries Hannah sent me were closer to 22k lines. When I ran this locally, that 19.2mb file compressed to 2mb, so I'm optimistic this will work as a solution at least for the time being.

## HOW
Just compress the file before sending it using ActiveRecord's gzip.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Email-Me-CSV-Data-button-not-working-on-View-Sessions-page-86ad7b0514a64c32beb37cee28f4ca41

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | no - tiny change, tested locally
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A