### PR TITLE
delete repeated code in grammar container

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -146,22 +146,6 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       this.saveToLMS(session)
     }
 
-    if (hasreceiveddata && grammarActivities.currentActivity && !session.hasreceiveddata && !session.pending && !session.error) {
-      const { questions, concepts, flag } = grammarActivities.currentActivity
-      if (questions && questions.length) {
-        dispatch(getQuestions(questions, flag))
-      } else {
-        dispatch(getQuestionsForConcepts(concepts, flag))
-      }
-    }
-
-    if (session.hasreceiveddata && !session.currentQuestion && session.unansweredQuestions.length === 0 && session.answeredQuestions.length > 0) {
-      this.saveToLMS(session)
-      // handles case where proofreader has no follow-up questions
-    } else if (session.hasreceiveddata && !session.currentQuestion && session.unansweredQuestions.length === 0 && session.proofreaderSession) {
-      this.saveToLMS(session)
-    }
-
     const sessionID = getParameterByName('student', window.location.href)
     const proofreaderSessionId = getParameterByName('proofreaderSessionId', window.location.href)
     const sessionIdentifier = sessionID || proofreaderSessionId


### PR DESCRIPTION
## WHAT
Delete a chunk of code that somehow got repeated in the Grammar activity container.

## WHY
A) it's redundant with lines 133-146 directly above and b) it was causing weird behavior because the saveToLMS function was firing twice, sometimes resulting in duplicate concept results.

## HOW
Just delete the identical second chunk of code.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Figure-out-why-we-are-getting-duplicate-concept-results-from-Grammar-Proofreader-activities-sometime-117ffc9583764ccc84dc7eb2e3e0f8fe?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - manually tested
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A