### PR TITLE
lms/even-more-vitally-script-tweaks

### DIFF
--- a/services/QuillLMS/lib/tasks/vitally.rake
+++ b/services/QuillLMS/lib/tasks/vitally.rake
@@ -30,7 +30,7 @@ namespace :vitally do
           row['accountExternalId2'],
           row['accountExternalId3'],
           row['accountExternalId4']
-        ].reject { |id| id.nil? || id.empty? }.map(&:to_i)
+        ].reject { |id| id.nil? || id.empty? }
 
         ids_to_unlink = vitally_school_ids.reject { |id| id == quill_school_id }
 


### PR DESCRIPTION
## WHAT
Don't cast "id"s to int.
## WHY
Apparently some of the external IDs in this file are strings (like, the name of a school).  This data doesn't come from our automated syncs, but it's in there, so we need to just use strings in all places.
## HOW
Remove `to_i` cast.  I've tested that the API calls work with strings instead of ints, so this should be safe to run on the whole dataset.

### Notion Card Links
https://www.notion.so/quill/Script-to-unlink-users-who-have-been-associated-with-multiple-accounts-in-Vitally-65df89265b8a44beb05bd205841a7208?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
