### PR TITLE
Lms/remove snapshot coming soon

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/usage-snapshot-report.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/usage-snapshot-report.scss
@@ -179,12 +179,6 @@
           font-size: 18px;
           line-height: 22px;
         }
-        .coming-soon {
-          font-weight: 700;
-          font-size: 18px;
-          line-height: 22px;
-          color: #757575;
-        }
         .count-and-label {
           display: flex;
           flex-direction: column;

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
@@ -57,9 +57,9 @@ exports[`SnapshotCount component size medium should match snapshot 1`] = `
       className="count-and-label"
     >
       <span
-        className="coming-soon"
+        className="count"
       >
-        Coming soon
+        —
       </span>
       <span
         className="snapshot-label"
@@ -387,9 +387,9 @@ exports[`SnapshotCount component size small when it is coming soon should match 
       className="count-and-label"
     >
       <span
-        className="coming-soon"
+        className="count"
       >
-        Coming soon
+        —
       </span>
       <span
         className="snapshot-label"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotRanking.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotRanking.test.tsx.snap
@@ -64,11 +64,8 @@ exports[`SnapshotRanking component when it is coming soon should match snapshot 
       <div
         className="header"
       >
-        <h3
-          className="coming-soon"
-        >
+        <h3>
           Sentences written
-           (coming soon)
         </h3>
       </div>
       <DataTable

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotSection.test.tsx.snap
@@ -192,7 +192,6 @@ exports[`SnapshotSection component when the section is Classrooms should match s
         </SnapshotCount>
         <SnapshotCount
           adminId={1}
-          comingSoon={true}
           customTimeframeEnd={null}
           customTimeframeStart={null}
           key="average-active-classrooms-per-teacher"
@@ -247,9 +246,9 @@ exports[`SnapshotSection component when the section is Classrooms should match s
               className="count-and-label"
             >
               <span
-                className="coming-soon"
+                className="count"
               >
-                Coming soon
+                —
               </span>
               <span
                 className="snapshot-label"
@@ -346,7 +345,6 @@ exports[`SnapshotSection component when the section is Classrooms should match s
         </SnapshotCount>
         <SnapshotCount
           adminId={1}
-          comingSoon={true}
           customTimeframeEnd={null}
           customTimeframeStart={null}
           key="average-active-students-per-classroom"
@@ -401,9 +399,9 @@ exports[`SnapshotSection component when the section is Classrooms should match s
               className="count-and-label"
             >
               <span
-                className="coming-soon"
+                className="count"
               >
-                Coming soon
+                —
               </span>
               <span
                 className="snapshot-label"
@@ -428,7 +426,6 @@ exports[`SnapshotSection component when the section is Classrooms should match s
       >
         <SnapshotRanking
           adminId={1}
-          comingSoon={true}
           customTimeframeEnd={null}
           customTimeframeStart={null}
           headers={
@@ -490,11 +487,8 @@ exports[`SnapshotSection component when the section is Classrooms should match s
               <div
                 className="header"
               >
-                <h3
-                  className="coming-soon"
-                >
+                <h3>
                   Most active grades
-                   (coming soon)
                 </h3>
               </div>
               <DataTable
@@ -1997,7 +1991,6 @@ exports[`SnapshotSection component when the section is Practice should match sna
       >
         <SnapshotRanking
           adminId={1}
-          comingSoon={true}
           customTimeframeEnd={null}
           customTimeframeStart={null}
           headers={
@@ -2059,11 +2052,8 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="header"
               >
-                <h3
-                  className="coming-soon"
-                >
+                <h3>
                   Most assigned activities
-                   (coming soon)
                 </h3>
               </div>
               <DataTable
@@ -2133,7 +2123,6 @@ exports[`SnapshotSection component when the section is Practice should match sna
         </SnapshotRanking>
         <SnapshotRanking
           adminId={1}
-          comingSoon={true}
           customTimeframeEnd={null}
           customTimeframeStart={null}
           headers={
@@ -2195,11 +2184,8 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="header"
               >
-                <h3
-                  className="coming-soon"
-                >
+                <h3>
                   Most completed activities
-                   (coming soon)
                 </h3>
               </div>
               <DataTable
@@ -2918,7 +2904,6 @@ exports[`SnapshotSection component when the section is Users should match snapsh
       >
         <SnapshotRanking
           adminId={1}
-          comingSoon={true}
           customTimeframeEnd={null}
           customTimeframeStart={null}
           headers={
@@ -2980,11 +2965,8 @@ exports[`SnapshotSection component when the section is Users should match snapsh
               <div
                 className="header"
               >
-                <h3
-                  className="coming-soon"
-                >
+                <h3>
                   Most active teachers
-                   (coming soon)
                 </h3>
               </div>
               <DataTable

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -26,22 +26,19 @@ interface SnapshotCountProps {
   adminId: number;
   customTimeframeStart?: any;
   customTimeframeEnd?: any;
-  comingSoon?: boolean;
   passedCount?: number;
   passedChange?: number;
   passedChangeDirection?: 'negative'|'positive';
   singularLabel?: string;
 }
 
-const SnapshotCount = ({ label, size, queryKey, comingSoon, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, passedCount, passedChange, passedChangeDirection, singularLabel, }: SnapshotCountProps) => {
+const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, passedCount, passedChange, passedChangeDirection, singularLabel, }: SnapshotCountProps) => {
   const [count, setCount] = React.useState(passedCount || null)
   const [change, setChange] = React.useState(passedChange || 0)
   const [changeDirection, setChangeDirection] = React.useState(passedChangeDirection || null)
   const [loading, setLoading] = React.useState(false)
 
   React.useEffect(() => {
-    if (comingSoon) { return }
-
     resetToDefault()
 
     getData()
@@ -129,7 +126,7 @@ const SnapshotCount = ({ label, size, queryKey, comingSoon, searchCount, selecte
     <section className={className}>
       {loading && <div className="loading-spinner-wrapper"><ButtonLoadingSpinner /></div>}
       <div className="count-and-label">
-        {comingSoon ? <span className="coming-soon">Coming soon</span> : <span className="count">{count?.toLocaleString() || '—'}</span>}
+        <span className="count">{count?.toLocaleString() || '—'}</span>
         <span className="snapshot-label">{count === 1 && singularLabel ? singularLabel : label}</span>
       </div>
       <div className="change">

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -23,7 +23,6 @@ interface SnapshotRankingProps {
   adminId: number;
   customTimeframeStart?: any;
   customTimeframeEnd?: any;
-  comingSoon?: boolean;
 }
 
 const RankingModal = ({ label, closeModal, headers, data, }) => {
@@ -71,14 +70,12 @@ const DataTable = ({ headers, data, numberOfRows, }) => {
   )
 }
 
-const SnapshotRanking = ({ label, queryKey, headers, comingSoon, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, passedData, }: SnapshotRankingProps) => {
+const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, passedData, }: SnapshotRankingProps) => {
   const [data, setData] = React.useState(null)
   const [loading, setLoading] = React.useState(false)
   const [showModal, setShowModal] = React.useState(false)
 
   React.useEffect(() => {
-    if (comingSoon) { return }
-
     resetToDefault()
 
     getData()
@@ -160,7 +157,7 @@ const SnapshotRanking = ({ label, queryKey, headers, comingSoon, searchCount, se
       )}
       <div onClick={openModal}>
         <div className="header">
-          {comingSoon ? <h3 className="coming-soon">{label} (coming soon)</h3> : <h3>{label}</h3>}
+          <h3>{label}</h3>
           {loading && <div className="loading-spinner-wrapper"><ButtonLoadingSpinner /></div>}
           {data && <button aria-label="Open modal with additional seven lines of table data" className="interactive-wrapper focus-on-light" onClick={openModal} type="button">{expandImg}</button>}
         </div>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotSection.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotSection.tsx
@@ -8,9 +8,8 @@ import { COUNT, RANKING, FEEDBACK, } from './shared'
 const SnapshotSection = ({ name, className, itemGroupings, searchCount, selectedGrades, selectedSchoolIds, selectedClassroomIds, selectedTeacherIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, adminId, }) => {
   const snapshotItemGroupings = itemGroupings.map(grouping => {
     const snapshotItems = grouping.items.map(item => {
-      const { label, size, type, queryKey, comingSoon, headers, singularLabel, } = item
+      const { label, size, type, queryKey, headers, singularLabel, } = item
       const sharedProps = {
-        comingSoon,
         key: queryKey,
         label,
         queryKey,


### PR DESCRIPTION
## WHAT
Remove the "Coming Soon" logic from the front-end of the Admin Snapshots code
## WHY
With #10742 all of the queries will be running in the back-end, and thus there will be no more "coming soon" widgets.  While this code may be useful again at some point in the future, it feels better to me to remove it for the moment given how lightweight it is and that we don't KNOW that we need it.

That said, I'm doing so in a separate PR so that it's super easy to revert if we need to.
## HOW
- Stop passing the `comingSoon` value between components since there are no longer any components where that value is set
- Remove logic that checks `comingSoon` values since they don't exist anymore


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
