### PR TITLE
lms/re-order-snapshot-grade-filters

### DIFF
--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -2,7 +2,6 @@
 
 class SnapshotsController < ApplicationController
   GRADE_OPTIONS = [
-    {value: "null", name: "No grade set"},
     {value: "Kindergarten", name: "Kindergarten"},
     {value: "1", name: "1st"},
     {value: "2", name: "2nd"},
@@ -17,7 +16,8 @@ class SnapshotsController < ApplicationController
     {value: "11", name: "11th"},
     {value: "12", name: "12th"},
     {value: "University", name: "University"},
-    {value: "Other", name: "Other"}
+    {value: "Other", name: "Other"},
+    {value: "null", name: "No grade set"}
   ]
 
   WORKERS_FOR_ACTIONS = {


### PR DESCRIPTION
## WHAT
Move "No grade set" to the end of the grade filters list
## WHY
We prefer that this be the last item in the list since it's "non standard"
## HOW
Just move it to the end of the list that the `options` action rerturns

### Notion Card Links
https://www.notion.so/quill/Add-None-selected-to-the-grade-filter-on-the-Usage-Snapshot-Report-e801ad2206874d08bf9eca1771337496?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Tests don't cover the actual order of this list
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
