### PR TITLE
Bs intermittent spec failures

### DIFF
--- a/services/QuillLMS/app/services/google_integration/teacher_classrooms_retriever.rb
+++ b/services/QuillLMS/app/services/google_integration/teacher_classrooms_retriever.rb
@@ -25,7 +25,7 @@ module GoogleIntegration
     end
 
     private def cache_classrooms_data
-      TeacherClassroomsCache.write(user_id, data.to_json)
+      GoogleIntegration::TeacherClassroomsCache.write(user_id, data.to_json)
     end
 
     private def data

--- a/services/QuillLMS/spec/requests/auth/learn_worlds_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/auth/learn_worlds_controller_spec.rb
@@ -59,7 +59,13 @@ RSpec.describe Auth::LearnWorldsController do
         end
 
         context 'user has existing learn_worlds_account' do
-          before { create(:learn_worlds_account, user: user, external_id: learn_worlds_account_external_id) }
+          before do
+            create(:learn_worlds_account,
+              external_id: learn_worlds_account_external_id,
+              last_login: 1.day.ago.to_datetime,
+              user: user
+            )
+          end
 
           it { expect { subject }.not_to change(user, :learn_worlds_account) }
           it { expect { subject }.to change { user.learn_worlds_account.last_login } }

--- a/services/QuillLMS/spec/services/google_integration/teacher_classrooms_retriever_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/teacher_classrooms_retriever_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 describe GoogleIntegration::TeacherClassroomsRetriever do
-  let(:user) { create(:user) }
+  subject { described_class.run(user.id) }
 
-  subject { described_class.new(user.id) }
+  let(:user) { create(:user) }
 
   it 'should trigger a pusher notification when now errors are raised' do
     expect(GoogleIntegration::Classroom::Main)
@@ -14,7 +14,7 @@ describe GoogleIntegration::TeacherClassroomsRetriever do
       .and_return({})
 
     expect(PusherTrigger).to receive(:run)
-    subject.run
+    subject
   end
 
   it 'should rescue GoogleIntegration::RefreshAccessToken::RefreshAccessTokenError in the Google integration' do
@@ -23,7 +23,7 @@ describe GoogleIntegration::TeacherClassroomsRetriever do
       .with(user)
       .and_raise(GoogleIntegration::RefreshAccessToken::RefreshAccessTokenError)
 
-    subject.run
+    subject
   end
 
   it 'should rescue GoogleIntegration::Client::AccessTokenError in the Google integration' do
@@ -32,6 +32,6 @@ describe GoogleIntegration::TeacherClassroomsRetriever do
       .with(user)
       .and_raise(GoogleIntegration::Client::AccessTokenError)
 
-    subject.run
+    subject
   end
 end


### PR DESCRIPTION
## WHAT
Fix a couple of intermittent spec failures.

## WHY
Intermittent spec failures slow the team down

## HOW
1. Since classes are lazy loaded, it's possible that the GoogleIntegration::TeacherClassroomsCache is not loaded before the base class and when the TeacherClassroomsCache is called.
2.  `Date.current` can be called multiple times and return the same value.  We need to set `last_login` to something earlier to ensure that Current.now is different from last_login.
<img width="370" alt="Screenshot 2023-06-27 at 10 55 47 AM" src="https://github.com/empirical-org/Empirical-Core/assets/2057805/45c32118-b104-43ec-8041-3becf3cf52bf">

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A