### PR TITLE
fix some modal css that got wonky between merges

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -1007,6 +1007,12 @@
   max-width: 100vw;
   position: fixed !important;
   overflow: hidden;
+  max-height: 100vh;
+  height: min-content;
+  .modal-body {
+    height: min-content;
+    max-height: 60vh;
+  }
   .import-clever-classrooms-modal-footer,
   .import-google-classrooms-modal-footer,
   .bulk-archive-classes-modal-footer {
@@ -1254,6 +1260,10 @@
   display: flex;
   flex-direction: column;
   padding: 0px;
+  margin-bottom: 0px;
+  overflow: scroll;
+  max-height: 90vh;
+  height: min-content;
   margin-bottom: 0px;
   .top-section {
     padding: 32px 32px 0px;

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/dashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/dashboard.tsx
@@ -23,8 +23,6 @@ import { GRAY_ARTICLE_FOOTER_BACKGROUND_COLOR, TEACHER_DASHBOARD_FEATURED_BLOG_P
 
 const MAX_VIEW_WIDTH_FOR_MOBILE = 1103
 
-const MAY = 4
-
 const Dashboard = ({ onboardingChecklist, firstName, mustSeeWelcomeModal, mustSeeTeacherInfoModal, linkedToClever, featuredBlogPosts, showEvidencePromotionCard, subjectAreas, userId, classrooms, }) => {
   const size = useWindowSize();
   const className = "dashboard white-background-accommodate-footer"


### PR DESCRIPTION
## WHAT
Fix CSS for some modals that got wonky between merges.

## WHY
We want them to display at the correct height!

## HOW
Just adjust CSS to make sure there's enough space to render content.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES