### PR TITLE
Lms/add no school assigned filter

### DIFF
--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -2,6 +2,7 @@
 
 class SnapshotsController < ApplicationController
   GRADE_OPTIONS = [
+    {value: "null", name: "No grade set"},
     {value: "Kindergarten", name: "Kindergarten"},
     {value: "1", name: "1st"},
     {value: "2", name: "2nd"},

--- a/services/QuillLMS/app/queries/snapshots/period_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/period_query.rb
@@ -49,7 +49,12 @@ module Snapshots
     def grades_where_clause
       return "" if grades.blank?
 
-      "AND classrooms.grade IN (#{grades.map { |g| "'#{g}'" }.join(',')})"
+      <<-SQL
+        AND (
+          classrooms.grade IN (#{grades.map { |g| "'#{g}'" }.join(',')})
+          #{"OR classrooms.grade IS NULL" if grades.include?("null")}
+        )
+      SQL
     end
 
     def teacher_ids_where_clause

--- a/services/QuillLMS/app/queries/snapshots/period_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/period_query.rb
@@ -52,7 +52,7 @@ module Snapshots
       <<-SQL
         AND (
           classrooms.grade IN (#{grades.map { |g| "'#{g}'" }.join(',')})
-          #{"OR classrooms.grade IS NULL" if grades.include?("null")}
+          #{'OR classrooms.grade IS NULL' if grades.include?('null')}
         )
       SQL
     end

--- a/services/QuillLMS/spec/queries/snapshots/most_active_schools_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/most_active_schools_query_spec.rb
@@ -57,10 +57,11 @@ module Snapshots
         # percentage has to be set for CTE to UNION these with items that have percentages set
         let(:unstarted_session) { create(:activity_session, :unstarted, classroom_unit: classroom_units[0], percentage: 0.0) }
         let(:started_session) { create(:activity_session, :started, classroom_unit: classroom_units[0], percentage: 0.0) }
+        let(:completed_session) { create(:activity_session, classroom_unit: classroom_units[0]) }
 
-        let(:cte_records) { [runner_context, unstarted_session, started_session] }
+        let(:cte_records) { [runner_context, unstarted_session, started_session, completed_session] }
 
-        it { expect(results).to eq([]) }
+        it { expect(results.first['count']).to eq(1) }
       end
     end
   end

--- a/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
@@ -68,6 +68,16 @@ module Snapshots
           it { expect(results).to match_array(classroom_ids[0]) }
         end
 
+        context 'filter for null grade' do
+          let(:classroom_with_grade) { create(:classroom, grade: 1) }
+          let(:classroom_without_grade) { create(:classroom, grade: nil) }
+          let(:classrooms) { [classroom_with_grade, classroom_without_grade] }
+
+          let(:filters) { { grades: ['null'] } }
+
+          it { expect(results).to eq([classroom_without_grade.id]) }
+        end
+
         context 'filter for one teacher' do
           let(:filters) { { teacher_ids: [teachers[0].id] } }
 

--- a/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
+++ b/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
@@ -54,7 +54,7 @@ module QuillBigQuery
       attr_type = record.class.column_for_attribute(attr).type
 
       if value.nil?
-        "''"
+        "NULL"
       elsif value.is_a?(Array)
         value.map { |v| attr_type_value(attr_type, v) }
       else


### PR DESCRIPTION
## WHAT
Add a new "No grade set" option to the grades fillters in the admin Snapshot report
## WHY
Google classrooms never set grades, so we want to make it clear to admins that some of their classrooms may not have grades assigned, and allow them to filter for them explicitly.
## HOW
- Add an additional option to the grades option hash
- Update `Snapshots::PeriodQuery` to do special handling if the value `"null"` is in the list of grades.  (I considered just using actual `nil` here, but was worried there was probably too many assumptions in our code in multiple places that values would be truth-y.  Open to discussion on this.)
- Update the BigQuery TestRunner to treat `NULL` values as `NULL`
- Refactor a spec to work cleanly with the new `NULL` handling in the test runner

### Screenshots
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/88cf96a9-88ce-4fe6-b0ce-f1b5e946babd)

### Notion Card Links
https://www.notion.so/quill/Add-None-selected-to-the-grade-filter-on-the-Usage-Snapshot-Report-e801ad2206874d08bf9eca1771337496

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
