### PR TITLE
Add CanvasInstanceAuthCredential model

### DIFF
--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -26,6 +26,7 @@
 #
 class AuthCredential < ApplicationRecord
   belongs_to :user
+  has_one :canvas_instance_auth_credential, dependent: :destroy
 
   CANVAS_PROVIDER = 'canvas'
 

--- a/services/QuillLMS/app/models/canvas_instance.rb
+++ b/services/QuillLMS/app/models/canvas_instance.rb
@@ -22,6 +22,8 @@ class CanvasInstance < ApplicationRecord
 
   has_many :canvas_configs, dependent: :destroy
 
+  has_many :canvas_instance_auth_credentials, dependent: :destroy
+
   before_validation :downcase_url
 
   validates :url,

--- a/services/QuillLMS/app/models/canvas_instance_auth_credential.rb
+++ b/services/QuillLMS/app/models/canvas_instance_auth_credential.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: canvas_instance_auth_credentials
+#
+#  id                 :bigint           not null, primary key
+#  auth_credential_id :bigint           not null
+#  canvas_instance_id :bigint           not null
+#
+# Indexes
+#
+#  index_canvas_instance_auth_credentials_on_auth_credential_id  (auth_credential_id)
+#  index_canvas_instance_auth_credentials_on_canvas_instance_id  (canvas_instance_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (auth_credential_id => auth_credentials.id)
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
+#
+class CanvasInstanceAuthCredential < ApplicationRecord
+  belongs_to :canvas_instance
+  belongs_to :auth_credential
+end

--- a/services/QuillLMS/app/models/canvas_instance_auth_credential.rb
+++ b/services/QuillLMS/app/models/canvas_instance_auth_credential.rb
@@ -10,7 +10,7 @@
 #
 # Indexes
 #
-#  index_canvas_instance_auth_credentials_on_auth_credential_id  (auth_credential_id)
+#  index_canvas_instance_auth_credentials_on_auth_credential_id  (auth_credential_id) UNIQUE
 #  index_canvas_instance_auth_credentials_on_canvas_instance_id  (canvas_instance_id)
 #
 # Foreign Keys
@@ -21,4 +21,6 @@
 class CanvasInstanceAuthCredential < ApplicationRecord
   belongs_to :canvas_instance
   belongs_to :auth_credential
+
+  validates :auth_credential_id, uniqueness: true
 end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -114,6 +114,7 @@ class User < ApplicationRecord
   has_secure_password validations: false
   has_one :admin_info, dependent: :destroy
   has_one :auth_credential, dependent: :destroy
+  has_one :canvas_instance_auth_credential, through: :auth_credential
   has_one :teacher_info, dependent: :destroy
   has_many :teacher_info_subject_areas, through: :teacher_info
   has_many :teacher_notifications, dependent: :destroy

--- a/services/QuillLMS/app/services/canvas_integration/auth_credential_saver.rb
+++ b/services/QuillLMS/app/services/canvas_integration/auth_credential_saver.rb
@@ -19,6 +19,7 @@ module CanvasIntegration
       raise CanvasInstanceNotFoundError unless canvas_instance
       raise CanvasAccountNotFoundError unless canvas_account
 
+      create_canvas_instance_auth_credential
       auth_credential
     end
 
@@ -27,17 +28,22 @@ module CanvasIntegration
     end
 
     private def auth_credential
-      AuthCredential.create!(
-        access_token: access_token,
-        expires_at: expires_at,
-        provider: PROVIDER,
-        refresh_token: refresh_token,
-        user: user
-      )
+      @auth_credential ||=
+        AuthCredential.create!(
+          access_token: access_token,
+          expires_at: expires_at,
+          provider: PROVIDER,
+          refresh_token: refresh_token,
+          user: user
+        )
     end
 
     private def canvas_account
       @canvas_account ||= CanvasAccount.find_by(external_id: external_id, canvas_instance: canvas_instance)
+    end
+
+    private def create_canvas_instance_auth_credential
+      auth_credential.create_canvas_instance_auth_credential!(canvas_instance: canvas_instance)
     end
 
     private def canvas_instance

--- a/services/QuillLMS/db/migrate/20230621161210_create_canvas_instance_auth_credential_join_table.rb
+++ b/services/QuillLMS/db/migrate/20230621161210_create_canvas_instance_auth_credential_join_table.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateCanvasInstanceAuthCredentialJoinTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canvas_instance_auth_credentials do |t|
+      t.references :canvas_instance, null: false, foreign_key: true
+      t.references :auth_credential, null: false, foreign_key: true
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20230621161210_create_canvas_instance_auth_credential_join_table.rb
+++ b/services/QuillLMS/db/migrate/20230621161210_create_canvas_instance_auth_credential_join_table.rb
@@ -4,7 +4,11 @@ class CreateCanvasInstanceAuthCredentialJoinTable < ActiveRecord::Migration[6.1]
   def change
     create_table :canvas_instance_auth_credentials do |t|
       t.references :canvas_instance, null: false, foreign_key: true
-      t.references :auth_credential, null: false, foreign_key: true
+
+      t.references :auth_credential,
+        null: false,
+        foreign_key: true,
+        index: { unique: true }
     end
   end
 end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -7713,7 +7713,7 @@ CREATE INDEX index_canvas_configs_on_canvas_instance_id ON public.canvas_configs
 -- Name: index_canvas_instance_auth_credentials_on_auth_credential_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_canvas_instance_auth_credentials_on_auth_credential_id ON public.canvas_instance_auth_credentials USING btree (auth_credential_id);
+CREATE UNIQUE INDEX index_canvas_instance_auth_credentials_on_auth_credential_id ON public.canvas_instance_auth_credentials USING btree (auth_credential_id);
 
 
 --

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1055,6 +1055,36 @@ ALTER SEQUENCE public.canvas_configs_id_seq OWNED BY public.canvas_configs.id;
 
 
 --
+-- Name: canvas_instance_auth_credentials; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.canvas_instance_auth_credentials (
+    id bigint NOT NULL,
+    canvas_instance_id bigint NOT NULL,
+    auth_credential_id bigint NOT NULL
+);
+
+
+--
+-- Name: canvas_instance_auth_credentials_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.canvas_instance_auth_credentials_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: canvas_instance_auth_credentials_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.canvas_instance_auth_credentials_id_seq OWNED BY public.canvas_instance_auth_credentials.id;
+
+
+--
 -- Name: canvas_instance_schools; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5387,6 +5417,13 @@ ALTER TABLE ONLY public.canvas_configs ALTER COLUMN id SET DEFAULT nextval('publ
 
 
 --
+-- Name: canvas_instance_auth_credentials id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.canvas_instance_auth_credentials ALTER COLUMN id SET DEFAULT nextval('public.canvas_instance_auth_credentials_id_seq'::regclass);
+
+
+--
 -- Name: canvas_instance_schools id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6402,6 +6439,14 @@ ALTER TABLE ONLY public.canvas_accounts
 
 ALTER TABLE ONLY public.canvas_configs
     ADD CONSTRAINT canvas_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: canvas_instance_auth_credentials canvas_instance_auth_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.canvas_instance_auth_credentials
+    ADD CONSTRAINT canvas_instance_auth_credentials_pkey PRIMARY KEY (id);
 
 
 --
@@ -7662,6 +7707,20 @@ CREATE INDEX index_canvas_accounts_on_user_id ON public.canvas_accounts USING bt
 --
 
 CREATE INDEX index_canvas_configs_on_canvas_instance_id ON public.canvas_configs USING btree (canvas_instance_id);
+
+
+--
+-- Name: index_canvas_instance_auth_credentials_on_auth_credential_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_canvas_instance_auth_credentials_on_auth_credential_id ON public.canvas_instance_auth_credentials USING btree (auth_credential_id);
+
+
+--
+-- Name: index_canvas_instance_auth_credentials_on_canvas_instance_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_canvas_instance_auth_credentials_on_canvas_instance_id ON public.canvas_instance_auth_credentials USING btree (canvas_instance_id);
 
 
 --
@@ -9157,6 +9216,14 @@ ALTER TABLE ONLY public.evidence_prompt_healths
 
 
 --
+-- Name: canvas_instance_auth_credentials fk_rails_26ff7f2393; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.canvas_instance_auth_credentials
+    ADD CONSTRAINT fk_rails_26ff7f2393 FOREIGN KEY (auth_credential_id) REFERENCES public.auth_credentials(id);
+
+
+--
 -- Name: teacher_notification_settings fk_rails_3291865e04; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9410,6 +9477,14 @@ ALTER TABLE ONLY public.learn_worlds_accounts
 
 ALTER TABLE ONLY public.comprehension_highlights
     ADD CONSTRAINT fk_rails_9d58aa0a3c FOREIGN KEY (feedback_id) REFERENCES public.comprehension_feedbacks(id) ON DELETE CASCADE;
+
+
+--
+-- Name: canvas_instance_auth_credentials fk_rails_a0ef1de1af; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.canvas_instance_auth_credentials
+    ADD CONSTRAINT fk_rails_a0ef1de1af FOREIGN KEY (canvas_instance_id) REFERENCES public.canvas_instances(id);
 
 
 --
@@ -10196,6 +10271,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230524142914'),
 ('20230524143000'),
 ('20230601210338'),
-('20230613164607');
+('20230613164607'),
+('20230621161210');
 
 

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -32,6 +32,10 @@ FactoryBot.define do
     expires_at 1.day.from_now
     user
 
+    factory :canvas_auth_credential do
+      provider AuthCredential::CANVAS_PROVIDER
+    end
+
     factory :google_auth_credential do
       provider AuthCredential::GOOGLE_PROVIDER
       expires_at AuthCredential::GOOGLE_EXPIRATION_DURATION.from_now

--- a/services/QuillLMS/spec/factories/canvas_instance_auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/canvas_instance_auth_credentials.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: canvas_instance_auth_credentials
+#
+#  id                 :bigint           not null, primary key
+#  auth_credential_id :bigint           not null
+#  canvas_instance_id :bigint           not null
+#
+# Indexes
+#
+#  index_canvas_instance_auth_credentials_on_auth_credential_id  (auth_credential_id)
+#  index_canvas_instance_auth_credentials_on_canvas_instance_id  (canvas_instance_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (auth_credential_id => auth_credentials.id)
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
+#
+FactoryBot.define do
+  factory :canvas_instance_auth_credential do
+    canvas_instance
+    canvas_auth_credential
+  end
+end

--- a/services/QuillLMS/spec/factories/canvas_instance_auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/canvas_instance_auth_credentials.rb
@@ -10,7 +10,7 @@
 #
 # Indexes
 #
-#  index_canvas_instance_auth_credentials_on_auth_credential_id  (auth_credential_id)
+#  index_canvas_instance_auth_credentials_on_auth_credential_id  (auth_credential_id) UNIQUE
 #  index_canvas_instance_auth_credentials_on_canvas_instance_id  (canvas_instance_id)
 #
 # Foreign Keys
@@ -21,6 +21,6 @@
 FactoryBot.define do
   factory :canvas_instance_auth_credential do
     canvas_instance
-    canvas_auth_credential
+    association :auth_credential, factory: :canvas_auth_credential
   end
 end

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -29,6 +29,8 @@ require 'rails_helper'
 describe AuthCredential, type: :model do
   it { should belong_to(:user) }
 
+  it { should have_one(:canvas_instance_auth_credential).dependent(:destroy) }
+
   let(:auth_credential) { create(factory) }
 
   context described_class::GOOGLE_PROVIDER do

--- a/services/QuillLMS/spec/models/canvas_instance_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_instance_auth_credential_spec.rb
@@ -10,7 +10,7 @@
 #
 # Indexes
 #
-#  index_canvas_instance_auth_credentials_on_auth_credential_id  (auth_credential_id)
+#  index_canvas_instance_auth_credentials_on_auth_credential_id  (auth_credential_id) UNIQUE
 #  index_canvas_instance_auth_credentials_on_canvas_instance_id  (canvas_instance_id)
 #
 # Foreign Keys
@@ -27,5 +27,13 @@ describe CanvasInstanceAuthCredential, type: :model do
 
   it { should belong_to(:canvas_instance) }
   it { should belong_to(:auth_credential) }
+
+  it { should validate_uniqueness_of(:auth_credential_id) }
+
+  it 'validates database uniqueness constraint of auth_credential_id' do
+    expect {
+      build(:canvas_instance_auth_credential, auth_credential: subject.auth_credential).save(validate: false)
+    }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
 end
 

--- a/services/QuillLMS/spec/models/canvas_instance_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_instance_auth_credential_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: canvas_instance_auth_credentials
+#
+#  id                 :bigint           not null, primary key
+#  auth_credential_id :bigint           not null
+#  canvas_instance_id :bigint           not null
+#
+# Indexes
+#
+#  index_canvas_instance_auth_credentials_on_auth_credential_id  (auth_credential_id)
+#  index_canvas_instance_auth_credentials_on_canvas_instance_id  (canvas_instance_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (auth_credential_id => auth_credentials.id)
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
+#
+require 'rails_helper'
+
+describe CanvasInstanceAuthCredential, type: :model do
+  subject { create(:canvas_instance_auth_credential) }
+
+  it { expect(subject).to be_valid }
+
+  it { should belong_to(:canvas_instance) }
+  it { should belong_to(:auth_credential) }
+end
+

--- a/services/QuillLMS/spec/models/canvas_instance_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_instance_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe CanvasInstance, type: :model do
 
   it { should have_many(:canvas_configs).dependent(:destroy)}
 
+  it { should have_many(:canvas_instance_auth_credentials).dependent(:destroy) }
+
   context 'callbacks' do
     context 'before_validation' do
       it 'converts the url to lower case' do

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -89,6 +89,8 @@ describe User, type: :model do
   it { should have_one(:learn_worlds_account) }
   it { should have_many(:canvas_accounts).dependent(:destroy) }
   it { should have_many(:canvas_instances).through(:canvas_accounts) }
+  it { should have_one(:auth_credential).dependent(:destroy) }
+  it { should have_one(:canvas_instance_auth_credential).through(:auth_credential) }
 
   it { should delegate_method(:name).to(:school).with_prefix(:school) }
   it { should delegate_method(:mail_city).to(:school).with_prefix(:school) }

--- a/services/QuillLMS/spec/services/canvas_integration/auth_credential_saver_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/auth_credential_saver_spec.rb
@@ -18,6 +18,7 @@ describe CanvasIntegration::AuthCredentialSaver do
 
     it { expect(subject).to eq user.auth_credential }
     it { expect { subject }.to change(AuthCredential, :count).by(1) }
+    it { expect { subject }.to change(CanvasInstanceAuthCredential, :count).by(1) }
   end
 
   context 'auth_hash contains invalid canvas_instance_url' do


### PR DESCRIPTION
## WHAT
Add a new join table `CanvasInstanceAuthCredential`

## WHY
 Users can have many `canvas_instances` but only one `auth_credential`, therefore we need to a way to record the most recent auth_credential with the appropriate CanvasInstance.
 
## HOW
Add a step CanvasIntegration::AuthCredentialSaver that creates the necessary join record.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
