### PR TITLE
lms/handle-invalid-ids-in-vitally-unlink

### DIFF
--- a/services/QuillLMS/lib/tasks/vitally.rake
+++ b/services/QuillLMS/lib/tasks/vitally.rake
@@ -19,8 +19,7 @@ namespace :vitally do
     # has a batch limit of 100.
     CSV.parse(pipe_data, headers: true).each_slice(33) do |batch|
       batch_payload = batch.map do |row|
-        # TIL `includes` makes a separate query to the db, and `joins` doesn't store the joined value in ActiveRecord, so if you want a single query to pull multiple models you need to use both?
-        user = User.joins(:schools_users).includes(:schools_users).find_by(id: row['externalId'])
+        user = User.eager_load(:schools_users).find_by(id: row['externalId'])
 
         # Some of the data provided by Vitally is bad, so we need to account for that
         next unless user

--- a/services/QuillLMS/lib/tasks/vitally.rake
+++ b/services/QuillLMS/lib/tasks/vitally.rake
@@ -19,7 +19,12 @@ namespace :vitally do
     # has a batch limit of 100.
     CSV.parse(pipe_data, headers: true).each_slice(33) do |batch|
       batch_payload = batch.map do |row|
-        user = User.includes(:schools_users).find(row['externalId'])
+        # TIL `includes` makes a separate query to the db, and `joins` doesn't store the joined value in ActiveRecord, so if you want a single query to pull multiple models you need to use both?
+        user = User.joins(:schools_users).includes(:schools_users).find_by(id: row['externalId'])
+
+        # Some of the data provided by Vitally is bad, so we need to account for that
+        next unless user
+
         quill_school_id = user.schools_users&.school_id
         vitally_school_ids = [
           row['accountExternalId1'],


### PR DESCRIPTION
## WHAT
Allow for cases where the Vitally data has invalid user ids
## WHY
Apparently the data file Vitally sent us includes some nonsense data in it which we need to account for
## HOW
Use `find_by` so that we don't error if the `id` value from Vitally is invalid, and use `next` to skip cases where there is no User.

### Notion Card Links
https://www.notion.so/quill/Script-to-unlink-users-who-have-been-associated-with-multiple-accounts-in-Vitally-65df89265b8a44beb05bd205841a7208?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on rake tasks
Have you deployed to Staging? | Tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
