### PR TITLE
Capitalize some edge case names 

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -159,6 +159,8 @@ gem 'awesome_print'
 # TODO: Remove this after migrating to Rails 7 encrypted attributes
 gem 'lockbox'
 
+gem 'capitalize-names'
+
 group :production, :staging do
   gem 'rails-autoscale-web'
   gem 'rails-autoscale-sidekiq'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
     cancancan (2.3.0)
+    capitalize-names (1.2.0)
     capybara (3.37.1)
       addressable
       matrix
@@ -805,6 +806,7 @@ DEPENDENCIES
   bullet
   byebug
   cancancan (~> 2.3)
+  capitalize-names
   capybara
   capybara-screenshot
   carrierwave (~> 1.3.2)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -57,6 +57,8 @@
 #
 
 # rubocop:disable Metrics/ClassLength
+require 'capitalize_names'
+
 class User < ApplicationRecord
   include Student
   include Teacher
@@ -430,16 +432,7 @@ class User < ApplicationRecord
   end
 
   def capitalize_name
-    result = name
-    if name.present?
-      f,l = name.split(/\s+/, 2)
-      if f.present? and l.present?
-        result = "#{f.capitalize} #{l.gsub(/\S+/, &:capitalize)}"
-      else
-        result = name.capitalize
-      end
-    end
-    self.name = result
+    self.name = ::CapitalizeNames.capitalize(name)
   end
 
   def admin?

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -330,18 +330,26 @@ describe User, type: :model do
   end
 
   describe '#capitalize_name' do
-    let(:user) { create(:user) }
+    subject { user.capitalize_name }
 
-    it 'should set the name as a capitalized name if name is single' do
-      user.name = "test"
-      expect(user.capitalize_name).to eq("Test")
-      expect(user.name).to eq("Test")
+    let(:user) { build(:user, name: name) }
+
+    context 'single name' do
+      let(:name) { 'test' }
+
+      it { expect { subject }.to change(user, :name).from(name).to('Test') }
     end
 
-    it 'should capitalize both first name and last name if exists' do
-      user.name = "test test"
-      expect(user.capitalize_name).to eq("Test Test")
-      expect(user.name).to eq("Test Test")
+    context 'two names' do
+      let(:name) { 'test test' }
+
+      it { expect { subject }.to change(user, :name).from(name).to('Test Test') }
+    end
+
+    context 'patronymic prefix' do
+      let(:name) { 'test mctest'}
+
+      it { expect { subject }.to change(user, :name).from(name).to('Test McTest') }
     end
   end
 

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -66,7 +66,7 @@ describe 'SerializeVitallySalesUser' do
     expect(teacher_data[:traits]).to include(
       email: 'teach@teaching.edu',
       flagset: 'production',
-      name: 'Pops Mcgee',
+      name: 'Pops McGee',
       school: 'Kool Skool',
       account_uid: school.id.to_s,
       signed_up: teacher.created_at.to_i,

--- a/services/QuillLMS/spec/support/faker.rb
+++ b/services/QuillLMS/spec/support/faker.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Faker
+  class Name
+    def self.custom_name
+      [first_name, last_name].join(' ')
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
I've been using the Faker gem to populate name for specs.  Recently it has been revealing some failures involving last names being improperly capitalized:
![Screenshot 2023-07-11 at 7 21 44 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/27d70f15-462f-44fd-ab17-324c19c537dc)
Add the capitalize gem to handle edge cases with names.

## WHY
Users don't like having their name capitalized incorrectly. 

## HOW
Add the gem to Gemfile.
I've also monkey-patched the Faker gem to add a `custom_name` method that generates first_name + last_name.  The regular `Faker::Name.name` adds titles like 'MD', 'Jr.', and 'Sr.' to some names which would require a separate PR.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
