### PR TITLE
Refactor ProviderClassroom to ProviderClassroomDelegator

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -195,7 +195,7 @@ class Teachers::ClassroomsController < ApplicationController
 
     classrooms.compact.map do |classroom|
       classroom_obj = classroom.attributes
-      classroom_obj[:providerClassroom] = classroom.provider_classroom if classroom.provider_classroom?
+      classroom_obj[:classroomProvider] = classroom.classroom_provider if classroom.classroom_provider?
       classroom_obj[:students] = format_students_for_classroom(classroom)
       classroom_teachers = format_teachers_for_classroom(classroom)
       pending_coteachers = format_pending_coteachers_for_classroom(classroom)
@@ -212,9 +212,9 @@ class Teachers::ClassroomsController < ApplicationController
       student.attributes.merge(number_of_completed_activities: ActivitySession.where(state: ActivitySession::STATE_FINISHED, user_id: student.id, classroom_unit_id: classroom_unit_ids).count || 0)
     end
 
-    return students unless classroom.provider_classroom?
+    return students unless classroom.classroom_provider?
 
-    provider_classroom = ProviderClassroom.new(classroom)
+    provider_classroom = ProviderClassroomDelegator.new(classroom)
     students.map { |student| student.merge(synced: provider_classroom.synced_status(student)) }
   end
 

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -193,7 +193,7 @@ class Classroom < ApplicationRecord
     -1
   end
 
-  def provider_classroom?
+  def classroom_provider?
     google_classroom? || clever_classroom?
   end
 
@@ -205,7 +205,7 @@ class Classroom < ApplicationRecord
     google_classroom_id.present?
   end
 
-  def provider_classroom
+  def classroom_provider
     return 'Google Classroom' if google_classroom?
     return 'Clever' if clever_classroom?
   end

--- a/services/QuillLMS/app/models/provider_classroom_delegator.rb
+++ b/services/QuillLMS/app/models/provider_classroom_delegator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProviderClassroom < SimpleDelegator
+class ProviderClassroomDelegator < SimpleDelegator
   def synced_status(student_attrs)
     return true if provider_active_user_ids.include?(provider_user_id(student_attrs))
     return false if provider_deleted_user_ids.include?(provider_user_id(student_attrs))

--- a/services/QuillLMS/app/services/clever_integration/classroom_students_importer.rb
+++ b/services/QuillLMS/app/services/clever_integration/classroom_students_importer.rb
@@ -26,7 +26,7 @@ module CleverIntegration
       ProviderClassroomUsersUpdater.run(classroom.clever_id, students.map(&:clever_id), CleverClassroomUser)
     end
 
-    def import_students
+    private def import_students
       students
     end
 

--- a/services/QuillLMS/app/services/provider_classrooms_with_unsynced_students_finder.rb
+++ b/services/QuillLMS/app/services/provider_classrooms_with_unsynced_students_finder.rb
@@ -17,8 +17,8 @@ class ProviderClassroomsWithUnsyncedStudentsFinder < ApplicationService
 
   private def provider_classrooms
     classrooms_i_own
-      .select(&:provider_classroom?)
-      .map { |classroom| ProviderClassroom.new(classroom) }
+      .select(&:classroom_provider?)
+      .map { |classroom| ProviderClassroomDelegator.new(classroom) }
   end
 
   private def provider_classrooms_with_unsynced_students

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -15,7 +15,7 @@ const questionMarkSrc = `${process.env.CDN_URL}/images/pages/classrooms/question
 const cleverSetupInstructionsPdf = `${process.env.CDN_URL}/documents/setup_instructions_pdfs/clever_setup_instructions.pdf`
 const googleSetupInstructionsPdf = `${process.env.CDN_URL}/documents/setup_instructions_pdfs/google_setup_instructions.pdf`
 
-function activeHeaders(hasProviderClassroom: boolean) {
+function activeHeaders(hasClassroomProvider: boolean) {
   const name = {
     width: '220px',
     name: 'Name',
@@ -23,7 +23,7 @@ function activeHeaders(hasProviderClassroom: boolean) {
   }
 
   const usernameOrEmail = {
-    width: hasProviderClassroom ? '280px' : '330px',
+    width: hasClassroomProvider ? '280px' : '330px',
     name: 'Username/Email',
     attribute: 'usernameOrEmail'
   }
@@ -62,10 +62,10 @@ function activeHeaders(hasProviderClassroom: boolean) {
     isActions: true
   }
 
-  return hasProviderClassroom ? [name, usernameOrEmail, logInMethod, lastActive, activities, synced, actions] : [name, usernameOrEmail, logInMethod, lastActive, activities, actions]
+  return hasClassroomProvider ? [name, usernameOrEmail, logInMethod, lastActive, activities, synced, actions] : [name, usernameOrEmail, logInMethod, lastActive, activities, actions]
 }
 
-function archivedHeaders(hasProviderClassroom: boolean) {
+function archivedHeaders(hasClassroomProvider: boolean) {
   const name = {
     width: '235px',
     name: 'Name',
@@ -73,7 +73,7 @@ function archivedHeaders(hasProviderClassroom: boolean) {
   }
 
   const usernameOrEmail = {
-    width: hasProviderClassroom ? '407px' : '531px',
+    width: hasClassroomProvider ? '407px' : '531px',
     name: 'Username/Email',
     attribute: 'usernameOrEmail'
   }
@@ -86,7 +86,7 @@ function archivedHeaders(hasProviderClassroom: boolean) {
     rowSectionClassName: 'show-overflow'
   }
 
-  return hasProviderClassroom ? [name, usernameOrEmail, synced] : [name, usernameOrEmail]
+  return hasClassroomProvider ? [name, usernameOrEmail, synced] : [name, usernameOrEmail]
 }
 
 enum modalNames {
@@ -488,7 +488,7 @@ export default class ClassroomStudentSection
     )
   }
 
-  syncedStatus(student: any, providerClassroom: string) {
+  syncedStatus(student: any, classroomProvider: string) {
     const { synced } = student
 
     if (synced === undefined || synced === null) { return '' }
@@ -496,7 +496,7 @@ export default class ClassroomStudentSection
 
     return (
       <Tooltip
-        tooltipText={`This student is no longer in this class in ${providerClassroom}`}
+        tooltipText={`This student is no longer in this class in ${classroomProvider}`}
 
         tooltipTriggerText={
           <div className="text-and-icon-wrapper">
@@ -514,13 +514,13 @@ export default class ClassroomStudentSection
   renderStudentDataTable() {
     const { classroom, } = this.props
     const { selectedStudentIds, } = this.state
-    const { providerClassroom } = classroom
-    const hasProviderClassroom = providerClassroom !== undefined
+    const { classroomProvider } = classroom
+    const hasClassroomProvider = classroomProvider !== undefined
 
     const rows = classroom.students.map(student => {
       const { name, username, email, id, google_id, clever_id, last_active, number_of_completed_activities, } = student
       const checked = !!selectedStudentIds.includes(id)
-      const synced = this.syncedStatus(student, providerClassroom)
+      const synced = this.syncedStatus(student, classroomProvider)
       let logInMethod = 'Username'
 
       if (clever_id) {
@@ -547,7 +547,7 @@ export default class ClassroomStudentSection
         checkAllRows={this.checkAllRows}
         checkRow={this.checkRow}
         className='show-overflow'
-        headers={classroom.visible ? activeHeaders(hasProviderClassroom) : archivedHeaders(hasProviderClassroom)}
+        headers={classroom.visible ? activeHeaders(hasClassroomProvider) : archivedHeaders(hasClassroomProvider)}
         rows={rows}
         showActions={classroom.visible}
         showCheckboxes={classroom.visible}

--- a/services/QuillLMS/spec/models/provider_classroom_delegator_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_delegator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ProviderClassroom do
+RSpec.describe ProviderClassroomDelegator do
   subject { described_class.new(classroom) }
 
   context 'google classroom' do

--- a/services/QuillLMS/spec/serializers/provider_classroom_with_unsynced_students_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/provider_classroom_with_unsynced_students_serializer_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 
 describe ProviderClassroomWithUnsyncedStudentsSerializer, type: :serializer do
+  subject { described_class.new(provider_classroom) }
+
   let(:classroom) { create(:classroom, :from_google, students: [student1, student2]) }
-  let(:provider_classroom) { ProviderClassroom.new(classroom) }
+  let(:provider_classroom) { ProviderClassroomDelegator.new(classroom) }
   let(:student1) { create(:student, :signed_up_with_google) }
   let(:student2) { create(:student, :signed_up_with_google) }
 
@@ -23,8 +25,6 @@ describe ProviderClassroomWithUnsyncedStudentsSerializer, type: :serializer do
       provider_user_id: student2.google_id
     )
   end
-
-  subject { described_class.new(provider_classroom) }
 
   let(:results) { subject.as_json }
 


### PR DESCRIPTION
## WHAT
1. Rename the SimpleDelegator `ProviderClassroom` as `ProviderClassroomDelegator`
1. Rename `provider_classroom?` and `provider_classroom` methods in classroom.rb to `classroom_provider?` and `classroom_provider` respectively

## WHY
1.  In preparation for a new [RFC](https://www.notion.so/quill/RFC-Canvas-Classrooms-modeling-3a7dda4ee9fc401ebc0c49284dd886fb?pvs=4) that will create a new model named `ProviderClassroom`, we need to rename an older class that uses the same name.  Fortunately, it's just a delegator and not an existing model.
1.  Since classrooms will eventually `has_one :provider_classroom` the existing method `provider_classroom` will need to be renamed.  Also `classroom_provider` more accurately describes the method as it isn't returning a classroom but instead just a provider name (i.e. 'Google' or 'Clever').

## HOW
1.  Update the various references to `ProviderClassroom`
1.  Update the various references to `provider_classroom`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
