### PR TITLE
fix issue with create a class modal not being scrollable

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -1087,7 +1087,9 @@
   position: fixed !important;
   text-align: left;
   overflow: hidden;
+  max-height: 100vh;
   .create-a-class-modal-content {
+    max-height: 100vh;
     height: 100%;
     overflow-y: scroll;
     padding-bottom: 120px;


### PR DESCRIPTION
## WHAT
Fix issue with create a class modal not being scrollable.

## WHY
We want teachers to be able to see and use the whole thing effectively.

## HOW
Add max-heights to both the modal itself and the content.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Create-accounts-for-students-pop-up-form-loads-without-a-scrolling-bar-1eec1097101541db830e1f24a87a51ab

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - CSS change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES