### PR TITLE
Add ProviderClassroom STI

### DIFF
--- a/services/QuillLMS/app/models/canvas_classroom.rb
+++ b/services/QuillLMS/app/models/canvas_classroom.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: provider_classrooms
+#
+#  id                 :bigint           not null, primary key
+#  type               :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  canvas_instance_id :bigint
+#  classroom_id       :bigint           not null
+#  external_id        :string           not null
+#
+# Indexes
+#
+#  index_provider_classrooms_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_classrooms_on_classroom_id        (classroom_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
+#  fk_rails_...  (classroom_id => classrooms.id)
+#
+class CanvasClassroom < ProviderClassroom
+  belongs_to :canvas_instance
+end

--- a/services/QuillLMS/app/models/provider_classroom.rb
+++ b/services/QuillLMS/app/models/provider_classroom.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: provider_classrooms
+#
+#  id                 :bigint           not null, primary key
+#  type               :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  canvas_instance_id :bigint
+#  classroom_id       :bigint           not null
+#  external_id        :string           not null
+#
+# Indexes
+#
+#  index_provider_classrooms_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_classrooms_on_classroom_id        (classroom_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
+#  fk_rails_...  (classroom_id => classrooms.id)
+#
+class ProviderClassroom < ApplicationRecord
+  belongs_to :classroom
+
+  TYPES = %w[CanvasClassroom].freeze
+
+  validates :type, inclusion: { in: TYPES }
+end

--- a/services/QuillLMS/db/migrate/20230630184901_create_provider_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20230630184901_create_provider_classrooms.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateProviderClassrooms < ActiveRecord::Migration[6.1]
+  def change
+    create_table :provider_classrooms do |t|
+      t.string :type, null: false
+      t.string :external_id, null: false
+      t.references :classroom, index: true, foreign_key: true, null: false
+      t.references :canvas_instance, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3600,6 +3600,40 @@ ALTER SEQUENCE public.provider_classroom_users_id_seq OWNED BY public.provider_c
 
 
 --
+-- Name: provider_classrooms; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.provider_classrooms (
+    id bigint NOT NULL,
+    type character varying NOT NULL,
+    external_id character varying NOT NULL,
+    classroom_id bigint NOT NULL,
+    canvas_instance_id bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: provider_classrooms_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.provider_classrooms_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: provider_classrooms_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.provider_classrooms_id_seq OWNED BY public.provider_classrooms.id;
+
+
+--
 -- Name: questions; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5922,6 +5956,13 @@ ALTER TABLE ONLY public.provider_classroom_users ALTER COLUMN id SET DEFAULT nex
 
 
 --
+-- Name: provider_classrooms id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.provider_classrooms ALTER COLUMN id SET DEFAULT nextval('public.provider_classrooms_id_seq'::regclass);
+
+
+--
 -- Name: questions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7016,6 +7057,14 @@ ALTER TABLE ONLY public.prompt_healths
 
 ALTER TABLE ONLY public.provider_classroom_users
     ADD CONSTRAINT provider_classroom_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: provider_classrooms provider_classrooms_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.provider_classrooms
+    ADD CONSTRAINT provider_classrooms_pkey PRIMARY KEY (id);
 
 
 --
@@ -8376,6 +8425,20 @@ CREATE INDEX index_provider_classroom_users_on_canvas_instance_id ON public.prov
 
 
 --
+-- Name: index_provider_classrooms_on_canvas_instance_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_provider_classrooms_on_canvas_instance_id ON public.provider_classrooms USING btree (canvas_instance_id);
+
+
+--
+-- Name: index_provider_classrooms_on_classroom_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_provider_classrooms_on_classroom_id ON public.provider_classrooms USING btree (classroom_id);
+
+
+--
 -- Name: index_provider_type_and_classroom_id_and_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9409,6 +9472,14 @@ ALTER TABLE ONLY public.pack_sequence_items
 
 
 --
+-- Name: provider_classrooms fk_rails_78d7d3d31c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.provider_classrooms
+    ADD CONSTRAINT fk_rails_78d7d3d31c FOREIGN KEY (classroom_id) REFERENCES public.classrooms(id);
+
+
+--
 -- Name: pack_sequences fk_rails_79fa628e65; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9478,6 +9549,14 @@ ALTER TABLE ONLY public.activity_topics
 
 ALTER TABLE ONLY public.learn_worlds_accounts
     ADD CONSTRAINT fk_rails_96f37b8ce0 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: provider_classrooms fk_rails_9c61f34d66; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.provider_classrooms
+    ADD CONSTRAINT fk_rails_9c61f34d66 FOREIGN KEY (canvas_instance_id) REFERENCES public.canvas_instances(id);
 
 
 --
@@ -10287,6 +10366,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230623154333'),
 ('20230623154418'),
 ('20230630172652'),
-('20230630173229');
+('20230630173229'),
+('20230630184901');
 
 

--- a/services/QuillLMS/spec/factories/provider_classrooms.rb
+++ b/services/QuillLMS/spec/factories/provider_classrooms.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: provider_classrooms
+#
+#  id                 :bigint           not null, primary key
+#  type               :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  canvas_instance_id :bigint
+#  classroom_id       :bigint           not null
+#  external_id        :string           not null
+#
+# Indexes
+#
+#  index_provider_classrooms_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_classrooms_on_classroom_id        (classroom_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
+#  fk_rails_...  (classroom_id => classrooms.id)
+#
+FactoryBot.define do
+  factory :provider_classroom do
+    external_id { Faker::Number.number(digits: 3) }
+    classroom
+
+    factory :canvas_classsroom, parent: :provider_classroom, class: 'CanvasClassroom' do
+      canvas_instance
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/provider_classroom_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_spec.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: provider_classrooms
+#
+#  id                 :bigint           not null, primary key
+#  type               :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  canvas_instance_id :bigint
+#  classroom_id       :bigint           not null
+#  external_id        :string           not null
+#
+# Indexes
+#
+#  index_provider_classrooms_on_canvas_instance_id  (canvas_instance_id)
+#  index_provider_classrooms_on_classroom_id        (classroom_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (canvas_instance_id => canvas_instances.id)
+#  fk_rails_...  (classroom_id => classrooms.id)
+#
+require 'rails_helper'
+
+RSpec.describe ProviderClassroom, type: :model do
+  it { should belong_to(:classroom) }
+
+  it { should validate_inclusion_of(:type).in_array(described_class::TYPES) }
+end

--- a/services/QuillLMS/spec/models/provider_classroom_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: provider_classrooms


### PR DESCRIPTION
## WHAT
Create a new STI model `ProviderClassroom` with one subclass `CanvasClassroom`

## WHY
We need to persist information about Canvas Classrooms being imported.  This will allow us to do that without adding new attributes onto the classrooms table.  See more discussion [here](https://www.notion.so/quill/RFC-ProviderClassroom-CanvasClassroom-3a7dda4ee9fc401ebc0c49284dd886fb?pvs=4)

## HOW
Create a migration for ProviderClassroom and then have CanvasClassroom inherit from that model.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/RFC-ProviderClassroom-CanvasClassroom-3a7dda4ee9fc401ebc0c49284dd886fb?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? |  Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
