### PR TITLE
Refactor Google auth logic

### DIFF
--- a/services/QuillLMS/app/services/google_integration/refresh_access_token.rb
+++ b/services/QuillLMS/app/services/google_integration/refresh_access_token.rb
@@ -105,8 +105,8 @@ module GoogleIntegration
     private def refresh_token_options
       {
         body: {
-          client_id: ENV["GOOGLE_CLIENT_ID"],
-          client_secret: ENV["GOOGLE_CLIENT_SECRET"],
+          client_id: Auth::Google::CLIENT_ID,
+          client_secret: Auth::Google::CLIENT_SECRET,
           refresh_token: refresh_token,
           grant_type: 'refresh_token'
         },

--- a/services/QuillLMS/config/initializers/auth/google.rb
+++ b/services/QuillLMS/config/initializers/auth/google.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Auth
+  module Google
+    CLIENT_ID = ENV['GOOGLE_CLIENT_ID']
+    CLIENT_SECRET = ENV['GOOGLE_CLIENT_SECRET']
+
+    ONLINE_ACCESS_NAME = 'google/online_access'
+    ONLINE_ACCESS_PATH = "/auth/#{ONLINE_ACCESS_NAME}"
+    ONLINE_ACCESS_CALLBACK_PATH = "#{ONLINE_ACCESS_PATH}/callback"
+
+    OFFLINE_ACCESS_NAME ='google/offline_access'
+    OFFLINE_ACCESS_PATH = "/auth/#{OFFLINE_ACCESS_NAME}"
+    OFFLINE_ACCESS_CALLBACK_PATH = "#{OFFLINE_ACCESS_PATH}/callback"
+
+    SCOPE_OPTIONS = [
+      'classroom.announcements',
+      'classroom.courses.readonly',
+      'classroom.profile.emails',
+      'classroom.rosters.readonly',
+      'email',
+      'profile'
+    ].freeze
+  end
+end
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2,
+    Auth::Google::CLIENT_ID,
+    Auth::Google::CLIENT_SECRET,
+    access_type: 'online',
+    name: Auth::Google::ONLINE_ACCESS_NAME,
+    provider_ignores_state: true,
+    scope: Auth::Google::SCOPE_OPTIONS,
+    skip_jwt: true
+
+  provider :google_oauth2,
+    Auth::Google::CLIENT_ID,
+    Auth::Google::CLIENT_SECRET,
+    access_type: 'offline',
+    name: Auth::Google::OFFLINE_ACCESS_NAME,
+    prompt: 'consent',
+    provider_ignores_state: true,
+    scope: Auth::Google::SCOPE_OPTIONS,
+    skip_jwt: true
+end

--- a/services/QuillLMS/config/initializers/omniauth.rb
+++ b/services/QuillLMS/config/initializers/omniauth.rb
@@ -1,51 +1,11 @@
 # frozen_string_literal: true
 
-module Auth
-  module Google
-    SCOPE_OPTIONS = [
-      'classroom.announcements',
-      'classroom.courses.readonly',
-      'classroom.profile.emails',
-      'classroom.rosters.readonly',
-      'email',
-      'profile'
-    ].freeze
-
-    ONLINE_ACCESS_NAME = 'google/online_access'
-    ONLINE_ACCESS_PATH = "/auth/#{ONLINE_ACCESS_NAME}"
-    ONLINE_ACCESS_CALLBACK_PATH = "#{ONLINE_ACCESS_PATH}/callback"
-
-    OFFLINE_ACCESS_NAME ='google/offline_access'
-    OFFLINE_ACCESS_PATH = "/auth/#{OFFLINE_ACCESS_NAME}"
-    OFFLINE_ACCESS_CALLBACK_PATH = "#{OFFLINE_ACCESS_PATH}/callback"
-  end
-end
-
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :clever,
     Clever::CLIENT_ID,
     Clever::CLIENT_SECRET,
     get_user_info: true,
     provider_ignores_state: true
-
-  provider :google_oauth2,
-    ENV["GOOGLE_CLIENT_ID"],
-    ENV["GOOGLE_CLIENT_SECRET"],
-    access_type: 'online',
-    name: Auth::Google::ONLINE_ACCESS_NAME,
-    provider_ignores_state: true,
-    scope: Auth::Google::SCOPE_OPTIONS,
-    skip_jwt: true
-
-  provider :google_oauth2,
-    ENV["GOOGLE_CLIENT_ID"],
-    ENV["GOOGLE_CLIENT_SECRET"],
-    access_type: 'offline',
-    name: Auth::Google::OFFLINE_ACCESS_NAME,
-    prompt: 'consent',
-    provider_ignores_state: true,
-    scope: Auth::Google::SCOPE_OPTIONS,
-    skip_jwt: true
 end
 
 OmniAuth.config.logger = Rails.logger

--- a/services/QuillLMS/spec/services/google_integration/refresh_access_token_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/refresh_access_token_spec.rb
@@ -169,14 +169,20 @@ describe GoogleIntegration::RefreshAccessToken do
   end
 
   describe '#refresh_token_options' do
+    let(:google_client_id) { 'foo' }
+    let(:google_client_secret) { 'bar' }
+    let(:refresh_token) { 'baz' }
+
+    before do
+      stub_const("Auth::Google::CLIENT_ID", google_client_id)
+      stub_const("Auth::Google::CLIENT_SECRET", google_client_secret)
+    end
+
     it 'should return the expected payload' do
-      client_id = 'foo'
-      client_secret = 'bar'
-      refresh_token = 'baz'
       expected_payload = {
         body: {
-          client_id: client_id,
-          client_secret: client_secret,
+          client_id: google_client_id,
+          client_secret: google_client_secret,
           refresh_token: refresh_token,
           grant_type: 'refresh_token'
         },
@@ -185,8 +191,6 @@ describe GoogleIntegration::RefreshAccessToken do
         }
       }
 
-      expect(ENV).to receive(:[]).with('GOOGLE_CLIENT_ID').and_return(client_id)
-      expect(ENV).to receive(:[]).with('GOOGLE_CLIENT_SECRET').and_return(client_secret)
       expect(subject).to receive(:refresh_token).and_return(refresh_token)
       expect(subject.send(:refresh_token_options)).to eq(expected_payload)
     end


### PR DESCRIPTION
## WHAT
Refactor some of the google omniauth logic

## WHY
Setting up a pattern for assigning omniauth providers in preparation for canvas integration.  Also, it's safer to deploy this as separate commit than subsequent canvas work.

## HOW
Move google omniauth into its own initializer.  

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
