### PR TITLE
lms/change-admin-snapshot-default-timeframe

### DIFF
--- a/services/QuillLMS/app/lib/snapshots/timeframes.rb
+++ b/services/QuillLMS/app/lib/snapshots/timeframes.rb
@@ -2,7 +2,7 @@
 
 module Snapshots
   class Timeframes
-    DEFAULT_TIMEFRAME = 'last-30-days'
+    DEFAULT_TIMEFRAME = 'this-school-year'
 
     TIMEFRAMES = [
       {

--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -5,11 +5,11 @@ module Snapshots
     context '#frontend_options' do
       it do
         expect(described_class.frontend_options).to eq([
-          {default: true, name: "Last 30 days", value: "last-30-days"},
+          {default: false, name: "Last 30 days", value: "last-30-days"},
           {default: false, name: "Last 90 days", value: "last-90-days"},
           {default: false, name: "This month", value: "this-month"},
           {default: false, name: "Last month", value: "last-month"},
-          {default: false, name: "This school year", value: "this-school-year"},
+          {default: true, name: "This school year", value: "this-school-year"},
           {default: false, name: "Last school year", value: "last-school-year"},
           {default: false, name: "All time", value: "all-time"},
           {default: false, name: "Custom", value: "custom"}


### PR DESCRIPTION
## WHAT
Update default timeframe for Admin Snapshots
## WHY
We've decided that this is possibly the most useful default to show users, so let's use it
## HOW
Update the `DEFAULT_TIMEFRAME` value to the name of the new default timeframe

### Notion Card Links
https://www.notion.so/quill/Implement-Admin-Usage-Snapshot-Report-Backend-0dd45ff4b92641328cec85660ea614fb?pvs=4#e83278940c5046469c5cad3b73357849

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
