### PR TITLE
evidence/add-mestres-to-spelling-exceptions

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -31,7 +31,8 @@ module Evidence
       'worldwatch',
       'wilmut',
       'quokkaselfie',
-      'quokkaselfies'
+      'quokkaselfies',
+      'mestres'
     ]
 
     attr_reader :entry


### PR DESCRIPTION
## WHAT
Add "mestres" to the spelling exceptions list
## WHY
It's an acceptable word in the context of Capoeira which we have a passage about
## HOW
Just add the word to the existing spelling exceptions list


### Notion Card Links
https://www.notion.so/quill/Mestres-caught-as-spelling-error-87a650a6d1db4a398d9f6e8b53ec282a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  We don't have test coverage for specific spelling exceptions
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
