### PR TITLE
Link omniauth-canvas configuration with SSO endpoint

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -23,6 +23,7 @@ gem 'atomic_arrays', '~> 1.1.0'
 gem 'bcrypt', '~> 3.1.12'
 gem "doorkeeper", "5.0.3"
 gem 'omniauth', '~> 1.9'
+gem 'omniauth-canvas'
 gem 'omniauth-google-oauth2', '0.6.0'
 gem 'omniauth-clever', git: 'https://github.com/Pioneer-Valley-Books/omniauth-clever'
 gem 'omniauth-rails_csrf_protection'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -446,6 +446,9 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
+    omniauth-canvas (1.0.2)
+      omniauth (~> 1.3)
+      omniauth-oauth2 (~> 1.4)
     omniauth-google-oauth2 (0.6.0)
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
@@ -843,6 +846,7 @@ DEPENDENCIES
   newrelic_rpm (~> 7.2)
   nokogiri (>= 1.13.2)
   omniauth (~> 1.9)
+  omniauth-canvas
   omniauth-clever!
   omniauth-google-oauth2 (= 0.6.0)
   omniauth-rails_csrf_protection

--- a/services/QuillLMS/app/controllers/auth/canvas_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/canvas_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Auth
+  class CanvasController < ApplicationController
+    skip_before_action :verify_authenticity_token, only: :lti_landing_page
+
+    def canvas
+      redirect_to root_path
+    end
+  end
+end

--- a/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
+++ b/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
@@ -3,19 +3,26 @@
 module CanvasIntegration
   class LtiController < ApplicationController
     # launch is loaded within Canvas in an iframe muddling the CSRF token
-    skip_before_action :verify_authenticity_token, only: :launch
+    skip_before_action :verify_authenticity_token, only: [:launch, :sso]
 
-    SSO_LINK_TEXT = 'Log in to Quill.org with your Canvas credentials'
+    layout 'canvas_integration/lti'
+
+    LAUNCH_TEXT = 'This link will redirect you to Quill.org for SSO'
+    SSO_TEXT = 'Log into Quill with your Canvas account (SSO)'
 
     def launch
-      @link_text = SSO_LINK_TEXT
-      @link_url = root_path # root_path will be replaced with SSO path in next PR
-
-      render layout: false  # Canvas will not allow javascript in the iframe
+      @link_text = LAUNCH_TEXT
+      @link_url = canvas_integration_lti_sso_path(canvas_instance_url: params[:custom_canvas_api_domain])
     end
 
     def launch_config
       @launch_url = canvas_integration_lti_launch_url
+    end
+
+    def sso
+      @canvas_instance_id = CanvasInstance.find_by(url: params[:canvas_instance_url])&.id
+      @button_text = SSO_TEXT
+      @button_url = Auth::Canvas::ACCESS_PATH
     end
   end
 end

--- a/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
+++ b/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
@@ -7,12 +7,12 @@ module CanvasIntegration
 
     layout 'canvas_integration/lti'
 
-    LAUNCH_TEXT = 'This link will redirect you to Quill.org for SSO'
-    SSO_TEXT = 'Log into Quill with your Canvas account (SSO)'
+    LAUNCH_TEXT = 'Log in to Quill.org with your Canvas credentials'
+    SSO_BUTTON_TEXT = 'Click here if you are not redirected automatically.'
 
     def launch
       @link_text = LAUNCH_TEXT
-      @link_url = canvas_integration_lti_sso_path(canvas_instance_url: params[:custom_canvas_api_domain])
+      @link_url = canvas_integration_lti_sso_path(canvas_instance_url: params[:custom_canvas_api_baseurl])
     end
 
     def launch_config
@@ -21,7 +21,7 @@ module CanvasIntegration
 
     def sso
       @canvas_instance_id = CanvasInstance.find_by(url: params[:canvas_instance_url])&.id
-      @button_text = SSO_TEXT
+      @button_text = SSO_BUTTON_TEXT
       @button_url = Auth::Canvas::ACCESS_PATH
     end
   end

--- a/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
+++ b/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
@@ -3,7 +3,7 @@
 module CanvasIntegration
   class LtiController < ApplicationController
     # launch is loaded within Canvas in an iframe muddling the CSRF token
-    skip_before_action :verify_authenticity_token, only: [:launch, :sso]
+    skip_before_action :verify_authenticity_token, only: [:launch]
 
     layout 'canvas_integration/lti'
 

--- a/services/QuillLMS/app/models/canvas_instance.rb
+++ b/services/QuillLMS/app/models/canvas_instance.rb
@@ -29,6 +29,18 @@ class CanvasInstance < ApplicationRecord
     uniqueness: true,
     url: true
 
+  def canvas_config
+    canvas_configs.last
+  end
+
+  def client_id
+    canvas_config&.client_id
+  end
+
+  def client_secret
+    canvas_config&.client_secret
+  end
+
   private def downcase_url
     self.url = url.downcase if url.present?
   end

--- a/services/QuillLMS/app/views/canvas_integration/lti/launch.html.erb
+++ b/services/QuillLMS/app/views/canvas_integration/lti/launch.html.erb
@@ -1,14 +1,1 @@
-<div style='background-color:green'>
-  <a aria-label='Quill' class='focus-on-dark' href='https://www.quill.org/'>
-    <img src='https://assets.quill.org/images/logos/quill-logo-white-2022.svg' alt='Quill.org logo'>
-  </a>
-
-  <br/>
-  <br/>
-</div>
-
-<div class='account-container text-center'>
-  <br />
-  <%= link_to @link_text, @link_url, target: '_blank' %>
-</div>
-
+<%= link_to @link_text, @link_url, target: '_blank' %>

--- a/services/QuillLMS/app/views/canvas_integration/lti/sso.html.erb
+++ b/services/QuillLMS/app/views/canvas_integration/lti/sso.html.erb
@@ -1,1 +1,10 @@
-<%= button_to @button_text, @button_url, params: { canvas_instance_id: @canvas_instance_id } %>
+<% button_id = 'redirect_to_canvas_to_verify_credentials' %>
+
+<span>You be will redirected to Canvas to verify credentials...please wait.</span>
+<%= button_to @button_text, @button_url, id: button_id, params: { canvas_instance_id: @canvas_instance_id } %>
+
+<script type='text/javascript'>
+  document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById("<%= button_id %>").click();
+  });
+</script>

--- a/services/QuillLMS/app/views/canvas_integration/lti/sso.html.erb
+++ b/services/QuillLMS/app/views/canvas_integration/lti/sso.html.erb
@@ -1,0 +1,1 @@
+<%= button_to @button_text, @button_url, params: { canvas_instance_id: @canvas_instance_id } %>

--- a/services/QuillLMS/app/views/layouts/canvas_integration/lti.html.erb
+++ b/services/QuillLMS/app/views/layouts/canvas_integration/lti.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%= csrf_meta_tags %>
+  </head>
+
+  <body>
+    <div style='background-color:green'>
+      <a aria-label='Quill' class='focus-on-dark' href='https://www.quill.org/'>
+        <img src='https://assets.quill.org/images/logos/quill-logo-white-2022.svg' alt='Quill.org logo'>
+      </a>
+
+      <br/>
+      <br/>
+    </div>
+
+    <div class='account-container text-center'>
+      <br />
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/services/QuillLMS/app/views/layouts/canvas_integration/lti.html.erb
+++ b/services/QuillLMS/app/views/layouts/canvas_integration/lti.html.erb
@@ -1,15 +1,10 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <%= csrf_meta_tags %>
-  </head>
-
   <body>
     <div style='background-color:green'>
       <a aria-label='Quill' class='focus-on-dark' href='https://www.quill.org/'>
         <img src='https://assets.quill.org/images/logos/quill-logo-white-2022.svg' alt='Quill.org logo'>
       </a>
-
       <br/>
       <br/>
     </div>

--- a/services/QuillLMS/config/initializers/auth/canvas.rb
+++ b/services/QuillLMS/config/initializers/auth/canvas.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Auth
+  module Canvas
+    ACCESS_PATH = '/auth/canvas'
+  end
+end

--- a/services/QuillLMS/config/initializers/auth/canvas.rb
+++ b/services/QuillLMS/config/initializers/auth/canvas.rb
@@ -3,5 +3,55 @@
 module Auth
   module Canvas
     ACCESS_PATH = '/auth/canvas'
+    ACCESS_CALLBACK_PATH = "#{ACCESS_PATH}/callback"
+
+    class Setup
+      attr_reader :env, :session
+
+      def self.call(env)
+        new(env).setup
+      end
+
+      def initialize(env)
+        @env = env
+        @session = Rack::Request.new(env).session
+      end
+
+      def setup
+        add_session_canvas_instance_id if request_phase?
+        set_omniauth_strategy
+        delete_session_canvas_instance_id if callback_phase?
+      end
+
+      private def add_session_canvas_instance_id
+        session[:canvas_instance_id] = env['rack.request.form_hash']['canvas_instance_id']
+      end
+
+      private def callback_phase?
+        env['REQUEST_PATH'] == ACCESS_CALLBACK_PATH
+      end
+
+      private def canvas_instance
+        @canvas_instance ||= CanvasInstance.find(session[:canvas_instance_id])
+      end
+
+      private def delete_session_canvas_instance_id
+        session.delete(:canvas_instance_id)
+      end
+
+      private def request_phase?
+        env['REQUEST_PATH'] == ACCESS_PATH
+      end
+
+      private def set_omniauth_strategy
+        env['omniauth.strategy'].options[:client_options].site = canvas_instance.url
+        env['omniauth.strategy'].options[:client_id] = canvas_instance.client_id
+        env['omniauth.strategy'].options[:client_secret] = canvas_instance&.client_secret
+      end
+    end
   end
+end
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :canvas, setup: Auth::Canvas::Setup
 end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -596,8 +596,9 @@ EmpiricalGrammar::Application.routes.draw do
   end
 
   namespace :canvas_integration do
-    get 'lti/launch_config.xml' => 'lti#launch_config'
-    post 'lti/launch' => 'lti#launch'
+    get '/lti/launch_config.xml' => 'lti#launch_config'
+    post '/lti/launch' => 'lti#launch'
+    get '/lti/sso', to: 'lti#sso'
   end
 
   namespace :clever_integration do

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -589,6 +589,7 @@ EmpiricalGrammar::Application.routes.draw do
 
   get Auth::Google::OFFLINE_ACCESS_CALLBACK_PATH => 'auth/google#offline_access_callback'
   get Auth::Google::ONLINE_ACCESS_CALLBACK_PATH => 'auth/google#online_access_callback'
+  get Auth::Canvas::ACCESS_CALLBACK_PATH => 'auth/canvas#canvas'
 
   namespace :auth do
     get '/clever/callback', to: 'clever#clever'

--- a/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
@@ -27,8 +27,16 @@ module CanvasIntegration
 
       it { expect(response).to have_http_status(:success) }
       it { expect(response.content_type).to eq 'text/html; charset=utf-8' }
-      it { expect(response.body).to include(described_class::SSO_LINK_TEXT) }
-      it { expect(response.body).not_to include('Home') } # check layout: false
+      it { expect(response.body).to include(described_class::LAUNCH_TEXT) }
+      it { expect(response.body).not_to include("<script") }  # LTI does not allow scripts
+    end
+
+    context '#sso' do
+      subject { get '/canvas_integration/lti/sso' }
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(response.content_type).to eq 'text/html; charset=utf-8' }
+      it { expect(response.body).not_to include("<script") }  # LTI does not allow scripts
     end
   end
 end

--- a/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
@@ -36,7 +36,6 @@ module CanvasIntegration
 
       it { expect(response).to have_http_status(:success) }
       it { expect(response.content_type).to eq 'text/html; charset=utf-8' }
-      it { expect(response.body).not_to include("<script") }  # LTI does not allow scripts
     end
   end
 end


### PR DESCRIPTION
## WHAT
Add an omniauth-canvas configuration and connect it with the sso endpoint in `CanvasIntegration::LtiController`

## WHY
This is the first part of functionality allowing users to do Single-Sign On using their canvas credentials.

## HOW
1.  The SSO endpoint gets a [canvas_instance_url parameter](https://github.com/empirical-org/Empirical-Core/pull/10640/files#diff-3c7c8294dc112227ee7bbea16f55d98332bb92747faa7525690a51a69fd973f6R23) from the launch endpoint, which gets us the CanvasInstance whose credentials will be used in a later step.
1.  While on the SSO page, there is some [javascript](https://github.com/empirical-org/Empirical-Core/pull/10640/files#diff-f1b802f56e849509c8d5ecd4c843c960ee9475c3f84f876feb792ab842024c72R8) that automatically clicks the button that takes us to `/auth/canvas`.  
1. In the request phase of the OAuth flow, this canvas instance is passed as a parameter to the `/auth/canvas` endpoint where it is [injected](https://github.com/empirical-org/Empirical-Core/compare/bs-canvas-sso?expand=1#diff-7ebaedc3e205cba68346fadb1ed3e2b4e0e2725a9b33547956a73f300bfcaec1R27) into the sessions via the OmniAuth middleware.  This crucially allows us to set client_id and client_secret dynamically per canvas instance.  
1. OAuth flow proceeds and the callback_phase returns us back to Quill ([temporarily](https://github.com/empirical-org/Empirical-Core/pull/10640/files#diff-0fad223e214939793ca81801a46cf78fdaceeeb360824036b35e3ff765a71dc0R8) the `root_path` for now).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES.  I will also be adding some end-to-end test later once all pieces are in place
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
