### PR TITLE
further adjust bulk archive modal css for overflow

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -1012,6 +1012,7 @@
   .modal-body {
     height: min-content;
     max-height: 60vh;
+    overflow: scroll;
   }
   .import-clever-classrooms-modal-footer,
   .import-google-classrooms-modal-footer,
@@ -1024,7 +1025,7 @@
   .data-table {
     height: 100%;
     overflow: scroll;
-    padding-bottom: 400px;
+    padding-bottom: 100px;
     .data-table-headers {
       z-index: 7;
     }


### PR DESCRIPTION
## WHAT
Further adjust modal CSS for overflow.

## WHY
This is an edge case I didn't catch in testing.

## HOW
Just make sure the table is scrolling properly when there are too many classes to render in the initial view.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes