### PR TITLE
lms/fix-admin-snapshot-timeframe-end

### DIFF
--- a/services/QuillLMS/app/queries/snapshots/period_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/period_query.rb
@@ -39,7 +39,7 @@ module Snapshots
     end
 
     def timeframe_where_clause
-      "#{relevant_date_column} BETWEEN '#{timeframe_start.to_date.to_s(:db)}' AND '#{timeframe_end.to_date.to_s(:db)}'"
+      "#{relevant_date_column} BETWEEN '#{timeframe_start.to_s(:db)}' AND '#{timeframe_end.to_s(:db)}'"
     end
 
     def school_ids_where_clause

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -51,10 +51,10 @@ module Snapshots
     end
 
     private def generate_payload(query, timeframe, school_ids, filters)
-      previous_timeframe_start = timeframe['previous_start']
-      previous_timeframe_end = timeframe['previous_end']
-      current_timeframe_start = timeframe['current_start']
-      timeframe_end = timeframe['current_end']
+      previous_timeframe_start = parse_datetime_string(timeframe['previous_start'])
+      previous_timeframe_end = parse_datetime_string(timeframe['previous_end'])
+      current_timeframe_start = parse_datetime_string(timeframe['current_start'])
+      timeframe_end = parse_datetime_string(timeframe['current_end'])
       filters_symbolized = filters.symbolize_keys
 
       current_snapshot = QUERIES[query].run(**{
@@ -74,6 +74,12 @@ module Snapshots
       end
 
       { current: current_snapshot&.fetch(:count, nil), previous: previous_snapshot&.fetch(:count, nil) }
+    end
+
+    private def parse_datetime_string(value)
+      return nil if value.nil?
+
+      DateTime.parse(value)
     end
   end
 end

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -42,8 +42,8 @@ module Snapshots
       filters_symbolized = filters.symbolize_keys
 
       QUERIES[query].run(**{
-        timeframe_start: timeframe['current_start'],
-        timeframe_end: timeframe['current_end'],
+        timeframe_start: DateTime.parse(timeframe['current_start']),
+        timeframe_end: DateTime.parse(timeframe['current_end']),
         school_ids: school_ids
       }.merge(filters_symbolized))
     end

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -4,7 +4,7 @@ import * as Pusher from 'pusher-js';
 
 import { SMALL, POSITIVE, NEGATIVE, } from './shared'
 
-import { requestGet, } from './../../../../modules/request'
+import { requestPost, } from './../../../../modules/request'
 import { ButtonLoadingSpinner, } from '../../../Shared/index'
 import { unorderedArraysAreEqual, } from '../../../../modules/unorderedArraysAreEqual'
 
@@ -64,9 +64,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
       grades: selectedGrades
     }
 
-    const requestUrl = queryString.stringifyUrl({ url: '/snapshots/count', query: searchParams }, { arrayFormat: 'bracket' })
-
-    requestGet(`${requestUrl}`, (body) => {
+    requestPost(`/snapshots/count`, searchParams, (body) => {
       if (!body.hasOwnProperty('results')) {
         setLoading(true)
       } else {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -4,7 +4,7 @@ import * as Pusher from 'pusher-js';
 
 import { Grade, School, Timeframe, } from './shared'
 
-import { requestGet, } from './../../../../modules/request'
+import { requestPost, } from './../../../../modules/request'
 import { ButtonLoadingSpinner, } from '../../../Shared/index'
 import { unorderedArraysAreEqual, } from '../../../../modules/unorderedArraysAreEqual'
 
@@ -99,9 +99,7 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
       grades: selectedGrades
     }
 
-    const requestUrl = queryString.stringifyUrl({ url: '/snapshots/top_x', query: searchParams }, { arrayFormat: 'bracket' })
-
-    requestGet(`${requestUrl}`, (body) => {
+    requestPost(`/snapshots/top_x`, searchParams, (body) => {
       if (!body.hasOwnProperty('results')) {
         setLoading(true)
       } else {

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -732,9 +732,9 @@ EmpiricalGrammar::Application.routes.draw do
 
   resources :snapshots, only: [] do
     collection do
-      get :count
+      post :count
       get :options
-      get :top_x
+      post :top_x
     end
   end
 

--- a/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
@@ -89,6 +89,20 @@ module Snapshots
 
           it { expect(results).to match_array(classroom_ids[0]) }
         end
+
+        context 'timeframe filters' do
+          let(:classrooms) { create_list(:classroom, num_classrooms, created_at: DateTime.current - 1.day) }
+          let(:timeframe) { Snapshots::Timeframes.calculate_timeframes(Snapshots::Timeframes::DEFAULT_TIMEFRAME) }
+          let(:query_args) do
+            {
+              timeframe_start: timeframe[2],
+              timeframe_end: timeframe[3],
+              school_ids: school_ids
+            }
+          end
+
+          it { expect(results).to match_array(classroom_ids) }
+        end
       end
     end
   end

--- a/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
+++ b/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
@@ -68,7 +68,7 @@ module QuillBigQuery
       when :inet then "'#{value}'"
       when :jsonb then "'#{value.to_json}'"
       when :string, :text then "\"#{value}\""
-      when :datetime then "'#{value&.iso8601}'"
+      when :datetime then "'#{value&.to_s(:db)}'"
       else
         raise "Error: value:'#{value}' type #{attr_type} not found"
       end

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
@@ -41,10 +41,21 @@ module Snapshots
       let(:timeframe) {
         {
           'name' => timeframe_name,
-          'previous_start' => previous_timeframe_start,
-          'previous_end' => previous_timeframe_end,
-          'current_start' => current_timeframe_start,
-          'current_end' => timeframe_end
+          'previous_start' => previous_timeframe_start.to_s,
+          'previous_end' => previous_timeframe_end.to_s,
+          'current_start' => current_timeframe_start.to_s,
+          'current_end' => timeframe_end.to_s
+        }
+      }
+
+      let(:expected_query_args) {
+        {
+          timeframe_start: current_timeframe_start,
+          timeframe_end: timeframe_end,
+          school_ids: school_ids,
+          grades: grades,
+          teacher_ids: teacher_ids,
+          classroom_ids: classroom_ids
         }
       }
 
@@ -55,13 +66,7 @@ module Snapshots
       end
 
       it 'should execute queries for both the current and previous timeframes' do
-        expect(query_double).to receive(:run).with(
-          timeframe_start: current_timeframe_start,
-          timeframe_end: timeframe_end,
-          school_ids: school_ids,
-          grades: grades,
-          teacher_ids: teacher_ids,
-          classroom_ids: classroom_ids)
+        expect(query_double).to receive(:run).with(expected_query_args)
         expect(query_double).to receive(:run).with(
           timeframe_start: previous_timeframe_start,
           timeframe_end: previous_timeframe_end,
@@ -75,15 +80,20 @@ module Snapshots
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters)
       end
 
+      context 'serialization/deserialization' do
+        it 'should desieralize timeframes back into DateTimes' do
+          allow(PusherTrigger).to receive(:run)
+          Sidekiq::Testing.inline! do
+            expect(query_double).to receive(:run).with(expected_query_args)
+
+            described_class.perform_async(cache_key, query, user_id, timeframe, school_ids, filters)
+          end
+        end
+      end
+
       context "params with string keys" do
         it 'should execute queries for both the current and previous timeframes' do
-          expect(query_double).to receive(:run).with(
-            timeframe_start: current_timeframe_start,
-            timeframe_end: timeframe_end,
-            school_ids: school_ids,
-            grades: grades,
-            teacher_ids: teacher_ids,
-            classroom_ids: classroom_ids)
+          expect(query_double).to receive(:run).with(expected_query_args)
           expect(query_double).to receive(:run).with(
             timeframe_start: previous_timeframe_start,
             timeframe_end: current_timeframe_start,

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
@@ -39,9 +39,19 @@ module Snapshots
       let(:timeframe) {
         {
           'name' => timeframe_name,
-          'previous_start' => previous_timeframe_start,
-          'current_start' => current_timeframe_start,
-          'current_end' => timeframe_end
+          'previous_start' => previous_timeframe_start.to_s,
+          'current_start' => current_timeframe_start.to_s,
+          'current_end' => timeframe_end.to_s
+        }
+      }
+      let(:expected_query_args) {
+        {
+          timeframe_start: current_timeframe_start,
+          timeframe_end: timeframe_end,
+          school_ids: school_ids,
+          grades: grades,
+          teacher_ids: teacher_ids,
+          classroom_ids: classroom_ids
         }
       }
 
@@ -52,28 +62,27 @@ module Snapshots
       end
 
       it 'should execute a query for the timeframe' do
-        expect(query_double).to receive(:run).with(
-          timeframe_start: current_timeframe_start,
-          timeframe_end: timeframe_end,
-          school_ids: school_ids,
-          grades: grades,
-          teacher_ids: teacher_ids,
-          classroom_ids: classroom_ids)
+        expect(query_double).to receive(:run).with(expected_query_args)
         expect(Rails.cache).to receive(:write)
         expect(PusherTrigger).to receive(:run)
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters)
       end
 
+      context 'serialization/deserialization' do
+        it 'should desieralize timeframes back into DateTimes' do
+          allow(PusherTrigger).to receive(:run)
+          Sidekiq::Testing.inline! do
+            expect(query_double).to receive(:run).with(expected_query_args)
+
+            described_class.perform_async(cache_key, query, user_id, timeframe, school_ids, filters)
+          end
+        end
+      end
+
       context "params with string keys" do
         it 'should execute a query for the timeframe' do
-          expect(query_double).to receive(:run).with(
-            timeframe_start: current_timeframe_start,
-            timeframe_end: timeframe_end,
-            school_ids: school_ids,
-            grades: grades,
-            teacher_ids: teacher_ids,
-            classroom_ids: classroom_ids)
+          expect(query_double).to receive(:run).with(expected_query_args)
           expect(Rails.cache).to receive(:write)
           expect(PusherTrigger).to receive(:run)
 


### PR DESCRIPTION
## WHAT
Fix a bug that was ending timeframes one day early
## WHY
This was excluding "yesterday's" data from timeframes, but we basically want that data in all non-custom timeframes.
## HOW
Stop converting timeframe dates `to_date` in Period queries.  This was truncating the timestamp part from `end_of_day` which we were getting from the Timeframe lib.  So instead of looking for dates up to (say) '2023-01-01 23:59:59', it was being truncated to '2023-01-01', and cutting out the entire day.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
