### PR TITLE
Refactor auth_credential table to STI

### DIFF
--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -26,8 +26,6 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class AuthCredential < ApplicationRecord
-  self.inheritance_column = :_type_disabled
-
   belongs_to :user
 
   def canvas_authorized?

--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -29,46 +29,20 @@ class AuthCredential < ApplicationRecord
   self.inheritance_column = :_type_disabled
 
   belongs_to :user
-  has_one :canvas_instance_auth_credential, dependent: :destroy
 
-  CANVAS_PROVIDER = 'canvas'
-
-  GOOGLE_PROVIDER = 'google'
-  GOOGLE_EXPIRATION_DURATION = 6.months
-
-  CLEVER_DISTRICT_PROVIDER = 'clever_district'
-  CLEVER_LIBRARY_PROVIDER = 'clever_library'
-  CLEVER_EXPIRATION_DURATION = 23.hours
-
-  def google_access_expired?
-    google_provider? && !refresh_token_valid?
-  end
-
-  def google_authorized?
-    google_provider? && refresh_token_valid?
-  end
-
-  def google_provider?
-    provider == GOOGLE_PROVIDER
+  def canvas_authorized?
+    false
   end
 
   def clever_authorized?
-    [CLEVER_DISTRICT_PROVIDER, CLEVER_LIBRARY_PROVIDER].include?(provider)
+    false
   end
 
-  def refresh_token_valid?
-    return false if !google_provider? || expires_at.nil? || refresh_token.nil?
-
-    Time.current < refresh_token_expires_at
+  def google_access_expired?
+    false
   end
 
-  def refresh_token_expires_at
-    return nil if !google_provider? || expires_at.nil?
-
-    expires_at + GOOGLE_EXPIRATION_DURATION
-  end
-
-  def token
-    access_token
+  def google_authorized?
+    false
   end
 end

--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #
@@ -27,6 +25,15 @@
 #
 class AuthCredential < ApplicationRecord
   belongs_to :user
+
+  TYPES = %w[
+    CanvasAuthCredential
+    CleverDistrictAuthCredential
+    CleverLibraryAuthCredential
+    GoogleAuthCredential
+  ].freeze
+
+  validates :type, inclusion: { in: TYPES }
 
   def canvas_authorized?
     false

--- a/services/QuillLMS/app/models/canvas_auth_credential.rb
+++ b/services/QuillLMS/app/models/canvas_auth_credential.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #

--- a/services/QuillLMS/app/models/canvas_auth_credential.rb
+++ b/services/QuillLMS/app/models/canvas_auth_credential.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
+#  provider      :string           not null
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string
@@ -25,14 +25,24 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-require 'rails_helper'
+class CanvasAuthCredential < AuthCredential
+  has_one :canvas_instance_auth_credential,
+    foreign_key: 'auth_credential_id',
+    dependent: :destroy
 
-describe AuthCredential, type: :model do
-  it { should belong_to(:user) }
+  has_one :canvas_instance, through: :canvas_instance_auth_credential
 
-  it { is_expected.not_to be_canvas_authorized }
-  it { is_expected.not_to be_clever_authorized }
-  it { is_expected.not_to be_google_access_expired }
-  it { is_expected.not_to be_google_authorized }
+  PROVIDER = 'canvas'
+
+  def canvas_authorized?
+    refresh_token_valid?
+  end
+
+  def token
+    access_token
+  end
+
+  private def refresh_token_valid?
+    expires_at.present? && refresh_token.present?
+  end
 end
-

--- a/services/QuillLMS/app/models/canvas_auth_credential.rb
+++ b/services/QuillLMS/app/models/canvas_auth_credential.rb
@@ -38,11 +38,11 @@ class CanvasAuthCredential < AuthCredential
     refresh_token_valid?
   end
 
-  def token
-    access_token
+  def refresh_token_valid?
+    expires_at.present? && refresh_token.present?
   end
 
-  private def refresh_token_valid?
-    expires_at.present? && refresh_token.present?
+  def token
+    access_token
   end
 end

--- a/services/QuillLMS/app/models/canvas_auth_credential.rb
+++ b/services/QuillLMS/app/models/canvas_auth_credential.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/app/models/clever_district_auth_credential.rb
+++ b/services/QuillLMS/app/models/clever_district_auth_credential.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #

--- a/services/QuillLMS/app/models/clever_district_auth_credential.rb
+++ b/services/QuillLMS/app/models/clever_district_auth_credential.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/app/models/clever_district_auth_credential.rb
+++ b/services/QuillLMS/app/models/clever_district_auth_credential.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: auth_credentials
+#
+#  id            :integer          not null, primary key
+#  access_token  :string           not null
+#  expires_at    :datetime
+#  provider      :string           not null
+#  refresh_token :string
+#  timestamp     :datetime
+#  type          :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#  user_id       :integer          not null
+#
+# Indexes
+#
+#  index_auth_credentials_on_provider       (provider)
+#  index_auth_credentials_on_refresh_token  (refresh_token)
+#  index_auth_credentials_on_user_id        (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class CleverDistrictAuthCredential < AuthCredential
+  EXPIRATION_DURATION = 23.hours
+  PROVIDER = 'clever_district'
+
+  def clever_authorized?
+    true
+  end
+end

--- a/services/QuillLMS/app/models/clever_library_auth_credential.rb
+++ b/services/QuillLMS/app/models/clever_library_auth_credential.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #

--- a/services/QuillLMS/app/models/clever_library_auth_credential.rb
+++ b/services/QuillLMS/app/models/clever_library_auth_credential.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/app/models/clever_library_auth_credential.rb
+++ b/services/QuillLMS/app/models/clever_library_auth_credential.rb
@@ -25,16 +25,11 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-require 'rails_helper'
+class CleverLibraryAuthCredential < AuthCredential
+  EXPIRATION_DURATION = 23.hours
+  PROVIDER = 'clever_library'
 
-describe CleverDistrictAuthCredential, type: :model do
-  subject { create(:clever_district_auth_credential) }
-
-  it { should belong_to(:user) }
-
-  it { is_expected.to be_clever_authorized }
-
-  it { is_expected.not_to be_canvas_authorized }
-  it { is_expected.not_to be_google_authorized }
+  def clever_authorized?
+    true
+  end
 end
-

--- a/services/QuillLMS/app/models/google_auth_credential.rb
+++ b/services/QuillLMS/app/models/google_auth_credential.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #

--- a/services/QuillLMS/app/models/google_auth_credential.rb
+++ b/services/QuillLMS/app/models/google_auth_credential.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/app/models/google_auth_credential.rb
+++ b/services/QuillLMS/app/models/google_auth_credential.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: auth_credentials
+#
+#  id            :integer          not null, primary key
+#  access_token  :string           not null
+#  expires_at    :datetime
+#  provider      :string           not null
+#  refresh_token :string
+#  timestamp     :datetime
+#  type          :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#  user_id       :integer          not null
+#
+# Indexes
+#
+#  index_auth_credentials_on_provider       (provider)
+#  index_auth_credentials_on_refresh_token  (refresh_token)
+#  index_auth_credentials_on_user_id        (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class GoogleAuthCredential < AuthCredential
+  GOOGLE_EXPIRATION_DURATION = 1.hour
+  PROVIDER = 'google'
+  EXPIRATION_DURATION = 6.months
+
+  def google_access_expired?
+    !refresh_token_valid?
+  end
+
+  def google_authorized?
+    refresh_token_valid?
+  end
+
+  def refresh_token_valid?
+    return false if expires_at.nil? || refresh_token.nil?
+
+    Time.current < refresh_token_expires_at
+  end
+
+  def refresh_token_expires_at
+    return nil if expires_at.nil?
+
+    expires_at + GOOGLE_EXPIRATION_DURATION
+  end
+
+  def token
+    access_token
+  end
+end

--- a/services/QuillLMS/app/models/google_auth_credential.rb
+++ b/services/QuillLMS/app/models/google_auth_credential.rb
@@ -26,9 +26,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class GoogleAuthCredential < AuthCredential
-  GOOGLE_EXPIRATION_DURATION = 1.hour
-  PROVIDER = 'google'
   EXPIRATION_DURATION = 6.months
+  PROVIDER = 'google'
 
   def google_access_expired?
     !refresh_token_valid?
@@ -38,19 +37,15 @@ class GoogleAuthCredential < AuthCredential
     refresh_token_valid?
   end
 
+  def refresh_token_expires_at
+    return nil if expires_at.nil?
+
+    expires_at + EXPIRATION_DURATION
+  end
+
   def refresh_token_valid?
     return false if expires_at.nil? || refresh_token.nil?
 
     Time.current < refresh_token_expires_at
-  end
-
-  def refresh_token_expires_at
-    return nil if expires_at.nil?
-
-    expires_at + GOOGLE_EXPIRATION_DURATION
-  end
-
-  def token
-    access_token
   end
 end

--- a/services/QuillLMS/app/services/canvas_integration/auth_credential_saver.rb
+++ b/services/QuillLMS/app/services/canvas_integration/auth_credential_saver.rb
@@ -30,7 +30,6 @@ module CanvasIntegration
         CanvasAuthCredential.create!(
           access_token: access_token,
           expires_at: expires_at,
-          provider: CanvasAuthCredential::PROVIDER,
           refresh_token: refresh_token,
           user: user
         )

--- a/services/QuillLMS/app/services/canvas_integration/auth_credential_saver.rb
+++ b/services/QuillLMS/app/services/canvas_integration/auth_credential_saver.rb
@@ -7,8 +7,6 @@ module CanvasIntegration
 
     attr_reader :credentials, :external_id, :info
 
-    PROVIDER = AuthCredential::CANVAS_PROVIDER
-
     def initialize(auth_hash)
       @credentials = auth_hash[:credentials]
       @external_id = auth_hash[:uid]
@@ -29,10 +27,10 @@ module CanvasIntegration
 
     private def auth_credential
       @auth_credential ||=
-        AuthCredential.create!(
+        CanvasAuthCredential.create!(
           access_token: access_token,
           expires_at: expires_at,
-          provider: PROVIDER,
+          provider: CanvasAuthCredential::PROVIDER,
           refresh_token: refresh_token,
           user: user
         )

--- a/services/QuillLMS/app/services/clever_integration/auth_credential_saver.rb
+++ b/services/QuillLMS/app/services/clever_integration/auth_credential_saver.rb
@@ -36,7 +36,6 @@ module CleverIntegration
       @new_auth_credential ||= auth_credential_class.create!(
         access_token: access_token,
         expires_at: expires_at,
-        provider: auth_credential_class::PROVIDER,
         user: user
       )
     end

--- a/services/QuillLMS/app/services/clever_integration/auth_credential_saver.rb
+++ b/services/QuillLMS/app/services/clever_integration/auth_credential_saver.rb
@@ -2,12 +2,12 @@
 
 module CleverIntegration
   class AuthCredentialSaver < ApplicationService
-    attr_reader :user, :access_token, :provider
+    attr_reader :access_token, :auth_credential_class, :user
 
-    def initialize(user, access_token, provider)
-      @user = user
+    def initialize(access_token:, auth_credential_class:, user:)
       @access_token = access_token
-      @provider = provider
+      @auth_credential_class = auth_credential_class
+      @user = user
     end
 
     def run
@@ -25,7 +25,7 @@ module CleverIntegration
     end
 
     private def expires_at
-      @expires_at ||= AuthCredential::CLEVER_EXPIRATION_DURATION.from_now
+      @expires_at ||= auth_credential_class::EXPIRATION_DURATION.from_now
     end
 
     private def initiate_expiration_worker
@@ -33,10 +33,10 @@ module CleverIntegration
     end
 
     private def new_auth_credential
-      @new_auth_credential ||= AuthCredential.create!(
+      @new_auth_credential ||= auth_credential_class.create!(
         access_token: access_token,
         expires_at: expires_at,
-        provider: provider,
+        provider: auth_credential_class::PROVIDER,
         user: user
       )
     end

--- a/services/QuillLMS/app/services/clever_integration/client_fetcher.rb
+++ b/services/QuillLMS/app/services/clever_integration/client_fetcher.rb
@@ -31,10 +31,10 @@ module CleverIntegration
     private def client
       raise NilAuthCredentialError if auth_credential.nil?
 
-      case provider
-      when AuthCredential::CLEVER_DISTRICT_PROVIDER then district_client
-      when AuthCredential::CLEVER_LIBRARY_PROVIDER then library_client
-      else raise UnsupportedProviderError, provider
+      case auth_credential
+      when CleverDistrictAuthCredential then district_client
+      when CleverLibraryAuthCredential then library_client
+      else raise UnsupportedProviderError, auth_credential.provider
       end
     end
 

--- a/services/QuillLMS/app/services/clever_integration/client_fetcher.rb
+++ b/services/QuillLMS/app/services/clever_integration/client_fetcher.rb
@@ -4,12 +4,12 @@ module CleverIntegration
   class ClientFetcher < ApplicationService
     attr_reader :user
 
-    class UnsupportedProviderError < StandardError; end
+    class UnsupportedAuthCredentialError < StandardError; end
     class NilAuthCredentialError < StandardError; end
 
     ERRORS = [
       ClientFetcher::NilAuthCredentialError,
-      ClientFetcher::UnsupportedProviderError
+      ClientFetcher::UnsupportedAuthCredentialError
     ].freeze
 
     def initialize(user)
@@ -34,7 +34,7 @@ module CleverIntegration
       case auth_credential
       when CleverDistrictAuthCredential then district_client
       when CleverLibraryAuthCredential then library_client
-      else raise UnsupportedProviderError, auth_credential.provider
+      else raise UnsupportedAuthCredentialError, auth_credential
       end
     end
 

--- a/services/QuillLMS/app/services/clever_integration/district_teacher_integration.rb
+++ b/services/QuillLMS/app/services/clever_integration/district_teacher_integration.rb
@@ -37,7 +37,11 @@ module CleverIntegration
     end
 
     private def save_auth_credential
-      AuthCredentialSaver.run(teacher, district.token, ::AuthCredential::CLEVER_DISTRICT_PROVIDER)
+      AuthCredentialSaver.run(
+        access_token: district.token,
+        auth_credential_class: CleverDistrictAuthCredential,
+        user: teacher
+      )
     end
   end
 end

--- a/services/QuillLMS/app/services/clever_integration/library_teacher_integration.rb
+++ b/services/QuillLMS/app/services/clever_integration/library_teacher_integration.rb
@@ -14,7 +14,11 @@ module CleverIntegration
     end
 
     private def save_auth_credential
-      AuthCredentialSaver.run(teacher, token, ::AuthCredential::CLEVER_LIBRARY_PROVIDER)
+      AuthCredentialSaver.run(
+        access_token: token,
+        auth_credential_class: CleverLibraryAuthCredential,
+        user: teacher
+      )
     end
   end
 end

--- a/services/QuillLMS/app/services/google_integration/user.rb
+++ b/services/QuillLMS/app/services/google_integration/user.rb
@@ -46,7 +46,6 @@ class GoogleIntegration::User
       access_token:  profile.access_token,
       expires_at:    profile.expires_at,
       refresh_token: profile.refresh_token,
-      provider: GoogleAuthCredential::PROVIDER,
       type: GoogleAuthCredential.name
     }
   end

--- a/services/QuillLMS/app/services/google_integration/user.rb
+++ b/services/QuillLMS/app/services/google_integration/user.rb
@@ -43,10 +43,11 @@ class GoogleIntegration::User
 
   private def auth_credential_attributes(user)
     {
-      provider:      'google',
-      refresh_token: profile.refresh_token || user&.auth_credential&.refresh_token,
-      expires_at:    profile.expires_at,
       access_token:  profile.access_token,
+      expires_at:    profile.expires_at,
+      refresh_token: profile.refresh_token || user&.auth_credential&.refresh_token,
+      provider: GoogleAuthCredential::PROVIDER,
+      type: GoogleAuthCredential.name
     }
   end
 end

--- a/services/QuillLMS/app/services/google_integration/user.rb
+++ b/services/QuillLMS/app/services/google_integration/user.rb
@@ -45,7 +45,7 @@ class GoogleIntegration::User
     {
       access_token:  profile.access_token,
       expires_at:    profile.expires_at,
-      refresh_token: profile.refresh_token || user&.auth_credential&.refresh_token,
+      refresh_token: profile.refresh_token,
       provider: GoogleAuthCredential::PROVIDER,
       type: GoogleAuthCredential.name
     }

--- a/services/QuillLMS/db/migrate/20230623154333_change_auth_credential_type_column_null.rb
+++ b/services/QuillLMS/db/migrate/20230623154333_change_auth_credential_type_column_null.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeAuthCredentialTypeColumnNull < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :auth_credentials, :type, false
+  end
+end

--- a/services/QuillLMS/db/migrate/20230623154418_remove_provider_from_auth_credential.rb
+++ b/services/QuillLMS/db/migrate/20230623154418_remove_provider_from_auth_credential.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class RemoveProviderFromAuthCredential < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :auth_credentials, :provider
+    remove_column :auth_credentials, :provider
+  end
+
+  def down
+    add_column :auth_credentials, :provider, :string
+    add_index :auth_credentials, :provider
+
+    AuthCredential.reset_column_information
+
+    {
+      canvas: CanvasAuthCredential,
+      google: GoogleAuthCredential,
+      clever_district: CleverDistrictAuthCredential,
+      clever_library: CleverLibraryAuthCredential
+    }.each_pair do |provider, klass|
+      klass.in_batches.update_all(provider: provider)
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -849,8 +849,7 @@ CREATE TABLE public.auth_credentials (
     access_token character varying NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    type character varying,
-    provider character varying
+    type character varying NOT NULL
 );
 
 
@@ -7634,13 +7633,6 @@ CREATE UNIQUE INDEX index_app_settings_on_name ON public.app_settings USING btre
 
 
 --
--- Name: index_auth_credentials_on_provider; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_auth_credentials_on_provider ON public.auth_credentials USING btree (provider);
-
-
---
 -- Name: index_auth_credentials_on_refresh_token; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10275,6 +10267,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230613164607'),
 ('20230621161210'),
 ('20230622125712'),
-('20230622525712');
+('20230622525712'),
+('20230623154333'),
+('20230623154418');
 
 

--- a/services/QuillLMS/spec/controllers/auth/canvas_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/auth/canvas_controller_spec.rb
@@ -15,7 +15,7 @@ module Auth
       subject { get Auth::Canvas::OMNIAUTH_CALLBACK_PATH }
 
       let(:user) { create(:user) }
-      let(:auth_credential) { create(:auth_credential, user: user) }
+      let(:auth_credential) { create(:canvas_auth_credential, user: user) }
 
       before { set_session_canvas_instance_id }
 

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -47,7 +47,7 @@ describe Teachers::UnitsController, type: :controller do
 
   describe '#create' do
     it 'kicks off a background job' do
-      create(:auth_credential, user: teacher)
+      create(:google_auth_credential, user: teacher)
 
       expect {
         post :create,

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -32,29 +32,5 @@ FactoryBot.define do
     provider 'hooli'
     expires_at 1.day.from_now
     user
-
-    factory :canvas_auth_credential do
-      provider AuthCredential::CANVAS_PROVIDER
-    end
-
-    factory :google_auth_credential do
-      provider AuthCredential::GOOGLE_PROVIDER
-      expires_at AuthCredential::GOOGLE_EXPIRATION_DURATION.from_now
-      association :user, factory: [:teacher, :signed_up_with_google]
-
-      trait(:expired) { expires_at AuthCredential::GOOGLE_EXPIRATION_DURATION.ago }
-    end
-
-    factory :clever_district_auth_credential do
-      provider AuthCredential::CLEVER_DISTRICT_PROVIDER
-      expires_at AuthCredential::CLEVER_EXPIRATION_DURATION.from_now
-      association :user, factory: [:teacher, :signed_up_with_clever]
-    end
-
-    factory :clever_library_auth_credential do
-      provider AuthCredential::CLEVER_LIBRARY_PROVIDER
-      expires_at AuthCredential::CLEVER_EXPIRATION_DURATION.from_now
-      association :user, factory: [:teacher, :signed_up_with_clever]
-    end
   end
 end

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #
@@ -29,28 +27,22 @@ FactoryBot.define do
   factory :auth_credential do
     access_token 'fake_token'
     refresh_token 'fake_refresh_token'
-    provider 'hooli'
     expires_at 1.day.from_now
     user
 
-    factory :canvas_auth_credential, parent: :auth_credential, class: :CanvasAuthCredential do
-      provider CanvasAuthCredential::PROVIDER
-    end
+    factory :canvas_auth_credential, parent: :auth_credential, class: :CanvasAuthCredential
 
     factory :clever_district_auth_credential, parent: :auth_credential, class: :CleverDistrictAuthCredential do
-      provider CleverDistrictAuthCredential::PROVIDER
       expires_at CleverDistrictAuthCredential::EXPIRATION_DURATION.from_now
       association :user, factory: [:teacher, :signed_up_with_clever]
     end
 
     factory :clever_library_auth_credential, parent: :auth_credential, class: :CleverLibraryAuthCredential do
-      provider CleverLibraryAuthCredential::PROVIDER
       expires_at CleverLibraryAuthCredential::EXPIRATION_DURATION.from_now
       association :user, factory: [:teacher, :signed_up_with_clever]
     end
 
     factory :google_auth_credential, parent: :auth_credential, class: :GoogleAuthCredential do
-      provider GoogleAuthCredential::PROVIDER
       expires_at GoogleAuthCredential::EXPIRATION_DURATION.from_now
       association :user, factory: [:teacher, :signed_up_with_google]
 

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -48,5 +48,13 @@ FactoryBot.define do
       expires_at CleverLibraryAuthCredential::EXPIRATION_DURATION.from_now
       association :user, factory: [:teacher, :signed_up_with_clever]
     end
+
+    factory :google_auth_credential, parent: :auth_credential, class: :GoogleAuthCredential do
+      provider GoogleAuthCredential::PROVIDER
+      expires_at GoogleAuthCredential::EXPIRATION_DURATION.from_now
+      association :user, factory: [:teacher, :signed_up_with_google]
+
+      trait(:expired) { expires_at GoogleAuthCredential::EXPIRATION_DURATION.ago }
+    end
   end
 end

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -32,5 +32,9 @@ FactoryBot.define do
     provider 'hooli'
     expires_at 1.day.from_now
     user
+
+    factory :canvas_auth_credential, parent: :auth_credential, class: :CanvasAuthCredential do
+      provider CanvasAuthCredential::PROVIDER
+    end
   end
 end

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -43,5 +43,10 @@ FactoryBot.define do
       association :user, factory: [:teacher, :signed_up_with_clever]
     end
 
+    factory :clever_library_auth_credential, parent: :auth_credential, class: :CleverLibraryAuthCredential do
+      provider CleverLibraryAuthCredential::PROVIDER
+      expires_at CleverLibraryAuthCredential::EXPIRATION_DURATION.from_now
+      association :user, factory: [:teacher, :signed_up_with_clever]
+    end
   end
 end

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -36,5 +36,12 @@ FactoryBot.define do
     factory :canvas_auth_credential, parent: :auth_credential, class: :CanvasAuthCredential do
       provider CanvasAuthCredential::PROVIDER
     end
+
+    factory :clever_district_auth_credential, parent: :auth_credential, class: :CleverDistrictAuthCredential do
+      provider CleverDistrictAuthCredential::PROVIDER
+      expires_at CleverDistrictAuthCredential::EXPIRATION_DURATION.from_now
+      association :user, factory: [:teacher, :signed_up_with_clever]
+    end
+
   end
 end

--- a/services/QuillLMS/spec/factories/omniauth_auth_hashes.rb
+++ b/services/QuillLMS/spec/factories/omniauth_auth_hashes.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     factory :canvas_auth_hash do
       initialize_with do
         OmniAuth::AuthHash.new(
-          provider: CanvasAuthCredential::PROVIDER,
+          provider: 'canvas',
           uid: uid,
           info:  {
             name: name,

--- a/services/QuillLMS/spec/factories/omniauth_auth_hashes.rb
+++ b/services/QuillLMS/spec/factories/omniauth_auth_hashes.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     factory :canvas_auth_hash do
       initialize_with do
         OmniAuth::AuthHash.new(
-          provider: AuthCredential::CANVAS_PROVIDER,
+          provider: CanvasAuthCredential::PROVIDER,
           uid: uid,
           info:  {
             name: name,

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #
@@ -34,5 +32,7 @@ describe AuthCredential, type: :model do
   it { is_expected.not_to be_clever_authorized }
   it { is_expected.not_to be_google_access_expired }
   it { is_expected.not_to be_google_authorized }
+
+  it { should validate_inclusion_of(:type).in_array(AuthCredential::TYPES) }
 end
 

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -30,79 +30,8 @@ require 'rails_helper'
 describe AuthCredential, type: :model do
   it { should belong_to(:user) }
 
-  it { should have_one(:canvas_instance_auth_credential).dependent(:destroy) }
-
-  let(:auth_credential) { create(factory) }
-
-  context described_class::GOOGLE_PROVIDER do
-    let(:factory) { :google_auth_credential }
-
-    describe '#google_authorized?' do
-      context 'nil expires_at' do
-        before { auth_credential.update(expires_at: nil) }
-
-        it { should_not_be_clever_authorized}
-        it { should_not_be_google_authorized }
-      end
-
-      context 'nil refresh token' do
-        before { auth_credential.update(refresh_token: nil) }
-
-        it { should_not_be_clever_authorized}
-        it { should_not_be_google_authorized }
-      end
-
-      context 'expired refresh token' do
-        let(:expires_at) { Time.current - AuthCredential::GOOGLE_EXPIRATION_DURATION - 1.month }
-
-        before { auth_credential.update(expires_at: expires_at) }
-
-        it { should_not_be_clever_authorized}
-        it { should_not_be_google_authorized }
-      end
-    end
-
-    describe '#refresh_token_expires_at' do
-      it { expect(auth_credential.refresh_token_expires_at).not_to be_nil }
-
-      context 'nil expires_at' do
-        before { auth_credential.update(expires_at: nil) }
-
-        it { expect(auth_credential.refresh_token_expires_at).to be_nil }
-      end
-    end
-  end
-
-  context described_class::CLEVER_DISTRICT_PROVIDER do
-    let(:factory) { :clever_district_auth_credential }
-
-    it { expect(auth_credential.refresh_token_expires_at).to eq nil }
-    it { expect(auth_credential.refresh_token_valid?).to eq false }
-
-    it { should_be_clever_authorized}
-    it { should_not_be_google_authorized }
-  end
-
-  context described_class::CLEVER_LIBRARY_PROVIDER do
-    let(:factory) { :clever_library_auth_credential }
-
-    it { expect(auth_credential.refresh_token_expires_at).to eq nil }
-    it { expect(auth_credential.refresh_token_valid?).to eq false }
-
-    it { should_be_clever_authorized}
-    it { should_not_be_google_authorized }
-  end
-
-  def should_not_be_google_authorized
-    expect(auth_credential.google_authorized?).to be false
-  end
-
-  def should_be_clever_authorized
-    expect(auth_credential.clever_authorized?).to be true
-  end
-
-  def should_not_be_clever_authorized
-    expect(auth_credential.clever_authorized?).to be false
-  end
+  it { is_expected.not_to be_canvas_authorized }
+  it { is_expected.not_to be_clever_authorized }
+  it { is_expected.not_to be_google_authorized }
 end
 

--- a/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #

--- a/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
@@ -10,6 +10,7 @@
 #  provider      :string           not null
 #  refresh_token :string
 #  timestamp     :datetime
+#  type          :string
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null

--- a/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
@@ -10,7 +10,6 @@
 #  provider      :string           not null
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null

--- a/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_auth_credential_spec.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
+#  provider      :string           not null
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string
@@ -27,12 +27,30 @@
 #
 require 'rails_helper'
 
-describe AuthCredential, type: :model do
+describe CanvasAuthCredential, type: :model do
   it { should belong_to(:user) }
+  it { should have_one(:canvas_instance_auth_credential).dependent(:destroy) }
+  it { should have_one(:canvas_instance).through(:canvas_instance_auth_credential)}
 
-  it { is_expected.not_to be_canvas_authorized }
+  subject { create(:canvas_auth_credential) }
+
   it { is_expected.not_to be_clever_authorized }
-  it { is_expected.not_to be_google_access_expired }
   it { is_expected.not_to be_google_authorized }
+
+  describe '#canvas_authorized?' do
+    it { is_expected.to be_canvas_authorized}
+
+    context 'nil expires_at' do
+      before { subject.update(expires_at: nil) }
+
+      it { is_expected.not_to be_canvas_authorized }
+    end
+
+    context 'nil refresh token' do
+      before { subject.update(refresh_token: nil) }
+
+      it { is_expected.not_to be_canvas_authorized }
+    end
+  end
 end
 

--- a/services/QuillLMS/spec/models/clever_district_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/clever_district_auth_credential_spec.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #

--- a/services/QuillLMS/spec/models/clever_district_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/clever_district_auth_credential_spec.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/spec/models/clever_district_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/clever_district_auth_credential_spec.rb
@@ -10,7 +10,6 @@
 #  provider      :string           not null
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
@@ -27,30 +26,15 @@
 #
 require 'rails_helper'
 
-describe CanvasAuthCredential, type: :model do
-  subject { create(:canvas_auth_credential) }
+describe CleverDistrictAuthCredential, type: :model do
+  subject { create(:clever_district_auth_credential) }
 
   it { should belong_to(:user) }
-  it { should have_one(:canvas_instance_auth_credential).dependent(:destroy) }
-  it { should have_one(:canvas_instance).through(:canvas_instance_auth_credential)}
+  it { should_not have_one(:canvas_instance_auth_credential).dependent(:destroy) }
+  it { should_not have_one(:canvas_instance).through(:canvas_instance_auth_credential)}
 
-  it { is_expected.not_to be_clever_authorized }
+  it { is_expected.not_to be_canvas_authorized }
+  it { is_expected.to be_clever_authorized }
   it { is_expected.not_to be_google_authorized }
-
-  describe '#canvas_authorized?' do
-    it { is_expected.to be_canvas_authorized}
-
-    context 'nil expires_at' do
-      before { subject.update(expires_at: nil) }
-
-      it { is_expected.not_to be_canvas_authorized }
-    end
-
-    context 'nil refresh token' do
-      before { subject.update(refresh_token: nil) }
-
-      it { is_expected.not_to be_canvas_authorized }
-    end
-  end
 end
 

--- a/services/QuillLMS/spec/models/clever_library_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/clever_library_auth_credential_spec.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #

--- a/services/QuillLMS/spec/models/clever_library_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/clever_library_auth_credential_spec.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/spec/models/clever_library_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/clever_library_auth_credential_spec.rb
@@ -27,8 +27,8 @@
 #
 require 'rails_helper'
 
-describe CleverDistrictAuthCredential, type: :model do
-  subject { create(:clever_district_auth_credential) }
+describe CleverLibraryAuthCredential, type: :model do
+  subject { create(:clever_library_auth_credential) }
 
   it { should belong_to(:user) }
 

--- a/services/QuillLMS/spec/models/google_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/google_auth_credential_spec.rb
@@ -7,17 +7,15 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
-#  type          :string
+#  type          :string           not null
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
 #
 # Indexes
 #
-#  index_auth_credentials_on_provider       (provider)
 #  index_auth_credentials_on_refresh_token  (refresh_token)
 #  index_auth_credentials_on_user_id        (user_id)
 #

--- a/services/QuillLMS/spec/models/google_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/google_auth_credential_spec.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/spec/models/google_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/google_auth_credential_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: auth_credentials
+#
+#  id            :integer          not null, primary key
+#  access_token  :string           not null
+#  expires_at    :datetime
+#  provider      :string           not null
+#  refresh_token :string
+#  timestamp     :datetime
+#  type          :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#  user_id       :integer          not null
+#
+# Indexes
+#
+#  index_auth_credentials_on_provider       (provider)
+#  index_auth_credentials_on_refresh_token  (refresh_token)
+#  index_auth_credentials_on_user_id        (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+describe GoogleAuthCredential, type: :model do
+  subject { create(:google_auth_credential) }
+
+  it { should belong_to(:user) }
+
+  it { is_expected.not_to be_canvas_authorized }
+  it { is_expected.not_to be_clever_authorized }
+
+  describe '#google_authorized?' do
+    it { is_expected.to be_google_authorized }
+
+    context 'nil expires_at' do
+      before { subject.update(expires_at: nil) }
+
+      it { is_expected.not_to be_google_authorized }
+    end
+
+    context 'nil refresh token' do
+      before { subject.update(refresh_token: nil) }
+
+      it { is_expected.not_to be_google_authorized }
+    end
+
+    context 'expired refresh token' do
+      let(:expires_at) { Time.current - GoogleAuthCredential::EXPIRATION_DURATION - 1.month }
+
+      before { subject.update(expires_at: expires_at) }
+
+      it { is_expected.not_to be_google_authorized }
+    end
+  end
+
+  describe '#refresh_token_expires_at' do
+    it { expect(subject.refresh_token_expires_at).not_to be_nil }
+
+    context 'nil expires_at' do
+      before { subject.update(expires_at: nil) }
+
+      it { expect(subject.refresh_token_expires_at).to be_nil }
+    end
+  end
+end
+

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -90,7 +90,6 @@ describe User, type: :model do
   it { should have_many(:canvas_accounts).dependent(:destroy) }
   it { should have_many(:canvas_instances).through(:canvas_accounts) }
   it { should have_one(:auth_credential).dependent(:destroy) }
-  it { should have_one(:canvas_instance_auth_credential).through(:auth_credential) }
 
   it { should delegate_method(:name).to(:school).with_prefix(:school) }
   it { should delegate_method(:mail_city).to(:school).with_prefix(:school) }

--- a/services/QuillLMS/spec/services/canvas_integration/auth_credential_saver_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/auth_credential_saver_spec.rb
@@ -17,7 +17,7 @@ describe CanvasIntegration::AuthCredentialSaver do
     before { canvas_account }
 
     it { expect(subject).to eq user.auth_credential }
-    it { expect { subject }.to change(AuthCredential, :count).by(1) }
+    it { expect { subject }.to change(CanvasAuthCredential, :count).by(1) }
     it { expect { subject }.to change(CanvasInstanceAuthCredential, :count).by(1) }
   end
 

--- a/services/QuillLMS/spec/services/clever_integration/auth_credential_saver_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/auth_credential_saver_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe CleverIntegration::AuthCredentialSaver do
   def expects_new_credentials_are_saved
     subject
     expect(teacher.auth_credential).to be_a auth_credential_class
-    expect(teacher.auth_credential.provider).to eq auth_credential_class::PROVIDER
     expect(teacher.auth_credential.access_token).to eq access_token
     expect(teacher.auth_credential.expires_at).to be_within(1.minute).of(expires_at)
   end

--- a/services/QuillLMS/spec/services/clever_integration/client_fetcher_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/client_fetcher_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe CleverIntegration::ClientFetcher do
   context 'non-clever auth_credential' do
     let!(:auth_credential) { create(:google_auth_credential, user: user) }
 
-    it { expect { subject }.to raise_error CleverIntegration::ClientFetcher::UnsupportedProviderError }
+    it { expect { subject }.to raise_error CleverIntegration::ClientFetcher::UnsupportedAuthCredentialError }
   end
 
-  context CleverDistrictAuthCredential::PROVIDER do
+  context CleverDistrictAuthCredential.name do
     let!(:auth_credential) { create(:clever_district_auth_credential, user: user) }
 
     it do
@@ -27,7 +27,7 @@ RSpec.describe CleverIntegration::ClientFetcher do
     end
   end
 
-  context CleverLibraryAuthCredential::PROVIDER do
+  context CleverLibraryAuthCredential.name do
     let!(:auth_credential) { create(:clever_library_auth_credential, user: user) }
 
     it do

--- a/services/QuillLMS/spec/services/clever_integration/client_fetcher_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/client_fetcher_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CleverIntegration::ClientFetcher do
     it { expect { subject }.to raise_error CleverIntegration::ClientFetcher::UnsupportedProviderError }
   end
 
-  context AuthCredential::CLEVER_DISTRICT_PROVIDER do
+  context CleverDistrictAuthCredential::PROVIDER do
     let!(:auth_credential) { create(:clever_district_auth_credential, user: user) }
 
     it do
@@ -27,7 +27,7 @@ RSpec.describe CleverIntegration::ClientFetcher do
     end
   end
 
-  context AuthCredential::CLEVER_LIBRARY_PROVIDER do
+  context CleverLibraryAuthCredential::PROVIDER do
     let!(:auth_credential) { create(:clever_library_auth_credential, user: user) }
 
     it do

--- a/services/QuillLMS/spec/services/clever_integration/district_teacher_integration_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/district_teacher_integration_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CleverIntegration::DistrictTeacherIntegration do
   let(:teacher) { create(:teacher, :signed_up_with_clever) }
   let(:district_id) { '1abcdefg'}
   let(:district) { create(:district, clever_id: district_id) }
+  let(:auth_credential_class) { CleverDistrictAuthCredential }
 
   subject { described_class.run(teacher, district_id) }
 
@@ -13,9 +14,16 @@ RSpec.describe CleverIntegration::DistrictTeacherIntegration do
     expect(CleverIntegration::Importers::CleverDistrict).to receive(:run).and_return(district)
     expect(CleverIntegration::Importers::School).to receive(:run).with(teacher, district.token)
 
+    expect(CleverIntegration::AuthCredentialSaver)
+      .to receive(:run)
+      .with(
+        access_token: district.token,
+        auth_credential_class: auth_credential_class,
+        user: teacher
+      )
+
     subject
 
-    expect(AuthCredential.count).to eq 1
     expect(teacher.districts).to eq [district]
   end
 

--- a/services/QuillLMS/spec/services/clever_integration/library_teacher_integration_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/library_teacher_integration_spec.rb
@@ -3,18 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe CleverIntegration::LibraryTeacherIntegration do
-  let!(:teacher) { classroom1.owner }
+  let(:teacher) { classroom.owner }
   let(:token) { "ila49754462" }
-  let(:provider) { AuthCredential::CLEVER_LIBRARY_PROVIDER }
-
-  let(:classroom1) { create(:classroom, :from_clever, students: [student1]) }
-
-  let(:student1) { create(:student, :signed_up_with_clever) }
+  let(:auth_credential_class) { CleverLibraryAuthCredential }
+  let(:classroom) { create(:classroom, :from_clever, students: [student]) }
+  let(:student) { create(:student, :signed_up_with_clever) }
 
   subject { described_class.run(teacher, token) }
 
   it do
-    expect(CleverIntegration::AuthCredentialSaver).to receive(:run).with(teacher, token, provider)
+    expect(CleverIntegration::AuthCredentialSaver)
+      .to receive(:run)
+      .with(
+        access_token: token,
+        auth_credential_class: auth_credential_class,
+        user: teacher
+      )
+
     subject
   end
 end

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Demo::ReportDemoCreator do
 
       context "teacher account has added data" do
         let(:teacher) {create(:teacher, google_id: 1234, clever_id: 5678)}
-        let!(:auth_credential) {create(:auth_credential, user: teacher) }
+        let!(:auth_credential) {create(:google_auth_credential, user: teacher) }
         let(:classroom) {create(:classroom)}
         let!(:classrooms_teacher) {create(:classrooms_teacher, classroom: classroom, user: teacher)}
 

--- a/services/QuillLMS/spec/workers/clear_user_data_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/clear_user_data_worker_spec.rb
@@ -7,7 +7,7 @@ describe ClearUserDataWorker, type: :worker do
 
   let!(:ip_location) { create(:ip_location) }
   let(:user) { create(:student_in_two_classrooms_with_many_activities, google_id: 'sergey_and_larry_were_here', send_newsletter: true, ip_location: ip_location) }
-  let!(:auth_credential) { create(:auth_credential, user: user) }
+  let!(:auth_credential) { create(:google_auth_credential, user: user) }
   let!(:activity_sessions) { user.activity_sessions }
   let!(:classroom_units) { ClassroomUnit.where("? = ANY (assigned_student_ids)", user.id) }
 

--- a/services/QuillLMS/spec/workers/purge_expired_auth_credential_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/purge_expired_auth_credential_worker_spec.rb
@@ -6,9 +6,9 @@ describe PurgeExpiredAuthCredentialWorker do
   subject { described_class.new.perform(auth_credential_id) }
 
   context 'auth_credential exists' do
-    let!(:auth_credential_id) { create(:auth_credential).id }
+    let!(:auth_credential_id) { create(:google_auth_credential).id }
 
-    it { expect { subject }.to change(AuthCredential, :count).from(1).to(0) }
+    it { expect { subject }.to change(GoogleAuthCredential, :count).from(1).to(0) }
   end
 
   context 'auth_credential does not exist' do


### PR DESCRIPTION
## WHAT
Reorganize the auth_credential table to use STI with subclasses based on the provider names.

## WHY
With the addition of another provider type (i.e. Canvas) it would simplify logic to move the respective providers into their own subclasses.

## HOW
1. Create subclasses `CanvasAuthCredential`, `CleverDistrictAuthCredential`, `CleverLibraryAuthCredential`, `GoogleAuthCredential`
1. Update the places where these AuthCredentials are saved to include these subtypes.
1. Add a backfill script to be run after migration.   Once the backfill is complete, a subsequent PR can add a `null: false` to the type column.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
