### PR TITLE
lms/de-duplicate-vitally-user-accounts

### DIFF
--- a/services/QuillLMS/lib/tasks/vitally.rake
+++ b/services/QuillLMS/lib/tasks/vitally.rake
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+namespace :vitally do
+  task unlink_extra_account_assignments: :environment do
+    pipe_data = $stdin.read unless $stdin.tty?
+
+    unless pipe_data
+      puts 'No data detected on STDIN.  You must pass data to the task for it to run.  Example:'
+      puts '  rake vitally:unlink_extra_account_assignments < path/to/local/file.csv'
+      puts ''
+      puts 'If you are piping data into Heroku, you need to include the --no-tty flag:'
+      puts '  heroku run rake vitally:unlink_extra_account_assignments -a empirical-grammar --no-tty < path/to/local/file.csv'
+      exit 1
+    end
+
+    vitally_api = VitallyApi.new
+
+    # Batching in 33s because each user could have up to 3 schools to unlink, and VitallyApi
+    # has a batch limit of 100.
+    CSV.parse(pipe_data, headers: true).each_slice(33) do |batch|
+      batch_payload = batch.map do |row|
+        user = User.includes(:schools_users).find(row['externalId'])
+        quill_school_id = user.schools_users.school_id
+        vitally_school_ids = [
+          row['accountExternalId1'],
+          row['accountExternalId2'],
+          row['accountExternalId3'],
+          row['accountExternalId4']
+        ].reject { |id| id.nil? || id.empty? }.map(&:to_i)
+
+        ids_to_unlink = vitally_school_ids.reject { |id| id == quill_school_id }
+
+        ids_to_unlink.map do |id|
+          {
+            type: 'unlink',
+            userId: user.id,
+            accountId: id,
+            messageId: SecureRandom.uuid
+          }
+        end
+      end.flatten
+      batch_payload.each do |api_call_payload|
+        puts "Unlinking user #{api_call_payload[:userId]} from account #{api_call_payload[:accountId]}"
+      end
+      vitally_api.batch(batch_payload)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add a rake task to bulk unlink Vitally users from double accounts

This script is intended to process a ~70k line CSV file of users who are assigned to multiple accounts and we need to figure out which accounts need to be unlinked from the user
## WHY
Users who are assigned to multiple accounts in Vitally causes confusion and double-counting when producing reports in Vitally about school usage.  We have implemented code to prevent users from being double-assigned to an account, but we have this big batch of legacy users who still need to be updated.
## HOW
- Write a script to parse the provided CSV, and then batch users into groups for `VitallyApi.batch` calls
- For each user, figure out what school (account) they are currently associated with, then build an API batch payload to unlink the user from all other accounts that they're connected to

### Notion Card Links
https://www.notion.so/quill/Script-to-unlink-users-who-have-been-associated-with-multiple-accounts-in-Vitally-65df89265b8a44beb05bd205841a7208?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on rake tests
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
