### PR TITLE
Delete Obsolete Sessions Optimization.

### DIFF
--- a/services/QuillLMS/app/workers/delete_obsolete_active_activity_sessions_worker.rb
+++ b/services/QuillLMS/app/workers/delete_obsolete_active_activity_sessions_worker.rb
@@ -4,13 +4,17 @@ class DeleteObsoleteActiveActivitySessionsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 
+  BATCH_SIZE = 100
+
   def perform
-    obsolete_query.in_batches.delete_all
+    while obsolete_query.delete_all > 0
+      # empty loop since condtional is also the action
+    end
   end
 
   private def obsolete_query
     ActiveActivitySession
-      .select(:id)
       .obsolete
+      .limit(BATCH_SIZE)
   end
 end

--- a/services/QuillLMS/spec/workers/delete_obsolete_active_activity_sessions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/delete_obsolete_active_activity_sessions_worker_spec.rb
@@ -16,6 +16,7 @@ describe DeleteObsoleteActiveActivitySessionsWorker, type: :worker do
       uid: obsolete_session2.uid,
       classroom_unit: create(:classroom_unit, visible: false)
     )
+    stub_const("DeleteObsoleteActiveActivitySessionsWorker::BATCH_SIZE", 1)
   end
 
   it 'should delete obsolete sessions' do


### PR DESCRIPTION
## WHAT
Tiny PR. Was looking at stats and saw this very slow job. This job is really slow since the queries used by `in_batches` are a select with ordering (which seems to be very slow on this table).
## WHY
This job is slow and getting slower, it took 39 minutes last week.
## HOW
Remove batch selects from job which involve ordering (this is the part that is slow). Loop through delete statements and delete in chunks.
### Screenshots
![Screenshot 2023-06-08 at 9 31 25 AM](https://github.com/empirical-org/Empirical-Core/assets/1304933/8feeca17-7f54-4bee-8115-a119811be4e4)
![Screenshot 2023-06-08 at 9 31 16 AM](https://github.com/empirical-org/Empirical-Core/assets/1304933/189bd301-22b8-4d89-9bc1-5e0c3b4fe4b5)
![Screenshot 2023-06-08 at 9 31 04 AM](https://github.com/empirical-org/Empirical-Core/assets/1304933/8f538df6-a69d-4fcf-9e22-cf912adfccd1)




PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes, but mostly a pure refactor.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
