### PR TITLE
stop making unnecessary calls for archived classrooms

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -205,11 +205,14 @@ class Teachers::ClassroomsController < ApplicationController
   end
 
   private def format_students_for_classroom(classroom)
-    sorted_students = classroom.students.sort_by(&:last_name)
-    classroom_unit_ids = ClassroomUnit.where(classroom: classroom).ids
+    students = classroom.students.sort_by(&:last_name)
 
-    students = sorted_students.map do |student|
-      student.attributes.merge(number_of_completed_activities: ActivitySession.where(state: ActivitySession::STATE_FINISHED, user_id: student.id, classroom_unit_id: classroom_unit_ids).count || 0)
+    if classroom.visible
+      classroom_unit_ids = ClassroomUnit.where(classroom: classroom).ids
+
+      students = students.map do |student|
+        student.attributes.merge(number_of_completed_activities: ActivitySession.where(state: ActivitySession::STATE_FINISHED, user_id: student.id, classroom_unit_id: classroom_unit_ids).count || 0)
+      end
     end
 
     return students unless classroom.classroom_provider?

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -235,6 +235,18 @@ describe Teachers::ClassroomsController, type: :controller do
               expect(assigns(:classrooms)[i][:students][0][:number_of_completed_activities]).to eq 1
             end
           end
+
+          it 'should assign students but not number_of_completed_activities if the classroom is archived' do
+            classroom.update(visible: false)
+
+            get :index
+
+            classrooms.count.times do |i|
+              next unless assigns(:classrooms)[i]['id'] == classroom.id
+
+              expect(assigns(:classrooms)[i][:students][0][:number_of_completed_activities]).not_to be
+            end
+          end
         end
 
         context "with order property" do


### PR DESCRIPTION
## WHAT
Stop pulling the number of completed activity sessions for archived classrooms, because we aren't showing it on the frontend.

## WHY
I noticed while testing a user with a very large number of classrooms and students (I think it was an admin that imported all of their school's classes) that the classrooms page was very slow to load (at least locally, change was less significant in prod though still a little slow) because we're now pulling a count of each student's completed activity sessions for each classroom. This is totally unnecessary for archived classes since we don't show this info on the frontend.

## HOW
Only make this call when the classroom is visible.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES