### PR TITLE
lms/migration-check-message-in-deploy-script

### DIFF
--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -83,7 +83,7 @@ then
     if [ $1 == 'prod' ]
     then
         CURRENT_DATE=(date +'%l:%M%p')
-        read -r -p "Does this deploy include a migration that need to run?  Quill policy is to not run migrations between the hours of 10am and 3pm Eastern time unless it is an emergency.  Your local time is $CURRENT_DATE.  You may cancel your deploy with ctrl-c.  If you want to continue this deploy, press any key."  response
+        read -r -p "Does this deploy include a migration that need to run?  Quill policy is to not run migrations between the hours of 10am and 3pm Eastern time on school days unless it is an emergency.  Your local time is $CURRENT_DATE.  You may cancel your deploy with ctrl-c.  If you want to continue this deploy, press any key."  response
         # For production, push directly from the remote production branch without going local
         # This 'remote merge' requires your local git history/pointers of the remote branches to be up-to-date, so we run a 'git fetch' to do that.
         # Documented here: https://github.com/empirical-org/test_repo/blob/destination_branch/test_file.txt

--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -82,7 +82,8 @@ then
     sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
     if [ $1 == 'prod' ]
     then
-        read -r -p "Does this deploy include a migration that you'll need to run?  Look at the time.  Is this a good time to run that migration?  If not, cancel your deploy with ctrl-c.  If you do want to deploy, press any key." response
+        CURRENT_DATE=(date +'%l:%M%p')
+        read -r -p "Does this deploy include a migration that need to run?  Quill policy is to not run migrations between the hours of 10am and 3pm Eastern time unless it is an emergency.  Your local time is $CURRENT_DATE.  You may cancel your deploy with ctrl-c.  If you want to continue this deploy, press any key."  response
         # For production, push directly from the remote production branch without going local
         # This 'remote merge' requires your local git history/pointers of the remote branches to be up-to-date, so we run a 'git fetch' to do that.
         # Documented here: https://github.com/empirical-org/test_repo/blob/destination_branch/test_file.txt

--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -82,6 +82,7 @@ then
     sh ../../scripts/post_slack_deploy.sh $app_name $1 $current_branch false
     if [ $1 == 'prod' ]
     then
+        read -r -p "Does this deploy include a migration that you'll need to run?  Look at the time.  Is this a good time to run that migration?  If not, cancel your deploy with ctrl-c.  If you do want to deploy, press any key." response
         # For production, push directly from the remote production branch without going local
         # This 'remote merge' requires your local git history/pointers of the remote branches to be up-to-date, so we run a 'git fetch' to do that.
         # Documented here: https://github.com/empirical-org/test_repo/blob/destination_branch/test_file.txt

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -456,7 +456,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
       expect(response).to be_successful
 
-      expect(classroom_unit.reload.assigned_student_ids).to eq([student1.id, student2.id])
+      expect(classroom_unit.reload.assigned_student_ids).to match_array([student1.id, student2.id])
     end
   end
 end


### PR DESCRIPTION
## WHAT
Add a message to check to see if there's a migration in a deploy

NOTE: I've also fixed another intermittent spec failure.  I went ahead and did it in this PR since it's so small.
## WHY
To make people more aware of the timing of their deploy to avoid running migrations during peak traffic
## HOW
Add a new `read` directive to the deploy script in order to pause the flow and give users a chance to interrupt it.

### Screenshots
lms/migration-check-message-in-deploy-script

### Notion Card Links
https://www.notion.so/quill/Post-Mortem-6-2-23-Site-outage-Hung-migration-7b74abd45bb74942a7cb209a09585fa2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on deploy scripts
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A