### PR TITLE
Canvas Rostering Backend Part 6: Canvas Rostering

### DIFF
--- a/services/QuillLMS/app/controllers/canvas_integration/teachers_controller.rb
+++ b/services/QuillLMS/app/controllers/canvas_integration/teachers_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class TeachersController < ::ApplicationController
+    include ClassroomImportable
+    include ClassroomRetrievable
+    include StudentImportable
+
+    private def current_user_classrooms
+      current_user.canvas_classrooms
+    end
+
+    private def reauthorization_required?
+      !current_user.canvas_authorized?
+    end
+  end
+end
+

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -218,8 +218,8 @@ class Teachers::ClassroomsController < ApplicationController
 
     return students unless classroom.classroom_provider?
 
-    provider_classroom = ProviderClassroomDelegator.new(classroom)
-    students.map { |student| student.merge(synced: provider_classroom.synced_status(student)) }
+    provider_classroom_delegator = ProviderClassroomDelegator.new(classroom)
+    students.map { |student| student.merge(synced: provider_classroom_delegator.synced_status(student)) }
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/services/QuillLMS/app/models/canvas_integration/teacher_classrooms_data.rb
+++ b/services/QuillLMS/app/models/canvas_integration/teacher_classrooms_data.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class TeacherClassroomsData
+    include Enumerable
+
+    attr_reader :user, :serialized_classrooms_data
+
+    def initialize(user, serialized_classrooms_data)
+      @user = user
+      @serialized_classrooms_data = serialized_classrooms_data
+    end
+
+    def each(&block)
+      classrooms_data.each(&block)
+    end
+
+    private def classrooms_data
+      JSON
+        .parse(serialized_classrooms_data)
+        .deep_symbolize_keys
+        .fetch(:classrooms)
+        .map { |data| data.merge(teacher_id: user.id) }
+    end
+  end
+end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -827,6 +827,18 @@ class User < ApplicationRecord
     user_logins.create
   end
 
+  def user_external_id(canvas_instance: nil)
+    return google_id if google_id.present?
+
+    return clever_id if clever_id.present?
+
+    return nil unless canvas_instance.is_a?(CanvasInstance)
+
+    canvas_accounts
+      .find_by(canvas_instance: canvas_instance)
+      &.user_external_id
+  end
+
   private def validate_flags
     invalid_flags = flags - VALID_FLAGS
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -250,6 +250,10 @@ class User < ApplicationRecord
     end
   end
 
+  def self.find_by_canvas_user_external_ids(user_external_ids)
+    where(id: CanvasAccount.custom_find_by_user_external_ids(user_external_ids).pluck(:user_id))
+  end
+
   def self.valid_email?(email)
     ValidatesEmailFormatOf.validate_email_format(email).nil?
   end

--- a/services/QuillLMS/app/services/canvas_integration/classroom_creator.rb
+++ b/services/QuillLMS/app/services/canvas_integration/classroom_creator.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class ClassroomCreator < ApplicationService
+    class CanvasInstanceNotFoundError < StandardError; end
+
+    OWNER = ClassroomsTeacher::ROLE_TYPES[:owner].freeze
+
+    attr_reader :classroom_external_id, :canvas_instance_id, :external_id, :data, :teacher_id
+
+    def initialize(data)
+      @data = data
+      @classroom_external_id = data[:classroom_external_id]
+      @canvas_instance_id, @external_id = ::CanvasClassroom.unpack_classroom_external_id!(classroom_external_id)
+      @teacher_id = data[:teacher_id]
+    end
+
+    def run
+      ::Classroom.create!(
+        name: name,
+        synced_name: synced_name,
+        canvas_classroom_attributes: {
+          canvas_instance: canvas_instance,
+          external_id: external_id
+        },
+        classrooms_teachers_attributes: [
+          {
+            role: role,
+            user_id: teacher_id
+          }
+        ]
+      )
+    end
+
+    private def canvas_instance
+      ::CanvasInstance.find_by(id: canvas_instance_id) || raise(CanvasInstanceNotFoundError)
+    end
+
+    private def name
+      data[:name].present? ? valid_name : "Classroom #{classroom_external_id}"
+    end
+
+    private def other_owned_classroom_names
+      teacher.classrooms_i_own.pluck(:name)
+    end
+
+    private def role
+      OWNER
+    end
+
+    private def synced_name
+      data[:name]
+    end
+
+    private def teacher
+      ::User.find(teacher_id)
+    end
+
+    private def valid_name
+      ::DuplicateNameResolver.run(data[:name], other_owned_classroom_names)
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/classroom_importer.rb
+++ b/services/QuillLMS/app/services/canvas_integration/classroom_importer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class ClassroomImporter < ApplicationService
+    attr_reader :data, :canvas_instance_id, :external_id
+
+    def initialize(data)
+      @data = data
+      @classroom_external_id = data[:classroom_external_id]
+      @canvas_instance_id, @external_id = ::CanvasClassroom.unpack_classroom_external_id!(data[:classroom_external_id])
+    end
+
+    def run
+      classroom ? ClassroomUpdater.run(classroom, data) : ClassroomCreator.run(data)
+    end
+
+    private def classroom
+      @classroom ||=
+        Classroom
+          .unscoped
+          .joins(:canvas_classroom)
+          .find_by(canvas_classroom: { canvas_instance_id: canvas_instance_id, external_id: external_id })
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/classroom_student_importer.rb
+++ b/services/QuillLMS/app/services/canvas_integration/classroom_student_importer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class ClassroomStudentImporter < ApplicationService
+    attr_reader :data, :classroom, :email, :user_external_id
+
+    def initialize(data)
+      @data = data
+      @classroom = data[:classroom]
+      @user_external_id = data[:user_external_id]
+      @email = data[:email]
+    end
+
+    def run
+      assign_classroom
+    end
+
+    private def assign_classroom
+      ::Associators::StudentsToClassrooms.run(imported_student, classroom)
+    end
+
+    private def canvas_account
+      @canvas_account ||= ::CanvasAccount.custom_find_by_user_external_id(user_external_id)
+    end
+
+    private def existing_student
+      return canvas_account.user if canvas_account
+      return new_canvas_account.user if student_with_email
+    end
+
+    private def imported_student
+      existing_student ? StudentUpdater.run(existing_student, data) : StudentCreator.run(data)
+    end
+
+    private def new_canvas_account
+      @new_canvas_account ||= CanvasAccount.custom_create_by_user_external_id!(user_external_id, student_with_email.id)
+    end
+
+    private def student_with_email
+      @student_with_email ||= ::User.find_by(email: email) if email.present?
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/classroom_students_data.rb
+++ b/services/QuillLMS/app/services/canvas_integration/classroom_students_data.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class ClassroomStudentsData
+    include Enumerable
+
+    attr_reader :classroom, :client
+
+    delegate :classroom_external_id, to: :classroom
+
+    def initialize(classroom, client)
+      @classroom = classroom
+      @client = client
+    end
+
+    def each
+      students_data.each { |student_data| yield student_data.merge(classroom: classroom) }
+    end
+
+    private def external_id
+      ::CanvasClassroom
+        .unpack_classroom_external_id!(classroom_external_id)
+        .second
+    end
+
+    private def students_data
+      client.classroom_students(external_id) || []
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/classroom_students_importer.rb
+++ b/services/QuillLMS/app/services/canvas_integration/classroom_students_importer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class ClassroomStudentsImporter < ApplicationService
+    attr_reader :classroom_students_data
+
+    delegate :classroom_external_id, to: :classroom_students_data
+
+    def initialize(classroom_students_data)
+      @classroom_students_data = classroom_students_data
+    end
+
+    def run
+      import_classroom_students
+      update_provider_classroom_users
+    end
+
+    private def import_classroom_students
+      classroom_students_data.map { |classroom_student_data| ClassroomStudentImporter.run(classroom_student_data) }
+    end
+
+    private def update_provider_classroom_users
+      ::ProviderClassroomUsersUpdater.run(classroom_external_id, user_external_ids, CanvasClassroomUser)
+    end
+
+    private def user_external_ids
+      classroom_students_data.pluck(:user_external_id)
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/classroom_updater.rb
+++ b/services/QuillLMS/app/services/canvas_integration/classroom_updater.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class ClassroomUpdater < ApplicationService
+    OWNER = ClassroomsTeacher::ROLE_TYPES[:owner].freeze
+    COTEACHER = ClassroomsTeacher::ROLE_TYPES[:coteacher].freeze
+
+    attr_reader :classroom, :data, :teacher_id
+
+    def initialize(classroom, data)
+      @classroom = classroom
+      @data = data
+      @teacher_id = data[:teacher_id]
+    end
+
+    def run
+      update
+      associate_teacher_and_classroom
+      classroom.reload
+    end
+
+    private def associate_teacher_and_classroom
+      return if ClassroomsTeacher.exists?(classroom: classroom, user_id: teacher_id)
+
+      ClassroomsTeacher.create!(
+        classroom: classroom,
+        user_id: teacher_id,
+        role: classroom.owner ? COTEACHER : OWNER
+      )
+    end
+
+    private def custom_name?
+      classroom.name != classroom.synced_name
+    end
+
+    private def name
+      custom_name? ? classroom.name : valid_name
+    end
+
+    private def other_owned_classroom_names
+      teacher.classrooms_i_own.reject { |c| c.id == classroom.id }.pluck(:name)
+    end
+
+    private def synced_name
+      data[:name]
+    end
+
+    private def teacher
+      ::User.find(teacher_id)
+    end
+
+    private def update
+      classroom.update!(name: name, synced_name: synced_name, visible: true)
+    end
+
+    private def valid_name
+      ::DuplicateNameResolver.run(data[:name], other_owned_classroom_names)
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/rest_client.rb
+++ b/services/QuillLMS/app/services/canvas_integration/rest_client.rb
@@ -3,6 +3,7 @@
 module CanvasIntegration
   class RestClient
     COURSES_PATH = 'courses'
+    SECTIONS_PATH = 'sections'
 
     attr_reader :canvas_auth_credential
 
@@ -10,8 +11,12 @@ module CanvasIntegration
       @canvas_auth_credential = canvas_auth_credential
     end
 
+    def classroom_students(section_id)
+      { students: students(section_id) }
+    end
+
     def teacher_classrooms
-      { canvas_instance_id: canvas_instance.id, classrooms: classrooms }
+      { classrooms: classrooms }
     end
 
     private def api
@@ -33,23 +38,42 @@ module CanvasIntegration
     private def classrooms
       courses_data.map do |course_data|
         sections_data(course_data[:id]).map do |section_data|
-          ClassroomDataAdapter.run(course_data, section_data)
+          ClassroomDataAdapter.run(canvas_instance.id, course_data, section_data)
         end
       end.flatten
     end
 
     private def courses_data
-      @courses_data ||= get_data(COURSES_PATH)
+      @courses_data ||= get_collection(COURSES_PATH)
     end
 
     private def get_data(path)
-      JSON
-        .parse(api.api_get_request(path).body)
-        .map(&:deep_symbolize_keys)
+      JSON.parse(api.api_get_request(path).body)
+    end
+
+    private def get_member(path)
+      get_data(path).deep_symbolize_keys
+    end
+
+    private def get_collection(path)
+      get_data(path).map(&:deep_symbolize_keys)
+    end
+
+    private def section_data(section_id)
+      get_member("#{SECTIONS_PATH}/#{section_id}?include[]=students")
     end
 
     private def sections_data(course_id)
-      get_data("#{COURSES_PATH}/#{course_id}/sections?include[]=students")
+      get_collection("#{COURSES_PATH}/#{course_id}/sections?include[]=students") || []
+    end
+
+    private def students(section_id)
+      students_data(section_id)
+        .map { |student_data| StudentDataAdapter.run(canvas_instance.id, student_data) }
+    end
+
+    private def students_data(section_id)
+      section_data(section_id)[:students] || []
     end
   end
 end

--- a/services/QuillLMS/app/services/canvas_integration/student_creator.rb
+++ b/services/QuillLMS/app/services/canvas_integration/student_creator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class StudentCreator < ApplicationService
+    ACCOUNT_TYPE = ::User::CANVAS_ACCOUNT
+    ROLE = ::User::STUDENT
+
+    attr_reader :canvas_instance_id, :data, :email, :external_id, :name
+
+    def initialize(data)
+      @email = data[:email]
+      @name = data[:name]
+      @canvas_instance_id, @external_id = CanvasAccount.unpack_user_external_id!(data[:user_external_id])
+    end
+
+    def run
+      student
+    end
+
+    private def student
+      ::User.create!(
+        account_type: ACCOUNT_TYPE,
+        email: email,
+        name: name,
+        role: ROLE,
+        canvas_accounts_attributes: [
+          {
+            canvas_instance_id: canvas_instance_id,
+            external_id: external_id
+          }
+        ]
+      )
+    end
+  end
+end
+
+

--- a/services/QuillLMS/app/services/canvas_integration/student_data_adapter.rb
+++ b/services/QuillLMS/app/services/canvas_integration/student_data_adapter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class StudentDataAdapter < ApplicationService
+    attr_reader :canvas_instance_id, :external_id, :login_id, :name
+
+    def initialize(canvas_instance_id, student_data)
+      @canvas_instance_id = canvas_instance_id
+      @external_id = student_data[:id]
+      @login_id = student_data[:login_id]
+      @name = student_data[:name]
+    end
+
+    def run
+      {
+        email: email,
+        name: name,
+        user_external_id: user_external_id
+      }
+    end
+
+    private def email
+      ::User.valid_email?(login_id) ? login_id.downcase : nil
+    end
+
+    private def user_external_id
+      ::CanvasAccount.build_user_external_id(canvas_instance_id, external_id)
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/student_updater.rb
+++ b/services/QuillLMS/app/services/canvas_integration/student_updater.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class StudentUpdater < ApplicationService
+    ACCOUNT_TYPE = ::User::CANVAS_ACCOUNT
+    ROLE = ::User::STUDENT
+
+    attr_reader :data, :initial_email, :student, :temp_email
+
+    def initialize(student, data)
+      @student = student
+      @data = data
+      @initial_email = student.email
+      @temp_email = data[:email]
+    end
+
+    def run
+      update_student
+      student
+    end
+
+    private def email
+      persist_initial_email? ? initial_email : temp_email
+    end
+
+    private def name
+      data[:name].presence || student.name
+    end
+
+    private def persist_initial_email?
+      data[:email].blank? || data[:email] == initial_email || ::User.exists?(email: temp_email)
+    end
+
+    private def update_student
+      student.update!(
+        account_type: ACCOUNT_TYPE,
+        clever_id: nil,
+        email: email,
+        google_id: nil,
+        name: name,
+        role: ROLE,
+        signed_up_with_google: false
+      )
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/teacher_classrooms_students_importer.rb
+++ b/services/QuillLMS/app/services/canvas_integration/teacher_classrooms_students_importer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class TeacherClassroomsStudentsImporter < ApplicationService
+    attr_reader :teacher, :classroom_ids
+
+    def initialize(teacher, classroom_ids)
+      @teacher = teacher
+      @classroom_ids = classroom_ids
+    end
+
+    def run
+      import_classrooms_students
+    end
+
+    private def classrooms
+      Classroom
+        .unscoped
+        .joins(:canvas_classroom)
+        .includes(:canvas_classroom)
+        .where(id: classroom_ids)
+    end
+
+    private def client
+      @client ||= ClientFetcher.run(teacher)
+    end
+
+    private def classrooms_students_data
+      classrooms.map { |classroom| ClassroomStudentsData.new(classroom, client) }
+    end
+
+    private def import_classrooms_students
+      classrooms_students_data.each { |classroom_students_data| ClassroomStudentsImporter.run(classroom_students_data) }
+    end
+  end
+end

--- a/services/QuillLMS/app/services/canvas_integration/teacher_imported_classrooms_updater.rb
+++ b/services/QuillLMS/app/services/canvas_integration/teacher_imported_classrooms_updater.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class TeacherImportedClassroomsUpdater < ApplicationService
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def run
+      update_classrooms
+      update_classrooms_students
+    end
+
+    private def classroom_data(classroom)
+      classrooms_data.find { |data| data[:classroom_external_id] == classroom.classroom_external_id }
+    end
+
+    private def classrooms_data
+      @classrooms_data ||= TeacherClassroomsData.new(user, serialized_classrooms_data)
+    end
+
+    private def classroom_external_ids
+      classrooms_data.pluck(:classroom_external_id)
+    end
+
+    private def canvas_instance_id
+      return nil if classrooms_data.blank?
+
+      CanvasClassroom
+        .unpack_classroom_external_id!(classrooms_data.first[:classroom_external_id])
+        .first
+    end
+
+    private def external_ids
+      classroom_external_ids
+        .map { |classroom_external_id| CanvasClassroom.unpack_classroom_external_id!(classroom_external_id).second }
+    end
+
+    private def imported_classrooms
+      @imported_classrooms ||=
+        user
+          .canvas_classrooms
+          .joins(:canvas_classroom)
+          .where(classrooms: { visible: true })
+          .where(canvas_classroom: { canvas_instance_id: canvas_instance_id, external_id: external_ids })
+    end
+
+    private def serialized_classrooms_data
+      CanvasIntegration::TeacherClassroomsCache.read(user.id)
+    end
+
+    private def update_classrooms
+      imported_classrooms.each { |classroom| ClassroomUpdater.run(classroom, classroom_data(classroom)) }
+    end
+
+    private def update_classrooms_students
+      ImportTeacherClassroomsStudentsWorker.perform_async(user.id, imported_classrooms.map(&:id))
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker.rb
+++ b/services/QuillLMS/app/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class HydrateTeacherClassroomsCacheWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
+    def perform(user_id)
+      user = ::User.find_by(id: user_id)
+
+      return if user.nil?
+      return unless user.teacher? && user.canvas_authorized?
+
+      TeacherClassroomsCacheHydrator.run(user)
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker.rb
+++ b/services/QuillLMS/app/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker.rb
@@ -9,7 +9,6 @@ module CanvasIntegration
       user = ::User.find_by(id: user_id)
 
       return if user.nil?
-      return unless user.teacher? && user.canvas_authorized?
 
       TeacherClassroomsCacheHydrator.run(user)
     end

--- a/services/QuillLMS/app/workers/canvas_integration/import_teacher_classrooms_students_worker.rb
+++ b/services/QuillLMS/app/workers/canvas_integration/import_teacher_classrooms_students_worker.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class ImportTeacherClassroomsStudentsWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
+    PUSHER_EVENT = 'canvas-classroom-students-imported'
+    PUSHER_FAILED_EVENT = 'canvas-account-reauthorization-required'
+
+    def perform(teacher_id, selected_classroom_ids = nil)
+      teacher = ::User.find(teacher_id)
+
+      if teacher.canvas_authorized?
+        TeacherClassroomsStudentsImporter.run(teacher, selected_classroom_ids)
+        PusherTrigger.run(teacher_id, PUSHER_EVENT, "Canvas classroom students imported for #{teacher_id}.")
+      else
+        PusherTrigger.run(teacher_id, PUSHER_FAILED_EVENT, "Reauthorization needed for user #{teacher_id}.")
+      end
+    rescue => e
+      ErrorNotifier.report(e)
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/canvas_integration/update_teacher_imported_classrooms_worker.rb
+++ b/services/QuillLMS/app/workers/canvas_integration/update_teacher_imported_classrooms_worker.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  class UpdateTeacherImportedClassroomsWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
+    def perform(user_id)
+      user = ::User.find_by(id: user_id)
+
+      return if user.nil?
+      return unless user.teacher? && user.canvas_authorized?
+
+      TeacherClassroomsCacheHydrator.run(user)
+      TeacherImportedClassroomsUpdater.run(user)
+    end
+  end
+end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -597,6 +597,10 @@ EmpiricalGrammar::Application.routes.draw do
     get '/lti/launch_config.xml' => 'lti#launch_config'
     post '/lti/launch' => 'lti#launch'
     get '/lti/sso', to: 'lti#sso'
+
+    get '/teachers/retrieve_classrooms', to: 'teachers#retrieve_classrooms'
+    post '/teachers/import_classrooms', to: 'teachers#import_classrooms'
+    put '/teachers/import_students', to: 'teachers#import_students'
   end
 
   namespace :clever_integration do

--- a/services/QuillLMS/spec/controllers/auth/canvas_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/auth/canvas_controller_spec.rb
@@ -2,61 +2,59 @@
 
 require 'rails_helper'
 
-module Auth
-  describe CanvasController, type: :request do
-    let(:user) { create(:teacher) }
-    let(:canvas_account) { create(:canvas_account, user: user) }
-    let(:canvas_instance) { canvas_account.canvas_instance }
-    let(:uid) { canvas_account.external_id }
-    let(:url) { canvas_instance.url }
+describe Auth::CanvasController, type: :request do
+  let(:user) { create(:teacher) }
+  let(:canvas_account) { create(:canvas_account, user: user) }
+  let(:canvas_instance) { canvas_account.canvas_instance }
+  let(:uid) { canvas_account.external_id }
+  let(:url) { canvas_instance.url }
 
-    let(:auth_hash) { create(:canvas_auth_hash, uid: uid, url: url ) }
+  let(:auth_hash) { create(:canvas_auth_hash, uid: uid, url: url ) }
 
-    before { OmniAuth.config.mock_auth[:canvas] = auth_hash }
+  before { OmniAuth.config.mock_auth[:canvas] = auth_hash }
 
-    describe '/auth/canvas/callback' do
-      subject { get Auth::Canvas::OMNIAUTH_CALLBACK_PATH }
+  describe '/auth/canvas/callback' do
+    subject { get Auth::Canvas::OMNIAUTH_CALLBACK_PATH }
 
-      let(:canvas_auth_credential) { create(:canvas_auth_credential, user: user) }
+    let(:canvas_auth_credential) { create(:canvas_auth_credential, user: user) }
 
-      before { set_session_canvas_instance_id }
+    before { set_session_canvas_instance_id }
+
+    it do
+      expect(CanvasIntegration::AuthCredentialSaver)
+        .to receive(:run)
+        .with(auth_hash)
+        .and_return(canvas_auth_credential)
+
+      subject
+    end
+
+    it do
+      expect(CanvasIntegration::UpdateTeacherImportedClassroomsWorker)
+        .to receive(:perform_async)
+        .with(user.id)
+
+      subject
+    end
+
+    context 'student user' do
+      before { user.update(role: 'student') }
 
       it do
-        expect(CanvasIntegration::AuthCredentialSaver)
-          .to receive(:run)
-          .with(auth_hash)
-          .and_return(canvas_auth_credential)
-
+        expect(CanvasIntegration::UpdateTeacherImportedClassroomsWorker).not_to receive(:perform_async)
         subject
-      end
-
-      it do
-        expect(CanvasIntegration::TeacherClassroomsCacheHydrator)
-          .to receive(:run)
-          .with(user)
-
-        subject
-      end
-
-      context 'student user' do
-        before { user.update(role: 'student') }
-
-        it do
-          expect(CanvasIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
-          subject
-        end
-      end
-
-      context 'with a valid auth_hash' do
-        before { subject }
-
-        it { expect(response).to redirect_to(profile_path) }
-        it { expect(response).to have_http_status(:found) }
       end
     end
 
-    def set_session_canvas_instance_id
-      post Auth::Canvas::OMNIAUTH_REQUEST_PATH, params: { canvas_instance_id: canvas_instance.id }
+    context 'with a valid auth_hash' do
+      before { subject }
+
+      it { expect(response).to redirect_to(profile_path) }
+      it { expect(response).to have_http_status(:found) }
     end
+  end
+
+  def set_session_canvas_instance_id
+    post Auth::Canvas::OMNIAUTH_REQUEST_PATH, params: { canvas_instance_id: canvas_instance.id }
   end
 end

--- a/services/QuillLMS/spec/controllers/canvas_integration/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/canvas_integration/teachers_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CanvasIntegration::TeachersController do
   before { allow(controller).to receive(:current_user) { teacher } }
 
   it { should use_before_action :authorize_owner! }
+  it { should use_before_action :teacher!}
 
   let(:response_body) { JSON.parse(response.body).deep_symbolize_keys }
   let(:teacher) { create(:teacher, :with_canvas_account) }

--- a/services/QuillLMS/spec/controllers/canvas_integration/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/canvas_integration/teachers_controller_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::TeachersController do
+  before { allow(controller).to receive(:current_user) { teacher } }
+
+  it { should use_before_action :authorize_owner! }
+
+  let(:response_body) { JSON.parse(response.body).deep_symbolize_keys }
+  let(:teacher) { create(:teacher, :with_canvas_account) }
+
+  context '#import_classrooms' do
+    subject { post :import_classrooms, params: params, as: :json }
+
+    let(:canvas_instance_id) { create(:canvas_instance).id }
+    let(:external_id1) { Faker::Number.number }
+    let(:external_id2) { Faker::Number.number }
+    let(:classroom_external_id1) { CanvasClassroom.build_classroom_external_id(canvas_instance_id, external_id1) }
+    let(:classroom_external_id2) { CanvasClassroom.build_classroom_external_id(canvas_instance_id, external_id2) }
+
+    let(:classroom1) { { classroom_external_id: classroom_external_id1 } }
+    let(:classroom2) { { classroom_external_id: classroom_external_id2 } }
+
+    let(:params) { { selected_classrooms: [classroom1, classroom2] } }
+
+    it { expect { subject }.to change(teacher.canvas_classrooms, :count).from(0).to(2) }
+
+    it do
+      expect(CanvasIntegration::ImportTeacherClassroomsStudentsWorker).to receive(:perform_async)
+      expect(CanvasIntegration::TeacherClassroomsCache).to receive(:delete).with(teacher.id)
+      expect(CanvasIntegration::HydrateTeacherClassroomsCacheWorker).to receive(:perform_async).with(teacher.id)
+      subject
+    end
+
+    it 'should return an array with two classrooms' do
+      subject
+
+      expect(response_body[:classrooms].pluck(:name))
+        .to match_array ["Classroom #{classroom_external_id1}", "Classroom #{classroom_external_id2}"]
+    end
+  end
+
+  describe '#import_students'  do
+    subject { put :import_students, params: params, as: :json }
+
+    let(:classroom) { create(:classroom, :from_canvas, :with_no_teacher) }
+
+    before { create(:classrooms_teacher, user: teacher, classroom: classroom) }
+
+    context 'import canvas classroom student flow' do
+      let(:params) { { classroom_id: classroom.id } }
+
+      it 'should kick off background job that imports students' do
+        expect(CanvasIntegration::TeacherClassroomsCache)
+          .to receive(:delete)
+          .with(teacher.id)
+
+        expect(CanvasIntegration::ImportTeacherClassroomsStudentsWorker)
+          .to receive(:perform_async)
+          .with(teacher.id, [classroom.id])
+
+        subject
+      end
+    end
+
+    context 'import classes flow' do
+      let(:selected_classroom_ids) { create_list(:classroom, 2).map(&:id) }
+      let(:params) { { selected_classroom_ids: selected_classroom_ids} }
+
+      it 'should kick off background job that imports students' do
+        expect(CanvasIntegration::TeacherClassroomsCache)
+          .to receive(:delete)
+          .with(teacher.id)
+
+        expect(CanvasIntegration::ImportTeacherClassroomsStudentsWorker)
+          .to receive(:perform_async)
+          .with(teacher.id, match_array(selected_classroom_ids))
+
+        subject
+      end
+    end
+  end
+
+  describe '#retreive_clasrooms' do
+    subject { get :retrieve_classrooms, as: :json }
+
+    let(:classroom) { create(:classroom, :from_canvas, :with_no_teacher) }
+
+    before { create(:classrooms_teacher, user: teacher, classroom: classroom) }
+
+    it do
+      subject
+      expect(response_body).to eq(user_id: teacher.id, reauthorization_required: true)
+    end
+
+    context 'user is canvas authorized' do
+      before { allow(teacher).to receive(:canvas_authorized?).and_return(true) }
+
+      it  do
+        subject
+        expect(response_body).to eq({ user_id: teacher.id, quill_retrieval_processing: true })
+      end
+
+      context 'teacher classrooms cache has data' do
+        let(:data) { { classrooms: [] } }
+
+        before { allow(CanvasIntegration::TeacherClassroomsCache).to receive(:read).and_return(data.to_json) }
+
+        it do
+          subject
+          expect(response_body).to eq data
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/factories/canvas_accounts.rb
+++ b/services/QuillLMS/spec/factories/canvas_accounts.rb
@@ -23,7 +23,7 @@
 #
 FactoryBot.define do
   factory :canvas_account do
-    external_id { SecureRandom.hex(12) }
+    external_id { Faker::Number.number }
     user
     canvas_instance
   end

--- a/services/QuillLMS/spec/factories/canvas_integration/canvas_course_payloads.rb
+++ b/services/QuillLMS/spec/factories/canvas_integration/canvas_course_payloads.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  FactoryBot.define do
+    factory :canvas_course_payload, class: Hash do
+      skip_create
+
+      initialize_with do
+        {
+          id: id,
+          name: name,
+          account_id: account_id,
+          uuid:  uuid,
+          start_at: nil,
+          grading_standard_id: nil,
+          is_public: nil,
+          created_at: created_at,
+          course_code: course_code,
+          default_view: :modules,
+          root_account_id: 1,
+          enrollment_term_id: 1,
+          license: nil,
+          grade_passback_setting: nil,
+          end_at: nil,
+          public_syllabus: false,
+          public_syllabus_to_auth: false,
+          storage_quota_mb: 500,
+          is_public_to_auth_users: false,
+          homeroom_course: false,
+          course_color: nil,
+          friendly_name: nil,
+          apply_assignment_group_weights: false,
+          time_zone: time_zone,
+          blueprint: false,
+          template: false,
+          sis_course_id: nil,
+          sis_import_id: nil,
+          integration_id: nil,
+          enrollments: [
+            {
+              type: :teacher,
+              role: :TeacherEnrollment,
+              role_id: 4,
+              user_id: id,
+              enrollment_state: :active,
+              limit_privileges_to_course_section: false
+            }
+          ],
+          hide_final_grades: false,
+          workflow_state: :unpublished,
+          restrict_enrollments_to_course_dates: false
+        }.as_json
+      end
+
+      transient do
+        sequence(:account_id)
+        course_code { :College }
+        created_at { Time.zone.now.strftime("%Y-%m-%dT%H:%M:%SZ") }
+        sequence(:id)
+        name { Faker::Educator.subject }
+        time_zone { Faker::Address.time_zone }
+        uuid { SecureRandom.hex(20) }
+      end
+    end
+  end
+end
+

--- a/services/QuillLMS/spec/factories/canvas_integration/canvas_section_payloads.rb
+++ b/services/QuillLMS/spec/factories/canvas_integration/canvas_section_payloads.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  FactoryBot.define do
+    factory :canvas_section_payload, class: Hash do
+      skip_create
+
+      initialize_with do
+        {
+          id: id,
+          course_id: course_id,
+          name: name,
+          start_at: nil,
+          end_at: nil,
+          created_at: created_at,
+          restrict_enrollments_to_section_dates: nil,
+          nonxlist_course_id: nil,
+          sis_section_id: nil,
+          sis_course_id: nil,
+          integration_id: nil,
+          students: students
+        }.as_json
+      end
+
+      transient do
+        sequence(:course_id)
+        created_at { Time.zone.now.strftime("%Y-%m-%dT%H:%M:%SZ") }
+        sequence(:id)
+        sequence(:name) { |n| "Section #{n}" }
+        students { nil }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/factories/canvas_integration/canvas_student_payloads.rb
+++ b/services/QuillLMS/spec/factories/canvas_integration/canvas_student_payloads.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CanvasIntegration
+  FactoryBot.define do
+    factory :canvas_student_payload, class: Hash do
+      skip_create
+
+      initialize_with do
+        {
+          id: id,
+          name: name,
+          created_at: created_at,
+          sortable_name: name.split.reverse.join(', '),
+          short_name: name.split.first,
+          sis_user_id: nil,
+          integration_id: nil,
+          login_id: email
+        }.as_json
+      end
+
+      transient do
+        sequence(:id)
+        created_at { Time.zone.now.strftime("%Y-%m-%dT%H:%M:%SZ") }
+        name { Faker::Name.custom_name }
+        email { Faker::Internet.email }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/factories/classrooms.rb
+++ b/services/QuillLMS/spec/factories/classrooms.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
     end
 
     trait :from_canvas do
-      transient { canvas_instance { create(:canvas_instance) } }
+      transient { canvas_instance { FactoryBot.create(:canvas_instance) } }
 
       after(:create) do |classroom, context|
         create(:canvas_classroom, classroom: classroom, canvas_instance: context.canvas_instance)

--- a/services/QuillLMS/spec/factories/classrooms.rb
+++ b/services/QuillLMS/spec/factories/classrooms.rb
@@ -42,7 +42,12 @@ FactoryBot.define do
     end
 
     trait :from_canvas do
-      after(:create) { |classroom| create(:canvas_classroom, classroom: classroom).reload }
+      transient { canvas_instance { create(:canvas_instance) } }
+
+      after(:create) do |classroom, context|
+        create(:canvas_classroom, classroom: classroom, canvas_instance: context.canvas_instance)
+        classroom.reload
+      end
     end
 
     factory :classroom_with_a_couple_students do

--- a/services/QuillLMS/spec/factories/omniauth_auth_hashes.rb
+++ b/services/QuillLMS/spec/factories/omniauth_auth_hashes.rb
@@ -52,11 +52,11 @@ FactoryBot.define do
         expires_at { 1.hour.from_now.to_i }
         lti_user_id { SecureRandom.uuid }
         login_id { Faker::Internet.username }
-        name { Faker::Name.name }
+        name { Faker::Name.custom_name }
         nickname { Faker::Name.first_name }
         primary_email { email }
         short_name { Faker::Name.first_name }
-        sortable_name { Faker::Name.name }
+        sortable_name { Faker::Name.custom_name }
         time_zone { 'America/New_York' }
         token { [rand(1..99999), SecureRandom.alphanumeric(64)].join('~') }
         refresh_token { [rand(1..99999), SecureRandom.alphanumeric(64)].join('~') }

--- a/services/QuillLMS/spec/factories/provider_classroom_users.rb
+++ b/services/QuillLMS/spec/factories/provider_classroom_users.rb
@@ -20,7 +20,10 @@ FactoryBot.define do
   factory :provider_classroom_user, class: 'ProviderClassroomUser' do
 
     trait(:active) { deleted_at { nil } }
+    trait(:synced) { active }
+
     trait(:deleted) { deleted_at { Time.current } }
+    trait(:unsynced) { deleted }
 
     factory :canvas_classroom_user, parent: :provider_classroom_user, class: 'CanvasClassroomUser' do
       classroom_external_id { [Faker::Number.number, Faker::Number.number].join(':') }

--- a/services/QuillLMS/spec/factories/users.rb
+++ b/services/QuillLMS/spec/factories/users.rb
@@ -245,9 +245,11 @@ FactoryBot.define do
       end
     end
 
-    trait(:with_canvas_account) do
-      after(:create) do |user|
-        create(:canvas_account, user: user)
+    trait :with_canvas_account do
+      transient { canvas_instance { FactoryBot.create(:canvas_instance) } }
+
+      after(:create) do |user, evaluator|
+        create(:canvas_account, canvas_instance: evaluator.canvas_instance, user: user)
         user.reload
       end
     end

--- a/services/QuillLMS/spec/factories/users.rb
+++ b/services/QuillLMS/spec/factories/users.rb
@@ -246,7 +246,7 @@ FactoryBot.define do
     end
 
     trait :with_canvas_account do
-      transient { canvas_instance { FactoryBot.create(:canvas_instance) } }
+      transient { canvas_instance { create(:canvas_instance) } }
 
       after(:create) do |user, evaluator|
         create(:canvas_account, canvas_instance: evaluator.canvas_instance, user: user)

--- a/services/QuillLMS/spec/factories/users.rb
+++ b/services/QuillLMS/spec/factories/users.rb
@@ -246,7 +246,7 @@ FactoryBot.define do
     end
 
     trait :with_canvas_account do
-      transient { canvas_instance { create(:canvas_instance) } }
+      transient { canvas_instance { FactoryBot.create(:canvas_instance) } }
 
       after(:create) do |user, evaluator|
         create(:canvas_account, canvas_instance: evaluator.canvas_instance, user: user)

--- a/services/QuillLMS/spec/models/canvas_integration/teacher_classrooms_data_spec.rb
+++ b/services/QuillLMS/spec/models/canvas_integration/teacher_classrooms_data_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::TeacherClassroomsData do
+  let(:teacher) { create(:teacher) }
+
+  subject { described_class.new(teacher, serialized_classrooms_data) }
+
+  context 'no classrooms' do
+    let(:serialized_classrooms_data) { { classrooms: [] }.to_json }
+
+    it 'has no elements' do
+      expect(subject.count).to eq 0
+    end
+  end
+
+  context 'two classrooms' do
+    let(:canvas_instance_id1) { create(:canvas_instance).id }
+    let(:canvas_instance_id2) { create(:canvas_instance).id }
+
+    let(:external_id1) { Faker::Number.number }
+    let(:external_id2) { Faker::Number.number }
+
+    let(:classroom_external_id1) { CanvasClassroom.build_classroom_external_id(canvas_instance_id1, external_id1) }
+    let(:classroom_external_id2) { CanvasClassroom.build_classroom_external_id(canvas_instance_id2, external_id2) }
+
+    let(:serialized_classrooms_data) do
+      { classrooms: [{ classroom_external_id: classroom_external_id1 }, { classroom_external_id: classroom_external_id2 }] }.to_json
+    end
+
+    let(:expected_classrooms_data) do
+      [
+        { classroom_external_id: classroom_external_id1, teacher_id: teacher.id },
+        { classroom_external_id: classroom_external_id2, teacher_id: teacher.id }
+      ]
+    end
+
+    it { expect(subject).to match_array expected_classrooms_data }
+  end
+end

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -371,4 +371,32 @@ describe Classroom, type: :model do
       end
     end
   end
+
+  describe '#classroom_external_id' do
+    subject { classroom.classroom_external_id }
+
+    context 'when classroom has no provider' do
+      let(:classroom) { create(:classroom) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when google_classroom_id is present' do
+      let(:classroom) { create(:classroom, :from_google) }
+
+      it { is_expected.to eq classroom.google_classroom_id }
+    end
+
+    context 'when clever_id is present' do
+      let(:classroom) { create(:classroom, :from_clever) }
+
+      it { is_expected.to eq classroom.clever_id }
+    end
+
+    context 'when canvas_classroom is present' do
+      let(:classroom) { create(:classroom, :from_canvas) }
+
+      it { is_expected.to eq classroom.canvas_classroom.classroom_external_id }
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/provider_classroom_delegator_spec.rb
+++ b/services/QuillLMS/spec/models/provider_classroom_delegator_spec.rb
@@ -70,4 +70,40 @@ RSpec.describe ProviderClassroomDelegator do
       it { expect(subject.synced_status(student3.attributes)).to eq nil }
     end
   end
+
+  context 'canvas classroom' do
+    let(:canvas_instance) { create(:canvas_instance) }
+    let(:classroom) { create(:classroom, :from_canvas, canvas_instance: canvas_instance, students: students) }
+
+    let(:student1) { create(:user, :with_canvas_account, canvas_instance: canvas_instance) }
+    let(:student2) { create(:user, :with_canvas_account, canvas_instance: canvas_instance) }
+    let(:student3) { create(:user) }
+    let(:students) { [student1, student2, student3] }
+
+    before do
+      create(
+        :canvas_classroom_user,
+        :synced,
+        classroom_external_id: classroom.classroom_external_id,
+        user_external_id: student1.user_external_id(canvas_instance: canvas_instance)
+      )
+
+      create(
+        :canvas_classroom_user,
+        :unsynced,
+        classroom_external_id: classroom.classroom_external_id,
+        user_external_id: student2.user_external_id(canvas_instance: canvas_instance)
+      )
+    end
+
+    describe '#unsynced_students' do
+      it { expect(subject.unsynced_students).to match_array [student2] }
+    end
+
+    describe '#synced_status' do
+      it { expect(subject.synced_status(student1.attributes)).to eq true }
+      it { expect(subject.synced_status(student2.attributes)).to eq false }
+      it { expect(subject.synced_status(student3.attributes)).to eq nil }
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2095,5 +2095,38 @@ describe User, type: :model do
       end
     end
   end
+
+  describe '.find_by_canvas_user_external_ids' do
+    subject { described_class.find_by_canvas_user_external_ids(user_external_ids) }
+
+    context 'user_external_ids is nil' do
+      let(:user_external_ids) { nil }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'user_external_ids is empty' do
+      let(:user_external_ids) { [] }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'user_external_ids is not empty' do
+      context 'canvas_accounts do not exist' do
+        let(:user_external_ids) { [CanvasAccount.build_user_external_id(0, 0)] }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'canvas_accounts exist' do
+        let(:canvas_account1) { create(:canvas_account) }
+        let(:canvas_account2) { create(:canvas_account) }
+        let(:user_external_ids) { [canvas_account1.user_external_id, canvas_account2.user_external_id] }
+
+        it { is_expected.to match_array [canvas_account1.user, canvas_account2.user] }
+      end
+
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
@@ -67,7 +67,7 @@ module CanvasIntegration
       let(:url) { canvas_instance.url }
       let(:email)  { Faker::Internet.email }
       let(:external_id) { Faker::Number.number }
-      let(:name) { Faker::Name.name }
+      let(:name) { Faker::Name.custom_name }
       let(:ext_roles) { CanvasIntegration::RoleExtractor::INSTRUCTOR_ROLE }
 
       context 'existing user' do

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_creator_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_creator_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::ClassroomCreator do
+  let(:teacher_id) { create(:teacher).id }
+  let(:classroom_external_id) { CanvasClassroom.build_classroom_external_id(canvas_instance_id, external_id) }
+  let(:name) { 'canvas classroom' }
+  let(:canvas_instance_id) { create(:canvas_instance).id }
+  let(:external_id) { Faker::Number.number }
+
+  let(:data) { { classroom_external_id: classroom_external_id, name: name, teacher_id: teacher_id } }
+
+  subject { described_class.run(data) }
+
+  it { expect(subject.classroom_external_id).to eq classroom_external_id }
+  it { expect(subject.name).to eq name }
+  it { expect(subject.synced_name).to eq name }
+
+  it { expect { subject }.to change(ClassroomsTeacher, :count).from(0).to(1) }
+
+  context 'canvas_instance does not exist' do
+    let(:canvas_instance_id) { 0 }
+
+    it { expect { subject }.to raise_error(described_class::CanvasInstanceNotFoundError) }
+  end
+
+  context "teacher owns another classroom with name #{name}" do
+    let(:classroom1) { create(:classroom, :from_canvas, :with_no_teacher, name: name) }
+
+    before { create(:classrooms_teacher, user_id: teacher_id, classroom: classroom1) }
+
+    it { expect(subject.classroom_external_id).to eq classroom_external_id }
+    it { expect(subject.name).to eq "#{name}_1" }
+    it { expect(subject.synced_name).to eq name }
+
+    it { expect { subject }.to change(ClassroomsTeacher, :count).from(1).to(2) }
+
+    context "teacher owns other classrooms with names #{name}_1, ... #{name}_max" do
+      let(:max) { ::DuplicateNameResolver::MAX_BEFORE_RANDOMIZED }
+
+      before do
+        2.upto(max) do |n|
+          classroom = create(:classroom, :from_canvas, :with_no_teacher, name: "name_#{n}")
+          create(:classrooms_teacher, user_id: teacher_id, classroom: classroom)
+        end
+      end
+
+      it "stops naming duplicates at max and then starts using random values" do
+        expect(subject.name).not_to eq "#{name}_11"
+      end
+
+      it { expect { subject }.to change(ClassroomsTeacher, :count).from(max).to(11) }
+    end
+  end
+
+  context 'nil name' do
+    let(:name) { nil }
+
+    it { expect(subject.classroom_external_id).to eq classroom_external_id }
+    it { expect(subject.name).to eq "Classroom #{classroom_external_id}" }
+    it { expect(subject.synced_name).to eq name }
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_importer_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_importer_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::ClassroomImporter do
+  let(:teacher) { create(:teacher) }
+  let(:name) { 'canvas classroom' }
+  let(:classroom_external_id) { CanvasClassroom.build_classroom_external_id(canvas_instance_id, external_id) }
+
+  let(:data) do
+    {
+      classroom_external_id: classroom_external_id,
+      name: name,
+      teacher_id: teacher.id
+    }
+  end
+
+  subject { described_class.run(data) }
+
+  context 'classroom exists' do
+    let(:synced_name) { "original #{name}"}
+    let!(:classroom) { create(:classroom, :from_canvas, synced_name: synced_name) }
+
+    let(:canvas_classroom) { classroom.canvas_classroom }
+    let(:canvas_instance_id) { canvas_classroom.canvas_instance_id }
+    let(:external_id) { canvas_classroom.external_id }
+
+    it { expect { subject }.to(change { classroom.reload.synced_name }.from(synced_name).to(name)) }
+  end
+
+  context 'classroom does not exist' do
+    let(:canvas_instance_id) { create(:canvas_instance).id }
+    let(:external_id) { Faker::Number.number }
+
+    it { expect { subject }.to change(Classroom, :count).from(0).to(1) }
+    it { expect { subject }.to change(ClassroomsTeacher, :count).from(0).to(1) }
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_student_importer_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_student_importer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CanvasIntegration::ClassroomStudentImporter do
+  subject { described_class.run(data) }
+
+  let(:classroom) { create(:classroom, :from_canvas) }
+  let(:canvas_instance) { classroom.canvas_instance }
+  let(:external_id) { Faker::Number.number }
+  let(:user_external_id) { CanvasAccount.build_user_external_id(canvas_instance.id, external_id) }
+  let(:email) { Faker::Internet.email }
+  let(:name) { Faker::Name.custom_name }
+
+  let(:data) do
+    {
+      classroom: classroom,
+      email: email,
+      name: name,
+      user_external_id: user_external_id
+    }
+  end
+
+  context 'student with canvas_account containing user_external_id exists' do
+    let(:student) { create(:student) }
+
+    before { create(:canvas_account, canvas_instance: canvas_instance, external_id: external_id, user: student) }
+
+    it { expect { subject }.not_to change(User.student, :count) }
+    it { expect { subject }.not_to change(CanvasAccount, :count) }
+    it { expect { subject }.to change(StudentsClassrooms, :count).by(1) }
+  end
+
+  context 'student with email exists' do
+    before { create(:student, email: email) }
+
+    it { expect { subject }.not_to change(User.student, :count) }
+    it { expect { subject }.to change(CanvasAccount, :count).by(1) }
+    it { expect { subject }.to change(StudentsClassrooms, :count).by(1) }
+  end
+
+  context 'no student with canvas_account containing user_external_id nor with email exists' do
+    it { expect { subject }.to change(User.student, :count).by(1) }
+    it { expect { subject }.to change(CanvasAccount, :count).by(1) }
+    it { expect { subject }.to change(StudentsClassrooms, :count).by(1) }
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_students_data_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_students_data_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::ClassroomStudentsData do
+  subject { described_class.new(classroom, client) }
+
+  let(:classroom) { create(:classroom, :from_canvas) }
+  let(:client) { double('client') }
+  let(:canvas_classroom) { classroom.canvas_classroom }
+  let(:classroom_external_id) { canvas_classroom.external_id }
+  let(:canvas_instance_id) { canvas_classroom.canvas_instance_id }
+
+  let(:student1_data) { create(:canvas_student_payload).deep_symbolize_keys }
+  let(:student1_attrs) { CanvasIntegration::StudentDataAdapter.run(canvas_instance_id, student1_data) }
+
+  let(:student2_data) { create(:canvas_student_payload).deep_symbolize_keys }
+  let(:student2_attrs) { CanvasIntegration::StudentDataAdapter.run(canvas_instance_id, student2_data) }
+
+  let(:students_data) { [student1_attrs, student2_attrs] }
+  let(:classroom_students_data) { students_data.map { |attrs| attrs.merge(classroom: classroom) } }
+
+  before { allow(client).to receive(:classroom_students).with(classroom_external_id).and_return(students_data) }
+
+  it { expect(subject.to_a).to match_array classroom_students_data }
+  it { expect(subject.classroom_external_id).to eq classroom.classroom_external_id }
+end
+
+

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_students_importer_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_students_importer_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::ClassroomStudentsImporter do
+  let(:classroom) { create(:classroom, :from_canvas) }
+  let(:canvas_classroom) { classroom.canvas_classroom }
+  let(:canvas_instance_id) { canvas_classroom.canvas_instance_id }
+  let(:classroom_external_id) { canvas_classroom.external_id }
+  let(:classroom_students_data) { CanvasIntegration::ClassroomStudentsData.new(classroom, client) }
+  let(:client) { double(:canvas_client) }
+
+  before { allow(client).to receive(:classroom_students).with(classroom_external_id).and_return(students_data) }
+
+  subject { described_class.run(classroom_students_data) }
+
+  context 'classroom_students_data is nil' do
+    let(:students_data) { nil }
+
+    it { expect { subject }.not_to change(User.student, :count) }
+    it { expect { subject }.not_to change(StudentsClassrooms, :count) }
+    it { expect { subject }.not_to change(CanvasClassroomUser, :count) }
+  end
+
+  context 'classroom_students_data is empty' do
+    let(:students_data) { [] }
+
+    it { expect { subject }.not_to change(User.student, :count) }
+    it { expect { subject }.not_to change(StudentsClassrooms, :count) }
+    it { expect { subject }.not_to change(CanvasClassroomUser, :count) }
+  end
+
+  context 'classroom_students_data has two students' do
+    let(:students_data) { [student1_attrs, student2_attrs] }
+
+    let(:student1_data) { create(:canvas_student_payload).deep_symbolize_keys }
+    let(:student1_attrs) { CanvasIntegration::StudentDataAdapter.run(canvas_instance_id, student1_data) }
+
+    let(:student2_data) { create(:canvas_student_payload).deep_symbolize_keys }
+    let(:student2_attrs) { CanvasIntegration::StudentDataAdapter.run(canvas_instance_id, student2_data) }
+
+    it { expect { subject }.to change(User.student, :count).from(0).to(2) }
+    it { expect { subject }.to change(StudentsClassrooms, :count).from(0).to(2) }
+    it { expect { subject }.to change(CanvasClassroomUser, :count).from(0).to(2) }
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_updater_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_updater_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::ClassroomUpdater do
+  let(:teacher) { create(:teacher) }
+  let!(:classroom) { create(:classroom, :from_canvas, name: name, synced_name: synced_name) }
+
+  let(:data) { { name: data_name, teacher_id: teacher.id } }
+
+  subject { described_class.run(classroom, data) }
+
+  context 'no custom classroom name' do
+    let(:name) { 'canvas classroom' }
+    let(:synced_name) { name }
+
+    context 'name on Canvas has not changed' do
+      let(:data_name) { synced_name }
+
+      it { expect(subject.name).to eq name }
+      it { expect(subject.synced_name).to eq synced_name }
+    end
+
+    context 'name on Canvas changed' do
+      let(:data_name) { "Renamed on Quill#{synced_name}" }
+
+      it { expect(subject.name).to eq data_name }
+      it { expect(subject.synced_name).to eq data_name }
+    end
+  end
+
+  context 'custom classroom name' do
+    let(:name) { "Renamed on Quill#{synced_name}" }
+    let(:synced_name) { 'Canvas Classroom' }
+
+    context 'name on Canvas has not changed' do
+      let(:data_name) { synced_name }
+
+      it { expect(subject.name).to eq name }
+      it { expect(subject.synced_name).to eq synced_name }
+    end
+
+    context 'name on Canvas has changed' do
+      let(:data_name) { "renamed on Canvas #{synced_name}" }
+
+      it { expect(subject.name).to eq name }
+      it { expect(subject.synced_name).to eq data_name }
+    end
+  end
+
+  context 'classrooms_teacher associations' do
+    let(:name) { 'canvas classroom' }
+    let(:synced_name) { name }
+    let(:data_name) { synced_name }
+
+    before { ClassroomsTeacher.where(classroom: classroom).delete_all }
+
+    context 'classroom has no owner or coteachers' do
+      it  { expect(subject.owner).to eq teacher }
+    end
+
+    context 'teacher owns classroom' do
+      before { create(:classrooms_teacher, classroom: classroom, user: teacher) }
+
+      it  { expect(subject.owner).to eq teacher }
+    end
+
+    context 'another teacher owns classroom' do
+      before { create(:classrooms_teacher, classroom: classroom) }
+
+      it { expect(subject.coteachers.first).to eq teacher }
+    end
+
+    context 'teacher is coteacher but no owner exists' do
+      before { create(:coteacher_classrooms_teacher, classroom: classroom, user: teacher) }
+
+      it { expect(subject.coteachers.first).to eq teacher }
+      it { expect(subject.owner).to_not eq teacher }
+    end
+  end
+
+  context "teacher owns another classroom with other_name" do
+    let(:other_name) { 'other canvas_classroom classroom' }
+    let(:classroom1) { create(:classroom, :from_canvas, :with_no_teacher, name: other_name) }
+
+    let(:name) { 'canvas_classroom classroom'}
+    let(:synced_name) { name }
+    let(:data_name) { other_name }
+
+    before { create(:classrooms_teacher, user_id: teacher.id, classroom: classroom1) }
+
+    it 'renames a name with duplicate if there is a collision' do
+      expect(subject.name).to eq "#{other_name}_1"
+    end
+
+    context 'teacher owns other classrooms with names other_name1, ... other_name_[max]' do
+      let(:max) { ::DuplicateNameResolver::MAX_BEFORE_RANDOMIZED }
+
+      before do
+        2.upto(max) do |n|
+          classroom = create(:classroom, :from_canvas, :with_no_teacher, name: "#{other_name}_#{n}")
+          create(:classrooms_teacher, user_id: teacher.id, classroom: classroom)
+        end
+      end
+
+      it "stops naming duplicates at max and then starts using random values" do
+        expect(subject.name).not_to eq "#{other_name}_11"
+        expect(subject.name.starts_with?(other_name)).to be true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/rest_client_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/rest_client_spec.rb
@@ -3,17 +3,19 @@
 require 'rails_helper'
 
 describe CanvasIntegration::RestClient do
-  subject { described_class.new(canvas_auth_credential) }
+  let(:rest_client) { described_class.new(canvas_auth_credential) }
 
   let(:canvas_auth_credential) { create(:canvas_auth_credential) }
   let(:canvas_instance) { canvas_auth_credential.canvas_instance }
   let(:canvas_api) { double(::LMS::Canvas) }
-  let(:courses_response) { double(HTTParty::Response, body: courses_data.to_json) }
 
   before { allow(::LMS::Canvas).to receive(:new).and_return(canvas_api) }
 
   describe '#teacher_classrooms' do
+    subject { rest_client.teacher_classrooms }
+
     let(:courses_path) { described_class::COURSES_PATH }
+    let(:courses_response) { double(HTTParty::Response, body: courses_data.to_json) }
 
     before { allow(canvas_api).to receive(:api_get_request).with(courses_path).and_return(courses_response) }
 
@@ -21,23 +23,88 @@ describe CanvasIntegration::RestClient do
       let(:courses_data) { [] }
       let(:classrooms) { [] }
 
-      it { expect(subject.teacher_classrooms).to eq(canvas_instance_id: canvas_instance.id, classrooms: classrooms) }
+      it { is_expected.to eq(classrooms: classrooms) }
     end
 
     context 'one classroom' do
-      let(:course_data) { create(:canvas_course_data) }
+      let(:course_data) { create(:canvas_course_payload) }
       let(:courses_data) { [course_data] }
+      let(:course_id) { course_data['id'] }
+      let(:course_name) { course_data['name'] }
 
-      let(:section_data) { create(:canvas_section_data, id: course_data['id'], name: course_data['name']) }
+      let(:section_data) { create(:canvas_section_payload, id: course_id, name: course_name) }
       let(:sections_data) { [section_data] }
-      let(:sections_path) { "#{courses_path}/#{course_data['id']}/sections?include[]=students" }
+      let(:sections_path) { "#{courses_path}/#{course_id}/sections?include[]=students" }
       let(:sections_response) { double(HTTParty::Response, body: sections_data.to_json) }
 
-      let(:classrooms) { [{name: course_data['name'], external_classroom_id: course_data['id'], students: []}] }
+      let(:already_imported) { false }
+      let(:classroom_external_id) { CanvasClassroom.build_classroom_external_id(canvas_instance.id, course_id) }
+
+      let(:classroom) do
+        {
+          alreadyImported: already_imported,
+          classroom_external_id: classroom_external_id,
+          name: course_name,
+          students: []
+        }
+      end
 
       before { allow(canvas_api).to receive(:api_get_request).with(sections_path).and_return(sections_response) }
 
-      it { expect(subject.teacher_classrooms).to eq(canvas_instance_id: canvas_instance.id, classrooms: classrooms) }
+      it { is_expected.to eq(classrooms: [classroom]) }
+
+      context 'classroom already imported' do
+        let(:already_imported) { true }
+
+        before { create(:canvas_classroom, canvas_instance_id: canvas_instance.id, external_id: section_data['id']) }
+
+        it { is_expected.to eq(classrooms: [classroom]) }
+      end
+    end
+  end
+
+  describe '#classroom_students' do
+    subject { rest_client.classroom_students(section_id) }
+
+    let(:sections_path) { described_class::SECTIONS_PATH }
+    let(:section_path) { "#{sections_path}/#{section_id}?include[]=students" }
+    let(:section_response) { double(HTTParty::Response, body: section_data.to_json) }
+
+    before { allow(canvas_api).to receive(:api_get_request).with(section_path).and_return(section_response) }
+
+    context 'no students' do
+      let(:section_id) { 0 }
+      let(:section_data) { {} }
+      let(:students) { [] }
+
+      it { is_expected.to eq(students: students) }
+    end
+
+    context 'one section with students' do
+      let(:course_data) { create(:canvas_course_payload) }
+
+      let(:section_id) { course_data['id'] }
+      let(:section_name) { course_data['name'] }
+      let(:section_data) { create(:canvas_section_payload, id: section_id, name: section_name, students: [student_data]) }
+
+      let(:student_data) { create(:canvas_student_payload) }
+      let(:student_id) { student_data['id'] }
+      let(:student_email) { student_data['login_id'] }
+      let(:student_name) { student_data['name'] }
+
+      let(:user_external_id) { CanvasAccount.build_user_external_id(canvas_instance.id, student_id) }
+
+      let(:student) do
+        {
+          email: student_email,
+          name: student_name,
+          user_external_id: user_external_id
+        }
+      end
+
+      before { allow(canvas_api).to receive(:api_get_request).with(section_path).and_return(section_response) }
+
+      it { is_expected.to eq(students: [student]) }
     end
   end
 end

--- a/services/QuillLMS/spec/services/canvas_integration/student_creator_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/student_creator_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CanvasIntegration::StudentCreator do
+  subject { described_class.run(data) }
+
+  let(:user_external_id) { CanvasAccount.build_user_external_id(canvas_instance.id, external_id) }
+  let(:canvas_instance) { create(:canvas_instance) }
+  let(:external_id) { Faker::Number.number }
+  let(:email) { Faker::Internet.email }
+  let(:name) { Faker::Name.custom_name }
+
+  let(:data) do
+    {
+      email: email,
+      name: name,
+      user_external_id: user_external_id
+    }
+  end
+
+  let(:canvas_account) { subject.canvas_accounts.first }
+
+  it { expect { subject }.to change(User, :count).from(0).to(1) }
+  it { expect { subject }.to change(CanvasAccount, :count).from(0).to(1) }
+
+  it { expect(subject.canvas_accounts.count).to eq 1 }
+
+  it { expect(canvas_account.user_external_id).to eq user_external_id }
+  it { expect(canvas_account.canvas_instance).to eq canvas_instance }
+  it { expect(canvas_account.external_id).to eq external_id }
+  it { expect(canvas_account.user).to eq subject }
+
+  it { expect(subject.email).to eq email }
+  it { expect(subject.name).to eq name }
+
+  it { expect(subject).to be_student }
+end

--- a/services/QuillLMS/spec/services/canvas_integration/student_data_adapter_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/student_data_adapter_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::StudentDataAdapter do
+  subject { described_class.run(canvas_instance_id, student_data) }
+
+  let(:canvas_instance_id) { create(:canvas_instance).id }
+  let(:student_data) { create(:canvas_student_payload).deep_symbolize_keys }
+
+  let(:name) { student_data[:name] }
+  let(:email) { student_data[:login_id] }
+  let(:external_id) { student_data[:id] }
+  let(:user_external_id) { CanvasAccount.build_user_external_id(canvas_instance_id, external_id) }
+
+  let(:student_attrs) do
+    {
+      email: email,
+      name: name,
+      user_external_id: user_external_id
+    }
+  end
+
+  it { expect(subject).to eq student_attrs }
+
+  context 'with uppercase email' do
+    before { student_data[:login_id] = email.upcase }
+
+    it { expect(subject).to eq student_attrs }
+  end
+
+  context 'with invalid email' do
+    let(:email) { nil }
+
+    before { student_data[:login_id] = 'not-a-valid-email' }
+
+    it { expect(subject).to eq student_attrs }
+  end
+end
+

--- a/services/QuillLMS/spec/services/canvas_integration/student_updater_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/student_updater_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CanvasIntegration::StudentUpdater do
+  subject { described_class.run(student, data) }
+
+  let(:student) { create(:student, :with_canvas_account) }
+  let(:canvas_account) { student.canvas_accounts.first }
+  let(:user_external_id) { canvas_account.user_external_id }
+  let(:email) { student.email }
+  let(:name) { student.name }
+
+  let(:data) do
+    {
+      email: email,
+      name: name,
+      user_external_id: user_external_id
+    }
+  end
+
+  context 'student has no email' do
+    before { student.update(email: nil) }
+
+    context 'nil email provided' do
+      let(:email) { nil }
+
+      it { expect { subject }.to_not change(student, :email) }
+    end
+
+    context 'another user has email' do
+      let(:email) { Faker::Internet.email }
+
+      before { create(:student, email: email) }
+
+      it { expect { subject }.to_not change(student, :email) }
+    end
+
+    context 'provided email is new and not taken' do
+      let(:email) { Faker::Internet.email }
+
+      it { expect { subject }.to change(student, :email).to(email) }
+    end
+  end
+
+  context 'student has email' do
+    context 'nil email provided' do
+      let(:email) { nil }
+
+      it { expect { subject }.to_not change(student, :email) }
+    end
+
+    context 'initial_email and email are the same' do
+      it { expect { subject }.to_not change(student, :email) }
+
+      it do
+        expect(User).not_to receive(:exists?).with(email: email)
+        subject
+      end
+    end
+
+    context 'another user has email' do
+      let(:email) { Faker::Internet.email }
+
+      before { create(:student, email: email) }
+
+      it { expect { subject }.to_not change(student, :email) }
+    end
+
+    context 'provided email is new and not taken' do
+      let(:email) { Faker::Internet.email }
+
+      it { expect { subject }.to change(student, :email).to(email) }
+    end
+  end
+
+  context 'nil name provided' do
+    let(:name) { nil }
+
+    it { expect { subject }.to_not change(student, :name) }
+  end
+
+  context 'new name provided' do
+    let(:name) { Faker::Name.custom_name }
+
+    it { expect { subject }.to change(student, :name).to(name) }
+  end
+
+  context 'account type is not canvas' do
+    before { student.update(account_type: nil) }
+
+    it { expect { subject }.to change(student, :account_type).to(User::CANVAS_ACCOUNT) }
+  end
+
+  context 'clever_id is present' do
+    before { student.update(clever_id: Faker::Number.number) }
+
+    it { expect { subject }.to change(student, :clever_id).to(nil) }
+  end
+
+  context 'google_id is present' do
+    before { student.update(google_id: Faker::Number.number) }
+
+    it { expect { subject }.to change(student, :google_id).to(nil) }
+  end
+
+  context 'role is not student' do
+    before { student.update(role: User::TEACHER) }
+
+    it { expect { subject }.to change(student, :role).to(User::STUDENT) }
+  end
+
+  context 'signed_up_with_google is true' do
+    before { student.update(signed_up_with_google: true) }
+
+    it { expect { subject }.to change(student, :signed_up_with_google).to(false) }
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/teacher_classrooms_students_importer_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/teacher_classrooms_students_importer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::TeacherClassroomsStudentsImporter do
+  subject { described_class.run(teacher, classroom_ids) }
+
+  let(:canvas_classroom) { create(:classroom, :from_canvas) }
+  let(:teacher) { canvas_classroom.owner }
+
+  let(:non_canvas_classroom) do
+    create(:classrooms_teacher, classroom: create(:classroom, :with_no_teacher), user: teacher).classroom
+  end
+
+  let(:classroom_ids) { [canvas_classroom.id, non_canvas_classroom.id] }
+
+  let(:client) { double(:client) }
+  let(:classroom_students_data) { double(:classroom_students_data) }
+
+  before do
+    allow(CanvasIntegration::ClassroomStudentsData)
+    .to receive(:new)
+    .with(canvas_classroom, client)
+    .and_return(classroom_students_data)
+  end
+
+  it 'runs the importer only on canvas classrooms' do
+    expect(CanvasIntegration::ClientFetcher).to receive(:run).with(teacher).and_return(client)
+    expect(CanvasIntegration::ClassroomStudentsImporter).to receive(:run).with(classroom_students_data)
+    subject
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/teacher_imported_classrooms_updater_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/teacher_imported_classrooms_updater_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::TeacherImportedClassroomsUpdater do
+  subject { described_class.run(user) }
+
+  let(:imported_classroom) { create(:classroom, :from_canvas) }
+  let(:canvas_classroom) { imported_classroom.canvas_classroom }
+  let(:user) { imported_classroom.owner }
+
+  let(:canvas_instance_id) { canvas_classroom.canvas_instance_id }
+  let(:new_external_id) { Faker::Number.number }
+  let(:new_classroom_external_id) { CanvasClassroom.build_classroom_external_id(canvas_instance_id, new_external_id) }
+
+  let(:updated_name) { "new_#{imported_classroom.name}"}
+
+  let(:data) do
+    {
+      classrooms: [
+        { classroom_external_id: canvas_classroom.classroom_external_id, name: updated_name },
+        { classroom_external_id: new_classroom_external_id }
+      ]
+    }.to_json
+  end
+
+  it 'updates only previously imported classrooms that have canvas_classroom_id' do
+    expect(CanvasIntegration::TeacherClassroomsCache)
+      .to receive(:read)
+      .with(user.id)
+      .and_return(data)
+
+    expect(CanvasIntegration::ImportTeacherClassroomsStudentsWorker)
+      .to receive(:perform_async)
+      .with(user.id, [imported_classroom.id])
+
+    subject
+
+    expect(Classroom.count).to eq 1
+    expect(imported_classroom.reload.synced_name).to eq updated_name
+  end
+end

--- a/services/QuillLMS/spec/services/canvas_integration/user_importer_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/user_importer_spec.rb
@@ -19,7 +19,7 @@ describe CanvasIntegration::UserImporter do
 
   let(:email) { Faker::Internet.email }
   let(:external_id) { Faker::Number.number }
-  let(:name) { Faker::Name.name }
+  let(:name) { Faker::Name.custom_name }
   let(:role) { User::TEACHER }
   let(:url) { canvas_instance.url }
 

--- a/services/QuillLMS/spec/services/provider_classrooms_with_unsynced_students_finder_spec.rb
+++ b/services/QuillLMS/spec/services/provider_classrooms_with_unsynced_students_finder_spec.rb
@@ -36,28 +36,28 @@ RSpec.describe ProviderClassroomsWithUnsyncedStudentsFinder do
 
       create(
         :google_classroom_user,
-        user_external_id: synced_student1.google_id,
-        classroom_external_id: classroom_i_own.classroom_external_id
+        classroom_external_id: classroom_i_own.classroom_external_id,
+        user_external_id: synced_student1.user_external_id
       )
 
       create(
         :google_classroom_user,
         :deleted,
-        user_external_id: unsynced_student1.google_id,
-        classroom_external_id: classroom_i_own.classroom_external_id
+        classroom_external_id: classroom_i_own.classroom_external_id,
+        user_external_id: unsynced_student1.user_external_id
+      )
+
+      create(
+        :google_classroom_user,
+        classroom_external_id: another_classroom_i_own.classroom_external_id,
+        user_external_id: synced_student2.user_external_id
       )
 
       create(
         :google_classroom_user,
         :deleted,
-        user_external_id: unsynced_student2.google_id,
-        classroom_external_id: classroom_i_coteach.classroom_external_id
-      )
-
-      create(
-        :google_classroom_user,
-        user_external_id: synced_student2.google_id,
-        classroom_external_id: another_classroom_i_own.classroom_external_id
+        classroom_external_id: classroom_i_coteach.classroom_external_id,
+        user_external_id: unsynced_student2.user_external_id
       )
     end
 
@@ -83,28 +83,103 @@ RSpec.describe ProviderClassroomsWithUnsyncedStudentsFinder do
 
       create(
         :clever_classroom_user,
-        :deleted,
         classroom_external_id: classroom_i_own.classroom_external_id,
-        user_external_id: unsynced_student1.clever_id
+        user_external_id: synced_student1.user_external_id
       )
 
       create(
         :clever_classroom_user,
+        :deleted,
         classroom_external_id: classroom_i_own.classroom_external_id,
-        user_external_id: synced_student1.clever_id
+        user_external_id: unsynced_student1.user_external_id
+      )
+
+      create(
+        :clever_classroom_user,
+        classroom_external_id: another_classroom_i_own.classroom_external_id,
+        user_external_id: synced_student2.user_external_id
       )
 
       create(
         :clever_classroom_user,
         :deleted,
         classroom_external_id: classroom_i_coteach.classroom_external_id,
-        user_external_id: synced_student2.clever_id
+        user_external_id: unsynced_student2.user_external_id
+      )
+    end
+
+    it 'returns only owned provider classrooms that have unsynced students' do
+      expect(subject).to eq [classroom_i_own]
+    end
+  end
+
+  context 'teacher has canvas classrooms' do
+    let(:canvas_instance) { create(:canvas_instance) }
+    let(:teacher) { create(:teacher, :with_canvas_account, canvas_instance: canvas_instance) }
+    let(:classroom_i_own) do
+      create(
+        :classroom,
+        :from_canvas,
+        :with_no_teacher,
+        canvas_instance: canvas_instance,
+        students: [unsynced_student1, synced_student1]
+      )
+    end
+
+    let(:another_classroom_i_own) do
+      create(
+        :classroom,
+        :from_canvas,
+        :with_no_teacher,
+        canvas_instance: canvas_instance,
+        students: [synced_student2]
+      )
+    end
+
+    let(:classroom_i_coteach) do
+      create(
+       :classroom,
+       :from_canvas,
+       canvas_instance: canvas_instance,
+       students: [unsynced_student2, another_student]
+      )
+    end
+
+    let(:unsynced_student1) { create(:student, :with_canvas_account, canvas_instance: canvas_instance) }
+    let(:unsynced_student2) { create(:student, :with_canvas_account, canvas_instance: canvas_instance) }
+    let(:synced_student1) { create(:student, :with_canvas_account, canvas_instance: canvas_instance) }
+    let(:synced_student2) { create(:student, :with_canvas_account, canvas_instance: canvas_instance) }
+    let(:another_student) { create(:student, :with_canvas_account, canvas_instance: canvas_instance) }
+
+    before do
+      create(:classrooms_teacher, user: teacher, classroom: classroom_i_own)
+      create(:classrooms_teacher, user: teacher, classroom: another_classroom_i_own)
+      create(:coteacher_classrooms_teacher, user: teacher, classroom: classroom_i_coteach)
+
+      create(
+        :canvas_classroom_user,
+        :deleted,
+        classroom_external_id: classroom_i_own.classroom_external_id,
+        user_external_id: unsynced_student1.user_external_id(canvas_instance: canvas_instance)
       )
 
       create(
-        :clever_classroom_user,
+        :canvas_classroom_user,
+        classroom_external_id: classroom_i_own.classroom_external_id,
+        user_external_id: synced_student1.user_external_id(canvas_instance: canvas_instance)
+      )
+
+      create(
+        :canvas_classroom_user,
         classroom_external_id: another_classroom_i_own.classroom_external_id,
-        user_external_id: synced_student2.clever_id
+        user_external_id: unsynced_student2.user_external_id(canvas_instance: canvas_instance)
+      )
+
+      create(
+        :canvas_classroom_user,
+        :deleted,
+        classroom_external_id: classroom_i_coteach.classroom_external_id,
+        user_external_id: synced_student2.user_external_id(canvas_instance: canvas_instance)
       )
     end
 

--- a/services/QuillLMS/spec/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CanvasIntegration::HydrateTeacherClassroomsCacheWorker do
+  subject { described_class.new.perform(user_id) }
+
+  context 'nil user_id' do
+    let(:user_id) { nil }
+
+    it { should_not_run_hydrator }
+  end
+
+  context 'user does not exist' do
+    let(:user_id) { 0 }
+
+    it { should_not_run_hydrator }
+  end
+
+  context 'user exists' do
+    let(:user_id) { create(:student).id }
+
+    it { should_not_run_hydrator }
+  end
+
+  context 'user is not canvas authorized' do
+    let(:user_id) { create(:teacher, :with_canvas_account).id }
+
+    it { should_not_run_hydrator }
+  end
+
+  context 'user is canvas authorized' do
+    let(:user) { create(:canvas_auth_credential).user }
+    let(:user_id) { user.id }
+
+    it { should_run_hydrator }
+  end
+
+  def should_run_hydrator
+    expect(CanvasIntegration::TeacherClassroomsCacheHydrator).to receive(:run).with(user)
+    subject
+  end
+
+  def should_not_run_hydrator
+    expect(CanvasIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
+    subject
+  end
+end

--- a/services/QuillLMS/spec/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker_spec.rb
@@ -8,41 +8,28 @@ describe CanvasIntegration::HydrateTeacherClassroomsCacheWorker do
   context 'nil user_id' do
     let(:user_id) { nil }
 
-    it { should_not_run_hydrator }
+    it do
+      expect(CanvasIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
+      subject
+    end
   end
 
   context 'user does not exist' do
     let(:user_id) { 0 }
 
-    it { should_not_run_hydrator }
+    it do
+      expect(CanvasIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
+      subject
+    end
   end
 
   context 'user exists' do
-    let(:user_id) { create(:student).id }
-
-    it { should_not_run_hydrator }
-  end
-
-  context 'user is not canvas authorized' do
-    let(:user_id) { create(:teacher, :with_canvas_account).id }
-
-    it { should_not_run_hydrator }
-  end
-
-  context 'user is canvas authorized' do
-    let(:user) { create(:canvas_auth_credential).user }
+    let(:user) { create(:teacher) }
     let(:user_id) { user.id }
 
-    it { should_run_hydrator }
-  end
-
-  def should_run_hydrator
-    expect(CanvasIntegration::TeacherClassroomsCacheHydrator).to receive(:run).with(user)
-    subject
-  end
-
-  def should_not_run_hydrator
-    expect(CanvasIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
-    subject
+    it do
+      expect(CanvasIntegration::TeacherClassroomsCacheHydrator).to receive(:run).with(user)
+      subject
+    end
   end
 end

--- a/services/QuillLMS/spec/workers/canvas_integration/import_teacher_classrooms_students_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/canvas_integration/import_teacher_classrooms_students_worker_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanvasIntegration::ImportTeacherClassroomsStudentsWorker do
+  subject { described_class.new }
+
+  let(:teacher) { create(:teacher, :with_canvas_account) }
+  let(:selected_classroom_ids) { [123, 456] }
+  let(:importer_class) { CanvasIntegration::TeacherClassroomsStudentsImporter }
+
+  it 'should report an error with nil teacher_id' do
+    expect(ErrorNotifier).to receive(:report).with(ActiveRecord::RecordNotFound)
+    subject.perform(nil)
+  end
+
+  it 'should report an error with not bad teacher_id' do
+    expect(ErrorNotifier).to receive(:report).with(ActiveRecord::RecordNotFound)
+    subject.perform(0)
+  end
+
+  it 'should not run importer when teacher is unauthorized' do
+    expect(importer_class).to_not receive(:run)
+    subject.perform(teacher.id)
+  end
+
+  context 'teacher is canvas authorized' do
+    before { create(:canvas_auth_credential, user: teacher) }
+
+    it 'should run importing with valid teacher id and no selected_classroom_ids' do
+      expect(importer_class).to receive(:run).with(teacher, nil)
+      subject.perform(teacher.id)
+    end
+
+    it 'should run importing with valid teacher id and selected_classroom_ids' do
+      expect(importer_class).to receive(:run).with(teacher, selected_classroom_ids)
+      subject.perform(teacher.id, selected_classroom_ids)
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/canvas_integration/update_teacher_imported_classrooms_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/canvas_integration/update_teacher_imported_classrooms_worker_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CanvasIntegration::UpdateTeacherImportedClassroomsWorker do
+  subject { described_class.new.perform(user_id) }
+
+  context 'nil user_id' do
+    let(:user_id) { nil }
+
+    it { should_not_run_service_objects }
+  end
+
+  context 'user does not exist' do
+    let(:user_id) { 0 }
+
+    it { should_not_run_service_objects }
+  end
+
+  context 'user exists' do
+    let(:user) { create(:teacher, :with_canvas_account) }
+    let(:user_id) { user.id }
+
+    context 'with no auth_credential' do
+      it { should_not_run_service_objects }
+    end
+
+    context 'with auth_credential' do
+      before { create(:canvas_auth_credential, user: user) }
+
+      it { should_run_service_objects }
+    end
+  end
+
+  def should_not_run_service_objects
+    expect(CanvasIntegration::TeacherClassroomsCacheHydrator).to_not receive(:run)
+    expect(CanvasIntegration::TeacherImportedClassroomsUpdater).to_not receive(:run)
+    subject
+  end
+
+  def should_run_service_objects
+    expect(CanvasIntegration::TeacherClassroomsCacheHydrator).to receive(:run).with(user)
+    expect(CanvasIntegration::TeacherImportedClassroomsUpdater).to receive(:run).with(user)
+    subject
+  end
+end


### PR DESCRIPTION
## WHAT
1.  Add CanvasController endpoints `import_classrooms', 'import_students' and 'retrieve_classrooms' via the same pattern in [Part 3](https://github.com/empirical-org/Empirical-Core/pull/10751) and [Part 4](https://github.com/empirical-org/Empirical-Core/pull/10753)
2.  Add processing for importing teacher_classrooms
3.  Add processing for importing classroom_students

## WHY
1.  Using the same endpoints make this code more flexible for future modifications
2.  Teacher classrooms data is used in the `import_classrooms` and `retrieve_classrooms` endpoints
3.   Classroom students data is used in the `import_students` endpoint

## HOW
1.  Use the same concerns from Google and Clever Rostering
2. Use the same processing for TeacherClassroomsData in Google and Clever
3. Use the same processing for ClassroomStudentsData in Google and Clever.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
