### PR TITLE
Add Canvas LTI Launch configuration

### DIFF
--- a/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
+++ b/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class LtiController < ApplicationController
+    # launch is loaded within Canvas in an iframe muddling the CSRF token
+    skip_before_action :verify_authenticity_token, only: :launch
+
+    SSO_LINK_TEXT = 'This link will redirect you to Quill.org for SSO'
+
+    def launch
+      @link_text = SSO_LINK_TEXT
+      @link_url = root_path # root_path will be replaced with SSO path in next PR
+
+      render layout: false  # Canvas will not allow javascript in the iframe
+    end
+
+    def launch_config
+      @launch_url = canvas_integration_lti_launch_url
+    end
+  end
+end

--- a/services/QuillLMS/app/views/canvas_integration/lti/launch.html.erb
+++ b/services/QuillLMS/app/views/canvas_integration/lti/launch.html.erb
@@ -1,0 +1,14 @@
+<div style='background-color:green'>
+  <a aria-label='Quill' class='focus-on-dark' href='https://www.quill.org/'>
+    <img src='https://assets.quill.org/images/logos/quill-logo-white-2022.svg' alt='Quill.org logo'>
+  </a>
+
+  <br/>
+  <br/>
+</div>
+
+<div class='account-container text-center'>
+  <br />
+  <%= link_to @link_text, @link_url, target: '_blank' %>
+</div>
+

--- a/services/QuillLMS/app/views/canvas_integration/lti/launch_config.xml.erb
+++ b/services/QuillLMS/app/views/canvas_integration/lti/launch_config.xml.erb
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cartridge_basiclti_link
+  xmlns="http://www.imsglobal.org/xsd/imslticc_v1p0"
+  xmlns:blti = "http://www.imsglobal.org/xsd/imsbasiclti_v1p0"
+  xmlns:lticm ="http://www.imsglobal.org/xsd/imslticm_v1p0"
+  xmlns:lticp ="http://www.imsglobal.org/xsd/imslticp_v1p0"
+  xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation = "
+      http://www.imsglobal.org/xsd/imslticc_v1p0
+      http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticc_v1p0.xsd
+      http://www.imsglobal.org/xsd/imsbasiclti_v1p0
+      http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0.xsd
+      http://www.imsglobal.org/xsd/imslticm_v1p0
+      http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd
+      http://www.imsglobal.org/xsd/imslticp_v1p0
+      http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd
+    "
+>
+  <blti:title>Quill SSO tool</blti:title>
+  <blti:description>This tool allows teachers and students to SSO into Quill</blti:description>
+  <blti:launch_url><%= @launch_url %></blti:launch_url>
+  <blti:extensions platform="canvas.instructure.com">
+    <lticm:property name="privacy_level">anonymous</lticm:property>
+    <lticm:options name="account_navigation">
+      <lticm:property name="enabled">true</lticm:property>
+    </lticm:options>
+    <lticm:options name="course_navigation">
+      <lticm:property name="enabled">true</lticm:property>
+    </lticm:options>
+    <lticm:options name="custom_fields">
+      <lticm:property name="canvas_api_baseurl">$Canvas.api.baseUrl</lticm:property>
+      <lticm:property name="canvas_user_id">$Canvas.user.id</lticm:property>
+    </lticm:options>
+  </blti:extensions>
+</cartridge_basiclti_link>

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -595,6 +595,11 @@ EmpiricalGrammar::Application.routes.draw do
     post '/learn_worlds/courses', to: 'learn_worlds#courses'
   end
 
+  namespace :canvas_integration do
+    get 'lti/launch_config.xml' => 'lti#launch_config'
+    post 'lti/launch' => 'lti#launch'
+  end
+
   namespace :clever_integration do
     get '/teachers/retrieve_classrooms', to: 'teachers#retrieve_classrooms'
     post '/teachers/import_classrooms', to: 'teachers#import_classrooms'

--- a/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module CanvasIntegration
+  describe LtiController, type: :request do
+    before { subject }
+
+    context '#lts_launch_config' do
+      subject { get '/canvas_integration/lti/launch_config.xml' }
+
+      let(:doc) { Nokogiri::XML(response.body) { |config| config.strict } }
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(response.content_type).to eq 'application/xml; charset=utf-8' }
+      it { expect { doc }.not_to raise_error }
+
+      context 'blti:launch_url' do
+        let(:node) { doc.at_xpath('//blti:launch_url') }
+
+        it { expect(node.content).to eq 'http://www.example.com/canvas_integration/lti/launch' }
+      end
+    end
+
+    context '#lti_launch' do
+      subject { post '/canvas_integration/lti/launch' }
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(response.content_type).to eq 'text/html; charset=utf-8' }
+      it { expect(response.body).to include(described_class::SSO_LINK_TEXT) }
+      it { expect(response.body).not_to include('Home') } # check layout: false
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add a LTI Launch configuration.

## WHY
As a pre-requisite for Canvas SSO, we need a LTI app that users can install in their Canvas Instances.

## HOW
There are two endpoints:
1) `canvas_integration/lti/launch_config.xml`: This XML file contains an LTI configuration:
![Screenshot 2023-06-09 at 8 30 40 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/17a4d797-b43c-4a40-9e45-0e0d02cf5fc9)

2) `canvas_integration/lti/launch`:  Using the launch_config.xml, the LTI app loads an iframe with the launch URL:
![Screenshot 2023-06-09 at 8 36 03 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/d45ba850-75f8-4054-8170-710a42840caf)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
