### PR TITLE
Fix hover state for Evidence teacher preview menu button

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/teacher-preview-menu.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/teacher-preview-menu.scss
@@ -159,6 +159,9 @@
           border-radius: 4px;
         }
       }
+      button:hover {
+        background-color: #f2f2f2;
+      }
       .sentence-stems-explanation-container {
         display: flex;
         font-size: 14px;
@@ -185,6 +188,15 @@
       font-weight: 700;
       text-decoration: underline;
       margin-top: 16px;
+      padding: 8px;
+      margin-left: -8px;
+      border-radius: 6px;
+    }
+    .toggle-text-button:hover {
+      background-color: #f2f2f2;
+    }
+    .toggle-text-button:focus {
+      outline-offset: 2px;
     }
   }
   .lower-prompts-preview-section {

--- a/services/QuillLMS/client/app/bundles/Shared/libs/activityPreviewHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/activityPreviewHelpers.tsx
@@ -303,7 +303,7 @@ const renderPassageAndPrompts = ({ passage, prompts, textIsExpanded, toggleExpan
       <section className="text-preview-section">
         <h2>Text</h2>
         {ReactHtmlParser(clippedHtml, {transform: transformNode})}
-        <button className="interactive-wrapper toggle-text-button" onClick={toggleExpandedText}>{buttonLabel}</button>
+        <button className="interactive-wrapper toggle-text-button focus-on-light" onClick={toggleExpandedText}>{buttonLabel}</button>
       </section>
       <div className="divider" />
       <section className="lower-prompts-preview-section">


### PR DESCRIPTION
## WHAT
fix hover state for Evidence teacher preview menu button

## WHY
we want all of the buttons to have the same hover state

## HOW
just tweak some CSS

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/UI-Issue-Evidence-Preview-Panel-Hover-Effect-Consistency-ca50533bd7b147a7b639aa540bc347c0

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- small CSS change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
