### PR TITLE
lms/allow-user-login-to-be-destroyed

### DIFF
--- a/services/QuillLMS/app/models/user_login.rb
+++ b/services/QuillLMS/app/models/user_login.rb
@@ -20,6 +20,8 @@ class UserLogin < ApplicationRecord
   belongs_to :user
 
   def readonly?
+    return false if destroyed_by_association
+
     !new_record?
   end
 end

--- a/services/QuillLMS/spec/models/user_login_spec.rb
+++ b/services/QuillLMS/spec/models/user_login_spec.rb
@@ -22,4 +22,15 @@ RSpec.describe UserLogin, type: :model do
   context 'should relations' do
     it { should belong_to(:user) }
   end
+
+  context 'dependent destroy' do
+    let(:user_login) { create(:user_login) }
+    let(:user) { user_login.user }
+
+    it 'should destroy all user_logins parent user is destroyed' do
+      user.destroy!
+
+      expect(UserLogin.find_by(id: user_login.id)).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Allow UserLogin records to be destroyed through dependency chains
## WHY
Originally making the record read-only meant that it couldn't be destroyed, and that prevented users from being destroyed due to the dependent: :destroy chain raising an error.
## HOW
Add a clause to the `readonly?` method in the model so that it is not read-only if it is being destroyed by an association.

### Notion Card Links
https://www.notion.so/quill/Staff-Demo-Account-Not-Resetting-Overnight-d34aba9e81204ec6a4829b8de79c961b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
