### PR TITLE
fix bug where invite coteachers modal exceeded height of page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -438,6 +438,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
   display: block;
+  max-height: 100vh;
   .checkbox-row {
     display: flex;
     align-items: center;
@@ -960,6 +961,10 @@
       overflow: scroll;
       padding-bottom: 400px;
     }
+  }
+  .invite-coteachers-modal-content {
+    max-height: 100vh;
+    overflow: scroll;
   }
   .invite-coteachers-modal-footer {
     justify-content: flex-end;


### PR DESCRIPTION
## WHAT
Fix bug where invite coteachers modal wasn't scrollable.

## WHY
We want this to be functional for users with long lists of classrooms.

## HOW
Just apply some max-height rules.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Create-accounts-for-students-pop-up-form-loads-without-a-scrolling-bar-1eec1097101541db830e1f24a87a51ab

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - CSS change
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES