### PR TITLE
Refactor Clever auth logic

### DIFF
--- a/services/QuillLMS/app/controllers/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/clever_controller.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 class CleverController < ApplicationController
-
   def auth_url_details
     render json: {
-      redirect_uri: Clever::REDIRECT_URL,
-      client_id: Clever::CLIENT_ID,
-      clever_scope: QuillClever.scope
+      redirect_uri: Auth::Clever::REDIRECT_URL,
+      client_id: Auth::Clever::CLIENT_ID,
+      clever_scope: Auth::Clever::SCOPE
     }
   end
 
   def no_classroom
     render 'clever/no_classroom'
   end
-
 end

--- a/services/QuillLMS/app/controllers/concerns/clever_authable.rb
+++ b/services/QuillLMS/app/controllers/concerns/clever_authable.rb
@@ -10,13 +10,9 @@ module CleverAuthable
   def clever_link_query_params
     {
       response_type: 'code',
-      redirect_uri: clever_link_redirect_uri,
-      client_id: Clever::CLIENT_ID,
-      scope: QuillClever.scope
+      redirect_uri: Auth::Clever::REDIRECT_URL,
+      client_id: Auth::Clever::CLIENT_ID,
+      scope: Auth::Clever::SCOPE
     }.to_param
-  end
-
-  def clever_link_redirect_uri
-    Clever::REDIRECT_URL
   end
 end

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -160,6 +160,7 @@ class Teachers::ClassroomManagerController < ApplicationController
     session[GOOGLE_REDIRECT] = request.env['PATH_INFO']
     session[:clever_redirect] = request.env['PATH_INFO']
     @google_or_clever_just_set = session[ApplicationController::GOOGLE_OR_CLEVER_JUST_SET]
+    @clever_link = clever_link
     session[ApplicationController::GOOGLE_OR_CLEVER_JUST_SET] = nil
     @account_info = current_user.generate_teacher_account_info
     @show_dismiss_school_selection_reminder_checkbox = show_school_selection_reminders

--- a/services/QuillLMS/app/services/clever_integration/oauth_client.rb
+++ b/services/QuillLMS/app/services/clever_integration/oauth_client.rb
@@ -6,15 +6,18 @@ module CleverIntegration
     base_uri 'https://clever.com'
 
     def initialize
-      @options = {
-        headers: {
-          "Authorization": "Basic #{Base64.strict_encode64("#{Clever.const_get(:CLIENT_ID)}:#{Clever.const_get(:CLIENT_SECRET)}")}"
-        }
-      }
+      @options = { headers: { "Authorization": "Basic #{basic_auth_header}" } }
     end
 
     def get_district_token(district_id:)
-      self.class.get("/oauth/tokens?owner_type=district&district=#{district_id}", @options).parsed_response["data"]
+      self
+        .class
+        .get("/oauth/tokens?owner_type=district&district=#{district_id}", @options)
+        .parsed_response["data"]
+    end
+
+    private def basic_auth_header
+      Base64.strict_encode64("#{Auth::Clever::CLIENT_ID}:#{Auth::Clever::CLIENT_SECRET}")
     end
   end
 end

--- a/services/QuillLMS/app/services/quill_clever.rb
+++ b/services/QuillLMS/app/services/quill_clever.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class QuillClever
-  cattr_accessor :scope
-  @@scope = 'read:user'
-end

--- a/services/QuillLMS/app/views/teachers/classroom_manager/my_account.html.erb
+++ b/services/QuillLMS/app/views/teachers/classroom_manager/my_account.html.erb
@@ -4,7 +4,7 @@
   accountInfo: @account_info,
   alternativeSchools: @alternative_schools,
   alternativeSchoolsNameMap: @alternative_schools_name_map,
-  cleverLink: "https://clever.com/oauth/authorize?#{ {response_type: 'code', redirect_uri: Clever::REDIRECT_URL, client_id: Clever::CLIENT_ID, scope: QuillClever.scope}.to_param }",
+  cleverLink: @clever_link,
   googleOrCleverJustSet: @google_or_clever_just_set,
   showDismissSchoolSelectionReminderCheckbox: @show_dismiss_school_selection_reminder_checkbox,
   subjectAreas: SubjectArea.all

--- a/services/QuillLMS/config/initializers/auth/clever.rb
+++ b/services/QuillLMS/config/initializers/auth/clever.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Auth
+  module Clever
+    CLIENT_ID = ENV['CLEVER_CLIENT_ID'] || '279109faf81350c2f429'
+    CLIENT_SECRET = ENV['CLEVER_CLIENT_SECRET'] || '5f6b971a3d678dd35499f7e4f46d44ca56c0adb3'
+    REDIRECT_URL = ENV['CLEVER_REDIRECT_URL'] || 'http://localhost:3000/auth/clever/callback'
+    SCOPE = 'read:user'
+  end
+end
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :clever,
+    Auth::Clever::CLIENT_ID,
+    Auth::Clever::CLIENT_SECRET,
+    get_user_info: true,
+    provider_ignores_state: true
+end

--- a/services/QuillLMS/config/initializers/clever.rb
+++ b/services/QuillLMS/config/initializers/clever.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Clever
-  CLIENT_ID = ENV['CLEVER_CLIENT_ID'] || '279109faf81350c2f429'
-  CLIENT_SECRET = ENV['CLEVER_CLIENT_SECRET'] || '5f6b971a3d678dd35499f7e4f46d44ca56c0adb3'
-  REDIRECT_URL = ENV['CLEVER_REDIRECT_URL'] || 'http://localhost:3000/auth/clever/callback'
-end

--- a/services/QuillLMS/config/initializers/omniauth.rb
+++ b/services/QuillLMS/config/initializers/omniauth.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :clever,
-    Clever::CLIENT_ID,
-    Clever::CLIENT_SECRET,
-    get_user_info: true,
-    provider_ignores_state: true
-end
-
 OmniAuth.config.logger = Rails.logger
 
 unless Rails.env.development?


### PR DESCRIPTION
## WHAT
Refactor some of the clever omniauth logic

## WHY
Setting up a pattern for assigning omniauth providers in preparation for canvas integration. Also, it's safer to deploy this as separate commit than subsequent canvas work.

## HOW
Move clever omniauth into its own initializer and then update references in app code.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  Just refactoring
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
