### PR TITLE
Lms/tweak snapshot timeframe logic

### DIFF
--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -118,10 +118,10 @@ class SnapshotsController < ApplicationController
 
   private def retrieve_cache_or_enqueue_worker(worker)
 
-    previous_start, current_start, current_end = Snapshots::Timeframes.calculate_timeframes(snapshot_params[:timeframe],
+    previous_start, previous_end, current_start, current_end = Snapshots::Timeframes.calculate_timeframes(snapshot_params[:timeframe],
       snapshot_params[:timeframe_custom_start],
       snapshot_params[:timeframe_custom_end])
-    cache_key = cache_key_for_timeframe(previous_start, current_start, current_end)
+    cache_key = cache_key_for_timeframe(snapshot_params[:timeframe], current_start, current_end)
     response = Rails.cache.read(cache_key)
 
     return { results: response } if response
@@ -145,7 +145,7 @@ class SnapshotsController < ApplicationController
     { message: 'Generating snapshot' }
   end
 
-  private def cache_key_for_timeframe(previous_start, current_start, current_end)
+  private def cache_key_for_timeframe(previous_start, previous_end, current_start, current_end)
 
     Snapshots::CacheKeys.generate_key(@query,
       previous_start,

--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -119,8 +119,8 @@ class SnapshotsController < ApplicationController
   private def retrieve_cache_or_enqueue_worker(worker)
 
     previous_start, previous_end, current_start, current_end = Snapshots::Timeframes.calculate_timeframes(snapshot_params[:timeframe],
-      snapshot_params[:timeframe_custom_start],
-      snapshot_params[:timeframe_custom_end])
+      custom_start: snapshot_params[:timeframe_custom_start],
+      custom_end: snapshot_params[:timeframe_custom_end])
     cache_key = cache_key_for_timeframe(snapshot_params[:timeframe], current_start, current_end)
     response = Rails.cache.read(cache_key)
 
@@ -132,6 +132,7 @@ class SnapshotsController < ApplicationController
       {
         name: snapshot_params[:timeframe],
         previous_start: previous_start,
+        previous_end: previous_end,
         current_start: current_start,
         current_end: current_end
       },
@@ -145,10 +146,10 @@ class SnapshotsController < ApplicationController
     { message: 'Generating snapshot' }
   end
 
-  private def cache_key_for_timeframe(previous_start, previous_end, current_start, current_end)
+  private def cache_key_for_timeframe(timeframe_name, current_start, current_end)
 
     Snapshots::CacheKeys.generate_key(@query,
-      previous_start,
+      timeframe_name,
       current_start,
       current_end,
       snapshot_params.fetch(:school_ids, []),

--- a/services/QuillLMS/app/lib/snapshots/cache_keys.rb
+++ b/services/QuillLMS/app/lib/snapshots/cache_keys.rb
@@ -10,7 +10,7 @@ module Snapshots
         .compact
     end
 
-    def self.root_key(query, previous_start, current_start, current_end, school_ids)
+    def self.root_key(query, timeframe_name, current_start, current_end, school_ids)
       [
         "admin-snapshot",
         query,

--- a/services/QuillLMS/app/lib/snapshots/cache_keys.rb
+++ b/services/QuillLMS/app/lib/snapshots/cache_keys.rb
@@ -2,8 +2,8 @@
 
 module Snapshots
   class CacheKeys
-    def self.generate_key(query, previous_start, current_start, current_end, school_ids, additional_filters: {})
-      root_key(query, previous_start, current_start, current_end, school_ids)
+    def self.generate_key(query, timeframe_name, current_start, current_end, school_ids, additional_filters: {})
+      root_key(query, timeframe_name, current_start, current_end, school_ids)
         .append(grades_segment(additional_filters[:grades]))
         .append(teacher_ids_segment(additional_filters[:teacher_ids]))
         .append(classroom_ids_segment(additional_filters[:classroom_ids]))
@@ -14,7 +14,7 @@ module Snapshots
       [
         "admin-snapshot",
         query,
-        previous_start,
+        timeframe_name,
         current_start,
         current_end,
         "school-ids-#{(school_ids || []).sort.join('-')}"

--- a/services/QuillLMS/app/lib/snapshots/timeframes.rb
+++ b/services/QuillLMS/app/lib/snapshots/timeframes.rb
@@ -23,7 +23,7 @@ module Snapshots
         value: 'this-month',
         name: 'This month',
         previous_start: proc { |reference_time| reference_time.beginning_of_month - 1.month },
-        previous_start: proc { |reference_time| reference_time - 1.month ) },
+        previous_end: proc { |reference_time| reference_time - 1.month },
         current_start: proc { |reference_time| reference_time.beginning_of_month },
         current_end: proc { |reference_time| reference_time },
       }, {
@@ -69,14 +69,14 @@ module Snapshots
       TIMEFRAMES.find { |timeframe| timeframe[:value] == timeframe_value }
     end
 
-    def self.calculate_timeframes(timeframe_value, custom_start, custom_end)
+    def self.calculate_timeframes(timeframe_value, custom_start: nil, custom_end: nil)
       timeframe = find_timeframe(timeframe_value)
 
       end_of_yesterday = DateTime.current.end_of_day - 1.day
 
       [:previous_start, :previous_end, :current_start, :current_end].map do |value|
         timeframe[value].call(end_of_yesterday, custom_start, custom_end)
-      ]
+      end
     end
 
     def self.frontend_options

--- a/services/QuillLMS/app/lib/snapshots/timeframes.rb
+++ b/services/QuillLMS/app/lib/snapshots/timeframes.rb
@@ -9,48 +9,57 @@ module Snapshots
         value: 'last-30-days',
         name: 'Last 30 days',
         previous_start: proc { |reference_time| reference_time - 60.days },
+        previous_end: proc { |reference_time| reference_time - 30.days },
         current_start: proc { |reference_time| reference_time - 30.days },
         current_end: proc { |reference_time| reference_time }
       }, {
         value: 'last-90-days',
         name: 'Last 90 days',
         previous_start: proc { |reference_time| reference_time - 180.days },
+        previous_end: proc { |reference_time| reference_time - 90.days },
         current_start: proc { |reference_time| reference_time - 90.days },
         current_end: proc { |reference_time| reference_time },
       }, {
         value: 'this-month',
         name: 'This month',
-        previous_start: proc { |reference_time| reference_time.beginning_of_month - (reference_time - reference_time.beginning_of_month) },
+        previous_start: proc { |reference_time| reference_time.beginning_of_month - 1.month },
+        previous_start: proc { |reference_time| reference_time - 1.month ) },
         current_start: proc { |reference_time| reference_time.beginning_of_month },
         current_end: proc { |reference_time| reference_time },
       }, {
         value: 'last-month',
         name: 'Last month',
         previous_start: proc { |reference_time| reference_time.beginning_of_month - 2.months },
+        previous_end: proc { |reference_time| reference_time.beginning_of_month - 1.months },
         current_start: proc { |reference_time| reference_time.beginning_of_month - 1.month },
         current_end: proc { |reference_time| reference_time.beginning_of_month },
       }, {
         value: 'this-year',
         name: 'This year',
-        previous_start: proc { |reference_time| reference_time.beginning_of_year - (reference_time - reference_time.beginning_of_year) },
+        previous_start: proc { |reference_time| reference_time.beginning_of_year - 1.year },
+        previous_end: proc { |reference_time| reference_time - 1.year },
         current_start: proc { |reference_time| reference_time.beginning_of_year },
         current_end: proc { |reference_time| reference_time },
       }, {
         value: 'last-year',
         name: 'Last year',
         previous_start: proc { |reference_time| reference_time.beginning_of_year - 2.years },
+        previous_end: proc { |reference_time| reference_time.beginning_of_year - 1.years },
         current_start: proc { |reference_time| reference_time.beginning_of_year - 1.year },
         current_end: proc { |reference_time| reference_time.beginning_of_year },
       }, {
         value: 'all-time',
         name: 'All time',
-        previous_start: proc { }, # A nil previous start passed to the worker results in the previous-period query being skipped
+        # A nil previous start passed to the worker results in the previous-period query being skipped
+        previous_start: proc { },
+        previous_end: proc { }, 
         current_start: proc { DateTime.new(2010,1,1) }, # This is well before any data exists in our system, so works for "all time"
         current_end: proc { |reference_time| reference_time },
       }, {
         value: 'custom',
         name: 'Custom',
         previous_start: proc { |_, custom_start, custom_end| DateTime.parse(custom_start) - (DateTime.parse(custom_end) - DateTime.parse(custom_start)) },
+        previous_end: proc { |_, custom_start| DateTime.parse(custom_start) },
         current_start: proc { |_, custom_start| DateTime.parse(custom_start) },
         current_end: proc { |_, _, custom_end| DateTime.parse(custom_end) }
       }
@@ -65,10 +74,8 @@ module Snapshots
 
       end_of_yesterday = DateTime.current.end_of_day - 1.day
 
-      [
-        timeframe[:previous_start].call(end_of_yesterday, custom_start, custom_end),
-        timeframe[:current_start].call(end_of_yesterday, custom_start, custom_end),
-        timeframe[:current_end].call(end_of_yesterday, custom_start, custom_end)
+      [:previous_start, :previous_end, :current_start, :current_end].map do |value|
+        timeframe[value].call(end_of_yesterday, custom_start, custom_end)
       ]
     end
 

--- a/services/QuillLMS/app/lib/snapshots/timeframes.rb
+++ b/services/QuillLMS/app/lib/snapshots/timeframes.rb
@@ -30,7 +30,7 @@ module Snapshots
         value: 'last-month',
         name: 'Last month',
         previous_start: proc { |reference_time| reference_time.beginning_of_month - 2.months },
-        previous_end: proc { |reference_time| reference_time.beginning_of_month - 1.months },
+        previous_end: proc { |reference_time| reference_time.beginning_of_month - 1.month },
         current_start: proc { |reference_time| reference_time.beginning_of_month - 1.month },
         current_end: proc { |reference_time| reference_time.beginning_of_month },
       }, {
@@ -44,7 +44,7 @@ module Snapshots
         value: 'last-year',
         name: 'Last year',
         previous_start: proc { |reference_time| reference_time.beginning_of_year - 2.years },
-        previous_end: proc { |reference_time| reference_time.beginning_of_year - 1.years },
+        previous_end: proc { |reference_time| reference_time.beginning_of_year - 1.year },
         current_start: proc { |reference_time| reference_time.beginning_of_year - 1.year },
         current_end: proc { |reference_time| reference_time.beginning_of_year },
       }, {
@@ -52,7 +52,7 @@ module Snapshots
         name: 'All time',
         # A nil previous start passed to the worker results in the previous-period query being skipped
         previous_start: proc { },
-        previous_end: proc { }, 
+        previous_end: proc { },
         current_start: proc { DateTime.new(2010,1,1) }, # This is well before any data exists in our system, so works for "all time"
         current_end: proc { |reference_time| reference_time },
       }, {

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -50,6 +50,7 @@ module Snapshots
 
     private def generate_payload(query, timeframe, school_ids, filters)
       previous_timeframe_start = timeframe['previous_start']
+      previous_timeframe_end = timeframe['previous_end']
       current_timeframe_start = timeframe['current_start']
       timeframe_end = timeframe['current_end']
 
@@ -62,7 +63,7 @@ module Snapshots
       if previous_timeframe_start
         previous_snapshot = QUERIES[query].run(**{
           timeframe_start: previous_timeframe_start,
-          timeframe_end: current_timeframe_start,
+          timeframe_end: previous_timeframe_end,
           school_ids: school_ids
         }.merge(filters))
       else

--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -2,43 +2,73 @@
 
 module Snapshots
   describe Timeframes do
-    it 'returns the expected frontend_options' do
-      expect(described_class.frontend_options).to eq([
-        {default: true, name: "Last 30 days", value: "last-30-days"},
-        {default: false, name: "Last 90 days", value: "last-90-days"},
-        {default: false, name: "This month", value: "this-month"},
-        {default: false, name: "Last month", value: "last-month"},
-        {default: false, name: "This year", value: "this-year"},
-        {default: false, name: "Last year", value: "last-year"},
-        {default: false, name: "All time", value: "all-time"},
-        {default: false, name: "Custom", value: "custom"}
-      ])
+    context '#frontend_options' do
+      it do
+        expect(described_class.frontend_options).to eq([
+          {default: true, name: "Last 30 days", value: "last-30-days"},
+          {default: false, name: "Last 90 days", value: "last-90-days"},
+          {default: false, name: "This month", value: "this-month"},
+          {default: false, name: "Last month", value: "last-month"},
+          {default: false, name: "This year", value: "this-year"},
+          {default: false, name: "Last year", value: "last-year"},
+          {default: false, name: "All time", value: "all-time"},
+          {default: false, name: "Custom", value: "custom"}
+        ])
+      end
     end
 
-    it 'accurately calculates a 30-day timeframe' do
-      timeframe_value = 'last-30-days'
-      now = DateTime.current
-      end_of_yesterday = now.end_of_day - 1.day
-      allow(DateTime).to receive(:current).and_return(now)
+    context 'timeframe calculations'
+      # Replacing usec with 0 lets us avoid in-memory vs database timestamp comparisons which have different precisions
+      let(:now) { DateTime.current.change(usec: 0) }
+      let(:end_of_yesterday) { now.end_of_day - 1.day }
 
-      expect(described_class.calculate_timeframes(timeframe_value, nil, nil)).to eq([
-        end_of_yesterday - 60.days,
-        end_of_yesterday - 30.days,
-        end_of_yesterday
-      ])
-    end
+      before do
+        allow(DateTime).to receive(:current).and_return(now)
+      end
 
-    it 'accurately calculates a custom timeframe previous_start value' do
-      now = DateTime.current.change(usec: 0) # strip fractional seconds to simplify conversion between string and DateTime
-      custom_start = now - 10.hours
-      custom_end = now - 30.minutes
-      timeframe_length = custom_end - custom_start
+      it do
+        expect(described_class.calculate_timeframes('last-30-days')).to eq([
+          end_of_yesterday - 60.days,
+          end_of_yesterday - 30.days,
+          end_of_yesterday - 30.days,
+          end_of_yesterday
+        ])
+      end
 
-      expect(described_class.calculate_timeframes('custom', custom_start.to_s, custom_end.to_s)).to eq([
-        custom_start - timeframe_length,
-        custom_start,
-        custom_end
-      ])
+      context 'previous timeframe calculations for "this month" and "this year"' do
+        let(:now) { DateTime.parse('2023-01-10') }
+
+        it do
+          expect(described_class.calculate_timeframes('this-month')).to eq([
+            end_of_yesterday.beginning_of_month - 1.month,
+            end_of_yesterday - 1.month,
+            end_of_yesterday.beginning_of_month,
+            end_of_yesterday
+          ])
+        end
+
+        it do
+          expect(described_class.calculate_timeframes('this-year')).to eq([
+            end_of_yesterday.beginning_of_year - 1.year,
+            end_of_yesterday - 1.year,
+            end_of_yesterday.beginning_of_year,
+            end_of_yesterday
+          ])
+        end
+      end
+
+      context 'custom timeframe previous start and end calculations' do
+        let(:custom_start) { now - 10.hours }
+        let(:custom_end) { now - 30.minute }
+
+        it do
+          expect(described_class.calculate_timeframes('custom', custom_start: custom_start.to_s, custom_end: custom_end.to_s)).to eq([
+            custom_start - (custom_end - custom_start),
+            custom_start,
+            custom_start,
+            custom_end
+          ])
+        end
+      end
     end
   end
-end

--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -72,3 +72,4 @@ module Snapshots
       end
     end
   end
+end

--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -17,7 +17,7 @@ module Snapshots
       end
     end
 
-    context 'timeframe calculations'
+    context 'timeframe calculations' do
       # Replacing usec with 0 lets us avoid in-memory vs database timestamp comparisons which have different precisions
       let(:now) { DateTime.current.change(usec: 0) }
       let(:end_of_yesterday) { now.end_of_day - 1.day }
@@ -59,7 +59,7 @@ module Snapshots
 
       context 'custom timeframe previous start and end calculations' do
         let(:custom_start) { now - 10.hours }
-        let(:custom_end) { now - 30.minute }
+        let(:custom_end) { now - 30.minutes }
 
         it do
           expect(described_class.calculate_timeframes('custom', custom_start: custom_start.to_s, custom_end: custom_end.to_s)).to eq([

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
@@ -29,10 +29,12 @@ module Snapshots
       let(:timeframe_end) { DateTime.now }
       let(:current_timeframe_start) { timeframe_end - 30.days }
       let(:previous_timeframe_start) { current_timeframe_start - 30.days }
+      let(:previous_timeframe_end) { current_timeframe_start }
       let(:timeframe) {
         {
           'name' => timeframe_name,
           'previous_start' => previous_timeframe_start,
+          'previous_end' => previous_timeframe_end,
           'current_start' => current_timeframe_start,
           'current_end' => timeframe_end
         }
@@ -54,7 +56,7 @@ module Snapshots
           classroom_ids: classroom_ids)
         expect(query_double).to receive(:run).with(
           timeframe_start: previous_timeframe_start,
-          timeframe_end: current_timeframe_start,
+          timeframe_end: previous_timeframe_end,
           school_ids: school_ids,
           grades: grades,
           teacher_ids: teacher_ids,


### PR DESCRIPTION
## WHAT
Tweak the way that we calculate and pass timeframes around 
## WHY
In the original design, things were set up such that the "previous period" and "current period" being compared in `Count` queries were a fixed number of days on either side of a fixed date.  That is, when looking at "this month" on the 7th day of the month, the timeframe would compare the first seven days of the current month against the seven days immediately preceding the start of that time (so the last seven days of the previous month).

Further discussion with product has us shifting that definition so that for "this month" or "this year" we want to compare the first X days of the current period to the first X days of the previous period.  So If it's July 7, and you select "this month" as your period, you want to compare July 1-7 to June 1-7 (instead of to June 24-30).
## HOW
- Update the `Snapshots::Timeframes` lib so that i calculates a `previous_end` value for each timeframe
- Update the way we calculate Snapshot cache keys to accommodate the new timeframe logic
- Update the `Count` worker to take the new timeframe (note that `TopX` queries don't care about previous timeframes, so that code doesn't need updating)
- Update the Snapshots controller to pass the new timeframe data to the worker

### Notion Card Links
https://www.notion.so/quill/On-the-Usage-Snapshot-Report-change-the-way-the-increase-or-decrease-is-calculated-for-This-mont-ef92a6aff8dd4e20b6d3eb5cb8d267b8#896228ada74c474c9e3f146ef03e01f6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
