### PR TITLE
add teacher and classroom filters to frontend for usage snapshot report

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/usage-snapshot-report.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/usage-snapshot-report.scss
@@ -35,7 +35,7 @@
       }
     }
     .filters {
-      padding: 32px 24px;
+      padding: 32px 24px 84px;
       min-height: calc(100% - 68px); // accounting for height of filter buttons
     }
     .filter-buttons {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
@@ -9,6 +9,13 @@ exports[`SnapshotCount component size medium should match snapshot 1`] = `
   label="Sentences written"
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -31,6 +38,13 @@ exports[`SnapshotCount component size medium should match snapshot 1`] = `
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -77,6 +91,13 @@ exports[`SnapshotCount component size medium when there is data with a negative 
   passedCount={1000}
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -99,6 +120,13 @@ exports[`SnapshotCount component size medium when there is data with a negative 
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -149,6 +177,13 @@ exports[`SnapshotCount component size medium when there is data with a positive 
   passedCount={1000}
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -171,6 +206,13 @@ exports[`SnapshotCount component size medium when there is data with a positive 
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -218,6 +260,13 @@ exports[`SnapshotCount component size medium when there is no data  should match
   label="Sentences written"
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -240,6 +289,13 @@ exports[`SnapshotCount component size medium when there is no data  should match
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -283,6 +339,13 @@ exports[`SnapshotCount component size small when it is coming soon should match 
   label="Sentences written"
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -305,6 +368,13 @@ exports[`SnapshotCount component size small when it is coming soon should match 
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -351,6 +421,13 @@ exports[`SnapshotCount component size small when there is data with a negative t
   passedCount={1000}
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -373,6 +450,13 @@ exports[`SnapshotCount component size small when there is data with a negative t
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -423,6 +507,13 @@ exports[`SnapshotCount component size small when there is data with a positive t
   passedCount={1000}
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -445,6 +536,13 @@ exports[`SnapshotCount component size small when there is data with a positive t
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -492,6 +590,13 @@ exports[`SnapshotCount component size small when there is no data  should match 
   label="Sentences written"
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -514,6 +619,13 @@ exports[`SnapshotCount component size small when there is no data  should match 
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotRanking.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotRanking.test.tsx.snap
@@ -15,6 +15,13 @@ exports[`SnapshotRanking component when it is coming soon should match snapshot 
   label="Sentences written"
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -37,6 +44,13 @@ exports[`SnapshotRanking component when it is coming soon should match snapshot 
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -183,6 +197,13 @@ exports[`SnapshotRanking component when there is data  should match snapshot 1`]
   }
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -205,6 +226,13 @@ exports[`SnapshotRanking component when there is data  should match snapshot 1`]
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -358,6 +386,13 @@ exports[`SnapshotRanking component when there is no data  should match snapshot 
   label="Sentences written"
   queryKey="sentences-written"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -380,6 +415,13 @@ exports[`SnapshotRanking component when there is no data  should match snapshot 
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotSection.test.tsx.snap
@@ -60,6 +60,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
   }
   name="Classrooms"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -82,6 +89,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -107,6 +121,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           label="Active classrooms"
           queryKey="active-classrooms"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -129,6 +150,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -171,6 +199,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           label="Average active classrooms per teacher"
           queryKey="average-active-classrooms-per-teacher"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -193,6 +228,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -233,6 +275,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           label="Classrooms created"
           queryKey="classrooms-created"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -255,6 +304,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -297,6 +353,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           label="Average active students per classroom"
           queryKey="average-active-students-per-classroom"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -319,6 +382,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -371,6 +441,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           label="Most active grades"
           queryKey="most-active-grades"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -393,6 +470,13 @@ exports[`SnapshotSection component when the section is Classrooms should match s
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -515,6 +599,13 @@ exports[`SnapshotSection component when the section is Highlights should match s
   }
   name="Highlights"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -537,6 +628,13 @@ exports[`SnapshotSection component when the section is Highlights should match s
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -562,6 +660,13 @@ exports[`SnapshotSection component when the section is Highlights should match s
           label="Sentences written"
           queryKey="sentences-written"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -584,6 +689,13 @@ exports[`SnapshotSection component when the section is Highlights should match s
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -625,6 +737,13 @@ exports[`SnapshotSection component when the section is Highlights should match s
           label="Student learning hours"
           queryKey="student-learning-hours"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -647,6 +766,13 @@ exports[`SnapshotSection component when the section is Highlights should match s
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -821,6 +947,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
   }
   name="Practice"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -843,6 +976,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -868,6 +1008,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Activities assigned"
           queryKey="activities-assigned"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -890,6 +1037,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -931,6 +1085,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Activities completed"
           queryKey="activities-completed"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -953,6 +1114,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -994,6 +1162,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Activity packs assigned"
           queryKey="activity-packs-assigned"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1016,6 +1191,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1057,6 +1239,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Activity packs completed"
           queryKey="activity-packs-completed"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1079,6 +1268,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1131,6 +1327,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Top concepts assigned"
           queryKey="top-concepts-assigned"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1153,6 +1356,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1249,6 +1459,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Top concepts practiced"
           queryKey="top-concepts-practiced"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1271,6 +1488,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1366,6 +1590,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Baseline diagnostics assigned"
           queryKey="baseline-diagnostics-assigned"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1388,6 +1619,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1429,6 +1667,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Baseline diagnostics completed"
           queryKey="baseline-diagnostics-completed"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1451,6 +1696,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1492,6 +1744,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Growth diagnostics assigned"
           queryKey="growth-diagnostics-assigned"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1514,6 +1773,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1555,6 +1821,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Growth diagnostics completed"
           queryKey="growth-diagnostics-completed"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1577,6 +1850,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1618,6 +1898,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Average activities completed per student"
           queryKey="average-activities-completed-per-student"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1640,6 +1927,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1716,6 +2010,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Most assigned activities"
           queryKey="most-assigned-activities"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1738,6 +2039,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1838,6 +2146,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           label="Most completed activities"
           queryKey="most-completed-activities"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -1860,6 +2175,13 @@ exports[`SnapshotSection component when the section is Practice should match sna
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -1977,6 +2299,13 @@ exports[`SnapshotSection component when the section is Schools should match snap
   }
   name="Schools"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -1999,6 +2328,13 @@ exports[`SnapshotSection component when the section is Schools should match snap
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -2030,6 +2366,13 @@ exports[`SnapshotSection component when the section is Schools should match snap
           label="Most active schools"
           queryKey="most-active-schools"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -2052,6 +2395,13 @@ exports[`SnapshotSection component when the section is Schools should match snap
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -2200,6 +2550,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
   }
   name="Users"
   searchCount={1}
+  selectedClassroomIds={
+    Array [
+      170171,
+      1203848,
+      1203849,
+    ]
+  }
   selectedGrades={
     Array [
       "Kindergarten",
@@ -2222,6 +2579,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
   selectedSchoolIds={
     Array [
       58452,
+    ]
+  }
+  selectedTeacherIds={
+    Array [
+      1500140,
+      1500832,
+      3570928,
     ]
   }
   selectedTimeframe="last-30-days"
@@ -2247,6 +2611,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           label="Active teachers"
           queryKey="active-teachers"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -2269,6 +2640,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -2310,6 +2688,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           label="Active students"
           queryKey="active-students"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -2332,6 +2717,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -2373,6 +2765,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           label="Teacher accounts created"
           queryKey="teacher-accounts-created"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -2395,6 +2794,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -2436,6 +2842,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           label="Student accounts created"
           queryKey="student-accounts-created"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -2458,6 +2871,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"
@@ -2511,6 +2931,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           label="Most active teachers"
           queryKey="most-active-teachers"
           searchCount={1}
+          selectedClassroomIds={
+            Array [
+              170171,
+              1203848,
+              1203849,
+            ]
+          }
           selectedGrades={
             Array [
               "Kindergarten",
@@ -2533,6 +2960,13 @@ exports[`SnapshotSection component when the section is Users should match snapsh
           selectedSchoolIds={
             Array [
               58452,
+            ]
+          }
+          selectedTeacherIds={
+            Array [
+              1500140,
+              1500832,
+              3570928,
             ]
           }
           selectedTimeframe="last-30-days"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/data.ts
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/data.ts
@@ -3,3 +3,7 @@ export const grades = [{"value":"Kindergarten","name":"Kindergarten","label":"Ki
 export const schools = [{"id":58452,"name":"Frelinghuysen Middle","label":"Frelinghuysen Middle","value":58452}]
 
 export const timeframes = [{"value":"last-30-days","name":"Last 30 days","default":true,"label":"Last 30 days"},{"value":"last-90-days","name":"Last 90 days","default":false,"label":"Last 90 days"},{"value":"this-month","name":"This month","default":false,"label":"This month"},{"value":"last-month","name":"Last month","default":false,"label":"Last month"},{"value":"this-year","name":"This year","default":false,"label":"This year"},{"value":"last-year","name":"Last year","default":false,"label":"Last year"},{"value":"all-time","name":"All time","default":false,"label":"All time"},{"value":"custom","name":"Custom","default":false,"label":"Custom"}]
+
+export const teachers = [{"id":1500140,"name":"Brendan Breen","label":"Brendan Breen","value":1500140},{"id":1500832,"name":"Tracey Villaverde","label":"Tracey Villaverde","value":1500832},{"id":3570928,"name":"Joseph Pozzuto","label":"Joseph Pozzuto","value":3570928}]
+
+export const classrooms = [{"id":170171,"name":"Library 01","label":"Library 01","value":170171},{"id":1203848,"name":"English 9 H-Period 9 2021-2022 9","label":"English 9 H-Period 9 2021-2022 9","value":1203848},{"id":1203849,"name":"English 9 H-Period 7 2021 - 2022 7","label":"English 9 H-Period 7 2021 - 2022 7","value":1203849}]

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/filters.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/filters.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
 
-import { timeframes, grades, schools, } from './data'
+import { timeframes, grades, schools, teachers, classrooms,} from './data'
 
 import Filters from '../filters';
 
@@ -10,6 +10,8 @@ describe('Filters component', () => {
     allTimeframes: timeframes,
     allSchools: schools,
     allGrades: grades,
+    allTeachers: teachers,
+    allClassrooms: classrooms,
     applyFilters: jest.fn(),
     clearFilters: jest.fn(),
     selectedGrades: grades,
@@ -18,6 +20,10 @@ describe('Filters component', () => {
     handleSetSelectedTimeframe: jest.fn(),
     selectedTimeframe: timeframes[0],
     selectedSchools: schools,
+    selectedTeachers: teachers,
+    selectedClassrooms: classrooms,
+    setSelectedTeachers: jest.fn(),
+    setSelectedClassrooms: jest.fn(),
     setSelectedSchools: jest.fn(),
     closeMobileFilterMenu: jest.fn(),
     showMobileFilterMenu: jest.fn()

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/snapshotCount.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/snapshotCount.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
 
-import { timeframes, grades, schools, } from './data'
+import { timeframes, grades, schools, teachers, classrooms, } from './data'
 
 import { SMALL, NEGATIVE, POSITIVE, MEDIUM, } from '../shared'
 import SnapshotCount from '../snapshotCount';
@@ -13,6 +13,8 @@ describe('SnapshotCount component', () => {
     searchCount: 1,
     selectedGrades: grades.map(g => g.value),
     selectedSchoolIds: schools.map(s => s.id),
+    selectedTeacherIds: teachers.map(s => s.id),
+    selectedClassroomIds: classrooms.map(s => s.id),
     selectedTimeframe: timeframes[0].value,
     adminId: 1,
     customTimeframeStart: null,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/snapshotRanking.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/snapshotRanking.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
 
-import { timeframes, grades, schools, } from './data'
+import { timeframes, grades, schools, teachers, classrooms, } from './data'
 
 import { SMALL, NEGATIVE, POSITIVE, MEDIUM, } from '../shared'
 import SnapshotRanking from '../snapshotRanking';
@@ -27,6 +27,8 @@ describe('SnapshotRanking component', () => {
     searchCount: 1,
     selectedGrades: grades.map(g => g.value),
     selectedSchoolIds: schools.map(s => s.id),
+    selectedTeacherIds: teachers.map(s => s.id),
+    selectedClassroomIds: classrooms.map(s => s.id),
     selectedTimeframe: timeframes[0].value,
     adminId: 1,
     customTimeframeStart: null,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/snapshotSection.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/snapshotSection.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
 
-import { timeframes, grades, schools, } from './data'
+import { timeframes, grades, schools, teachers, classrooms, } from './data'
 
 import { snapshotSections, } from '../shared'
 import SnapshotSection from '../snapshotSection';
@@ -11,6 +11,8 @@ describe('SnapshotSection component', () => {
     searchCount: 1,
     selectedGrades: grades.map(g => g.value),
     selectedSchoolIds: schools.map(s => s.id),
+    selectedTeacherIds: teachers.map(s => s.id),
+    selectedClassroomIds: classrooms.map(s => s.id),
     selectedTimeframe: timeframes[0].value,
     adminId: 1,
     customTimeframeStart: null,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
@@ -35,22 +35,42 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
 
   function handleRemoveSchool(school) {
     const newSchools = selectedSchools.filter(s => s.id !== school.id)
-    setSelectedSchools(newSchools)
+
+    if (newSchools.length) {
+      setSelectedSchools(newSchools)
+    } else {
+      setSelectedSchools(allSchools)
+    }
   }
 
   function handleRemoveTeacher(teacher) {
     const newTeachers = selectedTeachers.filter(s => s.id !== teacher.id)
-    setSelectedTeachers(newTeachers)
+
+    if (newTeachers.length) {
+      setSelectedTeachers(newTeachers)
+    } else {
+      setSelectedTeachers(allTeachers)
+    }
   }
 
   function handleRemoveClassroom(classroom) {
     const newClassrooms = selectedClassrooms.filter(s => s.id !== classroom.id)
-    setSelectedClassrooms(newClassrooms)
+
+    if (newClassrooms.length) {
+      setSelectedClassrooms(newClassrooms)
+    } else {
+      setSelectedClassrooms(allClassrooms)
+    }
   }
 
   function handleRemoveGrade(grade) {
     const newGrades = selectedGrades.filter(g => g.value !== grade.value)
-    setSelectedGrades(newGrades)
+
+    if (newGrades.length) {
+      setSelectedGrades(newGrades)
+    } else {
+      setSelectedGrades(allGrades)
+    }
   }
 
   const schoolSearchTokens = !unorderedArraysAreEqual(effectiveSelectedSchools(), allSchools) && effectiveSelectedSchools().map(s => (

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
@@ -21,6 +21,18 @@ const SearchToken = ({ searchItem, onRemoveSearchItem, }) => {
 const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassrooms, applyFilters, clearFilters, selectedGrades, setSelectedGrades, hasAdjustedFiltersFromDefault, handleSetSelectedTimeframe, selectedTimeframe, selectedSchools, setSelectedSchools, selectedTeachers, setSelectedTeachers, selectedClassrooms, setSelectedClassrooms, closeMobileFilterMenu, showMobileFilterMenu, hasAdjustedFiltersSinceLastSubmission, customStartDate, customEndDate, }) => {
   const size = useWindowSize();
 
+  function effectiveSelectedSchools() {
+    return selectedSchools.filter(s => allSchools.find(as => as.id === s.id))
+  }
+
+  function effectiveSelectedTeachers() {
+    return selectedTeachers.filter(t => allTeachers.find(at => at.id === t.id))
+  }
+
+  function effectiveSelectedClassrooms() {
+    return selectedClassrooms.filter(c => allClassrooms.find(ac => ac.id === c.id))
+  }
+
   function handleRemoveSchool(school) {
     const newSchools = selectedSchools.filter(s => s.id !== school.id)
     setSelectedSchools(newSchools)
@@ -41,7 +53,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
     setSelectedGrades(newGrades)
   }
 
-  const schoolSearchTokens = !unorderedArraysAreEqual(selectedSchools, allSchools) && selectedSchools.map(s => (
+  const schoolSearchTokens = !unorderedArraysAreEqual(effectiveSelectedSchools(), allSchools) && effectiveSelectedSchools().map(s => (
     <SearchToken
       key={s.id}
       onRemoveSearchItem={handleRemoveSchool}
@@ -49,7 +61,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
     />
   ))
 
-  const teacherSearchTokens = !unorderedArraysAreEqual(selectedTeachers, allTeachers) && selectedTeachers.map(t => (
+  const teacherSearchTokens = !unorderedArraysAreEqual(effectiveSelectedTeachers(), allTeachers) && effectiveSelectedTeachers().map(t => (
     <SearchToken
       key={t.id}
       onRemoveSearchItem={handleRemoveTeacher}
@@ -57,7 +69,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
     />
   ))
 
-  const classroomSearchTokens = !unorderedArraysAreEqual(selectedClassrooms, allClassrooms) && selectedClassrooms.map(c => (
+  const classroomSearchTokens = !unorderedArraysAreEqual(effectiveSelectedClassrooms(), allClassrooms) && effectiveSelectedClassrooms().map(c => (
     <SearchToken
       key={c.id}
       onRemoveSearchItem={handleRemoveClassroom}
@@ -118,7 +130,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
           label=""
           options={allSchools}
           optionType='school'
-          value={selectedSchools}
+          value={effectiveSelectedSchools()}
         />
         <div className="search-tokens">{schoolSearchTokens}</div>
         <label className="filter-label" htmlFor="grade-filter">Grade</label>
@@ -142,7 +154,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
           label=""
           options={allTeachers}
           optionType='teacher'
-          value={selectedTeachers}
+          value={effectiveSelectedTeachers()}
         />
         <div className="search-tokens">{teacherSearchTokens}</div>
         <label className="filter-label" htmlFor="classroom-filter">Classroom</label>
@@ -154,7 +166,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
           label=""
           options={allClassrooms}
           optionType='classroom'
-          value={selectedClassrooms}
+          value={effectiveSelectedClassrooms()}
         />
         <div className="search-tokens">{classroomSearchTokens}</div>
       </div>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
@@ -4,8 +4,6 @@ import { DropdownInput } from '../../../Shared/index'
 import useWindowSize from '../../../Shared/hooks/useWindowSize';
 import { unorderedArraysAreEqual, } from '../../../../modules/unorderedArraysAreEqual'
 
-const MAX_VIEW_WIDTH_FOR_MOBILE = 1134
-
 const removeSearchTokenSrc = `${process.env.CDN_URL}/images/pages/administrator/remove_search_token.svg`
 const closeIconSrc = `${process.env.CDN_URL}/images/icons/close.svg`
 
@@ -20,12 +18,22 @@ const SearchToken = ({ searchItem, onRemoveSearchItem, }) => {
   )
 }
 
-const Filters = ({ allTimeframes, allSchools, allGrades, applyFilters, clearFilters, selectedGrades, setSelectedGrades, hasAdjustedFiltersFromDefault, handleSetSelectedTimeframe, selectedTimeframe, selectedSchools, setSelectedSchools, closeMobileFilterMenu, showMobileFilterMenu, hasAdjustedFiltersSinceLastSubmission, customStartDate, customEndDate, }) => {
+const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassrooms, applyFilters, clearFilters, selectedGrades, setSelectedGrades, hasAdjustedFiltersFromDefault, handleSetSelectedTimeframe, selectedTimeframe, selectedSchools, setSelectedSchools, selectedTeachers, setSelectedTeachers, selectedClassrooms, setSelectedClassrooms, closeMobileFilterMenu, showMobileFilterMenu, hasAdjustedFiltersSinceLastSubmission, customStartDate, customEndDate, }) => {
   const size = useWindowSize();
 
   function handleRemoveSchool(school) {
     const newSchools = selectedSchools.filter(s => s.id !== school.id)
     setSelectedSchools(newSchools)
+  }
+
+  function handleRemoveTeacher(teacher) {
+    const newTeachers = selectedTeachers.filter(s => s.id !== teacher.id)
+    setSelectedTeachers(newTeachers)
+  }
+
+  function handleRemoveClassroom(classroom) {
+    const newClassrooms = selectedClassrooms.filter(s => s.id !== classroom.id)
+    setSelectedClassrooms(newClassrooms)
   }
 
   function handleRemoveGrade(grade) {
@@ -38,6 +46,22 @@ const Filters = ({ allTimeframes, allSchools, allGrades, applyFilters, clearFilt
       key={s.id}
       onRemoveSearchItem={handleRemoveSchool}
       searchItem={s}
+    />
+  ))
+
+  const teacherSearchTokens = !unorderedArraysAreEqual(selectedTeachers, allTeachers) && selectedTeachers.map(t => (
+    <SearchToken
+      key={t.id}
+      onRemoveSearchItem={handleRemoveTeacher}
+      searchItem={t}
+    />
+  ))
+
+  const classroomSearchTokens = !unorderedArraysAreEqual(selectedClassrooms, allClassrooms) && selectedClassrooms.map(c => (
+    <SearchToken
+      key={c.id}
+      onRemoveSearchItem={handleRemoveClassroom}
+      searchItem={c}
     />
   ))
 
@@ -109,6 +133,30 @@ const Filters = ({ allTimeframes, allSchools, allGrades, applyFilters, clearFilt
           value={selectedGrades}
         />
         <div className="search-tokens">{gradeSearchTokens}</div>
+        <label className="filter-label" htmlFor="teacher-filter">Teacher</label>
+        <DropdownInput
+          handleChange={setSelectedTeachers}
+          id="teacher-filter"
+          isMulti={true}
+          isSearchable={true}
+          label=""
+          options={allTeachers}
+          optionType='teacher'
+          value={selectedTeachers}
+        />
+        <div className="search-tokens">{teacherSearchTokens}</div>
+        <label className="filter-label" htmlFor="classroom-filter">Classroom</label>
+        <DropdownInput
+          handleChange={setSelectedClassrooms}
+          id="classroom-filter"
+          isMulti={true}
+          isSearchable={true}
+          label=""
+          options={allClassrooms}
+          optionType='classroom'
+          value={selectedClassrooms}
+        />
+        <div className="search-tokens">{classroomSearchTokens}</div>
       </div>
       {renderFilterButtons()}
     </section>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -20,6 +20,8 @@ interface SnapshotCountProps {
   searchCount: number;
   selectedGrades: Array<string>;
   selectedSchoolIds: Array<number>;
+  selectedClassroomIds: Array<number>;
+  selectedTeacherIds: Array<number>;
   selectedTimeframe: string;
   adminId: number;
   customTimeframeStart?: any;
@@ -31,7 +33,7 @@ interface SnapshotCountProps {
   singularLabel?: string;
 }
 
-const SnapshotCount = ({ label, size, queryKey, comingSoon, searchCount, selectedGrades, selectedSchoolIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, passedCount, passedChange, passedChangeDirection, singularLabel, }: SnapshotCountProps) => {
+const SnapshotCount = ({ label, size, queryKey, comingSoon, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, passedCount, passedChange, passedChangeDirection, singularLabel, }: SnapshotCountProps) => {
   const [count, setCount] = React.useState(passedCount || null)
   const [change, setChange] = React.useState(passedChange || 0)
   const [changeDirection, setChangeDirection] = React.useState(passedChangeDirection || null)
@@ -60,6 +62,8 @@ const SnapshotCount = ({ label, size, queryKey, comingSoon, searchCount, selecte
       timeframe_custom_start: customTimeframeStart,
       timeframe_custom_end: customTimeframeEnd,
       school_ids: selectedSchoolIds,
+      teacher_ids: selectedTeacherIds,
+      classroom_ids: selectedClassroomIds,
       grades: selectedGrades
     }
 
@@ -101,9 +105,11 @@ const SnapshotCount = ({ label, size, queryKey, comingSoon, searchCount, selecte
       const queryKeysAreEqual = message.query === queryKey
       const timeframesAreEqual = message.timeframe === selectedTimeframe
       const schoolIdsAreEqual = unorderedArraysAreEqual(message.school_ids, selectedSchoolIds.map(id => String(id)))
+      const teacherIdsAreEqual = unorderedArraysAreEqual(message.teacher_ids, selectedTeacherIds.map(id => String(id)))
+      const classroomIdsAreEqual = unorderedArraysAreEqual(message.classroom_ids, selectedClassroomIds.map(id => String(id)))
       const gradesAreEqual =  unorderedArraysAreEqual(message.grades, selectedGrades.map(grade => String(grade))) || (!message.grades && !selectedGrades.length)
 
-      if (queryKeysAreEqual && timeframesAreEqual && schoolIdsAreEqual && gradesAreEqual) {
+      if (queryKeysAreEqual && timeframesAreEqual && schoolIdsAreEqual && gradesAreEqual && teacherIdsAreEqual && classroomIdsAreEqual) {
         getData()
       }
     });

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -17,6 +17,8 @@ interface SnapshotRankingProps {
   searchCount: number;
   selectedGrades: Array<string>;
   selectedSchoolIds: Array<number>;
+  selectedTeacherIds: Array<number>;
+  selectedClassroomIds: Array<number>;
   selectedTimeframe: string;
   adminId: number;
   customTimeframeStart?: any;
@@ -69,7 +71,7 @@ const DataTable = ({ headers, data, numberOfRows, }) => {
   )
 }
 
-const SnapshotRanking = ({ label, queryKey, headers, comingSoon, searchCount, selectedGrades, selectedSchoolIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, passedData, }: SnapshotRankingProps) => {
+const SnapshotRanking = ({ label, queryKey, headers, comingSoon, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, passedData, }: SnapshotRankingProps) => {
   const [data, setData] = React.useState(null)
   const [loading, setLoading] = React.useState(false)
   const [showModal, setShowModal] = React.useState(false)
@@ -95,6 +97,8 @@ const SnapshotRanking = ({ label, queryKey, headers, comingSoon, searchCount, se
       timeframe_custom_start: customTimeframeStart,
       timeframe_custom_end: customTimeframeEnd,
       school_ids: selectedSchoolIds,
+      teacher_ids: selectedTeacherIds,
+      classroom_ids: selectedClassroomIds,
       grades: selectedGrades
     }
 
@@ -122,9 +126,11 @@ const SnapshotRanking = ({ label, queryKey, headers, comingSoon, searchCount, se
       const queryKeysAreEqual = message.query === queryKey
       const timeframesAreEqual = message.timeframe === selectedTimeframe
       const schoolIdsAreEqual = unorderedArraysAreEqual(message.school_ids, selectedSchoolIds.map(id => String(id)))
+      const teacherIdsAreEqual = unorderedArraysAreEqual(message.teacher_ids, selectedTeacherIds.map(id => String(id)))
+      const classroomIdsAreEqual = unorderedArraysAreEqual(message.classroom_ids, selectedClassroomIds.map(id => String(id)))
       const gradesAreEqual =  unorderedArraysAreEqual(message.grades, selectedGrades.map(grade => String(grade))) || (!message.grades && !selectedGrades.length)
 
-      if (queryKeysAreEqual && timeframesAreEqual && schoolIdsAreEqual && gradesAreEqual) {
+      if (queryKeysAreEqual && timeframesAreEqual && schoolIdsAreEqual && gradesAreEqual && teacherIdsAreEqual && classroomIdsAreEqual) {
         getData()
       }
     });

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotSection.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotSection.tsx
@@ -5,7 +5,7 @@ import SnapshotRanking from './snapshotRanking'
 import SnapshotFeedback from './snapshotFeedback'
 import { COUNT, RANKING, FEEDBACK, } from './shared'
 
-const SnapshotSection = ({ name, className, itemGroupings, searchCount, selectedGrades, selectedSchoolIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, }) => {
+const SnapshotSection = ({ name, className, itemGroupings, searchCount, selectedGrades, selectedSchoolIds, selectedClassroomIds, selectedTeacherIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, }) => {
   const snapshotItemGroupings = itemGroupings.map(grouping => {
     const snapshotItems = grouping.items.map(item => {
       const { label, size, type, queryKey, comingSoon, headers, singularLabel, } = item
@@ -17,6 +17,8 @@ const SnapshotSection = ({ name, className, itemGroupings, searchCount, selected
         searchCount,
         selectedGrades,
         selectedSchoolIds,
+        selectedTeacherIds,
+        selectedClassroomIds,
         selectedTimeframe,
         customTimeframeEnd,
         customTimeframeStart,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -150,12 +150,9 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
       const gradeOptions = filterData.grades.map(grade => ({ ...grade, label: grade.name }))
       const schoolOptions = filterData.schools.map(school => ({ ...school, label: school.name, value: school.id }))
 
-      // TODO: remove the deduplication here once the backend is returning deduplicated data
-      const teacherOptionsWithDuplicates = filterData.teachers.map(teacher => ({ ...teacher, label: teacher.name, value: teacher.id }))
-      const teacherOptions = _.uniqBy(teacherOptionsWithDuplicates, opt => opt.id)
+      const teacherOptions = filterData.teachers.map(teacher => ({ ...teacher, label: teacher.name, value: teacher.id }))
 
-      const classroomOptionsWithDuplicates = filterData.classrooms.map(classroom => ({ ...classroom, label: classroom.name, value: classroom.id }))
-      const classroomOptions = _.uniqBy(classroomOptionsWithDuplicates, opt => opt.id)
+      const classroomOptions = filterData.classrooms.map(classroom => ({ ...classroom, label: classroom.name, value: classroom.id }))
 
       const timeframe = defaultTimeframe(timeframeOptions)
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -136,7 +136,7 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
       school_ids: selectedSchools?.map(s => s.id) || null,
       teacher_ids: selectedTeachers?.map(t => t.id) || null,
       classroom_ids: selectedClassrooms?.map(c => c.id) || null,
-      grades: selectedGradesToPass()
+      grades: selectedGrades?.map(g => g.value)
     }
 
     const requestUrl = queryString.stringifyUrl({ url: '/snapshots/options', query: searchParams }, { arrayFormat: 'bracket' })
@@ -224,15 +224,6 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
 
   function handleSetSelectedTabFromDropdown(option) { setSelectedTab(option.value) }
 
-  function selectedGradesToPass() {
-    // we need to pass the backend an empty array when all grades are selected so we include data from classrooms that do not have a grade
-    if (!selectedGrades) { return [] }
-
-    // we need to pass the backend an empty array when all grades are selected so we include data from classrooms that do not have a grade
-    return selectedGrades.length === allGrades.length ? [] : selectedGrades.map(g => g.value)
-
-  }
-
   if (loadingFilters) {
     return <Spinner />
   }
@@ -273,7 +264,7 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
       name={section.name}
       searchCount={searchCount}
       selectedClassroomIds={selectedClassrooms.map(c => c.id)}
-      selectedGrades={selectedGradesToPass()}
+      selectedGrades={selectedGrades.map(g => g.value)}
       selectedSchoolIds={selectedSchools.map(s => s.id)}
       selectedTeacherIds={selectedTeachers.map(t => t.id)}
       selectedTimeframe={selectedTimeframe.value}

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -150,11 +150,9 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
       const gradeOptions = filterData.grades.map(grade => ({ ...grade, label: grade.name }))
       const schoolOptions = filterData.schools.map(school => ({ ...school, label: school.name, value: school.id }))
 
-      const teacherOptionsWithDuplicates = filterData.teachers.map(teacher => ({ ...teacher, label: teacher.name, value: teacher.id }))
-      const teacherOptions = _.uniqBy(teacherOptionsWithDuplicates, opt => opt.id)
+      const teacherOptions = filterData.teachers.map(teacher => ({ ...teacher, label: teacher.name, value: teacher.id }))
 
-      const classroomOptionsWithDuplicates = filterData.classrooms.map(classroom => ({ ...classroom, label: classroom.name, value: classroom.id }))
-      const classroomOptions = _.uniqBy(classroomOptionsWithDuplicates, opt => opt.id)
+      const classroomOptions = filterData.classrooms.map(classroom => ({ ...classroom, label: classroom.name, value: classroom.id }))
 
       const timeframe = defaultTimeframe(timeframeOptions)
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -29,16 +29,23 @@ const Tab = ({ section, setSelectedTab, selectedTab }) => {
 
 const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
   const [loadingFilters, setLoadingFilters] = React.useState(true)
+
   const [allTimeframes, setAllTimeframes] = React.useState(null)
   const [allSchools, setAllSchools] = React.useState(null)
   const [allGrades, setAllGrades] = React.useState(null)
   const [allTeachers, setAllTeachers] = React.useState(null)
   const [allClassrooms, setAllClassrooms] = React.useState(null)
+
+  const [originalAllSchools, setOriginalAllSchools] = React.useState(null)
+  const [originalAllTeachers, setOriginalAllTeachers] = React.useState(null)
+  const [originalAllClassrooms, setOriginalAllClassrooms] = React.useState(null)
+
   const [selectedSchools, setSelectedSchools] = React.useState(null)
   const [selectedGrades, setSelectedGrades] = React.useState(null)
   const [selectedTeachers, setSelectedTeachers] = React.useState(null)
   const [selectedClassrooms, setSelectedClassrooms] = React.useState(null)
   const [selectedTimeframe, setSelectedTimeframe] = React.useState(null)
+
   const [lastSubmittedSchools, setLastSubmittedSchools] = React.useState(null)
   const [lastSubmittedGrades, setLastSubmittedGrades] = React.useState(null)
   const [lastSubmittedTeachers, setLastSubmittedTeachers] = React.useState(null)
@@ -46,8 +53,10 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
   const [lastSubmittedTimeframe, setLastSubmittedTimeframe] = React.useState(null)
   const [lastSubmittedCustomStartDate, setLastSubmittedCustomStartDate] = React.useState(null)
   const [lastSubmittedCustomEndDate, setLastSubmittedCustomEndDate] = React.useState(null)
+
   const [hasAdjustedFiltersFromDefault, setHasAdjustedFiltersFromDefault] = React.useState(null)
   const [hasAdjustedFiltersSinceLastSubmission, setHasAdjustedFiltersSinceLastSubmission] = React.useState(null)
+
   const [customStartDate, setCustomStartDate] = React.useState(null)
   const [customEndDate, setCustomEndDate] = React.useState(null)
   const [searchCount, setSearchCount] = React.useState(0)
@@ -66,10 +75,10 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
     if (loadingFilters) { return }
 
     const newValueForHasAdjustedFiltersFromDefault = (
-      !unorderedArraysAreEqual(selectedSchools, allSchools)
+      !unorderedArraysAreEqual(selectedSchools, originalAllSchools)
       || !unorderedArraysAreEqual(selectedGrades, allGrades)
-      || !unorderedArraysAreEqual(selectedTeachers, allTeachers)
-      || !unorderedArraysAreEqual(selectedClassrooms, allClassrooms)
+      || !unorderedArraysAreEqual(selectedTeachers, originalAllTeachers)
+      || !unorderedArraysAreEqual(selectedClassrooms, originalAllClassrooms)
       || !_.isEqual(selectedTimeframe, defaultTimeframe(allTimeframes))
     )
 
@@ -97,6 +106,12 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
   }, [showCustomDateModal])
 
   React.useEffect(() => {
+    getFilters()
+  }, [])
+
+  React.useEffect(() => {
+    if (loadingFilters) { return }
+
     getFilters()
   }, [selectedSchools, selectedTeachers, selectedClassrooms])
 
@@ -153,30 +168,38 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
         setSelectedSchools(schoolOptions)
         setSelectedTeachers(teacherOptions)
         setSelectedClassrooms(classroomOptions)
-        setLastUsedTimeframe(timeframe)
         setSelectedTimeframe(timeframe)
+
+        setLastSubmittedGrades(gradeOptions)
+        setLastSubmittedSchools(schoolOptions)
+        setLastSubmittedTeachers(teacherOptions)
+        setLastSubmittedClassrooms(classroomOptions)
+        setLastSubmittedTimeframe(timeframe)
+
+        setLastUsedTimeframe(timeframe)
+
+        setOriginalAllClassrooms(classroomOptions)
+        setOriginalAllSchools(schoolOptions)
+        setOriginalAllTeachers(teacherOptions)
+
         setLoadingFilters(false)
-      } else {
-        // if (selectedSchools.length > schoolOptions.length) { setSelectedSchools(schoolOptions) }
-        // if (selectedTeachers.length > teacherOptions.length) { setSelectedTeachers(teacherOptions) }
-        // if (selectedClassrooms.length > classroomOptions.length) { setSelectedClassrooms(classroomOptions) }
       }
     })
   }
 
   function clearFilters() {
     setSelectedGrades(allGrades)
-    setSelectedSchools(allSchools)
-    setSelectedTeachers(allTeachers)
-    setSelectedClassrooms(allClassrooms)
+    setSelectedSchools(originalAllSchools)
+    setSelectedTeachers(originalAllTeachers)
+    setSelectedClassrooms(originalAllClassrooms)
     setSelectedTimeframe(defaultTimeframe(allTimeframes))
 
     // what follows is basically duplicating the logic in applyFilters, but avoids a race condition where the "lastSubmitted" values get set before the new selected values are set
     setSearchCount(searchCount + 1)
     setLastSubmittedGrades(allGrades)
-    setLastSubmittedSchools(allSchools)
-    setLastSubmittedTeachers(allTeachers)
-    setLastSubmittedClassrooms(allClassrooms)
+    setLastSubmittedSchools(originalAllSchools)
+    setLastSubmittedTeachers(originalAllTeachers)
+    setLastSubmittedClassrooms(originalAllClassrooms)
     setLastSubmittedTimeframe(defaultTimeframe(allTimeframes))
     setLastSubmittedCustomStartDate(null)
     setLastSubmittedCustomEndDate(null)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -69,7 +69,7 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
 
   React.useEffect(() => {
     getFilters()
-  }, [selectedSchools, selectedTeachers, selectedClassrooms])
+  }, [selectedSchools, selectedTeachers, selectedClassrooms, selectedGrades])
 
   React.useEffect(() => {
     if (loadingFilters) { return }
@@ -139,7 +139,8 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
     const searchParams = {
       school_ids: selectedSchools?.map(s => s.id) || null,
       teacher_ids: selectedTeachers?.map(t => t.id) || null,
-      classroom_ids: selectedClassrooms?.map(c => c.id) || null
+      classroom_ids: selectedClassrooms?.map(c => c.id) || null,
+      grades: selectedGradesToPass()
     }
 
     const requestUrl = queryString.stringifyUrl({ url: '/snapshots/options', query: searchParams }, { arrayFormat: 'bracket' })
@@ -153,7 +154,8 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
       const teacherOptionsWithDuplicates = filterData.teachers.map(teacher => ({ ...teacher, label: teacher.name, value: teacher.id }))
       const teacherOptions = _.uniqBy(teacherOptionsWithDuplicates, opt => opt.id)
 
-      const classroomOptions = filterData.classrooms.map(classroom => ({ ...classroom, label: classroom.name, value: classroom.id }))
+      const classroomOptionsWithDuplicates = filterData.classrooms.map(classroom => ({ ...classroom, label: classroom.name, value: classroom.id }))
+      const classroomOptions = _.uniqBy(classroomOptionsWithDuplicates, opt => opt.id)
 
       const timeframe = defaultTimeframe(timeframeOptions)
 
@@ -229,6 +231,15 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
 
   function handleSetSelectedTabFromDropdown(option) { setSelectedTab(option.value) }
 
+  function selectedGradesToPass() {
+    // we need to pass the backend an empty array when all grades are selected so we include data from classrooms that do not have a grade
+    if (!selectedGrades) { return [] }
+
+    // we need to pass the backend an empty array when all grades are selected so we include data from classrooms that do not have a grade
+    return selectedGrades.length === allGrades.length ? [] : selectedGrades.map(g => g.value)
+
+  }
+
   if (loadingFilters) {
     return <Spinner />
   }
@@ -257,9 +268,6 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
     />
   )
 
-  // we need to pass the backend an empty array when all grades are selected so we include data from classrooms that do not have a grade
-  const selectedGradesToPass = selectedGrades.length === allGrades.length ? [] : selectedGrades.map(g => g.value)
-
   const sectionsToShow = selectedTab === ALL ? snapshotSections : snapshotSections.filter(s => s.name === selectedTab)
   const snapshotSectionComponents = sectionsToShow.map(section => (
     <SnapshotSection
@@ -272,7 +280,7 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
       name={section.name}
       searchCount={searchCount}
       selectedClassroomIds={selectedClassrooms.map(c => c.id)}
-      selectedGrades={selectedGradesToPass}
+      selectedGrades={selectedGradesToPass()}
       selectedSchoolIds={selectedSchools.map(s => s.id)}
       selectedTeacherIds={selectedTeachers.map(t => t.id)}
       selectedTimeframe={selectedTimeframe.value}

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import queryString from 'query-string';
 import * as _ from 'lodash'
 
 import { FULL, restrictedPage, } from '../shared';
@@ -59,7 +60,7 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
 
   React.useEffect(() => {
     getFilters()
-  }, [])
+  }, [selectedSchools, selectedTeachers, selectedClassrooms])
 
   React.useEffect(() => {
     if (loadingFilters) { return }
@@ -95,6 +96,10 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
     setSelectedTimeframe(lastUsedTimeframe)
   }, [showCustomDateModal])
 
+  React.useEffect(() => {
+    getFilters()
+  }, [selectedSchools, selectedTeachers, selectedClassrooms])
+
   function openMobileFilterMenu() { setShowMobileFilterMenu(true) }
 
   function closeMobileFilterMenu() { setShowMobileFilterMenu(false) }
@@ -116,7 +121,15 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
   }
 
   function getFilters() {
-    requestGet('/snapshots/options', (filterData) => {
+    const searchParams = {
+      school_ids: selectedSchools?.map(s => s.id) || null,
+      teacher_ids: selectedTeachers?.map(t => t.id) || null,
+      classroom_ids: selectedClassrooms?.map(c => c.id) || null
+    }
+
+    const requestUrl = queryString.stringifyUrl({ url: '/snapshots/options', query: searchParams }, { arrayFormat: 'bracket' })
+
+    requestGet(requestUrl, (filterData) => {
       const timeframeOptions = filterData.timeframes.map(tf => ({ ...tf, label: tf.name }))
       const gradeOptions = filterData.grades.map(grade => ({ ...grade, label: grade.name }))
       const schoolOptions = filterData.schools.map(school => ({ ...school, label: school.name, value: school.id }))
@@ -129,18 +142,25 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
 
       const timeframe = defaultTimeframe(timeframeOptions)
 
-      setAllGrades(gradeOptions)
-      setAllTimeframes(timeframeOptions)
-      setAllSchools(schoolOptions)
-      setAllTeachers(teacherOptions)
-      setAllClassrooms(classroomOptions)
-      setSelectedGrades(gradeOptions)
-      setSelectedSchools(schoolOptions)
-      setSelectedTeachers(teacherOptions)
-      setSelectedClassrooms(classroomOptions)
-      setLastUsedTimeframe(timeframe)
-      setSelectedTimeframe(timeframe)
-      setLoadingFilters(false)
+      if (allGrades?.length !== gradeOptions.length) { setAllGrades(gradeOptions) }
+      if (allTimeframes?.length !== timeframeOptions.length) { setAllTimeframes(timeframeOptions)}
+      if (allSchools?.length !== schoolOptions.length) { setAllSchools(schoolOptions) }
+      if (allTeachers?.length !== teacherOptions.length) { setAllTeachers(teacherOptions) }
+      if (allClassrooms?.length !== classroomOptions.length) { setAllClassrooms(classroomOptions) }
+
+      if (loadingFilters) {
+        setSelectedGrades(gradeOptions)
+        setSelectedSchools(schoolOptions)
+        setSelectedTeachers(teacherOptions)
+        setSelectedClassrooms(classroomOptions)
+        setLastUsedTimeframe(timeframe)
+        setSelectedTimeframe(timeframe)
+        setLoadingFilters(false)
+      } else {
+        // if (selectedSchools.length > schoolOptions.length) { setSelectedSchools(schoolOptions) }
+        // if (selectedTeachers.length > teacherOptions.length) { setSelectedTeachers(teacherOptions) }
+        // if (selectedClassrooms.length > classroomOptions.length) { setSelectedClassrooms(classroomOptions) }
+      }
     })
   }
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -150,9 +150,11 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
       const gradeOptions = filterData.grades.map(grade => ({ ...grade, label: grade.name }))
       const schoolOptions = filterData.schools.map(school => ({ ...school, label: school.name, value: school.id }))
 
-      const teacherOptions = filterData.teachers.map(teacher => ({ ...teacher, label: teacher.name, value: teacher.id }))
+      const teacherOptionsWithDuplicates = filterData.teachers.map(teacher => ({ ...teacher, label: teacher.name, value: teacher.id }))
+      const teacherOptions = _.uniqBy(teacherOptionsWithDuplicates, opt => opt.id)
 
-      const classroomOptions = filterData.classrooms.map(classroom => ({ ...classroom, label: classroom.name, value: classroom.id }))
+      const classroomOptionsWithDuplicates = filterData.classrooms.map(classroom => ({ ...classroom, label: classroom.name, value: classroom.id }))
+      const classroomOptions = _.uniqBy(classroomOptionsWithDuplicates, opt => opt.id)
 
       const timeframe = defaultTimeframe(timeframeOptions)
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -69,6 +69,12 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
 
   React.useEffect(() => {
     getFilters()
+  }, [])
+
+  React.useEffect(() => {
+    if (loadingFilters) { return }
+
+    getFilters()
   }, [selectedSchools, selectedTeachers, selectedClassrooms, selectedGrades])
 
   React.useEffect(() => {
@@ -104,16 +110,6 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
 
     setSelectedTimeframe(lastUsedTimeframe)
   }, [showCustomDateModal])
-
-  React.useEffect(() => {
-    getFilters()
-  }, [])
-
-  React.useEffect(() => {
-    if (loadingFilters) { return }
-
-    getFilters()
-  }, [selectedSchools, selectedTeachers, selectedClassrooms])
 
   function openMobileFilterMenu() { setShowMobileFilterMenu(true) }
 


### PR DESCRIPTION
## WHAT
Add the teacher and classroom filters to the frontend of the usage snapshot report.

## WHY
We want admins to be able to filter their data this way.

## HOW
Just build on the paradigm I'd set up with schools and grades to include these new values in the filtering setup.

### Screenshots
<img width="257" alt="Screen Shot 2023-06-28 at 12 31 26 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/e6f041fb-9b4e-4c1c-9177-504feb037f6f">


### Notion Card Links
https://www.notion.so/quill/Add-the-Teacher-and-Classroom-filters-to-the-Usage-Snapshot-report-85ad5faac5814429b96d724cc2bd2619?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES