### PR TITLE
lms/handle-rare-teacher-notification-errors

### DIFF
--- a/services/QuillLMS/app/workers/teacher_notifications/send_notification_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_notifications/send_notification_worker.rb
@@ -9,6 +9,7 @@ module TeacherNotifications
     def perform(activity_session_id)
       @activity_session = find_activity_session(activity_session_id)
       return unless @activity_session
+      return unless @activity_session.classroom
       return unless should_send_notification?
 
       send_notification(notification_type, message_attrs)

--- a/services/QuillLMS/spec/workers/teacher_notifications/send_notification_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_notifications/send_notification_worker_spec.rb
@@ -14,8 +14,17 @@ module TeacherNotifications
       old_activity_session_id = activity_session.id
       activity_session.destroy
 
+      expect(subject).not_to receive(:should_send_notification?)
 
       subject.perform(old_activity_session_id)
+    end
+
+    it 'should return early if the provided ActivitySession does not link to a classroom' do
+      activity_session.update(classroom_unit_id: nil)
+
+      expect(subject).not_to receive(:should_send_notification?)
+
+      subject.perform(activity_session.id)
     end
 
     it 'should return early if the provided ActivitySession is not complete' do


### PR DESCRIPTION
## WHAT
Handle notifications for activity sessions with no classroom_unit
## WHY
ClassroomUnit is the only way an ActivitySession knows which classroom it should be associated with, and we require that information for the ways that we roll up notifications.  So in the rare case where an ActivitySession is completed without a ClassroomUnit, we return early.
## HOW
Just add an early return in the parent worker that all of the various notification creating workers inherit from

### Notion Card Links
https://www.notion.so/quill/Investigate-occasional-errors-with-TeacherNotification-workers-43a29e6a49514350b1b6a20e90dda81d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
