### PR TITLE
lms/fix-admin-snapshot-cache-expiry

### DIFF
--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -20,7 +20,7 @@ module Snapshots
     def perform(cache_key, query, user_id, timeframe, school_ids, grades)
       payload = generate_payload(query, timeframe, school_ids, grades)
 
-      Rails.cache.write(cache_key, payload, expires_in: DateTime.current.end_of_day)
+      Rails.cache.write(cache_key, payload, expires_in: cache_expiry)
 
       PusherTrigger.run(user_id, PUSHER_EVENT,
         {
@@ -30,6 +30,14 @@ module Snapshots
           grades: grades
         }
       )
+    end
+
+    private def cache_expiry
+      # We need to pass a number of seconds to Redis as a TTL value, and we
+      # want to expire our caches overnight so that each day reports can be
+      # updated, so we want the number of seconds until end of day
+      now = DateTime.current
+      now.end_of_day.to_i - now.to_i
     end
 
     private def generate_payload(query, timeframe, school_ids, grades)

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -15,7 +15,7 @@ module Snapshots
     def perform(cache_key, query, user_id, timeframe, school_ids, grades)
       payload = generate_payload(query, timeframe, school_ids, grades)
 
-      Rails.cache.write(cache_key, payload, expires_in: DateTime.current.end_of_day)
+      Rails.cache.write(cache_key, payload, expires_in: cache_expiry)
 
       PusherTrigger.run(user_id, PUSHER_EVENT,
         {
@@ -25,6 +25,14 @@ module Snapshots
           grades: grades
         }
       )
+    end
+
+    private def cache_expiry
+      # We need to pass a number of seconds to Redis as a TTL value, and we
+      # want to expire our caches overnight so that each day reports can be
+      # updated, so we want the number of seconds until end of day
+      now = DateTime.current
+      now.end_of_day.to_i - now.to_i
     end
 
     private def generate_payload(query, timeframe, school_ids, grades)

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
@@ -52,14 +52,17 @@ module Snapshots
       end
 
       it 'should write a payload to cache' do
+        cache_ttl = 1
         previous_count = 100
         previous_timeframe_query_result = { count: previous_count}
         current_count = 50
         current_timeframe_query_result = { count: current_count}
         payload = { current: current_count, previous: previous_count }
 
+        expect(subject).to receive(:cache_expiry).and_return(cache_ttl)
+
         expect(query_double).to receive(:run).and_return(current_timeframe_query_result, previous_timeframe_query_result)
-        expect(Rails.cache).to receive(:write).with(cache_key, payload, expires_in: DateTime.current.end_of_day)
+        expect(Rails.cache).to receive(:write).with(cache_key, payload, expires_in: cache_ttl)
         expect(PusherTrigger).to receive(:run)
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, grades)

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
@@ -42,10 +42,13 @@ module Snapshots
       end
 
       it 'should write a payload to cache' do
+        cache_ttl = 1
         payload = [{ value: 'Some Thing', count: 10 }]
 
+        expect(subject).to receive(:cache_expiry).and_return(cache_ttl)
+
         expect(query_double).to receive(:run).and_return(payload)
-        expect(Rails.cache).to receive(:write).with(cache_key, payload, expires_in: DateTime.current.end_of_day)
+        expect(Rails.cache).to receive(:write).with(cache_key, payload, expires_in: cache_ttl)
         expect(PusherTrigger).to receive(:run)
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, grades)


### PR DESCRIPTION
## WHAT
Make sure that we express cache expires_in in seconds rather than passing a DateTime (which becomes seconds since epoch, which is way higher than our intended TTLs).
## WHY
Rails cache expects `expires_in` to be a TTL in seconds, but we're passing a DateTime which then gets cast via `to_i`, and that in turn becomes seconds-since-epoch which is way longer than we want it to be.
## HOW
Add a helper function to the workers that figures out how many seconds it is until our desired cache expiry time, and use that value for `expires_in`

### Notion Card Links
https://www.notion.so/quill/Implement-Admin-Usage-Snapshot-Report-Backend-0dd45ff4b92641328cec85660ea614fb?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
