### PR TITLE
Remove teacher_id from classrooms table

### DIFF
--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -15,7 +15,6 @@
 #  updated_at          :datetime
 #  clever_id           :string
 #  google_classroom_id :bigint
-#  teacher_id          :integer
 #
 # Indexes
 #
@@ -24,7 +23,6 @@
 #  index_classrooms_on_google_classroom_id  (google_classroom_id)
 #  index_classrooms_on_grade                (grade)
 #  index_classrooms_on_grade_level          (grade_level)
-#  index_classrooms_on_teacher_id           (teacher_id)
 #
 class Classroom < ApplicationRecord
   include CheckboxCallback

--- a/services/QuillLMS/app/serializers/classroom_serializer.rb
+++ b/services/QuillLMS/app/serializers/classroom_serializer.rb
@@ -15,7 +15,6 @@
 #  updated_at          :datetime
 #  clever_id           :string
 #  google_classroom_id :bigint
-#  teacher_id          :integer
 #
 # Indexes
 #
@@ -24,7 +23,6 @@
 #  index_classrooms_on_google_classroom_id  (google_classroom_id)
 #  index_classrooms_on_grade                (grade)
 #  index_classrooms_on_grade_level          (grade_level)
-#  index_classrooms_on_teacher_id           (teacher_id)
 #
 class ClassroomSerializer < ApplicationSerializer
   attributes :id, :name, :code, :grade, :updated_at

--- a/services/QuillLMS/app/services/google_integration/classroom_importer.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_importer.rb
@@ -13,15 +13,11 @@ module GoogleIntegration
     end
 
     private def classroom
-      ::Classroom.unscoped.find_by(google_classroom_id: google_classroom_id, teacher_id: teacher_id)
+      ::Classroom.unscoped.find_by(google_classroom_id: google_classroom_id)
     end
 
     private def google_classroom_id
       data[:google_classroom_id]
-    end
-
-    private def teacher_id
-      data[:teacher_id]
     end
   end
 end

--- a/services/QuillLMS/db/migrate/20230706155155_remove_teacher_id_from_classrooms.rb
+++ b/services/QuillLMS/db/migrate/20230706155155_remove_teacher_id_from_classrooms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveTeacherIdFromClassrooms < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :classrooms, :teacher_id, :integer
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1374,7 +1374,6 @@ CREATE TABLE public.classrooms (
     id integer NOT NULL,
     name character varying,
     code character varying,
-    teacher_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     clever_id character varying,
@@ -7921,13 +7920,6 @@ CREATE INDEX index_classrooms_on_grade_level ON public.classrooms USING btree (g
 
 
 --
--- Name: index_classrooms_on_teacher_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_classrooms_on_teacher_id ON public.classrooms USING btree (teacher_id);
-
-
---
 -- Name: index_classrooms_teachers_on_classroom_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10367,6 +10359,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230623154418'),
 ('20230630172652'),
 ('20230630173229'),
-('20230630184901');
+('20230630184901'),
+('20230706155155');
 
 

--- a/services/QuillLMS/spec/factories/classrooms.rb
+++ b/services/QuillLMS/spec/factories/classrooms.rb
@@ -15,7 +15,6 @@
 #  updated_at          :datetime
 #  clever_id           :string
 #  google_classroom_id :bigint
-#  teacher_id          :integer
 #
 # Indexes
 #
@@ -24,7 +23,6 @@
 #  index_classrooms_on_google_classroom_id  (google_classroom_id)
 #  index_classrooms_on_grade                (grade)
 #  index_classrooms_on_grade_level          (grade_level)
-#  index_classrooms_on_teacher_id           (teacher_id)
 #
 FactoryBot.define do
   factory :simple_classroom, class: Classroom do

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -15,7 +15,6 @@
 #  updated_at          :datetime
 #  clever_id           :string
 #  google_classroom_id :bigint
-#  teacher_id          :integer
 #
 # Indexes
 #
@@ -24,7 +23,6 @@
 #  index_classrooms_on_google_classroom_id  (google_classroom_id)
 #  index_classrooms_on_grade                (grade)
 #  index_classrooms_on_grade_level          (grade_level)
-#  index_classrooms_on_teacher_id           (teacher_id)
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/unit_activity_spec.rb
+++ b/services/QuillLMS/spec/models/unit_activity_spec.rb
@@ -93,10 +93,6 @@ describe UnitActivity, type: :model, redis: true do
   end
 
   describe 'gives a checkbox when the teacher' do
-    before do
-      classroom.update(teacher_id: teacher.id)
-    end
-
     it 'assigns a unit activity through a custom activity pack' do
       obj = Objective.create(name: 'Build Your Own Activity Pack')
       new_unit = Unit.create(name: 'There is no way a featured activity pack would have this name', user: teacher)

--- a/services/QuillLMS/spec/services/google_integration/classroom_importer_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_importer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe GoogleIntegration::ClassroomImporter do
   context 'classroom exists with google_classroom_id' do
     let(:google_classroom_id) { 123456 }
 
-    before { create(:classroom, google_classroom_id: google_classroom_id, teacher_id: teacher.id) }
+    before { create(:classroom, google_classroom_id: google_classroom_id) }
 
     it 'runs classroom updater' do
       expect { subject }.to_not change(Classroom, :count)

--- a/services/QuillLMS/spec/services/google_integration/classroom_updater_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_updater_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe GoogleIntegration::ClassroomUpdater do
       google_classroom_id: google_classroom_id,
       grade: grade,
       name: name,
-      synced_name: synced_name,
-      teacher_id: teacher_id
+      synced_name: synced_name
     )
   end
 

--- a/services/QuillLMS/spec/services/students_to_classrooms_associator_spec.rb
+++ b/services/QuillLMS/spec/services/students_to_classrooms_associator_spec.rb
@@ -3,10 +3,9 @@
 require 'rails_helper'
 
 describe 'Associators:StudentsToClassrooms' do
-
-  let!(:teacher) {create(:teacher) }
-  let!(:student) {create(:student)}
-  let!(:classroom) {create(:classroom, teacher_id: teacher.id) }
+  let!(:teacher) { create(:teacher) }
+  let!(:student) { create(:student) }
+  let!(:classroom) { create(:classroom) }
 
   describe 'when the classroom and student are both extent' do
     it "creates a new student classroom object" do
@@ -17,7 +16,6 @@ describe 'Associators:StudentsToClassrooms' do
   end
 
   describe "when the classroom or teacher has a problem" do
-
     it "will not add a students classroom if the classroom does not exist" do
       classroom.destroy
       old_sc_count = StudentsClassrooms.count
@@ -38,9 +36,5 @@ describe 'Associators:StudentsToClassrooms' do
       Associators::StudentsToClassrooms.run(student, classroom)
       expect(StudentsClassrooms.count).to eq(old_sc_count)
     end
-
   end
-
-
-
 end


### PR DESCRIPTION
## WHAT
Remove the `teacher_id` column from the Classrooms table

## WHY
It is no longer used

## HOW
Write a migration with `remove_column :classrooms, :teacher_id, :integer`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
