### PR TITLE
Add canvas_instance, canvas_external_id unique index to canvas_account

### DIFF
--- a/services/QuillLMS/app/models/canvas_account.rb
+++ b/services/QuillLMS/app/models/canvas_account.rb
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_canvas_accounts_on_canvas_instance_id  (canvas_instance_id)
-#  index_canvas_accounts_on_user_id             (user_id)
+#  index_canvas_accounts_on_canvas_instance_id_and_external_id  (canvas_instance_id,external_id) UNIQUE
+#  index_canvas_accounts_on_user_id                             (user_id)
 #
 # Foreign Keys
 #
@@ -24,4 +24,12 @@
 class CanvasAccount < ApplicationRecord
   belongs_to :canvas_instance
   belongs_to :user
+
+  def self.canvas_id(canvas_instance_id, canvas_user_external_id)
+    [canvas_instance_id, canvas_user_external_id].join(':')
+  end
+
+  def canvas_id
+    self.class.canvas_id(canvas_instance_id, external_id)
+  end
 end

--- a/services/QuillLMS/app/models/canvas_account.rb
+++ b/services/QuillLMS/app/models/canvas_account.rb
@@ -25,11 +25,7 @@ class CanvasAccount < ApplicationRecord
   belongs_to :canvas_instance
   belongs_to :user
 
-  def self.canvas_id(canvas_instance_id, canvas_user_external_id)
-    [canvas_instance_id, canvas_user_external_id].join(':')
-  end
-
   def canvas_id
-    self.class.canvas_id(canvas_instance_id, external_id)
+    [canvas_instance_id, external_id].join(':')
   end
 end

--- a/services/QuillLMS/db/migrate/20230613164607_update_indices_on_canvas_account.rb
+++ b/services/QuillLMS/db/migrate/20230613164607_update_indices_on_canvas_account.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UpdateIndicesOnCanvasAccount < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :canvas_accounts, :canvas_instance_id
+    add_index :canvas_accounts, [:canvas_instance_id, :external_id], unique: true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -7644,10 +7644,10 @@ CREATE INDEX index_blog_posts_on_topic ON public.blog_posts USING btree (topic);
 
 
 --
--- Name: index_canvas_accounts_on_canvas_instance_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_canvas_accounts_on_canvas_instance_id_and_external_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_canvas_accounts_on_canvas_instance_id ON public.canvas_accounts USING btree (canvas_instance_id);
+CREATE UNIQUE INDEX index_canvas_accounts_on_canvas_instance_id_and_external_id ON public.canvas_accounts USING btree (canvas_instance_id, external_id);
 
 
 --
@@ -10195,6 +10195,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230523192828'),
 ('20230524142914'),
 ('20230524143000'),
-('20230601210338');
+('20230601210338'),
+('20230613164607');
 
 

--- a/services/QuillLMS/spec/factories/canvas_accounts.rb
+++ b/services/QuillLMS/spec/factories/canvas_accounts.rb
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_canvas_accounts_on_canvas_instance_id  (canvas_instance_id)
-#  index_canvas_accounts_on_user_id             (user_id)
+#  index_canvas_accounts_on_canvas_instance_id_and_external_id  (canvas_instance_id,external_id) UNIQUE
+#  index_canvas_accounts_on_user_id                             (user_id)
 #
 # Foreign Keys
 #

--- a/services/QuillLMS/spec/factories/classroom_unit_activity_states.rb
+++ b/services/QuillLMS/spec/factories/classroom_unit_activity_states.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: classroom_unit_activity_states
+#
+#  id                :integer          not null, primary key
+#  completed         :boolean          default(FALSE)
+#  data              :json
+#  locked            :boolean          default(FALSE)
+#  pinned            :boolean          default(FALSE)
+#  created_at        :datetime
+#  updated_at        :datetime
+#  classroom_unit_id :integer          not null
+#  unit_activity_id  :integer          not null
+#
+# Indexes
+#
+#  index_classroom_unit_activity_states_on_classroom_unit_id  (classroom_unit_id)
+#  index_classroom_unit_activity_states_on_unit_activity_id   (unit_activity_id)
+#  unique_classroom_and_activity_for_cua_state                (classroom_unit_id,unit_activity_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (classroom_unit_id => classroom_units.id)
+#  fk_rails_...  (unit_activity_id => unit_activities.id)
+#
 FactoryBot.define do
   factory :classroom_unit_activity_state do
     unit_activity            { create(:unit_activity) }

--- a/services/QuillLMS/spec/models/canvas_account_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_account_spec.rb
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_canvas_accounts_on_canvas_instance_id  (canvas_instance_id)
-#  index_canvas_accounts_on_user_id             (user_id)
+#  index_canvas_accounts_on_canvas_instance_id_and_external_id  (canvas_instance_id,external_id) UNIQUE
+#  index_canvas_accounts_on_user_id                             (user_id)
 #
 # Foreign Keys
 #
@@ -30,4 +30,19 @@ RSpec.describe CanvasAccount, type: :model do
 
   it { should belong_to(:canvas_instance) }
   it { should belong_to(:user) }
+
+  describe '.canvas_id' do
+    subject { described_class.canvas_id(canvas_instance_id, canvas_user_external_id) }
+
+    let(:canvas_instance_id) { 1 }
+    let(:canvas_user_external_id) { 2 }
+
+    it { expect(subject).to eq '1:2' }
+  end
+
+  describe '#canvas_id' do
+    subject { canvas_account.canvas_id }
+
+    it { expect(subject).to eq "#{canvas_account.canvas_instance_id}:#{canvas_account.external_id}" }
+  end
 end

--- a/services/QuillLMS/spec/models/canvas_account_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_account_spec.rb
@@ -31,15 +31,6 @@ RSpec.describe CanvasAccount, type: :model do
   it { should belong_to(:canvas_instance) }
   it { should belong_to(:user) }
 
-  describe '.canvas_id' do
-    subject { described_class.canvas_id(canvas_instance_id, canvas_user_external_id) }
-
-    let(:canvas_instance_id) { 1 }
-    let(:canvas_user_external_id) { 2 }
-
-    it { expect(subject).to eq '1:2' }
-  end
-
   describe '#canvas_id' do
     subject { canvas_account.canvas_id }
 

--- a/services/rubocop.sh
+++ b/services/rubocop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-rbenv local 2.6.6
+rbenv local 2.7.8
 gem install rubocop -v 1.28.2
 gem install rubocop-rspec -v 2.10
 gem install activesupport -v 6.1.5.1


### PR DESCRIPTION
## WHAT
1.  Add a unique index on `CanvasAccount` for  `[canvas_instance_id, canvas_user_external_id]`
2.  Remove the `:canvas_instance_id` index on `CanvasAccount`
3. Add some `canvas_id` class and instance methods on CanvasAccount 

## WHY
1.  `[canvas_instance_id, canvas_user_external_id]` should be unique to a specific user
2. The index is no longer needed with the addition of the composite key
3. These will standardize reference to the composite key in other parts of the codebase.

## HOW
1.  Create a migration with `add_index :canvas_accounts, [:canvas_instance_id, :external_id], unique: true`
2.  Create a migration with `remove_index :canvas_accounts, :canvas_instance_id`
3.  Join the two attributes with a [colon](https://github.com/empirical-org/Empirical-Core/blob/4a03bc4f99a13e14a7040ded69052affae16a691/services/QuillLMS/app/models/canvas_account.rb#L29).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
