### PR TITLE
update state correctly when switching between tabs

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/manage_units.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/manage_units.jsx
@@ -101,10 +101,11 @@ export default class ManageUnits extends React.Component {
     if (selectedClassroomId && selectedClassroomId !== allClassroomKey) {
       // TODO: Refactor this. It is ridiculous that we need to find a classroom and match on name. Instead, the units should just have a list of classroom_ids that we can match on.
       const selectedClassroom = classrooms.find(c => c.id === Number(selectedClassroomId));
-      const unitsInCurrentClassroom = allUnits.filter(unit => unit.classrooms.find(c => c.name === selectedClassroom.name) && unit.open === open);
+      const unitsInCurrentClassroom = allUnits.filter(unit => unit.classrooms.find(c => c.name === selectedClassroom.name));
       this.setState({ units: unitsInCurrentClassroom, loaded: true, });
     } else {
-      this.setState(prevState => ({ units: prevState.allUnits.filter(unit => unit.open === open), loaded: true, }));
+      this.setState(prevState => ({ units: prevState.allUnits, loaded: true, }));
+
     }
   };
 
@@ -193,14 +194,18 @@ export default class ManageUnits extends React.Component {
     } else {
       window.history.pushState({}, '', baseLink);
     }
-    this.setState({ selectedClassroomId: classroom.value, }, () => this.getUnitsForCurrentClassAndOpenState());
+
+    this.setState({ selectedClassroomId: classroom.value, });
+    this.getUnitsForCurrentClassAndOpenState()
   };
 
   stateBasedComponent = () => {
-    const { actions, open, } = this.props
-    const { units, selectedClassroomId, classrooms, } = this.state
+    const { open, } = this.props
+    const { units, selectedClassroomId } = this.state
 
-    if (!units.length && open) {
+    const displayableUnits = units.filter(unit => unit.open === open)
+
+    if (!displayableUnits.length && open) {
       return (
         <div className="my-activities-empty-state container">
           <img alt="Clipboard with notes written on it" src={clipboardSrc} />
@@ -210,7 +215,7 @@ export default class ManageUnits extends React.Component {
       )
     }
 
-    if (!units.length && !open) {
+    if (!displayableUnits.length && !open) {
       return (
         <div className="my-activities-empty-state container">
           <img alt="Clipboard with notes written on it" src={clipboardSrc} />
@@ -220,7 +225,7 @@ export default class ManageUnits extends React.Component {
       )
     }
 
-    const activityPacks = units.map(unit => (
+    const activityPacks = displayableUnits.map(unit => (
       <ActivityPack
         data={unit}
         getUnits={this.getUnits}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/manage_units.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/manage_units.jsx
@@ -96,7 +96,6 @@ export default class ManageUnits extends React.Component {
   };
 
   getUnitsForCurrentClassAndOpenState = () => {
-    const { open, } = this.props
     const { selectedClassroomId, classrooms, allUnits, } = this.state
     if (selectedClassroomId && selectedClassroomId !== allClassroomKey) {
       // TODO: Refactor this. It is ridiculous that we need to find a classroom and match on name. Instead, the units should just have a list of classroom_ids that we can match on.
@@ -194,9 +193,7 @@ export default class ManageUnits extends React.Component {
     } else {
       window.history.pushState({}, '', baseLink);
     }
-
-    this.setState({ selectedClassroomId: classroom.value, });
-    this.getUnitsForCurrentClassAndOpenState()
+    this.setState({ selectedClassroomId: classroom.value, }, () => this.getUnitsForCurrentClassAndOpenState());
   };
 
   stateBasedComponent = () => {


### PR DESCRIPTION
## WHAT
Fix bug where tabbing between a teacher's 'closed' and 'open' activity packs was not triggering the desired state change. 

## WHY
Bug fix 

## HOW
- Move the open/close feature out of state, into `render`, for simplicity.



### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/My-Closed-Activity-Packs-is-incorrectly-showing-all-open-packs-173c7cba1623405e8c58f9977e2f0d2c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
