### PR TITLE
Teacher Premium modal fix

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
@@ -122,7 +122,7 @@ li.premium-tab > a:hover {
   .quill-modal {
     z-index: 6;
   }
-  .already-has-premium-modal {
+  .already-has-premium-modal, .log-in-to-purchase-modal {
     max-width: calc(100vw - 20px);
     min-height: min-content;
     p {

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/PremiumPricingGuide.jsx
@@ -45,6 +45,21 @@ const AlreadyHasPremiumModal = ({ type, close, }) => (
   </div>
 )
 
+const LoginToPurchaseModal = ({ close }) => (
+  <div className="modal-container log-in-to-purchase-modal-container">
+    <div className="modal-background" />
+    <div className="log-in-to-purchase-modal quill-modal modal-body">
+      <div>
+        <h3 className="title">Log in to purchase</h3>
+      </div>
+      <p>Please <a className="focus-on-light" href="/session/new">log in to your Quill account</a> to purchase Teacher Premium.</p>
+      <div className="form-buttons">
+        <button className="quill-button medium contained primary focus-on-light" onClick={close} type="button">OK</button>
+      </div>
+    </div>
+  </div>
+)
+
 export const PremiumPricingGuide = ({
   customerEmail,
   diagnosticActivityCount,
@@ -60,6 +75,7 @@ export const PremiumPricingGuide = ({
   const [showSchoolAndDistrictPremiumModal, setShowSchoolAndDistrictPremiumModal] = React.useState(!!openModalToSchoolSelection)
   const [showAlreadyHasTeacherPremiumModal, setShowAlreadyHasTeacherPremiumModal] = React.useState(false)
   const [showAlreadyHasSchoolPremiumModal, setShowAlreadyHasSchoolPremiumModal] = React.useState(false)
+  const [showLoginToPurchaseModal, setShowLoginToPurchaseModal] = React.useState(false)
   const [showSnackbar, setShowSnackbar] = React.useState(false)
 
   useSnackbarMonitor(showSnackbar, setShowSnackbar, defaultSnackbarTimeout)
@@ -80,6 +96,7 @@ export const PremiumPricingGuide = ({
 
   function openAlreadyHasTeacherPremiumModal() { setShowAlreadyHasTeacherPremiumModal(true) }
 
+  function toggleLoginToPurchaseModal() { setShowLoginToPurchaseModal(!showLoginToPurchaseModal) }
 
   function handleNotListedSelection() {
     setShowSnackbar(true)
@@ -100,7 +117,9 @@ export const PremiumPricingGuide = ({
   }
 
   const teacherBuyNowButton = () => {
-    if (!userIsEligibleForNewSubscription) {
+    if(!customerEmail) {
+      return <button className="quill-button contained medium primary focus-on-light" onClick={toggleLoginToPurchaseModal} type="button">Buy now</button>
+    } else if (!userIsEligibleForNewSubscription) {
       return <button className="quill-button contained medium primary focus-on-light" onClick={openAlreadyHasTeacherPremiumModal} type="button">Buy now</button>
     }
     return (
@@ -150,6 +169,7 @@ export const PremiumPricingGuide = ({
         )}
         {showAlreadyHasSchoolPremiumModal && <AlreadyHasPremiumModal close={closeAlreadyHasSchoolPremiumModal} type="School Premium" />}
         {showAlreadyHasTeacherPremiumModal && <AlreadyHasPremiumModal close={closeAlreadyHasTeacherPremiumModal} type="Teacher Premium" />}
+        {showLoginToPurchaseModal && <LoginToPurchaseModal close={toggleLoginToPurchaseModal} />}
         <div className="overview text-center">
           <PremiumPricingMinisRow
             diagnosticActivityCount={diagnosticActivityCount}
@@ -161,14 +181,12 @@ export const PremiumPricingGuide = ({
             teacherBuyNowButton={teacherBuyNowButton}
             userIsEligibleForNewSubscription={userIsEligibleForNewSubscription}
           />
-
           <PremiumFeaturesTable
             diagnosticActivityCount={diagnosticActivityCount}
             independentPracticeActivityCount={independentPracticeActivityCount}
             lessonsActivityCount={lessonsActivityCount}
           />
         </div>
-
         <div className="features text-center">
           <SchoolPremium />
           <SubscriberLogos subscribers={subscribers} />


### PR DESCRIPTION
## WHAT
add log in to purchase modal to the Teacher Premium page for when an unauthenticated user clicks the "Buy Now" button

## WHY
we are showing a "You already have Teacher Premium" message which was confusing for users

## HOW
just add the new modal element and update rendering logic

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1375" alt="Screen Shot 2023-06-02 at 12 22 58 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/a6c090b1-bb53-4e3d-b70e-ff4f34f928f1">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Teacher-Premium-Pop-Up-d91e0b8f2aa4405d8bb63a2f49a82c20?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
