### PR TITLE
Add type column to AuthCredential for STI

### DIFF
--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -10,6 +10,7 @@
 #  provider      :string           not null
 #  refresh_token :string
 #  timestamp     :datetime
+#  type          :string
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null

--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -26,6 +26,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class AuthCredential < ApplicationRecord
+  self.inheritance_column = :_type_disabled
+
   belongs_to :user
   has_one :canvas_instance_auth_credential, dependent: :destroy
 

--- a/services/QuillLMS/db/migrate/20230622125712_add_type_to_auth_credential.rb
+++ b/services/QuillLMS/db/migrate/20230622125712_add_type_to_auth_credential.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTypeToAuthCredential < ActiveRecord::Migration[6.1]
+  def change
+    add_column :auth_credentials, :type, :string
+  end
+end

--- a/services/QuillLMS/db/migrate/20230622525712_remove_null_false_from_auth_credential_provider.rb
+++ b/services/QuillLMS/db/migrate/20230622525712_remove_null_false_from_auth_credential_provider.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNullFalseFromAuthCredentialProvider < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :auth_credentials, :provider, true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -849,7 +849,8 @@ CREATE TABLE public.auth_credentials (
     access_token character varying NOT NULL,
     provider character varying NOT NULL,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    type character varying
 );
 
 
@@ -10272,6 +10273,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230524143000'),
 ('20230601210338'),
 ('20230613164607'),
-('20230621161210');
+('20230621161210'),
+('20230622125712');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -847,10 +847,10 @@ CREATE TABLE public.auth_credentials (
     expires_at timestamp without time zone,
     "timestamp" timestamp without time zone,
     access_token character varying NOT NULL,
-    provider character varying NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    type character varying
+    type character varying,
+    provider character varying
 );
 
 
@@ -10274,6 +10274,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230601210338'),
 ('20230613164607'),
 ('20230621161210'),
-('20230622125712');
+('20230622125712'),
+('20230622525712');
 
 

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -26,4 +26,12 @@ namespace :users do
       DualGoogleIdAndCleverIdResolver.run(user)
     end
   end
+
+  task update_auth_credential_types: :environment do
+    ['canvas', 'google', 'clever_district', 'clever_library'].each do |provider|
+      AuthCredential.where(provider: provider).find_each do |auth_credential|
+        auth_credential.update(type: type)
+      end
+    end
+  end
 end

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -28,7 +28,12 @@ namespace :users do
   end
 
   task update_auth_credential_types: :environment do
-    ['canvas', 'google', 'clever_district', 'clever_library'].each do |provider|
+    {
+      canvas: 'CanvasAuthCredential',
+      google: 'GoogleAuthCredential',
+      clever_district: 'CleverDistrictAuthCredential',
+      clever_library: 'CleverLibraryAuthCredential'
+    }.each_pair do |provider, type|
       AuthCredential.where(provider: provider).find_each do |auth_credential|
         auth_credential.update(type: type)
       end

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -34,9 +34,7 @@ namespace :users do
       clever_district: 'CleverDistrictAuthCredential',
       clever_library: 'CleverLibraryAuthCredential'
     }.each_pair do |provider, type|
-      AuthCredential.where(provider: provider).find_each do |auth_credential|
-        auth_credential.update(type: type)
-      end
+      AuthCredential.where(provider: provider, type: nil).update_all(type: type)
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -34,7 +34,10 @@ namespace :users do
       clever_district: 'CleverDistrictAuthCredential',
       clever_library: 'CleverLibraryAuthCredential'
     }.each_pair do |provider, type|
-      AuthCredential.where(provider: provider, type: nil).update_all(type: type)
+      AuthCredential
+        .where(provider: provider, type: nil)
+        .in_batches
+        .update_all(type: type)
     end
   end
 end

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -10,6 +10,7 @@
 #  provider      :string           not null
 #  refresh_token :string
 #  timestamp     :datetime
+#  type          :string
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -7,7 +7,7 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
 #  type          :string

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -10,6 +10,7 @@
 #  provider      :string           not null
 #  refresh_token :string
 #  timestamp     :datetime
+#  type          :string
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null


### PR DESCRIPTION
## WHAT
1.  Add type column to AuthCredential in preparation for STI
2.  Add backfill rake task to be run after migration
3.  Remove non-null requirement on AuthCredential provider

## WHY
1. This column will be needed to differentiate subclasses of AuthCredential
2.  Existing records will need this value set for STI to function properly
3.  This will allow for migration removing of provider later

## HOW
1.  Create a Rails migration with: `add_column :auth_credentials, :type, :string`
2.  Iterate through each of the providers and update the appropriate records
3. Add a migration with `change_null_column :auth_credentials, :provider, true`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Migration file and manual testing of rake task
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
