### PR TITLE
lms/remove-kindergarten-from-snapshot-grades

### DIFF
--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -2,7 +2,6 @@
 
 class SnapshotsController < ApplicationController
   GRADE_OPTIONS = [
-    {value: "Kindergarten", name: "Kindergarten"},
     {value: "1", name: "1st"},
     {value: "2", name: "2nd"},
     {value: "3", name: "3rd"},

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -106,7 +106,7 @@ describe SnapshotsController, type: :controller do
       end
 
       it 'should include school_ids and grades in the call to the cache worker if they are in params' do
-        grades = ["Kindergarten", "1", "2"]
+        grades = ["1", "2"]
 
         allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return([previous_timeframe, current_timeframe, timeframe_end])
         expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)


### PR DESCRIPTION
## WHAT
Remove Kindergarten from the grade options
## WHY
So that it better matches grade options during teacher onboarding and classroom setup
## HOW
Just remove the value from the grade options constant in the Snapshots controller

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
