### PR TITLE
Fix quill academy feature flag

### DIFF
--- a/services/QuillLMS/app/helpers/quill_academy_helper.rb
+++ b/services/QuillLMS/app/helpers/quill_academy_helper.rb
@@ -68,6 +68,6 @@ module QuillAcademyHelper
   }
 
   def render_quill_academy_button?
-    !!(AppSetting.where(name: 'quill_academy', enabled: true)&.first&.user_ids_allow_list&.include?(current_user.id))
+    !!(AppSetting.find_by(name: 'quill_academy', enabled: true)&.enabled_for_user?(current_user))
   end
 end


### PR DESCRIPTION
## WHAT
Fix a bug with rolling out a Quill Academy to 25% users

## WHY
It's not being rolled out to anyone.

## HOW
Use `enabled_for_user` instead of checking user_ids_allow_list since we're using 25% rollout.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
