### PR TITLE
remove classrooms.teacher_id from diagnostic reports query rake task

### DIFF
--- a/services/QuillLMS/lib/tasks/reports.rake
+++ b/services/QuillLMS/lib/tasks/reports.rake
@@ -19,7 +19,7 @@ namespace :reports do
       join classrooms_teachers
       on schools_users.user_id = classrooms_teachers.user_id
       join classrooms
-      on classrooms.teacher_id = schools_users.user_id or classrooms.id=classrooms_teachers.classroom_id
+      on classrooms.id=classrooms_teachers.classroom_id
       join classroom_units
       on classroom_units.classroom_id = classrooms.id
       join units


### PR DESCRIPTION
## WHAT
Remove `classrooms.teacher_id` from the diagnostic reports query rake task.

## WHY
This column was removed, so the query is now erroring.

## HOW
Just delete that part of the query.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Diagnostic-Skill-Score-Pull-Request-Brewster-Central-School-District-e9af1e0f74194d96869090e9e27d066b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A