### PR TITLE
lms/sort-classroom-and-teacher-filters

### DIFF
--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -41,7 +41,7 @@ class SnapshotsController < ApplicationController
       timeframes: Snapshots::Timeframes.frontend_options,
       schools: format_option_list(school_options),
       grades: GRADE_OPTIONS,
-      teachers: format_option_list(teacher_options),
+      teachers: format_option_list(sorted_teacher_options),
       classrooms: format_option_list(classroom_options)
     }
   end
@@ -66,13 +66,19 @@ class SnapshotsController < ApplicationController
   private def teacher_options
     grades = option_params[:grades]
 
-    teachers = User.joins(:schools_users)
+    teachers = User.distinct
+      .joins(:schools_users)
       .joins(:classrooms_i_teach)
       .where(schools_users: {school_id: filtered_schools.pluck(:id)})
 
     return teachers.where(classrooms: {grade: grades}) if grades.present?
 
     teachers
+  end
+
+  private def sorted_teacher_options
+    # We sort these in Ruby because we want to sort by last name which is a value derived from the database rather than stored in it
+    teacher_options.sort_by(&:last_name)
   end
 
   private def filtered_teachers
@@ -84,8 +90,10 @@ class SnapshotsController < ApplicationController
   end
 
   private def classroom_options
-    Classroom.joins(:classrooms_teachers)
+    Classroom.distinct
+      .joins(:classrooms_teachers)
       .where(classrooms_teachers: {user_id: filtered_teachers.pluck(:id)})
+      .order(:name)
   end
 
   private def set_query

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -324,7 +324,7 @@ describe SnapshotsController, type: :controller do
         json_response = JSON.parse(response.body)
 
         expect(json_response['teachers'].length).to eq(1)
-      end      
+      end
     end
 
     context 'classrooms with multiple teachers' do

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -314,6 +314,49 @@ describe SnapshotsController, type: :controller do
       expect(json_response['classrooms']).to eq([{"id" => classroom.id, "name" => classroom.name}])
     end
 
+    context 'teachers in multiple classrooms' do
+      let(:classroom2) { create(:classroom, grade: target_grade) }
+      let!(:classrooms_teacher2) { create(:classrooms_teacher, user: teacher, classroom: classroom2, role: 'owner') }
+
+      it 'should only list a teacher once even if they have multiple classrooms' do
+        get :options
+
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['teachers'].length).to eq(1)
+      end      
+    end
+
+    context 'classrooms with multiple teachers' do
+      let(:co_teacher) { create(:teacher, school: school) }
+      let!(:classrooms_teacher2) { create(:classrooms_teacher, user: co_teacher, classroom: classroom, role: 'coteacher') }
+
+      it 'should only list each classroom once' do
+        get :options
+
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['classrooms'].length).to eq(1)
+      end
+    end
+
+    context 'teacher sorting' do
+      let(:teacher_names) { ['Alice', 'Carol', 'Bob'] }
+      let(:new_school) { create(:school) }
+      let(:user) { create(:user, administered_schools: [new_school]) }
+      let(:teachers) { teacher_names.map { |name| create(:teacher, name: name, school: new_school) } }
+      let(:classrooms) { create_list(:classroom, teachers.length, grade: target_grade) }
+      let!(:classrooms_teachers) { teachers.map.with_index { |teacher, i| create(:classrooms_teacher, user: teacher, classroom: classrooms[i], role: 'owner') } }
+
+      it 'should sort teachers by name' do
+        get :options
+
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['teachers'].map{ |t| t['name'] }).to eq(teacher_names.sort)
+      end
+    end
+
     context 'params' do
       let(:excluded_school_id) { school.id + 1 }
       let(:excluded_grade) { '2' }


### PR DESCRIPTION
## WHAT
Add distinct and order to teacher and classroom options
## WHY
So that we don't get duplicate options, and so that they come back in a useful and consistent order
## HOW
- Add `distinct` to the teacher and classroom queries
- Use `sort_by` for teacher options (sorting in Ruby instead of SQL because the `last_name` value is derived, not stored)
- User `order` for classroom options

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
