### PR TITLE
lms/allow-vitally-unlink-users-with-no-schools

### DIFF
--- a/services/QuillLMS/lib/tasks/vitally.rake
+++ b/services/QuillLMS/lib/tasks/vitally.rake
@@ -20,7 +20,7 @@ namespace :vitally do
     CSV.parse(pipe_data, headers: true).each_slice(33) do |batch|
       batch_payload = batch.map do |row|
         user = User.includes(:schools_users).find(row['externalId'])
-        quill_school_id = user.schools_users.school_id
+        quill_school_id = user.schools_users&.school_id
         vitally_school_ids = [
           row['accountExternalId1'],
           row['accountExternalId2'],


### PR DESCRIPTION
## WHAT
Allow users who are not assigned to a school to be processed
## WHY
Because apparently some of the users in the list we got from Vitally have no current school assignments in the LMS
## HOW
Use a nil-safe accessor when getting to `school_id` to allow for cases where the user has no school assigned.

### Notion Card Links
https://www.notion.so/quill/Script-to-unlink-users-who-have-been-associated-with-multiple-accounts-in-Vitally-65df89265b8a44beb05bd205841a7208?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test on rake tasks
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
