### PR TITLE
Add TeacherClassroomsCache hydration after Canvas SSO flow

### DIFF
--- a/services/QuillLMS/app/controllers/auth/canvas_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/canvas_controller.rb
@@ -5,7 +5,7 @@ module Auth
     around_action :force_writer_db_role, only: :canvas
 
     def canvas
-      run_background_jobs
+      hydrate_teacher_classrooms_cache if user.teacher?
       sign_in(user)
 
       redirect_to profile_path
@@ -21,12 +21,6 @@ module Auth
 
     private def hydrate_teacher_classrooms_cache
       CanvasIntegration::TeacherClassroomsCacheHydrator.run(user)
-    end
-
-    private def run_background_jobs
-      return unless user.teacher?
-
-      hydrate_teacher_classrooms_cache
     end
 
     private def user

--- a/services/QuillLMS/app/services/canvas_integration/client_fetcher.rb
+++ b/services/QuillLMS/app/services/canvas_integration/client_fetcher.rb
@@ -15,11 +15,11 @@ module CanvasIntegration
       raise NilCanvasAuthCredentialError if canvas_auth_credential.nil?
       raise NilCanvasInstanceError if canvas_instance.nil?
 
-      RestClient.new(canvas_auth_credential, canvas_instance)
+      RestClient.new(canvas_auth_credential)
     end
 
     private def canvas_auth_credential
-      canvas_auth_credential ||= CanvasAuthCredential.find_by(user: user)
+      @canvas_auth_credential ||= CanvasAuthCredential.find_by(user: user)
     end
 
     private def canvas_instance

--- a/services/QuillLMS/app/services/canvas_integration/client_fetcher.rb
+++ b/services/QuillLMS/app/services/canvas_integration/client_fetcher.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class ClientFetcher < ApplicationService
+    class NilCanvasAuthCredentialError < ::StandardError; end
+    class NilCanvasInstanceError < ::StandardError; end
+
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def run
+      raise NilCanvasAuthCredentialError if canvas_auth_credential.nil?
+      raise NilCanvasInstanceError if canvas_instance.nil?
+
+      RestClient.new(canvas_auth_credential, canvas_instance)
+    end
+
+    private def canvas_auth_credential
+      canvas_auth_credential ||= CanvasAuthCredential.find_by(user: user)
+    end
+
+    private def canvas_instance
+      @canvas_instance ||= canvas_auth_credential.canvas_instance
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/teacher_classrooms_cache_hydrator.rb
+++ b/services/QuillLMS/app/services/canvas_integration/teacher_classrooms_cache_hydrator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class TeacherClassroomsCacheHydrator < ApplicationService
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def run
+      cache_classrooms_data
+    rescue => e
+      ErrorNotifier.report(e, user_id: user.id)
+    end
+
+    private def cache_classrooms_data
+      TeacherClassroomsCache.write(user.id, serialized_teacher_classrooms)
+    end
+
+    private def client
+      ClientFetcher.run(user)
+    end
+
+    private def serialized_teacher_classrooms
+      client
+        .teacher_classrooms
+        .to_json
+    end
+  end
+end

--- a/services/QuillLMS/spec/controllers/auth/canvas_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/auth/canvas_controller_spec.rb
@@ -4,29 +4,50 @@ require 'rails_helper'
 
 module Auth
   describe CanvasController, type: :request do
-    let(:canvas_instance) { create(:canvas_instance) }
+    let(:canvas_account) { create(:canvas_account) }
+    let(:canvas_instance) { canvas_account.canvas_instance }
+    let(:uid) { canvas_account.external_id }
     let(:url) { canvas_instance.url }
-    let(:auth_hash) { create(:canvas_auth_hash, url: url) }
-    let(:external_id) { auth_hash[:uid] }
+    let(:user) { canvas_account.user }
+
+    let(:auth_hash) { create(:canvas_auth_hash, uid: uid, url: url ) }
 
     before { OmniAuth.config.mock_auth[:canvas] = auth_hash }
 
     describe '/auth/canvas/callback' do
       subject { get Auth::Canvas::OMNIAUTH_CALLBACK_PATH }
 
-      let(:auth_credential) { create(:canvas_auth_credential) }
-      let(:user) { auth_credential.user }
+      let(:canvas_auth_credential) { create(:canvas_auth_credential, user: user) }
 
       before { set_session_canvas_instance_id }
 
       it do
-        expect(CanvasIntegration::AuthCredentialSaver).to receive(:run).with(auth_hash).and_return(auth_credential)
+        expect(CanvasIntegration::AuthCredentialSaver)
+          .to receive(:run)
+          .with(auth_hash)
+          .and_return(canvas_auth_credential)
+
         subject
       end
 
-      context 'with a valid auth_hash' do
-        let!(:canvas_account) { create(:canvas_account, canvas_instance: canvas_instance, external_id: external_id, user: user) }
+      it do
+        expect(CanvasIntegration::TeacherClassroomsCacheHydrator)
+          .to receive(:run)
+          .with(user)
 
+        subject
+      end
+
+      context 'student user' do
+        before { user.update(role: 'student') }
+
+        it do
+          expect(CanvasIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
+          subject
+        end
+      end
+
+      context 'with a valid auth_hash' do
         before { subject }
 
         it { expect(response).to redirect_to(profile_path) }

--- a/services/QuillLMS/spec/controllers/auth/canvas_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/auth/canvas_controller_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 
 module Auth
   describe CanvasController, type: :request do
-    let(:canvas_account) { create(:canvas_account) }
+    let(:user) { create(:teacher) }
+    let(:canvas_account) { create(:canvas_account, user: user) }
     let(:canvas_instance) { canvas_account.canvas_instance }
     let(:uid) { canvas_account.external_id }
     let(:url) { canvas_instance.url }
-    let(:user) { canvas_account.user }
 
     let(:auth_hash) { create(:canvas_auth_hash, uid: uid, url: url ) }
 

--- a/services/QuillLMS/spec/services/canvas_integration/client_fetcher_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/client_fetcher_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CanvasIntegration::ClientFetcher do
   end
 
   context 'with canvas_auth_credential, but no canvas_instance_auth_credential' do
-    before { create(:canvas_auth_credential, user: user) }
+    before { create(:canvas_auth_credential_without_canvas_instance_auth_credential, user: user) }
 
     it { expect { subject }.to raise_error CanvasIntegration::ClientFetcher::NilCanvasInstanceError }
   end

--- a/services/QuillLMS/spec/services/canvas_integration/client_fetcher_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/client_fetcher_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::ClientFetcher do
+  subject { described_class.run(user) }
+
+  let(:user) { create(:teacher, :with_canvas_account) }
+
+  context 'no canvas_auth_credential' do
+    it { expect { subject }.to raise_error CanvasIntegration::ClientFetcher::NilCanvasAuthCredentialError }
+  end
+
+  context 'with canvas_auth_credential, but no canvas_instance_auth_credential' do
+    before { create(:canvas_auth_credential, user: user) }
+
+    it { expect { subject }.to raise_error CanvasIntegration::ClientFetcher::NilCanvasInstanceError }
+  end
+
+  context 'with canvas_auth_credential and canvas_instance_auth_credential' do
+    let!(:canvas_auth_credential) { create(:canvas_auth_credential, user: user) }
+
+    it { expect(subject).to be_a CanvasIntegration::RestClient }
+
+    it do
+      expect(CanvasIntegration::RestClient).to receive(:new).with(canvas_auth_credential)
+      subject
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/teacher_classrooms_cache_hydrator_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/teacher_classrooms_cache_hydrator_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CanvasIntegration::TeacherClassroomsCacheHydrator do
+  let(:classrooms) { ['classroom_data'] }
+  let(:data) { { classrooms: classrooms, canvas_instance_id: canvas_instance&.id }}
+
+  subject { described_class.run(user) }
+
+  context 'teacher has canvas_auth_credential' do
+    let(:user) { create(:teacher, :with_canvas_account) }
+    let(:canvas_instance) { user.canvas_instances.first }
+    let(:canvas_auth_credential) { create(:canvas_auth_credential, user: user) }
+    let(:client) { double(:canvas_client, teacher_classrooms: data) }
+
+    it do
+      expect(CanvasIntegration::RestClient)
+        .to receive(:new)
+        .with(canvas_auth_credential, canvas_instance)
+        .and_return(client)
+
+      expect(CanvasIntegration::TeacherClassroomsCache)
+        .to receive(:write)
+        .with(user.id, data.to_json)
+
+      subject
+    end
+  end
+
+  context 'teacher has no auth_credential' do
+    let(:user) { create(:teacher) }
+    let(:error_class) { CanvasIntegration::ClientFetcher::NilCanvasAuthCredentialError }
+
+    it 'does not cache any teacher classrooms and it reports an error' do
+      expect(CanvasIntegration::TeacherClassroomsCache).not_to receive(:write)
+      expect(PusherTrigger).not_to receive(:run)
+      expect(ErrorNotifier).to receive(:report).with(error_class, user_id: user.id)
+      subject
+    end
+  end
+
+  context 'teacher has google auth_credential' do
+    let(:user) { create(:teacher, :signed_up_with_google) }
+    let(:error_class) { CanvasIntegration::ClientFetcher::NilCanvasAuthCredentialError }
+
+    it 'does not cache any teacher classrooms and it reports an error' do
+      expect(CanvasIntegration::TeacherClassroomsCache).not_to receive(:write)
+      expect(PusherTrigger).not_to receive(:run)
+      expect(ErrorNotifier).to receive(:report).with(error_class, user_id: user.id)
+      subject
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/teacher_classrooms_cache_hydrator_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/teacher_classrooms_cache_hydrator_spec.rb
@@ -10,14 +10,14 @@ describe CanvasIntegration::TeacherClassroomsCacheHydrator do
 
   context 'teacher has canvas_auth_credential' do
     let(:user) { create(:teacher, :with_canvas_account) }
-    let(:canvas_instance) { user.canvas_instances.first }
     let(:canvas_auth_credential) { create(:canvas_auth_credential, user: user) }
+    let(:canvas_instance) { canvas_auth_credential.canvas_instance }
     let(:client) { double(:canvas_client, teacher_classrooms: data) }
 
     it do
       expect(CanvasIntegration::RestClient)
         .to receive(:new)
-        .with(canvas_auth_credential, canvas_instance)
+        .with(canvas_auth_credential)
         .and_return(client)
 
       expect(CanvasIntegration::TeacherClassroomsCache)


### PR DESCRIPTION
## WHAT
NB: This PR requires the [RestClient PR](https://github.com/empirical-org/Empirical-Core/pull/10713) as a dependency

1.  Add `CanvasIntegration::ClientFetcher` service object
1.  Add `CanvasIntegration::TeacherClassroomsCacheHydrator` service object
1.  Add `TeacherClassroomsCacheHydrator` after Canvas SSO flow

## WHY
1.  This fetcher continues with the ClientFetcher pattern used in Clever and BigQuery
1.  This object will pull classroom rostering information from the RestAPI and store in for the classroom rostering flow
1.  We'd like to cache the Teacher Classrooms data whenever a user completes Canvas SSO so that classroom information doesn't become stale

## HOW
1.  Pass in a user and return a RestClient to Canvas if a valid CanvasAuthCredential exists
2. Using the RestClient, hit the teacher_classrooms endpoint and fill the cache with the appropriate data
3. For teachers user, hydrate the cache

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? |  YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A