### PR TITLE
Change the Bing Spell Check API endpoint

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/evidence/spelling_check.rb
@@ -7,7 +7,7 @@ module Evidence
     FALLBACK_INCORRECT_FEEDBACK = '<p>Update the spelling of the bolded word(s).</p>'
     FEEDBACK_TYPE = Rule::TYPE_SPELLING
     RESPONSE_TYPE = 'response'
-    BING_API_URL = 'https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck'
+    BING_API_URL = 'https://api.bing.microsoft.com/v7.0/spellcheck'
     SPELLING_CONCEPT_UID = 'H-2lrblngQAQ8_s-ctye4g'
 
     class BingRateLimitException < StandardError; end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
@@ -102,7 +102,7 @@ module Evidence
         end
 
         it 'should return correct spelling feedback when endpoint returns 200' do
-          stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=#{ERB::Util.url_encode(entry_with_error)}").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
+          stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=#{ERB::Util.url_encode(entry_with_error)}").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
           post :create, params: { entry: entry_with_error, :prompt_id => prompt.id, :session_id => 1 }, as: :json
 
           parsed_response = JSON.parse(response.body)
@@ -114,7 +114,7 @@ module Evidence
           expect(Evidence.error_notifier).to receive(:report).with(Evidence::Check::Spelling::BingException, error_context).once
           expect(Evidence.error_notifier).to receive(:report).with(NoMethodError).once
 
-          stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=#{ERB::Util.url_encode(entry)}").to_return(:status => 200, :body => { :error => { :message => "There's a problem here" } }.to_json, :headers => ({}))
+          stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=#{ERB::Util.url_encode(entry)}").to_return(:status => 200, :body => { :error => { :message => "There's a problem here" } }.to_json, :headers => ({}))
           post :create, params: { entry: entry, :prompt_id => prompt.id, :session_id => 1 }, as: :json
 
           parsed_response = JSON.parse(response.body)
@@ -688,7 +688,7 @@ module Evidence
       end
 
       it 'should return correct spelling feedback when endpoint returns 200' do
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=test%20spelin%20error").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=test%20spelin%20error").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
         post :create, :params => ({ :entry => "test spelin error", :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json
         parsed_response = JSON.parse(response.body)
         expect(response.status).to(eq(200))
@@ -696,7 +696,7 @@ module Evidence
       end
 
       it 'should return 200 with fallback feedback if there is an error on the bing API' do
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
         post :create, :params => ({ :entry => "there is no spelling error here", :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json
         parsed_response = JSON.parse(response.body)
         expect(response.status).to(eq(200))

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/feedback_controller_spec.rb
@@ -102,7 +102,7 @@ module Evidence
         end
 
         it 'should return correct spelling feedback when endpoint returns 200' do
-          stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=#{ERB::Util.url_encode(entry_with_error)}").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
+          stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=#{ERB::Util.url_encode(entry_with_error)}").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
           post :create, params: { entry: entry_with_error, :prompt_id => prompt.id, :session_id => 1 }, as: :json
 
           parsed_response = JSON.parse(response.body)
@@ -114,7 +114,7 @@ module Evidence
           expect(Evidence.error_notifier).to receive(:report).with(Evidence::Check::Spelling::BingException, error_context).once
           expect(Evidence.error_notifier).to receive(:report).with(NoMethodError).once
 
-          stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=#{ERB::Util.url_encode(entry)}").to_return(:status => 200, :body => { :error => { :message => "There's a problem here" } }.to_json, :headers => ({}))
+          stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=#{ERB::Util.url_encode(entry)}").to_return(:status => 200, :body => { :error => { :message => "There's a problem here" } }.to_json, :headers => ({}))
           post :create, params: { entry: entry, :prompt_id => prompt.id, :session_id => 1 }, as: :json
 
           parsed_response = JSON.parse(response.body)
@@ -688,7 +688,7 @@ module Evidence
       end
 
       it 'should return correct spelling feedback when endpoint returns 200' do
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=test%20spelin%20error").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=test%20spelin%20error").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
         post :create, :params => ({ :entry => "test spelin error", :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json
         parsed_response = JSON.parse(response.body)
         expect(response.status).to(eq(200))
@@ -696,7 +696,7 @@ module Evidence
       end
 
       it 'should return 200 with fallback feedback if there is an error on the bing API' do
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
         post :create, :params => ({ :entry => "there is no spelling error here", :prompt_id => prompt.id, :session_id => 1, :previous_feedback => ([]) }), :as => :json
         parsed_response = JSON.parse(response.body)
         expect(response.status).to(eq(200))

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
@@ -248,15 +248,6 @@ ActiveRecord::Schema.define(version: 2023_03_06_215624) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "evidence_rule_hints", force: :cascade do |t|
-    t.bigint "rule_id", null: false
-    t.bigint "hint_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["hint_id"], name: "index_evidence_rule_hints_on_hint_id"
-    t.index ["rule_id"], name: "index_evidence_rule_hints_on_rule_id"
-  end
-
   create_table "evidence_text_generations", force: :cascade do |t|
     t.string "type", null: false
     t.jsonb "config"
@@ -274,6 +265,4 @@ ActiveRecord::Schema.define(version: 2023_03_06_215624) do
   add_foreign_key "comprehension_plagiarism_texts", "comprehension_rules", column: "rule_id", on_delete: :cascade
   add_foreign_key "comprehension_regex_rules", "comprehension_rules", column: "rule_id", on_delete: :cascade
   add_foreign_key "evidence_prompt_healths", "evidence_activity_healths", on_delete: :cascade
-  add_foreign_key "evidence_rule_hints", "comprehension_rules", column: "rule_id", on_delete: :cascade
-  add_foreign_key "evidence_rule_hints", "evidence_hints", column: "hint_id", on_delete: :cascade
 end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/schema.rb
@@ -248,6 +248,15 @@ ActiveRecord::Schema.define(version: 2023_03_06_215624) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "evidence_rule_hints", force: :cascade do |t|
+    t.bigint "rule_id", null: false
+    t.bigint "hint_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["hint_id"], name: "index_evidence_rule_hints_on_hint_id"
+    t.index ["rule_id"], name: "index_evidence_rule_hints_on_rule_id"
+  end
+
   create_table "evidence_text_generations", force: :cascade do |t|
     t.string "type", null: false
     t.jsonb "config"
@@ -265,4 +274,6 @@ ActiveRecord::Schema.define(version: 2023_03_06_215624) do
   add_foreign_key "comprehension_plagiarism_texts", "comprehension_rules", column: "rule_id", on_delete: :cascade
   add_foreign_key "comprehension_regex_rules", "comprehension_rules", column: "rule_id", on_delete: :cascade
   add_foreign_key "evidence_prompt_healths", "evidence_activity_healths", on_delete: :cascade
+  add_foreign_key "evidence_rule_hints", "comprehension_rules", column: "rule_id", on_delete: :cascade
+  add_foreign_key "evidence_rule_hints", "evidence_hints", column: "hint_id", on_delete: :cascade
 end

--- a/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
@@ -9,7 +9,7 @@ module Evidence
     context 'should #feedback_object' do
 
       it 'should return appropriate feedback attributes if there is a spelling error' do
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
         entry = "there is a spelin error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -24,7 +24,7 @@ module Evidence
 
       it 'should not flag error if the spelling error downcased is in exception list' do
         spelling_error = "SpeliN"
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => spelling_error }]) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => spelling_error }]) }.to_json, :headers => ({}))
         stub_const("Evidence::SpellingCheck::EXCEPTIONS", [spelling_error.downcase])
         entry = "there is a spelin error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
@@ -40,7 +40,7 @@ module Evidence
       end
 
       it 'should return appropriate feedback attributes if there is no spelling error' do
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ({}) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ({}) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -53,7 +53,7 @@ module Evidence
       end
 
       it 'should return appropriate feedback attributes if there is no spelling error even if Bing does not return a "flaggedTokens" value' do
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => {}.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => {}.to_json, :headers => ({}))
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -66,7 +66,7 @@ module Evidence
       end
 
       it 'should raise error if the Bing API request times out' do
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_timeout
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_timeout
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
 
@@ -74,7 +74,7 @@ module Evidence
       end
 
       it 'should raise error if the Bing API request times out with a Net::ReadTimeout' do
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_raise(Net::ReadTimeout)
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_raise(Net::ReadTimeout)
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
 
@@ -83,7 +83,7 @@ module Evidence
 
 
       it 'should return appropriate error if the endpoint returns an error' do
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -135,7 +135,7 @@ module Evidence
 
     context 'should handle appropriate Bing API errors' do
       it 'should raise exception if the endpoint returns a rate-limit error' do
-        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 429, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 429, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         expect { spelling_check.feedback_object }.to raise_error(Evidence::SpellingCheck::BingRateLimitException)

--- a/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
@@ -9,7 +9,7 @@ module Evidence
     context 'should #feedback_object' do
 
       it 'should return appropriate feedback attributes if there is a spelling error' do
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => "spelin" }]) }.to_json, :headers => ({}))
         entry = "there is a spelin error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -24,7 +24,7 @@ module Evidence
 
       it 'should not flag error if the spelling error downcased is in exception list' do
         spelling_error = "SpeliN"
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => spelling_error }]) }.to_json, :headers => ({}))
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => spelling_error }]) }.to_json, :headers => ({}))
         stub_const("Evidence::SpellingCheck::EXCEPTIONS", [spelling_error.downcase])
         entry = "there is a spelin error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
@@ -40,7 +40,7 @@ module Evidence
       end
 
       it 'should return appropriate feedback attributes if there is no spelling error' do
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ({}) }.to_json, :headers => ({}))
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ({}) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -53,7 +53,7 @@ module Evidence
       end
 
       it 'should return appropriate feedback attributes if there is no spelling error even if Bing does not return a "flaggedTokens" value' do
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => {}.to_json, :headers => ({}))
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => {}.to_json, :headers => ({}))
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -66,7 +66,7 @@ module Evidence
       end
 
       it 'should raise error if the Bing API request times out' do
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_timeout
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_timeout
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
 
@@ -74,7 +74,7 @@ module Evidence
       end
 
       it 'should raise error if the Bing API request times out with a Net::ReadTimeout' do
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_raise(Net::ReadTimeout)
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_raise(Net::ReadTimeout)
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
 
@@ -83,7 +83,7 @@ module Evidence
 
 
       it 'should return appropriate error if the endpoint returns an error' do
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -135,7 +135,7 @@ module Evidence
 
     context 'should handle appropriate Bing API errors' do
       it 'should raise exception if the endpoint returns a rate-limit error' do
-        stub_request(:get, "https://api.cognitive.microsoft.com/bing/v7.0/SpellCheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 429, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
+        stub_request(:get, "https://api.bing.microsoft.com/v7.0/spellcheck?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 429, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
         entry = "there is no spelling error here"
         spelling_check = Evidence::SpellingCheck.new(entry)
         expect { spelling_check.feedback_object }.to raise_error(Evidence::SpellingCheck::BingRateLimitException)


### PR DESCRIPTION
## WHAT
Bing is expiring their old spell check endpoint and they have moved their spell check services to a new resource. We need to update our code to point to a new resource.

## WHY
The old resource will expire in October of this year and we will not be able to get spelling feedback from it.

## HOW
I've already set up the new resource in Bing Azure, so we just need to point the endpoints we have hard-coded in to refer to this new resource.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=8b26bb192e364fab8e9c633cc6f30a74&pm=c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
