### PR TITLE
Fix learn_worlds import bug with empty username

### DIFF
--- a/services/QuillLMS/app/services/auth/learn_worlds/sso_request.rb
+++ b/services/QuillLMS/app/services/auth/learn_worlds/sso_request.rb
@@ -18,7 +18,7 @@ module Auth
         raise NilUserError if user.nil?
         raise NilEmailError if email.nil?
 
-        response = HTTParty.post(SSO_ENDPOINT, body: body, headers: headers)
+        HTTParty.post(SSO_ENDPOINT, body: body, headers: headers)
       end
 
       private def body
@@ -40,7 +40,7 @@ module Auth
         {
           email: email,
           redirectURL: COURSES_ENDPOINT,
-          username: username || email
+          username: username.presence || email
         }
       end
 

--- a/services/QuillLMS/spec/services/auth/learn_worlds/sso_request_spec.rb
+++ b/services/QuillLMS/spec/services/auth/learn_worlds/sso_request_spec.rb
@@ -63,6 +63,17 @@ RSpec.describe Auth::LearnWorlds::SSORequest do
           subject
         end
       end
+
+      context 'username is empty' do
+        let(:username) { user.email }
+
+        before { user.update(username: '') }
+
+        it do
+          expect(URI).to receive(:encode_www_form).with(data)
+          subject
+        end
+      end
     end
 
     context 'learn_worlds_account exists' do


### PR DESCRIPTION
## WHAT
Fix a bug with new users attempting to login to LearnWorlds

## WHY
It's preventing support from testing out LearnWorlds with a new account

## HOW
Use `username.presence || email` to discard empty strings for username.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
