### PR TITLE
Add type column to AuthCredential for STI (#10683)

### DIFF
--- a/services/QuillLMS/app/models/auth_credential.rb
+++ b/services/QuillLMS/app/models/auth_credential.rb
@@ -7,9 +7,10 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
+#  type          :string
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null
@@ -25,6 +26,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class AuthCredential < ApplicationRecord
+  self.inheritance_column = :_type_disabled
+
   belongs_to :user
   has_one :canvas_instance_auth_credential, dependent: :destroy
 

--- a/services/QuillLMS/db/migrate/20230622125712_add_type_to_auth_credential.rb
+++ b/services/QuillLMS/db/migrate/20230622125712_add_type_to_auth_credential.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTypeToAuthCredential < ActiveRecord::Migration[6.1]
+  def change
+    add_column :auth_credentials, :type, :string
+  end
+end

--- a/services/QuillLMS/db/migrate/20230622525712_remove_null_false_from_auth_credential_provider.rb
+++ b/services/QuillLMS/db/migrate/20230622525712_remove_null_false_from_auth_credential_provider.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNullFalseFromAuthCredentialProvider < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :auth_credentials, :provider, true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -847,9 +847,10 @@ CREATE TABLE public.auth_credentials (
     expires_at timestamp without time zone,
     "timestamp" timestamp without time zone,
     access_token character varying NOT NULL,
-    provider character varying NOT NULL,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    type character varying,
+    provider character varying
 );
 
 
@@ -10272,6 +10273,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230524143000'),
 ('20230601210338'),
 ('20230613164607'),
-('20230621161210');
+('20230621161210'),
+('20230622125712'),
+('20230622525712');
 
 

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -26,4 +26,18 @@ namespace :users do
       DualGoogleIdAndCleverIdResolver.run(user)
     end
   end
+
+  task update_auth_credential_types: :environment do
+    {
+      canvas: 'CanvasAuthCredential',
+      google: 'GoogleAuthCredential',
+      clever_district: 'CleverDistrictAuthCredential',
+      clever_library: 'CleverLibraryAuthCredential'
+    }.each_pair do |provider, type|
+      AuthCredential
+        .where(provider: provider, type: nil)
+        .in_batches
+        .update_all(type: type)
+    end
+  end
 end

--- a/services/QuillLMS/spec/factories/auth_credentials.rb
+++ b/services/QuillLMS/spec/factories/auth_credentials.rb
@@ -7,9 +7,10 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
+#  type          :string
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null

--- a/services/QuillLMS/spec/models/auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/auth_credential_spec.rb
@@ -7,9 +7,10 @@
 #  id            :integer          not null, primary key
 #  access_token  :string           not null
 #  expires_at    :datetime
-#  provider      :string           not null
+#  provider      :string
 #  refresh_token :string
 #  timestamp     :datetime
+#  type          :string
 #  created_at    :datetime
 #  updated_at    :datetime
 #  user_id       :integer          not null


### PR DESCRIPTION
* Add type column to AuthCredential for STI

* Add backfill to be run after migration

* Disable STI for now

* Fix backfill script

* Update rake task

* Remove non-null requirement for provider on AuthCredential

* Add in_batches to speed up rake task

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
