### PR TITLE
fix invite students modal sizing

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
@@ -145,6 +145,7 @@
     h4 {
       font-weight: 700;
       font-size: 14px;
+      line-height: 20px;
     }
   }
 

--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/bulk_archive_classrooms_card.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/bulk_archive_classrooms_card.scss
@@ -19,7 +19,6 @@
     color: #FFF;
     text-align: center;
     font-size: 9px;
-    font-family: Adelle Sans;
     font-weight: 700;
     padding: 5px;
     background-color: #06806B;
@@ -37,7 +36,6 @@
   }
   .link-section button {
     font-size: 14px;
-    font-family: Adelle Sans;
     font-weight: 700;
     line-height: 20px;
     color: #5c5c5c;

--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -436,7 +436,6 @@
   position: fixed !important;
   top: 50%;
   left: 50%;
-  bottom: 72px;
   transform: translate(-50%, -50%);
   display: block;
   .checkbox-row {

--- a/services/QuillLMS/client/app/bundles/Shared/styles/input.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/input.scss
@@ -54,6 +54,7 @@
 
   input, input:focus {
     height: 20px;
+    padding-left: 0px;
   }
 
   textarea, textarea:focus {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/create_student_accounts.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/create_student_accounts.tsx
@@ -27,7 +27,7 @@ const tableHeaders = [{
 {
   name: 'Username',
   attribute: 'username',
-  width: '267px'
+  width: '260px'
 },
 {
   name: 'Password',


### PR DESCRIPTION
## WHAT
Fix invite students modal sizing (and other small visual bugs I noticed in interacting with this component).

## WHY
We don't want users to have to scroll to see the option to create student accounts.

## HOW
Just adjust some CSS that was causing the modal to render with less space than necessary.

### Screenshots
<img width="870" alt="Screen Shot 2023-06-27 at 8 35 07 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/6c7e9205-267a-4daa-8768-aa5d1cfc4ed9">

### Notion Card Links
https://www.notion.so/quill/Invite-students-form-not-properly-loading-5ee1263868bc4bab8b203c1bb786c9a3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES