### PR TITLE
Rename ProviderClassroomUser fields and add canvas_instance_id

### DIFF
--- a/services/QuillLMS/app/models/clever_classroom_user.rb
+++ b/services/QuillLMS/app/models/clever_classroom_user.rb
@@ -9,19 +9,25 @@
 #  type                  :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  provider_classroom_id :string           not null
-#  provider_user_id      :string           not null
+#  canvas_instance_id    :bigint
+#  classroom_external_id :string           not null
+#  user_external_id      :string           not null
 #
 # Indexes
 #
-#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
+#  index_provider_classroom_users_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_type_and_classroom_id_and_user_id      (type,classroom_external_id,user_external_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
 #
 class CleverClassroomUser < ProviderClassroomUser
   def clever_classroom_id
-    provider_classroom_id
+    classroom_external_id
   end
 
   def clever_user_id
-    provider_user_id
+    user_external_id
   end
 end

--- a/services/QuillLMS/app/models/google_classroom_user.rb
+++ b/services/QuillLMS/app/models/google_classroom_user.rb
@@ -9,19 +9,25 @@
 #  type                  :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  provider_classroom_id :string           not null
-#  provider_user_id      :string           not null
+#  canvas_instance_id    :bigint
+#  classroom_external_id :string           not null
+#  user_external_id      :string           not null
 #
 # Indexes
 #
-#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
+#  index_provider_classroom_users_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_type_and_classroom_id_and_user_id      (type,classroom_external_id,user_external_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
 #
 class GoogleClassroomUser < ProviderClassroomUser
   def google_classroom_id
-    provider_classroom_id
+    classroom_external_id
   end
 
   def google_id
-    provider_user_id
+    user_external_id
   end
 end

--- a/services/QuillLMS/app/models/provider_classroom_delegator.rb
+++ b/services/QuillLMS/app/models/provider_classroom_delegator.rb
@@ -2,8 +2,8 @@
 
 class ProviderClassroomDelegator < SimpleDelegator
   def synced_status(student_attrs)
-    return true if provider_active_user_ids.include?(provider_user_id(student_attrs))
-    return false if provider_deleted_user_ids.include?(provider_user_id(student_attrs))
+    return true if provider_active_user_ids.include?(user_external_id(student_attrs))
+    return false if provider_deleted_user_ids.include?(user_external_id(student_attrs))
 
     return nil
   end
@@ -16,19 +16,19 @@ class ProviderClassroomDelegator < SimpleDelegator
     @provider_active_user_ids ||=
       provider_classroom_user_class
         .active
-        .where(provider_classroom_id: provider_classroom_id)
-        .pluck(:provider_user_id)
+        .where(classroom_external_id: classroom_external_id)
+        .pluck(:user_external_id)
   end
 
   private def provider_deleted_user_ids
     @provider_deleted_user_ids ||=
       provider_classroom_user_class
         .deleted
-        .where(provider_classroom_id: provider_classroom_id)
-        .pluck(:provider_user_id)
+        .where(classroom_external_id: classroom_external_id)
+        .pluck(:user_external_id)
   end
 
-  private def provider_classroom_id
+  private def classroom_external_id
     return google_classroom_id if google_classroom?
     return clever_id if clever_classroom?
   end
@@ -38,7 +38,7 @@ class ProviderClassroomDelegator < SimpleDelegator
     return CleverClassroomUser if clever_classroom?
   end
 
-  private def provider_user_id(student_attrs)
+  private def user_external_id(student_attrs)
     return student_attrs['google_id'] if google_classroom?
     return student_attrs['clever_id'] if clever_classroom?
   end

--- a/services/QuillLMS/db/migrate/20230630172652_rename_provider_classroom_user_fields.rb
+++ b/services/QuillLMS/db/migrate/20230630172652_rename_provider_classroom_user_fields.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RenameProviderClassroomUserFields < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :provider_classroom_users, :provider_classroom_id, :classroom_external_id
+    rename_column :provider_classroom_users, :user_external_id, :user_external_id
+  end
+end

--- a/services/QuillLMS/db/migrate/20230630172652_rename_provider_classroom_user_fields.rb
+++ b/services/QuillLMS/db/migrate/20230630172652_rename_provider_classroom_user_fields.rb
@@ -3,6 +3,6 @@
 class RenameProviderClassroomUserFields < ActiveRecord::Migration[6.1]
   def change
     rename_column :provider_classroom_users, :provider_classroom_id, :classroom_external_id
-    rename_column :provider_classroom_users, :user_external_id, :user_external_id
+    rename_column :provider_classroom_users, :provider_user_id, :user_external_id
   end
 end

--- a/services/QuillLMS/db/migrate/20230630173229_add_canvas_instance_ref_to_provider_classoom_user.rb
+++ b/services/QuillLMS/db/migrate/20230630173229_add_canvas_instance_ref_to_provider_classoom_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCanvasInstanceRefToProviderClassoomUser < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :provider_classroom_users, :canvas_instance, foreign_key: true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3571,11 +3571,12 @@ ALTER SEQUENCE public.prompt_healths_id_seq OWNED BY public.prompt_healths.id;
 CREATE TABLE public.provider_classroom_users (
     id bigint NOT NULL,
     type character varying NOT NULL,
-    provider_classroom_id character varying NOT NULL,
-    provider_user_id character varying NOT NULL,
+    classroom_external_id character varying NOT NULL,
+    user_external_id character varying NOT NULL,
     deleted_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    canvas_instance_id bigint
 );
 
 
@@ -8368,10 +8369,17 @@ CREATE UNIQUE INDEX index_plans_on_name ON public.plans USING btree (name);
 
 
 --
+-- Name: index_provider_classroom_users_on_canvas_instance_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_provider_classroom_users_on_canvas_instance_id ON public.provider_classroom_users USING btree (canvas_instance_id);
+
+
+--
 -- Name: index_provider_type_and_classroom_id_and_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_provider_type_and_classroom_id_and_user_id ON public.provider_classroom_users USING btree (type, provider_classroom_id, provider_user_id);
+CREATE UNIQUE INDEX index_provider_type_and_classroom_id_and_user_id ON public.provider_classroom_users USING btree (type, classroom_external_id, user_external_id);
 
 
 --
@@ -9409,6 +9417,14 @@ ALTER TABLE ONLY public.pack_sequences
 
 
 --
+-- Name: provider_classroom_users fk_rails_7ad4319bc6; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.provider_classroom_users
+    ADD CONSTRAINT fk_rails_7ad4319bc6 FOREIGN KEY (canvas_instance_id) REFERENCES public.canvas_instances(id);
+
+
+--
 -- Name: standards fk_rails_7c2e427970; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10269,6 +10285,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230622125712'),
 ('20230622525712'),
 ('20230623154333'),
-('20230623154418');
+('20230623154418'),
+('20230630172652'),
+('20230630173229');
 
 

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -551,15 +551,15 @@ describe TeacherFixController do
 
           create(
             :google_classroom_user,
-            provider_user_id: synced_student.google_id,
-            provider_classroom_id: classroom.google_classroom_id
+            user_external_id: synced_student.google_id,
+            classroom_external_id: classroom.google_classroom_id
           )
 
           create(
             :google_classroom_user,
             :deleted,
-            provider_user_id: unsynced_student.google_id,
-            provider_classroom_id: classroom.google_classroom_id
+            user_external_id: unsynced_student.google_id,
+            classroom_external_id: classroom.google_classroom_id
           )
         end
 

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -284,14 +284,14 @@ describe Teachers::ClassroomsController, type: :controller do
         before do
           create(:google_classroom_user,
             :active,
-            provider_classroom_id: classroom.google_classroom_id,
-            provider_user_id: student1.google_id
+            classroom_external_id: classroom.google_classroom_id,
+            user_external_id: student1.google_id
           )
 
           create(:google_classroom_user,
             :deleted,
-            provider_classroom_id: classroom.google_classroom_id,
-            provider_user_id: student2.google_id
+            classroom_external_id: classroom.google_classroom_id,
+            user_external_id: student2.google_id
           )
         end
 

--- a/services/QuillLMS/spec/factories/provider_classroom_users.rb
+++ b/services/QuillLMS/spec/factories/provider_classroom_users.rb
@@ -9,17 +9,23 @@
 #  type                  :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  provider_classroom_id :string           not null
-#  provider_user_id      :string           not null
+#  canvas_instance_id    :bigint
+#  classroom_external_id :string           not null
+#  user_external_id      :string           not null
 #
 # Indexes
 #
-#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
+#  index_provider_classroom_users_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_type_and_classroom_id_and_user_id      (type,classroom_external_id,user_external_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
 #
 FactoryBot.define do
   factory :provider_classroom_user, class: 'ProviderClassroomUser' do
-    provider_classroom_id { (1..10).map { (1..9).to_a.sample }.join }
-    provider_user_id { (1..21).map{(1..9).to_a.sample}.join }
+    classroom_external_id { (1..10).map { (1..9).to_a.sample }.join }
+    user_external_id { (1..21).map{(1..9).to_a.sample}.join }
 
     trait(:active) { deleted_at { nil } }
     trait(:deleted) { deleted_at { Time.current } }

--- a/services/QuillLMS/spec/models/clever_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/clever_classroom_user_spec.rb
@@ -9,12 +9,18 @@
 #  type                  :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  provider_classroom_id :string           not null
-#  provider_user_id      :string           not null
+#  canvas_instance_id    :bigint
+#  classroom_external_id :string           not null
+#  user_external_id      :string           not null
 #
 # Indexes
 #
-#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
+#  index_provider_classroom_users_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_type_and_classroom_id_and_user_id      (type,classroom_external_id,user_external_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
 #
 require 'rails_helper'
 
@@ -23,7 +29,7 @@ RSpec.describe CleverClassroomUser, type: :model do
   let(:clever_user_id) { '12345' }
 
   subject do
-    create(:clever_classroom_user, provider_classroom_id: clever_classroom_id, provider_user_id: clever_user_id)
+    create(:clever_classroom_user, classroom_external_id: clever_classroom_id, user_external_id: clever_user_id)
   end
 
   it { expect(subject.clever_classroom_id).to eq clever_classroom_id }

--- a/services/QuillLMS/spec/models/google_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/google_classroom_user_spec.rb
@@ -9,12 +9,18 @@
 #  type                  :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  provider_classroom_id :string           not null
-#  provider_user_id      :string           not null
+#  canvas_instance_id    :bigint
+#  classroom_external_id :string           not null
+#  user_external_id      :string           not null
 #
 # Indexes
 #
-#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
+#  index_provider_classroom_users_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_type_and_classroom_id_and_user_id      (type,classroom_external_id,user_external_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
 #
 require 'rails_helper'
 
@@ -24,8 +30,8 @@ RSpec.describe GoogleClassroomUser, type: :model do
 
   subject do
     create(:google_classroom_user,
-      provider_user_id: google_id,
-      provider_classroom_id: google_classroom_id
+      user_external_id: google_id,
+      classroom_external_id: google_classroom_id
     )
   end
 

--- a/services/QuillLMS/spec/models/provider_classroom_delegator_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_delegator_spec.rb
@@ -14,16 +14,16 @@ RSpec.describe ProviderClassroomDelegator do
     let!(:synced_student) do
       create(:google_classroom_user,
         :active,
-        provider_classroom_id: classroom.google_classroom_id,
-        provider_user_id: student1.google_id
+        classroom_external_id: classroom.google_classroom_id,
+        user_external_id: student1.google_id
       )
     end
 
     let!(:unsynced_student) do
       create(:google_classroom_user,
         :deleted,
-        provider_classroom_id: classroom.google_classroom_id,
-        provider_user_id: student2.google_id
+        classroom_external_id: classroom.google_classroom_id,
+        user_external_id: student2.google_id
       )
     end
 
@@ -47,16 +47,16 @@ RSpec.describe ProviderClassroomDelegator do
     let!(:unsynced_student) do
       create(:clever_classroom_user,
         :deleted,
-        provider_classroom_id: classroom.clever_id,
-        provider_user_id: student1.clever_id
+        classroom_external_id: classroom.clever_id,
+        user_external_id: student1.clever_id
       )
     end
 
     let!(:synced_student) do
       create(:clever_classroom_user,
         :active,
-        provider_classroom_id: classroom.clever_id,
-        provider_user_id: student2.clever_id
+        classroom_external_id: classroom.clever_id,
+        user_external_id: student2.clever_id
       )
     end
 

--- a/services/QuillLMS/spec/models/provider_classroom_user_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_user_spec.rb
@@ -9,12 +9,18 @@
 #  type                  :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  provider_classroom_id :string           not null
-#  provider_user_id      :string           not null
+#  canvas_instance_id    :bigint
+#  classroom_external_id :string           not null
+#  user_external_id      :string           not null
 #
 # Indexes
 #
-#  index_provider_type_and_classroom_id_and_user_id  (type,provider_classroom_id,provider_user_id) UNIQUE
+#  index_provider_classroom_users_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_type_and_classroom_id_and_user_id      (type,classroom_external_id,user_external_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
 #
 require 'rails_helper'
 
@@ -26,8 +32,8 @@ RSpec.describe ProviderClassroomUser, type: :model do
   context 'attributes' do
     subject { create(factory) }
 
-    it { expect(subject.provider_classroom_id).to_not be_nil }
-    it { expect(subject.provider_user_id).to_not be_nil }
+    it { expect(subject.classroom_external_id).to_not be_nil }
+    it { expect(subject.user_external_id).to_not be_nil }
     it { expect(subject.type).to eq type }
   end
 
@@ -38,27 +44,27 @@ RSpec.describe ProviderClassroomUser, type: :model do
       it { expect { provider_classroom_user }.to raise_error ActiveRecord::RecordInvalid }
     end
 
-    describe 'provider_classroom_id length' do
+    describe 'classroom_external_id length' do
       let(:too_long_id) { 'a' * 26 }
-      let(:provider_classroom_user) { create(factory, provider_classroom_id: too_long_id) }
+      let(:provider_classroom_user) { create(factory, classroom_external_id: too_long_id) }
 
       it { expect { provider_classroom_user }.to raise_error ActiveRecord::RecordInvalid }
     end
 
-    describe 'provider_user_id length' do
+    describe 'user_external_id length' do
       let(:too_long_id) { 'a' * 26 }
-      let(:provider_classroom_user) { create(factory, provider_user_id: too_long_id) }
+      let(:provider_classroom_user) { create(factory, user_external_id: too_long_id) }
 
       it { expect { provider_classroom_user }.to raise_error ActiveRecord::RecordInvalid }
     end
   end
 
   context 'uniqueness' do
-    let(:provider_classroom_id) { '987' }
-    let(:provider_user_id) { '123' }
+    let(:classroom_external_id) { '987' }
+    let(:user_external_id) { '123' }
 
     let!(:provider_classroom_user) do
-      create(factory, provider_classroom_id: provider_classroom_id, provider_user_id: provider_user_id)
+      create(factory, classroom_external_id: classroom_external_id, user_external_id: user_external_id)
     end
 
     it { expect { provider_classroom_user.dup.save!}.to raise_error ActiveRecord::RecordNotUnique }
@@ -78,24 +84,24 @@ RSpec.describe ProviderClassroomUser, type: :model do
   end
 
   context '.create_list' do
-    subject { klass.create_list(provider_classroom_id, provider_user_ids) }
+    subject { klass.create_list(classroom_external_id, user_external_ids) }
 
-    let(:provider_classroom_id) { 'provider-classroom-id' }
+    let(:classroom_external_id) { 'provider-classroom-id' }
 
-    context 'zero provider_user_ids' do
-      let(:provider_user_ids) { [] }
+    context 'zero user_external_ids' do
+      let(:user_external_ids) { [] }
 
       it { expect { subject }.not_to change(klass, :count) }
     end
 
-    context 'one provider_user_id' do
-      let(:provider_user_ids) { ['a-provider-user-id'] }
+    context 'one user_external_id' do
+      let(:user_external_ids) { ['a-provider-user-id'] }
 
       it { expect { subject }.to change(klass, :count).from(0).to(1) }
     end
 
-    context 'two provider_user_ids' do
-      let(:provider_user_ids) { ['a-provider-user-id', 'the-provider-user-id'] }
+    context 'two user_external_ids' do
+      let(:user_external_ids) { ['a-provider-user-id', 'the-provider-user-id'] }
 
       it { expect { subject }.to change(klass, :count).from(0).to(2) }
     end

--- a/services/QuillLMS/spec/serializers/provider_classroom_with_unsynced_students_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/provider_classroom_with_unsynced_students_serializer_spec.rb
@@ -13,16 +13,16 @@ describe ProviderClassroomWithUnsyncedStudentsSerializer, type: :serializer do
   let!(:synced_student) do
     create(:google_classroom_user,
       :active,
-      provider_classroom_id: classroom.google_classroom_id,
-      provider_user_id: student1.google_id
+      classroom_external_id: classroom.google_classroom_id,
+      user_external_id: student1.google_id
     )
   end
 
   let!(:unsynced_student) do
     create(:google_classroom_user,
       :deleted,
-      provider_classroom_id: classroom.google_classroom_id,
-      provider_user_id: student2.google_id
+      classroom_external_id: classroom.google_classroom_id,
+      user_external_id: student2.google_id
     )
   end
 

--- a/services/QuillLMS/spec/services/classroom_unit_updater_spec.rb
+++ b/services/QuillLMS/spec/services/classroom_unit_updater_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ClassroomUnitUpdater do
     let(:assigned_student_ids) { [student1.id] }
     let(:student_ids) { [student2.id] }
 
-    it { expect { subject }.to change { classroom_unit.reload.assigned_student_ids }.to [student1.id, student2.id] }
+    it { expect { subject }.to change { classroom_unit.reload.assigned_student_ids }.to match_array [student1.id, student2.id] }
     it { expect { subject }.not_to change { classroom_unit.reload.visible}.from(true) }
     it { unarchives_an_archived_classroom_unit }
 

--- a/services/QuillLMS/spec/services/google_integration/classroom_students_importer_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_students_importer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GoogleIntegration::ClassroomStudentsImporter do
     let(:google_id) { student.google_id }
     let(:google_classroom_id) { classroom.google_classroom_id }
 
-    before { create(:google_classroom_user, provider_classroom_id: google_classroom_id, provider_user_id: google_id) }
+    before { create(:google_classroom_user, classroom_external_id: google_classroom_id, user_external_id: google_id) }
 
     let(:students_data) do
       [

--- a/services/QuillLMS/spec/services/google_integration/teacher_classrooms_students_importer_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/teacher_classrooms_students_importer_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe GoogleIntegration::TeacherClassroomsStudentsImporter do
       expect(User.student.count).to eq 0
       subject
       expect(GoogleClassroomUser.count).to eq 2
-      expect(GoogleClassroomUser.where(provider_classroom_id: google_classroom_id1).count).to eq 1
-      expect(GoogleClassroomUser.where(provider_classroom_id: google_classroom_id2).count).to eq 1
+      expect(GoogleClassroomUser.where(classroom_external_id: google_classroom_id1).count).to eq 1
+      expect(GoogleClassroomUser.where(classroom_external_id: google_classroom_id2).count).to eq 1
       expect(User.student.count).to eq 2
     end
   end
@@ -59,8 +59,8 @@ RSpec.describe GoogleIntegration::TeacherClassroomsStudentsImporter do
       expect(User.student.count).to eq 0
       subject
       expect(GoogleClassroomUser.count).to eq 1
-      expect(GoogleClassroomUser.where(provider_classroom_id: google_classroom_id1).count).to eq 0
-      expect(GoogleClassroomUser.where(provider_classroom_id: google_classroom_id2).count).to eq 1
+      expect(GoogleClassroomUser.where(classroom_external_id: google_classroom_id1).count).to eq 0
+      expect(GoogleClassroomUser.where(classroom_external_id: google_classroom_id2).count).to eq 1
       expect(User.student.count).to eq 1
     end
   end

--- a/services/QuillLMS/spec/services/provider_classroom_users_updater_spec.rb
+++ b/services/QuillLMS/spec/services/provider_classroom_users_updater_spec.rb
@@ -3,37 +3,37 @@
 require 'rails_helper'
 
 RSpec.describe ProviderClassroomUsersUpdater do
-  let(:provider_classroom_id) { '123' }
+  let(:classroom_external_id) { '123' }
   let(:type) { ProviderClassroomUser::TYPES.sample }
   let(:klass) { type.constantize }
   let(:factory) { type.underscore }
 
-  subject { described_class.run(factory, provider_user_ids, klass) }
+  subject { described_class.run(factory, user_external_ids, klass) }
 
   context 'no provider_classroom_users exist' do
     context 'create zero records' do
-      let(:provider_user_ids) { [] }
+      let(:user_external_ids) { [] }
 
       it { expect { subject }.not_to change(klass, :count) }
     end
 
     context 'create one record' do
-      let(:provider_user_ids) { ['some-provider-user-id'] }
+      let(:user_external_ids) { ['some-provider-user-id'] }
 
       it { expect { subject }.to change(klass, :count).from(0).to(1) }
     end
 
     context 'creates two records' do
-      let(:provider_user_ids) { ['some-provider-user-id', 'another-provider-user-id'] }
+      let(:user_external_ids) { ['some-provider-user-id', 'another-provider-user-id'] }
 
       it { expect { subject }.to change(klass, :count).from(0).to(2) }
     end
   end
 
   context 'one provider_classroom_user exists' do
-    let!(:user) { create(factory, provider_classroom_id: provider_classroom_id) }
+    let!(:user) { create(factory, classroom_external_id: classroom_external_id) }
 
-    let(:provider_user_ids) { ['some-provider-user-id'] }
+    let(:user_external_ids) { ['some-provider-user-id'] }
 
     it { expect { subject }.to change(klass, :count).from(1).to(2) }
   end
@@ -62,17 +62,17 @@ RSpec.describe ProviderClassroomUsersUpdater do
       user2_now = transition_config[:user2][:now]
 
       it "User 1: #{user1_before} before, #{user1_now} now; User 2: #{user2_before} before, #{user2_now} now" do
-        user1 = create(factory, user1_before, provider_classroom_id: provider_classroom_id)
-        user2 = create(factory, user2_before, provider_classroom_id: provider_classroom_id)
+        user1 = create(factory, user1_before, classroom_external_id: classroom_external_id)
+        user2 = create(factory, user2_before, classroom_external_id: classroom_external_id)
 
         expect(user1.status).to eq user1_before
         expect(user2.status).to eq user2_before
 
-        provider_user_ids = []
-        provider_user_ids << user1.provider_user_id if user1_now == ACTIVE
-        provider_user_ids << user2.provider_user_id if user2_now == ACTIVE
+        user_external_ids = []
+        user_external_ids << user1.user_external_id if user1_now == ACTIVE
+        user_external_ids << user2.user_external_id if user2_now == ACTIVE
 
-        updater = described_class.new(provider_classroom_id, provider_user_ids, klass)
+        updater = described_class.new(classroom_external_id, user_external_ids, klass)
         updater.run
 
         user1.reload

--- a/services/QuillLMS/spec/services/provider_classrooms_with_unsynced_students_finder_spec.rb
+++ b/services/QuillLMS/spec/services/provider_classrooms_with_unsynced_students_finder_spec.rb
@@ -36,28 +36,28 @@ RSpec.describe ProviderClassroomsWithUnsyncedStudentsFinder do
 
       create(
         :google_classroom_user,
-        provider_user_id: synced_student1.google_id,
-        provider_classroom_id: classroom_i_own.google_classroom_id
+        user_external_id: synced_student1.google_id,
+        classroom_external_id: classroom_i_own.google_classroom_id
       )
 
       create(
         :google_classroom_user,
         :deleted,
-        provider_user_id: unsynced_student1.google_id,
-        provider_classroom_id: classroom_i_own.google_classroom_id
+        user_external_id: unsynced_student1.google_id,
+        classroom_external_id: classroom_i_own.google_classroom_id
       )
 
       create(
         :google_classroom_user,
         :deleted,
-        provider_user_id: unsynced_student2.google_id,
-        provider_classroom_id: classroom_i_coteach.google_classroom_id
+        user_external_id: unsynced_student2.google_id,
+        classroom_external_id: classroom_i_coteach.google_classroom_id
       )
 
       create(
         :google_classroom_user,
-        provider_user_id: synced_student2.google_id,
-        provider_classroom_id: another_classroom_i_own.google_classroom_id
+        user_external_id: synced_student2.google_id,
+        classroom_external_id: another_classroom_i_own.google_classroom_id
       )
     end
 
@@ -84,27 +84,27 @@ RSpec.describe ProviderClassroomsWithUnsyncedStudentsFinder do
       create(
         :clever_classroom_user,
         :deleted,
-        provider_user_id: unsynced_student1.clever_id,
-        provider_classroom_id: classroom_i_own.clever_id
+        user_external_id: unsynced_student1.clever_id,
+        classroom_external_id: classroom_i_own.clever_id
       )
 
       create(
         :clever_classroom_user,
-        provider_user_id: synced_student1.clever_id,
-        provider_classroom_id: classroom_i_own.clever_id
+        user_external_id: synced_student1.clever_id,
+        classroom_external_id: classroom_i_own.clever_id
       )
 
       create(
         :clever_classroom_user,
         :deleted,
-        provider_user_id: unsynced_student2.clever_id,
-        provider_classroom_id: classroom_i_coteach.clever_id
+        user_external_id: unsynced_student2.clever_id,
+        classroom_external_id: classroom_i_coteach.clever_id
       )
 
       create(
         :clever_classroom_user,
-        provider_user_id: synced_student2.clever_id,
-        provider_classroom_id: another_classroom_i_own.clever_id
+        user_external_id: synced_student2.clever_id,
+        classroom_external_id: another_classroom_i_own.clever_id
       )
     end
 


### PR DESCRIPTION
## WHAT
Within the ProviderClassroomUsers table do the following:
1.  Rename `provider_classroom_id` to `classroom_external_id` 
1.  Rename `provider_user_id` to `user_external_id` 
1.  Add an optional foreign key references `canvas_instance_id`

## WHY
1.  There will soon be a `ProviderClassroom` model and the presence of `provider_classroom_id` string attribute would be very confusing.
1.  For naming consistency with `classroom_external_id`
1.  Uniquely identifying a canvas resource on Quill requires an external_id and a canvas_instance_id.

Out of scope, but long term ProviderClassroomUser should point to `provider_classroom_id` removing the need for `canvas_instance_id` and `classroom_external_id`.

## HOW
1.  Add migration and update all references
1.  Add migration and update all references
1.  Add migration and update the constructors for ProviderClassroomUser to include canvas_instance_id

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
