### PR TITLE
Fix intermittent spec failures

### DIFF
--- a/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
@@ -143,8 +143,12 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
 
           expect(response).to have_http_status(200)
           expect(parsed_response['activity_sessions'].length).to eq(2)
-          expect(parsed_response['activity_sessions'][0]['session_uid']).to eq(@feedback_history3.feedback_session_uid)
-          expect(parsed_response['activity_sessions'][1]['session_uid']).to eq(@feedback_history1.feedback_session_uid)
+
+          actual_session_uid1 = parsed_response['activity_sessions'][0]['session_uid']
+          actual_session_uid2 = parsed_response['activity_sessions'][1]['session_uid']
+
+          expect([actual_session_uid1, actual_session_uid2])
+            .to match_array [@feedback_history3.feedback_session_uid, @feedback_history1.feedback_session_uid]
         end
 
         it 'should retrieve only unscored sessions when filter_type is unscored' do

--- a/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/session_feedback_histories_controller_spec.rb
@@ -131,9 +131,17 @@ describe Api::V1::SessionFeedbackHistoriesController, type: :controller do
 
           expect(response).to have_http_status(200)
           expect(parsed_response['activity_sessions'].length).to eq(3)
-          expect(parsed_response['activity_sessions'][0]['session_uid']).to eq(@feedback_history3.feedback_session_uid)
-          expect(parsed_response['activity_sessions'][1]['session_uid']).to eq(@feedback_history2.feedback_session_uid)
-          expect(parsed_response['activity_sessions'][2]['session_uid']).to eq(@feedback_history1.feedback_session_uid)
+
+          actual_session_uid1 = parsed_response['activity_sessions'][0]['session_uid']
+          actual_session_uid2 = parsed_response['activity_sessions'][1]['session_uid']
+          actual_session_uid3 = parsed_response['activity_sessions'][2]['session_uid']
+
+          expect([actual_session_uid1, actual_session_uid2, actual_session_uid3])
+            .to match_array [
+              @feedback_history3.feedback_session_uid,
+              @feedback_history2.feedback_session_uid,
+              @feedback_history1.feedback_session_uid
+            ]
         end
 
         it 'should retrieve only scored sessions when filter_type is scored' do

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -99,7 +99,7 @@ describe DiagnosticReports do
       let!(:unit_activity2) { create(:unit_activity, unit: unit2, activity: unit_activity1.activity) }
       let!(:activity_session1) { create(:activity_session, :finished, user: student1, classroom_unit: classroom_unit1, activity: unit_activity1.activity) }
       let!(:activity_session2) { create(:activity_session, :finished, user: student2, classroom_unit: classroom_unit1, activity: unit_activity1.activity) }
-      let!(:activity_session3) { create(:activity_session, :finished, user: student2, classroom_unit: classroom_unit2, activity: unit_activity1.activity) }
+      let!(:activity_session3) { create(:activity_session, :finished, completed_at: activity_session2.completed_at.since(1.minute), user: student2, classroom_unit: classroom_unit2, activity: unit_activity1.activity) }
 
       it 'should set the variables for all the final score activity sessions for that activity, classroom, and unit, with only one per student' do
         set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)

--- a/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
@@ -99,7 +99,7 @@ describe TeachersController, type: :controller do
 
         it 'returns an array with both lessons activities in it in reverse order of creation' do
           get :lessons_info_for_dashboard_mini
-          expect(response.body).to eq({ units: [
+          expected_response = [
             {
               classroom_name: classroom.name,
               activity_name: lesson_activity2.name,
@@ -116,7 +116,9 @@ describe TeachersController, type: :controller do
               classroom_id: classroom.id,
               supporting_info: lesson_activity1.supporting_info
             }
-          ]}.to_json)
+          ].map(&:stringify_keys)
+
+          expect(JSON.parse(response.body)['units']).to match_array expected_response
         end
       end
 
@@ -168,9 +170,9 @@ describe TeachersController, type: :controller do
               unit_id: unit.id,
               classroom_id: classroom.id
             }
-          ]
+          ].map(&:stringify_keys)
 
-          expect(JSON.parse(response.body)['units']).to match_array(expected_response.map(&:stringify_keys))
+          expect(JSON.parse(response.body)['units']).to match_array expected_response
         end
       end
 
@@ -209,9 +211,9 @@ describe TeachersController, type: :controller do
               unit_id: unit.id,
               classroom_id: classroom.id
             }
-          ]
+          ].map(&:stringify_keys)
 
-          expect(JSON.parse(response.body)['units']).to match_array(expected_response.map(&:stringify_keys))
+          expect(JSON.parse(response.body)['units']).to match_array expected_response.map(&:stringify_keys)
         end
       end
 

--- a/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
@@ -93,13 +93,13 @@ describe TeachersController, type: :controller do
         let!(:classroom_teacher) { create(:classrooms_teacher, classroom: classroom, user: teacher) }
         let!(:classroom_unit) { create(:classroom_unit, classroom: classroom, unit: unit, assigned_student_ids: classroom.students.ids)}
         let!(:unit_activity1) { create(:unit_activity, unit: unit, activity: lesson_activity1)}
-        let!(:unit_activity2) { create(:unit_activity, unit: unit, activity: lesson_activity2)}
+        let!(:unit_activity2) { create(:unit_activity, created_at: unit_activity1.created_at.since(1.minute), unit: unit, activity: lesson_activity2)}
         let!(:classroom_unit_activity_state1) { create(:classroom_unit_activity_state, unit_activity: unit_activity1, classroom_unit: classroom_unit, completed: false)}
         let!(:classroom_unit_activity_state2) { create(:classroom_unit_activity_state, unit_activity: unit_activity2, classroom_unit: classroom_unit, completed: false)}
 
         it 'returns an array with both lessons activities in it in reverse order of creation' do
           get :lessons_info_for_dashboard_mini
-          expected_response = [
+          expect(response.body).to eq({ units: [
             {
               classroom_name: classroom.name,
               activity_name: lesson_activity2.name,
@@ -116,9 +116,7 @@ describe TeachersController, type: :controller do
               classroom_id: classroom.id,
               supporting_info: lesson_activity1.supporting_info
             }
-          ].map(&:stringify_keys)
-
-          expect(JSON.parse(response.body)['units']).to match_array expected_response
+          ]}.to_json)
         end
       end
 

--- a/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers_controller_spec.rb
@@ -144,6 +144,7 @@ describe TeachersController, type: :controller do
 
         it 'returns a row for each diagnostic' do
           get :diagnostic_info_for_dashboard_mini
+
           expected_response = [
             {
               assigned_count: classroom.students.ids.length,
@@ -168,7 +169,8 @@ describe TeachersController, type: :controller do
               classroom_id: classroom.id
             }
           ]
-          expect(response.body).to eq({units: expected_response}.to_json)
+
+          expect(JSON.parse(response.body)['units']).to match_array(expected_response.map(&:stringify_keys))
         end
       end
 
@@ -208,7 +210,8 @@ describe TeachersController, type: :controller do
               classroom_id: classroom.id
             }
           ]
-          expect(response.body).to eq({units: expected_response}.to_json)
+
+          expect(JSON.parse(response.body)['units']).to match_array(expected_response.map(&:stringify_keys))
         end
       end
 

--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -497,7 +497,7 @@ RSpec.describe FeedbackHistory, type: :model do
       it 'return the total count of activity sessions' do
         expect(FeedbackHistory.get_total_count).to eq(2)
         expect(FeedbackHistory.get_total_count(activity_id: @activity1.id)).to eq(1)
-        expect(FeedbackHistory.get_total_count(start_date: Time.current)).to eq(0)
+        expect(FeedbackHistory.get_total_count(start_date: FeedbackHistory.last.created_at.since(1.minute))).to eq(0)
         expect(FeedbackHistory.get_total_count(activity_version: @current_activity_version)).to eq(1)
         expect(FeedbackHistory.get_total_count(activity_version: @previous_activity_version)).to eq(1)
       end


### PR DESCRIPTION
## WHAT
Fix the following intermittent spec failures
1) [session_feedback_histories_controller_spec:134](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/22066/workflows/c068e476-a78f-46b4-ae3b-b27cb42103bb/jobs/270605?invite=true#step-108-82)

1) [session_feedback_histories_controller_spec.rb:127](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/22058/workflows/5050a34e-5cf0-4476-8ce2-3a1360b74337/jobs/270548?invite=true#step-108-98)

1) [feedback_history_spec.rb:497](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/22058/workflows/5050a34e-5cf0-4476-8ce2-3a1360b74337/jobs/270548?invite=true#step-108-101)

1) [controllers/concerns/diagnostic_reports_spec.rb:104](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/22058/workflows/5050a34e-5cf0-4476-8ce2-3a1360b74337/jobs/270548?invite=true#step-108-99)

1) [controllers/concerns/diagnostic_reports_spec.rb:110](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/22058/workflows/5050a34e-5cf0-4476-8ce2-3a1360b74337/jobs/270548?invite=true#step-108-100)

1) [teachers_controller_spec.rb:185](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/22066/workflows/c068e476-a78f-46b4-ae3b-b27cb42103bb/jobs/270605?invite=true#step-108-83)

1) [teachers_controller_spec.rb:145](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/22066/workflows/c068e476-a78f-46b4-ae3b-b27cb42103bb/jobs/270605?invite=true#step-108-84)

1) [teachers_controller_spec.rb:100](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/22067/workflows/c99a56e4-4e25-4152-985c-de7705c804c9/jobs/270618?invite=true#step-108-72)

## WHY
False positives slow down velocity

## HOW
Most of these issues are from order clauses combined with timestamps (e.g. `created_at`). 

1) There is a an  `.order('start_date DESC')` in [FeedbackHistory.list_by_activity_session](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/models/feedback_history.rb#L311) that can cause non-deterministic behavior
1) Same as previous
1) The query param for start_date is on `Time.current` which could lead to some non-deterministic behavior.  Instead, couple it to the last created FeedbackHistory
1) Within the method [set_pre_test_activity_sessions_and_assigned_students](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb#L57)  there is a    `.order(completed_at: :desc).uniq { |activity_session| activity_session.user_id }` chaining sequence that due to the `uniq` clause can lead to non-deterministic throwing out of activity sessions.
1) same as previous
1) There is an `.order(Arel.sql("greatest(classroom_units.created_at, unit_activities.created_at) DESC"))` in [teachers_controller](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/controllers/teachers_controller.rb#L123) which can lead to non-deterministic behavior
1) Same as previous
1) Same as previous

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
