### PR TITLE
lms/include-archived-data-in-vitally-sync

### DIFF
--- a/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
+++ b/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
@@ -5,7 +5,7 @@ module VitallySchoolStats
 
   private def active_students_query(school)
     # use raw SQL to bypass scope limits (visible: true) on classrooms
-    ActivitySession.select(:user_id)
+    ActivitySession.unscoped.select(:user_id)
       .distinct
       .joins("JOIN classroom_units on classroom_units.id=activity_sessions.classroom_unit_id")
       .joins("JOIN classrooms ON classrooms.id=classroom_units.classroom_id")


### PR DESCRIPTION
## WHAT
Tweak Vitally active student count to include archived activity sessions
## WHY
Since the student was active at some point even if we've canceled their activity results
## HOW
Just add `unscoped` to the ActiveRecord query so that we exclude the default scope of `visible: true`.


### Notion Card Links
https://www.notion.so/quill/Update-how-we-calculate-active-student-metrics-for-the-Vitally-sync-e18fb26e47d74a878a25462b51477eff?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
