### PR TITLE
Fix bug with staff/activity route

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -114,7 +114,6 @@ class User < ApplicationRecord
   has_secure_password validations: false
   has_one :admin_info, dependent: :destroy
   has_one :auth_credential, dependent: :destroy
-  has_one :canvas_instance_auth_credential, through: :auth_credential
   has_one :teacher_info, dependent: :destroy
   has_many :teacher_info_subject_areas, through: :teacher_info
   has_many :teacher_notifications, dependent: :destroy


### PR DESCRIPTION
## WHAT
Fix a `ActionView::Template::Error: ActiveRecord::Reflection::ThroughReflection#foreign_key delegated to source_reflection.foreign_key, but source_reflection is nil` [bug](https://quillorg-5s.sentry.io/issues/4278653591/?project=11238&referrer=slac)

## WHY
The `has_one :canvas_instance_auth_credential, through: :auth_credential` no longer works due to a previous auth_credential STI refactor


## HOW
Remove the has_one relation since it only applies to CanvasAuthCredential.
At some point we can put it back if we introduce `has_one :canvas_auth_credential`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
