### PR TITLE
Engine Factory Loading Tweak

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
@@ -4,6 +4,8 @@
 begin
   require 'factory_bot_rails'
 rescue LoadError
+  # factory_bot_rails is only available when development_dependencies
+  # from the gemspec are loaded (development and test environments).
 end
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/engine.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 # require_relative '../quill_scaffold_controller'
-require 'factory_bot_rails' unless Rails.env.production?
+begin
+  require 'factory_bot_rails'
+rescue LoadError
+end
 
 module Evidence
   class Engine < ::Rails::Engine
@@ -23,7 +26,7 @@ module Evidence
       g.fallbacks[:shoulda] = :test_unit
     end
 
-    unless Rails.env.production?
+    if defined?(FactoryBot)
       initializer "evidence.factories", after: "factory_bot.set_factory_paths" do
         FactoryBot.definition_file_paths << File.expand_path('../../../spec/factories/evidence', __FILE__)
       end


### PR DESCRIPTION
## WHAT
Load factory_bot_rails configs if factory_bot is present (it's only available in `test` and `development` environments since it's in the gemspec file as `s.add_development_dependency 'factory_bot_rails'`)

This is [factory_bot's recommended way to do this](https://github.com/thoughtbot/factory_bot_rails#automatic-factory-definition-loading) (although we use slightly older syntax).
## WHY
Deploys to staging were failing with the new factory sharing, but changing this to `load_this if Rails.env.production? || Rails.env.staging?`(flagged by Brendan) is a bit of a code smell.
## HOW
Share factories if factory_bot is present.
### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   No, test config change.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yup
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 