### PR TITLE
fix 500 error on my classes page

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -205,14 +205,16 @@ class Teachers::ClassroomsController < ApplicationController
   end
 
   private def format_students_for_classroom(classroom)
-    students = classroom.students.sort_by(&:last_name)
+    sorted_students = classroom.students.sort_by(&:last_name)
 
     if classroom.visible
       classroom_unit_ids = ClassroomUnit.where(classroom: classroom).ids
 
-      students = students.map do |student|
+      students = sorted_students.map do |student|
         student.attributes.merge(number_of_completed_activities: ActivitySession.where(state: ActivitySession::STATE_FINISHED, user_id: student.id, classroom_unit_id: classroom_unit_ids).count || 0)
       end
+    else
+      students = sorted_students.map(&:attributes)
     end
 
     return students unless classroom.classroom_provider?

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -204,6 +204,7 @@ class Teachers::ClassroomsController < ApplicationController
     end.compact
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   private def format_students_for_classroom(classroom)
     students = classroom.students.sort_by(&:last_name).map(&:attributes)
 
@@ -220,6 +221,7 @@ class Teachers::ClassroomsController < ApplicationController
     provider_classroom = ProviderClassroomDelegator.new(classroom)
     students.map { |student| student.merge(synced: provider_classroom.synced_status(student)) }
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private def format_pending_coteachers_for_classroom(classroom)
     classroom.coteacher_classroom_invitations.map do |cci|

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -205,16 +205,14 @@ class Teachers::ClassroomsController < ApplicationController
   end
 
   private def format_students_for_classroom(classroom)
-    sorted_students = classroom.students.sort_by(&:last_name)
+    students = classroom.students.sort_by(&:last_name).map(&:attributes)
 
     if classroom.visible
       classroom_unit_ids = ClassroomUnit.where(classroom: classroom).ids
 
-      students = sorted_students.map do |student|
-        student.attributes.merge(number_of_completed_activities: ActivitySession.where(state: ActivitySession::STATE_FINISHED, user_id: student.id, classroom_unit_id: classroom_unit_ids).count || 0)
+      students = students.map do |student|
+        student.merge(number_of_completed_activities: ActivitySession.where(state: ActivitySession::STATE_FINISHED, user_id: student.id, classroom_unit_id: classroom_unit_ids).count || 0)
       end
-    else
-      students = sorted_students.map(&:attributes)
     end
 
     return students unless classroom.classroom_provider?

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -211,7 +211,7 @@ class Teachers::ClassroomsController < ApplicationController
       classroom_unit_ids = ClassroomUnit.where(classroom: classroom).ids
 
       students = students.map do |student|
-        student.merge(number_of_completed_activities: ActivitySession.where(state: ActivitySession::STATE_FINISHED, user_id: student.id, classroom_unit_id: classroom_unit_ids).count || 0)
+        student.merge(number_of_completed_activities: ActivitySession.where(state: ActivitySession::STATE_FINISHED, user_id: student['id'], classroom_unit_id: classroom_unit_ids).count || 0)
       end
     end
 

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -316,7 +316,7 @@ describe Teachers::ClassroomsController, type: :controller do
 
         it 'reports which students are no longer in provider classroom in archived classroom' do
           classroom.update(visible: false)
-          
+
           get :index, as: :json
           parsed_response = JSON.parse(response.body)
           expect(parsed_response["classrooms"][0]["students"][0]["synced"]).to eq true

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -307,12 +307,22 @@ describe Teachers::ClassroomsController, type: :controller do
           )
         end
 
-        it 'reports which students are no longer in provider classroom' do
+        it 'reports which students are no longer in provider classroom in visible classroom' do
           get :index, as: :json
           parsed_response = JSON.parse(response.body)
           expect(parsed_response["classrooms"][0]["students"][0]["synced"]).to eq true
           expect(parsed_response["classrooms"][0]["students"][1]["synced"]).to eq false
         end
+
+        it 'reports which students are no longer in provider classroom in archived classroom' do
+          classroom.update(visible: false)
+          
+          get :index, as: :json
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response["classrooms"][0]["students"][0]["synced"]).to eq true
+          expect(parsed_response["classrooms"][0]["students"][1]["synced"]).to eq false
+        end
+
       end
     end
   end


### PR DESCRIPTION
## WHAT
Fix bug I introduced yesterday where a Google or Clever classroom that was archived would have `.merge` called on an actual `User` object, not a hash of the user's attributes, resulting in an error.

## WHY
We want users to be able to access this page and not see a 500 error.

## HOW
Make sure the students array is always an array of attribute hashes and not `User` objects.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/500-error-on-My-Classes-page-97538945180844f9a8a90fe231e7d2e7?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - trying to get fix out, tested locally with staging data
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A