### PR TITLE
Rails Prework Part 1: Move Analytics module file to proper namespace

### DIFF
--- a/services/QuillLMS/app/controllers/coteacher_classroom_invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/coteacher_classroom_invitations_controller.rb
@@ -27,7 +27,7 @@ class CoteacherClassroomInvitationsController < ApplicationController
     invitations.each do |invitation|
       ClassroomsTeacher.create(classroom_id: invitation['classroom_id'], role: ClassroomsTeacher::ROLE_TYPES[:coteacher], user_id: current_user.id)
       CoteacherClassroomInvitation.find_by(classroom_id: invitation['classroom_id'], invitation_id: invitation['invitation_id'])&.destroy
-      Analyzer.new.track(current_user, SegmentIo::BackgroundEvents::COTEACHER_ACCEPTANCE)
+      Analytics::Analyzer.new.track(current_user, Analytics::SegmentIo::BackgroundEvents::COTEACHER_ACCEPTANCE)
     end
 
     respond_to do |format|

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -262,7 +262,7 @@ class Teachers::ClassroomManagerController < ApplicationController
   def preview_as_student
     student = User.find_by_id(params[:student_id])
     if student && (student&.classrooms&.to_a & current_user&.classrooms_i_teach)&.any?
-      Analyzer.new.track(current_user, SegmentIo::BackgroundEvents::VIEWED_AS_STUDENT)
+      Analyzer.new.track(current_user, Analytics::SegmentIo::BackgroundEvents::VIEWED_AS_STUDENT)
       self.preview_student_id= params[:student_id]
     end
     redirect_to '/profile'

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -262,7 +262,7 @@ class Teachers::ClassroomManagerController < ApplicationController
   def preview_as_student
     student = User.find_by_id(params[:student_id])
     if student && (student&.classrooms&.to_a & current_user&.classrooms_i_teach)&.any?
-      Analyzer.new.track(current_user, Analytics::SegmentIo::BackgroundEvents::VIEWED_AS_STUDENT)
+      Analytics::Analyzer.new.track(current_user, Analytics::SegmentIo::BackgroundEvents::VIEWED_AS_STUDENT)
       self.preview_student_id= params[:student_id]
     end
     redirect_to '/profile'

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -152,7 +152,7 @@ class Teachers::ClassroomsController < ApplicationController
       end
       Analyzer.new.track_with_attributes(
           current_user,
-          SegmentIo::BackgroundEvents::TRANSFER_OWNERSHIP,
+          Analytics::SegmentIo::BackgroundEvents::TRANSFER_OWNERSHIP,
 { properties: { new_owner_id: requested_new_owner_id } }
       )
     rescue => e

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -150,10 +150,11 @@ class Teachers::ClassroomsController < ApplicationController
         ClassroomsTeacher.find_by(user_id: current_user.id, classroom_id: @classroom.id, role: owner_role).update(role: coteacher_role)
         ClassroomsTeacher.find_by(user_id: requested_new_owner_id, classroom_id: @classroom.id, role: coteacher_role).update(role: owner_role)
       end
-      Analyzer.new.track_with_attributes(
-          current_user,
-          Analytics::SegmentIo::BackgroundEvents::TRANSFER_OWNERSHIP,
-{ properties: { new_owner_id: requested_new_owner_id } }
+
+      Analytics::Analyzer.new.track_with_attributes(
+        current_user,
+        Analytics::SegmentIo::BackgroundEvents::TRANSFER_OWNERSHIP,
+        properties: { new_owner_id: requested_new_owner_id }
       )
     rescue => e
       return render json: { error: "Please ensure this teacher is a co-teacher before transferring ownership. #{e}" }, status: 401

--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -74,7 +74,7 @@ module QuillAuthentication
   def current_user_demo_id=(demo_id)
     session[:demo_id] = demo_id
     if demo_id
-      Analyzer.new.track(current_user, Analytics::SegmentIo::BackgroundEvents::VIEWED_DEMO)
+      Analytics::Analyzer.new.track(current_user, Analytics::SegmentIo::BackgroundEvents::VIEWED_DEMO)
       @current_user = User.find(session[:demo_id])
     else
       @current_user = User.find(session[:user_id])

--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -74,7 +74,7 @@ module QuillAuthentication
   def current_user_demo_id=(demo_id)
     session[:demo_id] = demo_id
     if demo_id
-      Analyzer.new.track(current_user, SegmentIo::BackgroundEvents::VIEWED_DEMO)
+      Analyzer.new.track(current_user, Analytics::SegmentIo::BackgroundEvents::VIEWED_DEMO)
       @current_user = User.find(session[:demo_id])
     else
       @current_user = User.find(session[:user_id])

--- a/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
+++ b/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
@@ -55,7 +55,7 @@ class CoteacherClassroomInvitation < ApplicationRecord
     UserMilestone.find_or_create_by(user_id: invitation.inviter_id, milestone_id: Milestone.find_or_create_by(name: Milestone::TYPES[:invite_a_coteacher]).id)
     Analyzer.new.track_with_attributes(
         User.find(invitation.inviter_id),
-        SegmentIo::BackgroundEvents::COTEACHER_INVITATION,
+        Analytics::SegmentIo::BackgroundEvents::COTEACHER_INVITATION,
         { properties: { invitee_email: invitation.invitee_email } }
     )
   end

--- a/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
+++ b/services/QuillLMS/app/models/coteacher_classroom_invitation.rb
@@ -53,10 +53,10 @@ class CoteacherClassroomInvitation < ApplicationRecord
   private def trigger_analytics
     invitation = self.invitation
     UserMilestone.find_or_create_by(user_id: invitation.inviter_id, milestone_id: Milestone.find_or_create_by(name: Milestone::TYPES[:invite_a_coteacher]).id)
-    Analyzer.new.track_with_attributes(
-        User.find(invitation.inviter_id),
-        Analytics::SegmentIo::BackgroundEvents::COTEACHER_INVITATION,
-        { properties: { invitee_email: invitation.invitee_email } }
+    Analytics::Analyzer.new.track_with_attributes(
+      User.find(invitation.inviter_id),
+      Analytics::SegmentIo::BackgroundEvents::COTEACHER_INVITATION,
+      properties: { invitee_email: invitation.invitee_email }
     )
   end
 

--- a/services/QuillLMS/app/models/referrals_user.rb
+++ b/services/QuillLMS/app/models/referrals_user.rb
@@ -113,14 +113,14 @@ class ReferralsUser < ApplicationRecord
     # Unlike other analytics events, we want to track this event with respect
     # to the referrer, not the current user, because we are attempting to
     # measure the referrer's referring activity and not the current user's.
-    ReferrerAnalytics.new.track_referral_invited(referrer, referred_user.id)
+    Analytics::ReferrerAnalytics.new.track_referral_invited(referrer, referred_user.id)
   end
 
   private def trigger_activated_event
     # Unlike other analytics events, we want to track this event with respect
     # to the referrer, not the current user, because we are attempting to
     # measure the referrer's referring activity and not the current user's.
-    ReferrerAnalytics.new.track_referral_activated(referrer, referred_user.id)
+    Analytics::ReferrerAnalytics.new.track_referral_activated(referrer, referred_user.id)
     UserMilestone.find_or_create_by(user_id: referrer.id, milestone_id: Milestone.find_or_create_by(name: Milestone::TYPES[:refer_an_active_teacher]).id)
     ReferralEmailWorker.perform_async(id)
   end

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -56,14 +56,14 @@ module SegmentIntegration
 
     def school_params
       if admin? && school && School::ALTERNATIVE_SCHOOL_NAMES.exclude?(school.name)
-        cache = CacheSegmentSchoolData.new(school).read || {}
+        cache = Analytics::CacheSegmentSchoolData.new(school).read || {}
         {
-          total_teachers_at_school: cache[CacheSegmentSchoolData::TOTAL_TEACHERS_AT_SCHOOL],
-          total_students_at_school: cache[CacheSegmentSchoolData::TOTAL_STUDENTS_AT_SCHOOL],
-          total_activities_completed_by_students_at_school: cache[CacheSegmentSchoolData::TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL],
-          active_teachers_at_school_this_year: cache[CacheSegmentSchoolData::ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR],
-          active_students_at_school_this_year: cache[CacheSegmentSchoolData::ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR],
-          total_activities_completed_by_students_at_school_this_year: cache[CacheSegmentSchoolData::TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR]
+          total_teachers_at_school: cache[Analytics::CacheSegmentSchoolData::TOTAL_TEACHERS_AT_SCHOOL],
+          total_students_at_school: cache[Analytics::CacheSegmentSchoolData::TOTAL_STUDENTS_AT_SCHOOL],
+          total_activities_completed_by_students_at_school: cache[Analytics::CacheSegmentSchoolData::TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL],
+          active_teachers_at_school_this_year: cache[Analytics::CacheSegmentSchoolData::ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR],
+          active_students_at_school_this_year: cache[Analytics::CacheSegmentSchoolData::ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR],
+          total_activities_completed_by_students_at_school_this_year: cache[Analytics::CacheSegmentSchoolData::TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR]
         }.reject {|_,v| v.nil? }
       else
         {}

--- a/services/QuillLMS/app/services/analytics/analyzer.rb
+++ b/services/QuillLMS/app/services/analytics/analyzer.rb
@@ -1,33 +1,35 @@
 # frozen_string_literal: true
 
-class Analyzer
-  attr_accessor :analytics
+module Analytics
+  class Analyzer
+    attr_accessor :analytics
 
-  def initialize(analyzer = SegmentAnalytics.new)
-    @analytics = analyzer
-  end
+    def initialize(analyzer = SegmentAnalytics.new)
+      @analytics = analyzer
+    end
 
-  def track(user, event)
-    analytics.identify(user)
-    analytics.track({user_id: user.id,
-      event: event,
-      context: { ip: user.ip_address } }
-    )
-  end
-
-  def track_with_attributes(user, event, attributes)
-    analytics.identify(user)
-    analytics.track({user_id: user.id, event: event}.merge(attributes))
-  end
-
-  def track_chain(user, events)
-    analytics.identify(user)
-    events.each do |event|
-      analytics.track({
-        user_id: user.id,
+    def track(user, event)
+      analytics.identify(user)
+      analytics.track({user_id: user.id,
         event: event,
-        context: { ip: user.ip_address }
-      })
+        context: { ip: user.ip_address } }
+      )
+    end
+
+    def track_with_attributes(user, event, attributes)
+      analytics.identify(user)
+      analytics.track({user_id: user.id, event: event}.merge(attributes))
+    end
+
+    def track_chain(user, events)
+      analytics.identify(user)
+      events.each do |event|
+        analytics.track({
+          user_id: user.id,
+          event: event,
+          context: { ip: user.ip_address }
+        })
+      end
     end
   end
 end

--- a/services/QuillLMS/app/services/analytics/cache_segment_school_data.rb
+++ b/services/QuillLMS/app/services/analytics/cache_segment_school_data.rb
@@ -1,76 +1,78 @@
 # frozen_string_literal: true
 
-class CacheSegmentSchoolData
-  CACHED_SCHOOL_DATA = 'CACHED_SCHOOL_DATA'
+module Analytics
+  class CacheSegmentSchoolData
+    CACHED_SCHOOL_DATA = 'CACHED_SCHOOL_DATA'
 
-  TOTAL_TEACHERS_AT_SCHOOL = 'TOTAL_TEACHERS_AT_SCHOOL'
-  TOTAL_STUDENTS_AT_SCHOOL = 'TOTAL_STUDENTS_AT_SCHOOL'
-  TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL = 'TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL'
-  ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR = 'ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR'
-  ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR = 'ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR'
-  TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR = 'TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR'
+    TOTAL_TEACHERS_AT_SCHOOL = 'TOTAL_TEACHERS_AT_SCHOOL'
+    TOTAL_STUDENTS_AT_SCHOOL = 'TOTAL_STUDENTS_AT_SCHOOL'
+    TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL = 'TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL'
+    ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR = 'ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR'
+    ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR = 'ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR'
+    TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR = 'TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR'
 
-  CACHE_LIFE = 60*60*25
+    CACHE_LIFE = 60*60*25
 
-  def initialize(school)
-    @school = school
+    def initialize(school)
+      @school = school
+    end
+
+    def read
+      Rails.cache.read(@school.id, namespace: CACHED_SCHOOL_DATA)
+    end
+
+    def write(data)
+      Rails.cache.write(@school.id, data, namespace: CACHED_SCHOOL_DATA, expires_in: CACHE_LIFE)
+    end
+
+    def calculate_and_set_cache
+      hash = {
+        TOTAL_TEACHERS_AT_SCHOOL => teachers_at_school.count,
+        TOTAL_STUDENTS_AT_SCHOOL => students_at_school.count,
+        TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL => activities_completed_by_students_at_school.count,
+        ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR => active_teachers_at_school_this_year.count,
+        ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR => active_students_at_school_this_year.count,
+        TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR => activities_completed_by_students_at_school_this_year.count
+      }
+      write(hash)
+    end
+
+    def active_teachers_at_school_this_year
+      teachers_at_school
+        .where("last_sign_in > ?", School.school_year_start(Time.current))
+    end
+
+    def active_students_at_school_this_year
+      students_at_school
+        .where("last_sign_in > ?", School.school_year_start(Time.current))
+    end
+
+    def activities_completed_by_students_at_school_this_year
+      activities_completed_by_students_at_school
+        .where("completed_at > ?", School.school_year_start(Time.current))
+    end
+
+    def activities_completed_by_students_at_school
+      @activities_completed_by_students_at_school ||= ActivitySession
+        .completed
+        .where(user_id: students_at_school.ids)
+    end
+
+    def students_at_school
+      @students_at_school ||= User
+        .joins(:students_classrooms)
+        .where(:students_classrooms => { classroom_id: classrooms_at_school.ids })
+    end
+
+    def classrooms_at_school
+      @classrooms_at_school ||= Classroom
+        .joins(:classrooms_teachers)
+        .where(:classrooms_teachers => { user_id: teachers_at_school.ids })
+    end
+
+    def teachers_at_school
+      @teachers_at_school ||= @school.users
+    end
+
   end
-
-  def read
-    Rails.cache.read(@school.id, namespace: CACHED_SCHOOL_DATA)
-  end
-
-  def write(data)
-    Rails.cache.write(@school.id, data, namespace: CACHED_SCHOOL_DATA, expires_in: CACHE_LIFE)
-  end
-
-  def calculate_and_set_cache
-    hash = {
-      TOTAL_TEACHERS_AT_SCHOOL => teachers_at_school.count,
-      TOTAL_STUDENTS_AT_SCHOOL => students_at_school.count,
-      TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL => activities_completed_by_students_at_school.count,
-      ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR => active_teachers_at_school_this_year.count,
-      ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR => active_students_at_school_this_year.count,
-      TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR => activities_completed_by_students_at_school_this_year.count
-    }
-    write(hash)
-  end
-
-  def active_teachers_at_school_this_year
-    teachers_at_school
-      .where("last_sign_in > ?", School.school_year_start(Time.current))
-  end
-
-  def active_students_at_school_this_year
-    students_at_school
-      .where("last_sign_in > ?", School.school_year_start(Time.current))
-  end
-
-  def activities_completed_by_students_at_school_this_year
-    activities_completed_by_students_at_school
-      .where("completed_at > ?", School.school_year_start(Time.current))
-  end
-
-  def activities_completed_by_students_at_school
-    @activities_completed_by_students_at_school ||= ActivitySession
-      .completed
-      .where(user_id: students_at_school.ids)
-  end
-
-  def students_at_school
-    @students_at_school ||= User
-      .joins(:students_classrooms)
-      .where(:students_classrooms => { classroom_id: classrooms_at_school.ids })
-  end
-
-  def classrooms_at_school
-    @classrooms_at_school ||= Classroom
-      .joins(:classrooms_teachers)
-      .where(:classrooms_teachers => { user_id: teachers_at_school.ids })
-  end
-
-  def teachers_at_school
-    @teachers_at_school ||= @school.users
-  end
-
 end

--- a/services/QuillLMS/app/services/analytics/error_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/error_analytics.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
-class ErrorAnalytics
-  attr_accessor :analytics
+module Analytics
+  class ErrorAnalytics
+    attr_accessor :analytics
 
-  def initialize(analyzer = SegmentAnalytics.new)
-    self.analytics = analyzer
+    def initialize(analyzer = SegmentAnalytics.new)
+      self.analytics = analyzer
+    end
+
+    def track500
+      anonymous_id = SecureRandom.urlsafe_base64
+      user = nil
+      analytics.track({event: SegmentIo::BackgroundEvents::ERROR_500, anonymous_id: anonymous_id})
+    end
   end
-
-  def track500
-    anonymous_id = SecureRandom.urlsafe_base64
-    user = nil
-    analytics.track({event: SegmentIo::BackgroundEvents::ERROR_500, anonymous_id: anonymous_id})
-  end
-
 end

--- a/services/QuillLMS/app/services/analytics/referrer_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/referrer_analytics.rb
@@ -10,20 +10,20 @@ module Analytics
 
     def track_referral_invited(referrer, referral_id)
       analytics.identify(referrer)
-      analytics.track({
-                        user_id: referrer.id,
-                        event: Analytics::SegmentIo::BackgroundEvents::REFERRAL_INVITED,
-                        properties: { referral_id: referral_id }
-      })
+      analytics.track(
+        event: Analytics::SegmentIo::BackgroundEvents::REFERRAL_INVITED,
+        properties: { referral_id: referral_id },
+        user_id: referrer.id
+      )
     end
 
     def track_referral_activated(referrer, referral_id)
       analytics.identify(referrer)
-      analytics.track({
-                        user_id: referrer.id,
-                        event: Analytics::SegmentIo::BackgroundEvents::REFERRAL_ACTIVATED,
-                        properties: { referral_id: referral_id }
-      })
+      analytics.track(
+        event: Analytics::SegmentIo::BackgroundEvents::REFERRAL_ACTIVATED,
+        properties: { referral_id: referral_id },
+        user_id: referrer.id
+      )
     end
   end
 end

--- a/services/QuillLMS/app/services/analytics/referrer_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/referrer_analytics.rb
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
 
-class ReferrerAnalytics
-  attr_accessor :analytics
+module Analytics
+  class ReferrerAnalytics
+    attr_accessor :analytics
 
-  def initialize
-    self.analytics = SegmentAnalytics.new
-  end
+    def initialize
+      self.analytics = SegmentAnalytics.new
+    end
 
-  def track_referral_invited(referrer, referral_id)
-    analytics.identify(referrer)
-    analytics.track({
-                      user_id: referrer.id,
-                      event: SegmentIo::BackgroundEvents::REFERRAL_INVITED,
-                      properties: { referral_id: referral_id }
-    })
-  end
+    def track_referral_invited(referrer, referral_id)
+      analytics.identify(referrer)
+      analytics.track({
+                        user_id: referrer.id,
+                        event: Analytics::SegmentIo::BackgroundEvents::REFERRAL_INVITED,
+                        properties: { referral_id: referral_id }
+      })
+    end
 
-  def track_referral_activated(referrer, referral_id)
-    analytics.identify(referrer)
-    analytics.track({
-                      user_id: referrer.id,
-                      event: SegmentIo::BackgroundEvents::REFERRAL_ACTIVATED,
-                      properties: { referral_id: referral_id }
-    })
+    def track_referral_activated(referrer, referral_id)
+      analytics.identify(referrer)
+      analytics.track({
+                        user_id: referrer.id,
+                        event: Analytics::SegmentIo::BackgroundEvents::REFERRAL_ACTIVATED,
+                        properties: { referral_id: referral_id }
+      })
+    end
   end
 end

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -1,333 +1,335 @@
 # frozen_string_literal: true
 
-class SegmentAnalytics
-  # The actual backend that this uses to talk with segment.io.
-  # This will be a fake backend under test and a real object
-  # elsewhere.
-  class_attribute :backend
 
+module Analytics
+  class SegmentAnalytics
+    # The actual backend that this uses to talk with segment.io.
+    # This will be a fake backend under test and a real object
+    # elsewhere.
+    class_attribute :backend
 
-  # TODO : split this all out in the way that SigninAnalytics splits out
+    # TODO : split this all out in the way that SigninAnalytics splits out
 
-  def initialize
-    # Do not clobber the backend object if we already set a fake one under test
-    return if Rails.env.test?
+    def initialize
+      # Do not clobber the backend object if we already set a fake one under test
+      return if Rails.env.test?
 
-    self.backend ||= Segment::Analytics.new(
-      write_key: SegmentIo.configuration.write_key,
-      on_error: proc { |status, msg| print msg }
-    )
-  end
-
-  def track_event_from_string(event_name, user_id)
-    # make sure that event name is written as a string in the pattern of
-    # those in app/services/analytics/segment_io.rb
-    # i.e. "BUILD_YOUR_OWN_ACTIVITY_PACK"
-    track({
-       user_id: user_id,
-       event: "SegmentIo::BackgroundEvents::#{event_name}".constantize
-      })
-  end
-
-  def track_activity_assignment(teacher_id, activity_id)
-    activity = Activity.find_by(id: activity_id) || Activity.find_by(uid: activity_id)
-
-    # properties here get used by Heap
-    track({
-      user_id: teacher_id,
-      event: SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT,
-      properties: activity.segment_activity.content_params
-    })
-
-    # this event is for Vitally, which does not show properties
-    return unless Activity.diagnostic_activity_ids.include?(activity_id)
-
-    track({
-      user_id: teacher_id,
-      event: "#{SegmentIo::BackgroundEvents::DIAGNOSTIC_ASSIGNMENT} | #{activity.name}"
-    })
-  end
-
-  def track_activity_pack_assignment(teacher_id, unit_id)
-    unit = Unit.find_by_id(unit_id)
-
-    if unit&.unit_template_id
-      if unit.activities.all? { |a| Activity.diagnostic_activity_ids.include?(a.id) }
-        activity_pack_type = 'Diagnostic'
-      else
-        activity_pack_type = 'Pre-made'
-      end
-    else
-      activity_pack_type = 'Custom'
-    end
-
-    track({
-      user_id: teacher_id,
-      event: SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT,
-      properties: {
-        activity_pack_name: unit&.unit_template&.name || unit&.name,
-        activity_pack_type: activity_pack_type
-      }
-    })
-  end
-
-  def track_activity_completion(user, student_id, activity, activity_session)
-    track({
-      user_id: user&.id,
-      event: SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION,
-      properties: activity.segment_activity.content_params.merge({student_id: student_id})
-    })
-    track_activity_pack_completion(user, student_id, activity_session) if activity_pack_completed?(student_id, activity_session)
-  end
-
-  def activity_pack_completed?(student_id, activity_session)
-    classroom_unit = ClassroomUnit.find_by(id: activity_session.classroom_unit_id)
-    activity_ids = classroom_unit&.unit_activities&.pluck(:activity_id)
-
-    activity_ids.all? do |activity_id|
-      ActivitySession.exists?(
-        activity_id: activity_id,
-        classroom_unit: classroom_unit,
-        state: ActivitySession::STATE_FINISHED,
-        user_id: student_id
+      self.backend ||= Segment::Analytics.new(
+        write_key: Analytics::SegmentIo.configuration.write_key,
+        on_error: proc { |status, msg| print msg }
       )
     end
-  end
 
-  def track_activity_pack_completion(user, student_id, activity_session)
-    unit = activity_session.unit
-    activity_pack_name = unit&.unit_template&.name || unit&.name
-    track({
-      user_id: user&.id,
-      event: SegmentIo::BackgroundEvents::ACTIVITY_PACK_COMPLETION,
-      properties: {
-        activity_pack_name: activity_pack_name,
-        student_id: student_id
-      }
-    })
-  end
-
-  # rubocop:disable Metrics/CyclomaticComplexity
-  def track_classroom_creation(classroom)
-    # TODO: Remove early return once this bug is fixed
-    # https://sentry.io/organizations/quillorg-5s/issues/2459924163/?project=11238&query=is%3Aunresolved
-    # https://www.notion.so/quill/Clever-Classrooms-missing-Teachers-1be9032fb94e4af48a1afa3e8156804d
-    return unless classroom&.owner&.id
-
-    # first event is for Vitally, which does not show properties
-    track({
-      user_id: classroom&.owner&.id,
-      event: "#{SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | #{classroom.classroom_type_for_segment}"
-    })
-    # second event is for Heap, which does
-    track({
-      user_id: classroom&.owner&.id,
-      event: SegmentIo::BackgroundEvents::CLASSROOM_CREATION,
-      properties: {
-        classroom_type: classroom&.classroom_type_for_segment,
-        classroom_grade: classroom && classroom.grade_as_integer >= 0 ? classroom.grade_as_integer : nil
-      }
-    })
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity
-
-  def track_activity_search(user_id, search_query)
-    track({
-      user_id: user_id,
-      event: SegmentIo::BackgroundEvents::ACTIVITY_SEARCH,
-      properties: {
-        search_query: search_query
-      }
-    })
-  end
-
-  def track_student_login_pdf_download(user_id, classroom_id)
-    track({
-      user_id: user_id,
-      event: SegmentIo::BackgroundEvents::STUDENT_LOGIN_PDF_DOWNLOAD,
-      properties: {
-        classroom_id: classroom_id
-      }
-    })
-  end
-
-  def track_previewed_activity(user_id, activity_id)
-    activity = Activity.find_by(id: activity_id) || Activity.find_by(uid: activity_id)
-
-    track({
-      user_id: user_id,
-      event: SegmentIo::BackgroundEvents::PREVIEWED_ACTIVITY,
-      properties: activity.segment_activity.common_params
-    })
-
-  end
-
-  def track_teacher_subscription(subscription, event)
-    teacher_id = subscription.users.first.id
-
-    track({
-      user_id: teacher_id,
-      event: event,
-      properties: {
-        subscription_id: subscription.id
-      }
-    })
-  end
-
-  def track_school_subscription(subscription, event)
-    school_id = subscription.schools.first.id
-
-    if subscription.purchaser_id.present?
+    def track_event_from_string(event_name, user_id)
+      # make sure that event name is written as a string in the pattern of
+      # those in app/services/analytics/segment_io.rb
+      # i.e. "BUILD_YOUR_OWN_ACTIVITY_PACK"
       track({
-        user_id: subscription.purchaser_id,
-        event: event,
-        properties: {
-          subscription_id: subscription.id,
-          school_id: school_id
-        }
+        user_id: user_id,
+        event: "Analytics::SegmentIo::BackgroundEvents::#{event_name}".constantize
+        })
+    end
+
+    def track_activity_assignment(teacher_id, activity_id)
+      activity = Activity.find_by(id: activity_id) || Activity.find_by(uid: activity_id)
+
+      # properties here get used by Heap
+      track({
+        user_id: teacher_id,
+        event: Analytics::SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT,
+        properties: activity.segment_activity.content_params
       })
-    else
+
+      # this event is for Vitally, which does not show properties
+      return unless Activity.diagnostic_activity_ids.include?(activity_id)
+
       track({
-        # Segment requires us to send a unique User ID or Anonymous ID for every event
-        # generate a random UUID here because we don't want the School Subscription event to be associated to any real user
-        anonymous_id: SecureRandom.uuid,
-        event: event,
+        user_id: teacher_id,
+        event: "#{Analytics::SegmentIo::BackgroundEvents::DIAGNOSTIC_ASSIGNMENT} | #{activity.name}"
+      })
+    end
+
+    def track_activity_pack_assignment(teacher_id, unit_id)
+      unit = Unit.find_by_id(unit_id)
+
+      if unit&.unit_template_id
+        if unit.activities.all? { |a| Activity.diagnostic_activity_ids.include?(a.id) }
+          activity_pack_type = 'Diagnostic'
+        else
+          activity_pack_type = 'Pre-made'
+        end
+      else
+        activity_pack_type = 'Custom'
+      end
+
+      track({
+        user_id: teacher_id,
+        event: Analytics::SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT,
         properties: {
-          subscription_id: subscription.id,
-          school_id: school_id
+          activity_pack_name: unit&.unit_template&.name || unit&.name,
+          activity_pack_type: activity_pack_type
         }
       })
     end
-  end
 
-  def track_teacher_school_not_listed(user, school_name, zipcode)
-    track({
-      user_id: user.id,
-      event: SegmentIo::BackgroundEvents::TEACHER_SCHOOL_NOT_LISTED,
-      properties: {
-        email: user.email,
-        school_name: school_name,
-        zipcode: zipcode
-      }
-    })
-  end
+    def track_activity_completion(user, student_id, activity, activity_session)
+      track({
+        user_id: user&.id,
+        event: Analytics::SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION,
+        properties: activity.segment_activity.content_params.merge({student_id: student_id})
+      })
+      track_activity_pack_completion(user, student_id, activity_session) if activity_pack_completed?(student_id, activity_session)
+    end
 
-  def track_school_admin_user(user, event, school_name, referring_admin_name)
-    track({
-      user_id: user.id,
-      event: event,
-      properties: {
-        first_name: user.first_name,
-        last_name: user.last_name,
-        email: user.email,
-        school_name: school_name,
-        admin_name: referring_admin_name
-      }
-    })
-  end
+    def activity_pack_completed?(student_id, activity_session)
+      classroom_unit = ClassroomUnit.find_by(id: activity_session.classroom_unit_id)
+      activity_ids = classroom_unit&.unit_activities&.pluck(:activity_id)
 
-  def track_district_admin_user(user, event, district_name, referring_admin_name)
-    track({
-      user_id: user.id,
-      event: event,
-      properties: {
-        first_name: user.first_name,
-        last_name: user.last_name,
-        email: user.email,
-        district_name: district_name,
-        admin_name: referring_admin_name
-      }
-    })
-  end
+      activity_ids.all? do |activity_id|
+        ActivitySession.exists?(
+          activity_id: activity_id,
+          classroom_unit: classroom_unit,
+          state: ActivitySession::STATE_FINISHED,
+          user_id: student_id
+        )
+      end
+    end
 
-  def track_admin_received_admin_upgrade_request_from_teacher(admin, teacher, reason, new_user)
-    identify(admin)
-    track({
-      user_id: admin.id,
-      event: new_user ? SegmentIo::BackgroundEvents::ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_NEW_USER : SegmentIo::BackgroundEvents::ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_TEACHER,
-      properties: {
-        teacher_first_name: teacher.first_name,
-        teacher_last_name: teacher.last_name,
-        teacher_email: teacher.email,
-        teacher_school: teacher.school&.name,
-        reason: reason
-      }
-    })
-  end
+    def track_activity_pack_completion(user, student_id, activity_session)
+      unit = activity_session.unit
+      activity_pack_name = unit&.unit_template&.name || unit&.name
+      track({
+        user_id: user&.id,
+        event: Analytics::SegmentIo::BackgroundEvents::ACTIVITY_PACK_COMPLETION,
+        properties: {
+          activity_pack_name: activity_pack_name,
+          student_id: student_id
+        }
+      })
+    end
 
-  def track_admin_invited_by_teacher(admin_name, admin_email, teacher, note)
-    admin = User.find_by_email(admin_email)
-    properties = {
-      admin_name: admin_name,
-      admin_email: admin_email,
-      teacher_first_name: teacher.first_name,
-      teacher_last_name: teacher.last_name,
-      teacher_school: teacher.school&.name,
-      note: note
-    }
-    if admin
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def track_classroom_creation(classroom)
+      # TODO: Remove early return once this bug is fixed
+      # https://sentry.io/organizations/quillorg-5s/issues/2459924163/?project=11238&query=is%3Aunresolved
+      # https://www.notion.so/quill/Clever-Classrooms-missing-Teachers-1be9032fb94e4af48a1afa3e8156804d
+      return unless classroom&.owner&.id
+
+      # first event is for Vitally, which does not show properties
+      track({
+        user_id: classroom&.owner&.id,
+        event: "#{Analytics::SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | #{classroom.classroom_type_for_segment}"
+      })
+      # second event is for Heap, which does
+      track({
+        user_id: classroom&.owner&.id,
+        event: Analytics::SegmentIo::BackgroundEvents::CLASSROOM_CREATION,
+        properties: {
+          classroom_type: classroom&.classroom_type_for_segment,
+          classroom_grade: classroom && classroom.grade_as_integer >= 0 ? classroom.grade_as_integer : nil
+        }
+      })
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+
+    def track_activity_search(user_id, search_query)
+      track({
+        user_id: user_id,
+        event: Analytics::SegmentIo::BackgroundEvents::ACTIVITY_SEARCH,
+        properties: {
+          search_query: search_query
+        }
+      })
+    end
+
+    def track_student_login_pdf_download(user_id, classroom_id)
+      track({
+        user_id: user_id,
+        event: Analytics::SegmentIo::BackgroundEvents::STUDENT_LOGIN_PDF_DOWNLOAD,
+        properties: {
+          classroom_id: classroom_id
+        }
+      })
+    end
+
+    def track_previewed_activity(user_id, activity_id)
+      activity = Activity.find_by(id: activity_id) || Activity.find_by(uid: activity_id)
+
+      track({
+        user_id: user_id,
+        event: Analytics::SegmentIo::BackgroundEvents::PREVIEWED_ACTIVITY,
+        properties: activity.segment_activity.common_params
+      })
+
+    end
+
+    def track_teacher_subscription(subscription, event)
+      teacher_id = subscription.users.first.id
+
+      track({
+        user_id: teacher_id,
+        event: event,
+        properties: {
+          subscription_id: subscription.id
+        }
+      })
+    end
+
+    def track_school_subscription(subscription, event)
+      school_id = subscription.schools.first.id
+
+      if subscription.purchaser_id.present?
+        track({
+          user_id: subscription.purchaser_id,
+          event: event,
+          properties: {
+            subscription_id: subscription.id,
+            school_id: school_id
+          }
+        })
+      else
+        track({
+          # Segment requires us to send a unique User ID or Anonymous ID for every event
+          # generate a random UUID here because we don't want the School Subscription event to be associated to any real user
+          anonymous_id: SecureRandom.uuid,
+          event: event,
+          properties: {
+            subscription_id: subscription.id,
+            school_id: school_id
+          }
+        })
+      end
+    end
+
+    def track_teacher_school_not_listed(user, school_name, zipcode)
+      track({
+        user_id: user.id,
+        event: Analytics::SegmentIo::BackgroundEvents::TEACHER_SCHOOL_NOT_LISTED,
+        properties: {
+          email: user.email,
+          school_name: school_name,
+          zipcode: zipcode
+        }
+      })
+    end
+
+    def track_school_admin_user(user, event, school_name, referring_admin_name)
+      track({
+        user_id: user.id,
+        event: event,
+        properties: {
+          first_name: user.first_name,
+          last_name: user.last_name,
+          email: user.email,
+          school_name: school_name,
+          admin_name: referring_admin_name
+        }
+      })
+    end
+
+    def track_district_admin_user(user, event, district_name, referring_admin_name)
+      track({
+        user_id: user.id,
+        event: event,
+        properties: {
+          first_name: user.first_name,
+          last_name: user.last_name,
+          email: user.email,
+          district_name: district_name,
+          admin_name: referring_admin_name
+        }
+      })
+    end
+
+    def track_admin_received_admin_upgrade_request_from_teacher(admin, teacher, reason, new_user)
       identify(admin)
       track({
         user_id: admin.id,
-        event: SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
-        properties: properties,
-      })
-    else
-      identify_anonymous_user({ anonymous_id: admin_email, traits: { email: admin_email, name: admin_name }})
-      track({
-        # Segment requires us to send a unique User ID or Anonymous ID for every event
-        # sending the admin email as the anonymous id because that's how we find people in Ortto
-        anonymous_id: admin_email,
-        event: SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
-        properties: properties
+        event: new_user ? Analytics::SegmentIo::BackgroundEvents::ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_NEW_USER : Analytics::SegmentIo::BackgroundEvents::ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_TEACHER,
+        properties: {
+          teacher_first_name: teacher.first_name,
+          teacher_last_name: teacher.last_name,
+          teacher_email: teacher.email,
+          teacher_school: teacher.school&.name,
+          reason: reason
+        }
       })
     end
-  end
 
-  def track_teacher_invited_admin(teacher, admin_name, admin_email, note)
-    track({
-      user_id: teacher.id,
-      event: SegmentIo::BackgroundEvents::TEACHER_INVITED_ADMIN,
-      properties: {
+    def track_admin_invited_by_teacher(admin_name, admin_email, teacher, note)
+      admin = User.find_by_email(admin_email)
+      properties = {
         admin_name: admin_name,
         admin_email: admin_email,
+        teacher_first_name: teacher.first_name,
+        teacher_last_name: teacher.last_name,
+        teacher_school: teacher.school&.name,
         note: note
       }
-    })
-  end
+      if admin
+        identify(admin)
+        track({
+          user_id: admin.id,
+          event: Analytics::SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
+          properties: properties,
+        })
+      else
+        identify_anonymous_user({ anonymous_id: admin_email, traits: { email: admin_email, name: admin_name }})
+        track({
+          # Segment requires us to send a unique User ID or Anonymous ID for every event
+          # sending the admin email as the anonymous id because that's how we find people in Ortto
+          anonymous_id: admin_email,
+          event: Analytics::SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
+          properties: properties
+        })
+      end
+    end
 
-  def default_integration_rules
-    { all: true, Intercom: false }
-  end
+    def track_teacher_invited_admin(teacher, admin_name, admin_email, note)
+      track({
+        user_id: teacher.id,
+        event: Analytics::SegmentIo::BackgroundEvents::TEACHER_INVITED_ADMIN,
+        properties: {
+          admin_name: admin_name,
+          admin_email: admin_email,
+          note: note
+        }
+      })
+    end
 
-  def track(options)
-    return unless backend.present?
+    def default_integration_rules
+      { all: true, Intercom: false }
+    end
 
-    user = User.find(options[:user_id]) if options[:user_id] && options[:user_id] != 0
-    options[:integrations] = user&.segment_user&.integration_rules || default_integration_rules
-    backend.track(options)
-  end
+    def track(options)
+      return unless backend.present?
+
+      user = User.find(options[:user_id]) if options[:user_id] && options[:user_id] != 0
+      options[:integrations] = user&.segment_user&.integration_rules || default_integration_rules
+      backend.track(options)
+    end
 
 
-  def identify(user)
-    return unless backend.present?
-    return unless user&.teacher?
+    def identify(user)
+      return unless backend.present?
+      return unless user&.teacher?
 
-    identify_params = user&.segment_user&.identify_params
-    backend.identify(identify_params) if identify_params
-  end
+      identify_params = user&.segment_user&.identify_params
+      backend.identify(identify_params) if identify_params
+    end
 
-  def identify_anonymous_user(params)
-    return unless backend.present?
+    def identify_anonymous_user(params)
+      return unless backend.present?
 
-    backend.identify(params)
-  end
+      backend.identify(params)
+    end
 
-  private def anonymous_uid
-    SecureRandom.urlsafe_base64
-  end
+    private def anonymous_uid
+      SecureRandom.urlsafe_base64
+    end
 
-  private def user_traits(user)
-    SegmentAnalyticsUserSerializer.new(user).as_json(root: false)
+    private def user_traits(user)
+      SegmentAnalyticsUserSerializer.new(user).as_json(root: false)
+    end
   end
 end

--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -1,92 +1,92 @@
 # frozen_string_literal: true
 
-module SegmentIo
+module Analytics
+  module Analytics::SegmentIo
+    class << self
+      attr_accessor :configuration
+    end
 
-  class << self
-    attr_accessor :configuration
+    class Configuration
+      attr_accessor :write_key
+    end
+
+    def self.configure
+      self.configuration ||= Configuration.new
+      yield(configuration)
+    end
+
+    module BackgroundEvents
+      TEACHER_ACCOUNT_CREATION = 'Teacher created an account'
+      TEACHER_SIGNED_UP_FOR_NEWSLETTER = 'Teacher signed up for newsletter'
+      TEACHERS_STUDENT_ACCOUNT_CREATION = "Teacher's student account created"
+      TEACHER_SIGNIN = 'Teacher signed in'
+      TEACHER_GOOGLE_AND_CLEVER = 'Teacher attempted to connect to Google and Clever'
+      TEACHERS_STUDENT_SIGNIN = "Teacher's student signed in"
+      CLASSROOM_CREATION = 'Teacher created a classroom'
+      ACTIVITY_COMPLETION = 'Student completed an activity'
+      ACTIVITY_PACK_ASSIGNMENT = 'Teacher assigned an activity pack'
+      ACTIVITY_PACK_COMPLETION = 'Student completed an activity pack'
+      ACTIVITY_ASSIGNMENT = 'Teacher assigned an activity'
+      DIAGNOSTIC_ASSIGNMENT = 'Teacher assigned a diagnostic'
+      ACCESS_PROGRESS_REPORT = 'Teacher opened progress report'
+      ASSIGN_RECOMMENDATIONS = 'Teacher assigned a recommended activity pack'
+      ASSIGN_ALL_RECOMMENDATIONS = 'Teacher assigned all recommended activity packs'
+      ERROR_500 = '500 Error'
+      TEACHER_BEGAN_PREMIUM = 'Teacher began premium'
+      TEACHER_DELETED_STUDENT_ACCOUNT = 'Teacher deleted student account'
+      MYSTERY_STUDENT_DELETION = 'Mystery student deletion'
+      ACTIVITY_SEARCH = 'Activity search'
+      STUDENT_LOGIN_PDF_DOWNLOAD = 'Student login PDF download'
+      REFERRAL_INVITED = "A new teacher signed up from this teacher's referral link"
+      REFERRAL_ACTIVATED = "One of this teacher's referrals is now active"
+      COTEACHER_INVITATION = 'Teacher invited a coteacher'
+      COTEACHER_ACCEPTANCE = 'Teacher accepted coteacher invitation'
+      TRANSFER_OWNERSHIP = 'Teacher transferred ownership of a classroom'
+      VIEWED_AS_STUDENT = 'Teacher viewed Quill as a student'
+      VIEWED_DEMO = 'User logged into Demo account'
+      PREVIEWED_ACTIVITY = 'Teacher previewed an activity'
+      TEACHER_COMPLETED_ONBOARDING_CHECKLIST = 'Teacher completed onboarding checklist'
+      TEACHER_SCHOOL_NOT_LISTED = 'Teacher school not listed'
+      # renewing subscriptions
+      TEACHER_SUB_WILL_RENEW_IN_30 = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
+      SCHOOL_SUB_WILL_RENEW_IN_30 = 'School Premium Renews in 30 Days | Automatic Renewal On'
+      TEACHER_SUB_WILL_RENEW_IN_7 = 'Teacher Premium Renews in 7 Days | Automatic Renewal On'
+      SCHOOL_SUB_WILL_RENEW_IN_7 = 'School Premium Renews in 7 Days | Automatic Renewal On'
+      # expiring subscriptions
+      TEACHER_SUB_WILL_EXPIRE_IN_30 = 'Teacher Premium Expires in 30 Days | Automatic Renewal Off'
+      SCHOOL_SUB_WILL_EXPIRE_IN_30 = 'School Premium Expires in 30 Days | Automatic Renewal Off'
+      TEACHER_SUB_WILL_EXPIRE_IN_14 = 'Teacher Premium Expires in 14 Days | Automatic Renewal Off'
+      SCHOOL_SUB_WILL_EXPIRE_IN_14 = 'School Premium Expires in 14 Days | Automatic Renewal Off'
+      # admin users
+      ADMIN_CREATED_TEACHER_ACCOUNT = 'Admin created a teacher account'
+      ADMIN_CREATED_SCHOOL_ADMIN_ACCOUNT = 'Admin created a school admin account'
+      ADMIN_SENT_LINK_REQUEST = 'Admin sent a link request to teacher'
+      ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN = 'Admin made an existing user a school admin'
+      STAFF_CREATED_SCHOOL_ADMIN_ACCOUNT = 'Quill team member created a school admin account'
+      STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN = 'Quill team member made an existing user a school admin'
+      STAFF_CREATED_DISTRICT_ADMIN_ACCOUNT = 'Quill team member created a district admin account'
+      STAFF_MADE_EXISTING_USER_DISTRICT_ADMIN = 'Quill team member made an existing user district admin'
+      # teacher requested admin upgrade from existing admins
+      ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_TEACHER = "Admin received request from teacher to become admin"
+      TEACHER_REQUESTED_TO_BECOME_ADMIN = "Teacher requested to become admin"
+      TEACHER_APPROVED_TO_BECOME_ADMIN = "Teacher’s request to become admin approved"
+      TEACHER_DENIED_TO_BECOME_ADMIN = "Teacher’s request to become admin denied"
+      # new user requested admin upgrade from existing admins
+      ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_NEW_USER = "Admin received request from new user to become admin"
+      NEW_USER_REQUESTED_TO_BECOME_ADMIN = "New user requested to become admin"
+      NEW_USER_APPROVED_TO_BECOME_ADMIN = "New user's request to become admin approved"
+      NEW_USER_DENIED_TO_BECOME_ADMIN = "New user's request to become admin denied"
+      # teacher invited admin
+      ADMIN_INVITED_BY_TEACHER = "Admin invited by teacher"
+      TEACHER_INVITED_ADMIN = "Teacher invited admin"
+    end
+
+    module Properties
+      STAFF_USER = "The Quill Team"
+    end
+
+    module Events
+      # New events that may overlap with those defined in a front-end React module
+    end
   end
-
-  class Configuration
-    attr_accessor :write_key
-  end
-
-  def self.configure
-    self.configuration ||= Configuration.new
-    yield(configuration)
-  end
-
-  module BackgroundEvents
-    TEACHER_ACCOUNT_CREATION = 'Teacher created an account'
-    TEACHER_SIGNED_UP_FOR_NEWSLETTER = 'Teacher signed up for newsletter'
-    TEACHERS_STUDENT_ACCOUNT_CREATION = "Teacher's student account created"
-    TEACHER_SIGNIN = 'Teacher signed in'
-    TEACHER_GOOGLE_AND_CLEVER = 'Teacher attempted to connect to Google and Clever'
-    TEACHERS_STUDENT_SIGNIN = "Teacher's student signed in"
-    CLASSROOM_CREATION = 'Teacher created a classroom'
-    ACTIVITY_COMPLETION = 'Student completed an activity'
-    ACTIVITY_PACK_ASSIGNMENT = 'Teacher assigned an activity pack'
-    ACTIVITY_PACK_COMPLETION = 'Student completed an activity pack'
-    ACTIVITY_ASSIGNMENT = 'Teacher assigned an activity'
-    DIAGNOSTIC_ASSIGNMENT = 'Teacher assigned a diagnostic'
-    ACCESS_PROGRESS_REPORT = 'Teacher opened progress report'
-    ASSIGN_RECOMMENDATIONS = 'Teacher assigned a recommended activity pack'
-    ASSIGN_ALL_RECOMMENDATIONS = 'Teacher assigned all recommended activity packs'
-    ERROR_500 = '500 Error'
-    TEACHER_BEGAN_PREMIUM = 'Teacher began premium'
-    TEACHER_DELETED_STUDENT_ACCOUNT = 'Teacher deleted student account'
-    MYSTERY_STUDENT_DELETION = 'Mystery student deletion'
-    ACTIVITY_SEARCH = 'Activity search'
-    STUDENT_LOGIN_PDF_DOWNLOAD = 'Student login PDF download'
-    REFERRAL_INVITED = "A new teacher signed up from this teacher's referral link"
-    REFERRAL_ACTIVATED = "One of this teacher's referrals is now active"
-    COTEACHER_INVITATION = 'Teacher invited a coteacher'
-    COTEACHER_ACCEPTANCE = 'Teacher accepted coteacher invitation'
-    TRANSFER_OWNERSHIP = 'Teacher transferred ownership of a classroom'
-    VIEWED_AS_STUDENT = 'Teacher viewed Quill as a student'
-    VIEWED_DEMO = 'User logged into Demo account'
-    PREVIEWED_ACTIVITY = 'Teacher previewed an activity'
-    TEACHER_COMPLETED_ONBOARDING_CHECKLIST = 'Teacher completed onboarding checklist'
-    TEACHER_SCHOOL_NOT_LISTED = 'Teacher school not listed'
-    # renewing subscriptions
-    TEACHER_SUB_WILL_RENEW_IN_30 = 'Teacher Premium Renews in 30 Days | Automatic Renewal On'
-    SCHOOL_SUB_WILL_RENEW_IN_30 = 'School Premium Renews in 30 Days | Automatic Renewal On'
-    TEACHER_SUB_WILL_RENEW_IN_7 = 'Teacher Premium Renews in 7 Days | Automatic Renewal On'
-    SCHOOL_SUB_WILL_RENEW_IN_7 = 'School Premium Renews in 7 Days | Automatic Renewal On'
-    # expiring subscriptions
-    TEACHER_SUB_WILL_EXPIRE_IN_30 = 'Teacher Premium Expires in 30 Days | Automatic Renewal Off'
-    SCHOOL_SUB_WILL_EXPIRE_IN_30 = 'School Premium Expires in 30 Days | Automatic Renewal Off'
-    TEACHER_SUB_WILL_EXPIRE_IN_14 = 'Teacher Premium Expires in 14 Days | Automatic Renewal Off'
-    SCHOOL_SUB_WILL_EXPIRE_IN_14 = 'School Premium Expires in 14 Days | Automatic Renewal Off'
-    # admin users
-    ADMIN_CREATED_TEACHER_ACCOUNT = 'Admin created a teacher account'
-    ADMIN_CREATED_SCHOOL_ADMIN_ACCOUNT = 'Admin created a school admin account'
-    ADMIN_SENT_LINK_REQUEST = 'Admin sent a link request to teacher'
-    ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN = 'Admin made an existing user a school admin'
-    STAFF_CREATED_SCHOOL_ADMIN_ACCOUNT = 'Quill team member created a school admin account'
-    STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN = 'Quill team member made an existing user a school admin'
-    STAFF_CREATED_DISTRICT_ADMIN_ACCOUNT = 'Quill team member created a district admin account'
-    STAFF_MADE_EXISTING_USER_DISTRICT_ADMIN = 'Quill team member made an existing user district admin'
-    # teacher requested admin upgrade from existing admins
-    ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_TEACHER = "Admin received request from teacher to become admin"
-    TEACHER_REQUESTED_TO_BECOME_ADMIN = "Teacher requested to become admin"
-    TEACHER_APPROVED_TO_BECOME_ADMIN = "Teacher’s request to become admin approved"
-    TEACHER_DENIED_TO_BECOME_ADMIN = "Teacher’s request to become admin denied"
-    # new user requested admin upgrade from existing admins
-    ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_NEW_USER = "Admin received request from new user to become admin"
-    NEW_USER_REQUESTED_TO_BECOME_ADMIN = "New user requested to become admin"
-    NEW_USER_APPROVED_TO_BECOME_ADMIN = "New user's request to become admin approved"
-    NEW_USER_DENIED_TO_BECOME_ADMIN = "New user's request to become admin denied"
-    # teacher invited admin
-    ADMIN_INVITED_BY_TEACHER = "Admin invited by teacher"
-    TEACHER_INVITED_ADMIN = "Teacher invited admin"
-  end
-
-  module Properties
-    STAFF_USER = "The Quill Team"
-  end
-
-  module Events
-    # New events that may overlap with those defined in a front-end React module
-  end
-
 end

--- a/services/QuillLMS/app/services/clever_integration/creators/teacher.rb
+++ b/services/QuillLMS/app/services/clever_integration/creators/teacher.rb
@@ -21,6 +21,6 @@ module CleverIntegration::Creators::Teacher
 
     teacher.update(google_id: nil)
 
-    SegmentAnalytics.new.track_event_from_string('TEACHER_GOOGLE_AND_CLEVER', teacher.id)
+    Analytics::SegmentAnalytics.new.track_event_from_string('TEACHER_GOOGLE_AND_CLEVER', teacher.id)
   end
 end

--- a/services/QuillLMS/app/workers/access_progress_report_worker.rb
+++ b/services/QuillLMS/app/workers/access_progress_report_worker.rb
@@ -8,6 +8,6 @@ class AccessProgressReportWorker
 
     # tell segment.io
     analytics = Analyzer.new
-    analytics.track(@user, SegmentIo::BackgroundEvents::ACCESS_PROGRESS_REPORT)
+    analytics.track(@user, Analytics::SegmentIo::BackgroundEvents::ACCESS_PROGRESS_REPORT)
   end
 end

--- a/services/QuillLMS/app/workers/access_progress_report_worker.rb
+++ b/services/QuillLMS/app/workers/access_progress_report_worker.rb
@@ -7,7 +7,7 @@ class AccessProgressReportWorker
     @user = User.find(id)
 
     # tell segment.io
-    analytics = Analyzer.new
+    analytics = Analytics::Analyzer.new
     analytics.track(@user, Analytics::SegmentIo::BackgroundEvents::ACCESS_PROGRESS_REPORT)
   end
 end

--- a/services/QuillLMS/app/workers/account_creation_worker.rb
+++ b/services/QuillLMS/app/workers/account_creation_worker.rb
@@ -10,8 +10,8 @@ class AccountCreationWorker
     analytics = Analyzer.new
     return unless @user.teacher?
 
-    events = [SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION]
-    events += [SegmentIo::BackgroundEvents::TEACHER_SIGNED_UP_FOR_NEWSLETTER] if @user.send_newsletter
+    events = [Analytics::SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION]
+    events += [Analytics::SegmentIo::BackgroundEvents::TEACHER_SIGNED_UP_FOR_NEWSLETTER] if @user.send_newsletter
     analytics.track_chain(@user, events)
   end
 end

--- a/services/QuillLMS/app/workers/account_creation_worker.rb
+++ b/services/QuillLMS/app/workers/account_creation_worker.rb
@@ -7,7 +7,7 @@ class AccountCreationWorker
     @user = User.find(id)
 
     # tell segment.io
-    analytics = Analyzer.new
+    analytics = Analytics::Analyzer.new
     return unless @user.teacher?
 
     events = [Analytics::SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION]

--- a/services/QuillLMS/app/workers/activity_search_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/activity_search_analytics_worker.rb
@@ -5,7 +5,7 @@ class ActivitySearchAnalyticsWorker
   sidekiq_options queue: SidekiqQueue::LOW
 
   def perform(user_id, search_query)
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.track_activity_search(user_id, search_query)
   end
 end

--- a/services/QuillLMS/app/workers/admin_invited_by_teacher_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/admin_invited_by_teacher_analytics_worker.rb
@@ -5,7 +5,7 @@ class AdminInvitedByTeacherAnalyticsWorker
 
   def perform(admin_name, admin_email, teacher_id, note)
     teacher = User.find_by_id(teacher_id)
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.track_admin_invited_by_teacher(admin_name, admin_email, teacher, note)
   end
 end

--- a/services/QuillLMS/app/workers/admin_received_admin_upgrade_request_from_teacher_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/admin_received_admin_upgrade_request_from_teacher_analytics_worker.rb
@@ -4,7 +4,7 @@ class AdminReceivedAdminUpgradeRequestFromTeacherAnalyticsWorker
   include Sidekiq::Worker
 
   def perform(admin_id, teacher_id, reason, new_user)
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     admin = User.find_by_id(admin_id)
     teacher = User.find_by_id(teacher_id)
     analytics.track_admin_received_admin_upgrade_request_from_teacher(admin, teacher, reason, new_user)

--- a/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/alert_soon_to_expire_subscriptions_worker.rb
@@ -4,15 +4,15 @@ class AlertSoonToExpireSubscriptionsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 
-  TEACHER_RENEW_IN_30 = SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30
-  SCHOOL_RENEW_IN_30 = SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30
-  TEACHER_RENEW_IN_7 = SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_7
-  SCHOOL_RENEW_IN_7 = SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_7
+  TEACHER_RENEW_IN_30 = Analytics::SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30
+  SCHOOL_RENEW_IN_30 = Analytics::SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30
+  TEACHER_RENEW_IN_7 = Analytics::SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_7
+  SCHOOL_RENEW_IN_7 = Analytics::SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_7
 
-  TEACHER_EXPIRE_IN_30 = SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30
-  TEACHER_EXPIRE_IN_14 = SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14
-  SCHOOL_EXPIRE_IN_30 = SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30
-  SCHOOL_EXPIRE_IN_14 = SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14
+  TEACHER_EXPIRE_IN_30 = Analytics::SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30
+  TEACHER_EXPIRE_IN_14 = Analytics::SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14
+  SCHOOL_EXPIRE_IN_30 = Analytics::SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30
+  SCHOOL_EXPIRE_IN_14 = Analytics::SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14
 
   # Send a segment event for each credit card subscription that is expiring soon
   # to trigger specific reminder emails from Intercom
@@ -45,7 +45,7 @@ class AlertSoonToExpireSubscriptionsWorker
   end
 
   private def analytics
-    @analytics ||= SegmentAnalytics.new
+    @analytics ||= Analytics::SegmentAnalytics.new
   end
 
   private def track_teachers(finder, event)

--- a/services/QuillLMS/app/workers/assign_activity_worker.rb
+++ b/services/QuillLMS/app/workers/assign_activity_worker.rb
@@ -5,7 +5,7 @@ class AssignActivityWorker
   sidekiq_options queue: SidekiqQueue::DEFAULT, retry: false
 
   def perform(teacher_id, unit_id)
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.track_activity_pack_assignment(teacher_id, unit_id) if teacher_id
   end
 end

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -54,7 +54,7 @@ class AssignRecommendationsWorker
   end
 
   def track_assign_all_recommendations(teacher)
-    analytics = Analyzer.new
+    analytics = Analytics::Analyzer.new
     analytics.track(teacher, Analytics::SegmentIo::BackgroundEvents::ASSIGN_ALL_RECOMMENDATIONS)
   end
 

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -46,7 +46,7 @@ class AssignRecommendationsWorker
   end
 
   def track_recommendation_assignment(teacher, release_method)
-    Analyzer.new.track_with_attributes(
+    Analytics::Analyzer.new.track_with_attributes(
       teacher,
       Analytics::SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS,
       properties: { release_method: release_method }

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -48,14 +48,14 @@ class AssignRecommendationsWorker
   def track_recommendation_assignment(teacher, release_method)
     Analyzer.new.track_with_attributes(
       teacher,
-      SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS,
+      Analytics::SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS,
       properties: { release_method: release_method }
     )
   end
 
   def track_assign_all_recommendations(teacher)
     analytics = Analyzer.new
-    analytics.track(teacher, SegmentIo::BackgroundEvents::ASSIGN_ALL_RECOMMENDATIONS)
+    analytics.track(teacher, Analytics::SegmentIo::BackgroundEvents::ASSIGN_ALL_RECOMMENDATIONS)
   end
 
   def handle_error_tracking_for_diagnostic_recommendation_assignment_time(teacher_id, lesson)

--- a/services/QuillLMS/app/workers/calculate_and_cache_school_data_for_segment_worker.rb
+++ b/services/QuillLMS/app/workers/calculate_and_cache_school_data_for_segment_worker.rb
@@ -7,7 +7,7 @@ class CalculateAndCacheSchoolDataForSegmentWorker
   def perform(school_id)
     school = School.includes(:users).find(school_id)
 
-    cache = CacheSegmentSchoolData.new(school)
+    cache = Analytics::CacheSegmentSchoolData.new(school)
     cache.calculate_and_set_cache
   end
 end

--- a/services/QuillLMS/app/workers/checkbox_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/checkbox_analytics_worker.rb
@@ -6,7 +6,7 @@ class CheckboxAnalyticsWorker
   def perform(user_id, activity_id)
     return unless User.exists?(id: user_id)
 
-    SegmentAnalytics
+    Analytics::SegmentAnalytics
       .new
       .track_activity_assignment(user_id, activity_id)
   end

--- a/services/QuillLMS/app/workers/classroom_creation_worker.rb
+++ b/services/QuillLMS/app/workers/classroom_creation_worker.rb
@@ -8,7 +8,7 @@ class ClassroomCreationWorker
     classroom = Classroom.unscoped.find_by_id(classroom_id)
     return unless classroom
 
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.track_classroom_creation(classroom)
   end
 end

--- a/services/QuillLMS/app/workers/delete_student_worker.rb
+++ b/services/QuillLMS/app/workers/delete_student_worker.rb
@@ -7,9 +7,9 @@ class DeleteStudentWorker
     teacher = User.find(teacher_id)
     analytics = Analyzer.new
     if referred_from_class_path
-      event = SegmentIo::BackgroundEvents::TEACHER_DELETED_STUDENT_ACCOUNT
+      event = Analytics::SegmentIo::BackgroundEvents::TEACHER_DELETED_STUDENT_ACCOUNT
     else
-      event = SegmentIo::BackgroundEvents::MYSTERY_STUDENT_DELETION
+      event = Analytics::SegmentIo::BackgroundEvents::MYSTERY_STUDENT_DELETION
     end
     # tell segment.io
     analytics.track(teacher, event)

--- a/services/QuillLMS/app/workers/delete_student_worker.rb
+++ b/services/QuillLMS/app/workers/delete_student_worker.rb
@@ -5,7 +5,7 @@ class DeleteStudentWorker
 
   def perform(teacher_id, referred_from_class_path)
     teacher = User.find(teacher_id)
-    analytics = Analyzer.new
+    analytics = Analytics::Analyzer.new
     if referred_from_class_path
       event = Analytics::SegmentIo::BackgroundEvents::TEACHER_DELETED_STUDENT_ACCOUNT
     else

--- a/services/QuillLMS/app/workers/error_worker.rb
+++ b/services/QuillLMS/app/workers/error_worker.rb
@@ -4,8 +4,8 @@ class ErrorWorker
   include Sidekiq::Worker
 
   def perform
-    ea = ErrorAnalytics.new
-    ea.track500
+    Analytics::ErrorAnalytics
+      .new
+      .track500
   end
-
 end

--- a/services/QuillLMS/app/workers/finish_activity_worker.rb
+++ b/services/QuillLMS/app/workers/finish_activity_worker.rb
@@ -27,7 +27,7 @@ class FinishActivityWorker
 
     return unless activity_session.eligible_for_tracking?
 
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.track_activity_completion(activity_session.classroom_owner, activity_session.user_id, activity_session.activity, activity_session)
   end
 end

--- a/services/QuillLMS/app/workers/identify_worker.rb
+++ b/services/QuillLMS/app/workers/identify_worker.rb
@@ -7,7 +7,7 @@ class IdentifyWorker
     user = User.find_by_id(id)
     return unless user
 
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.identify(user)
   end
 end

--- a/services/QuillLMS/app/workers/internal_tool/admin_account_created_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/admin_account_created_email_worker.rb
@@ -11,11 +11,11 @@ class InternalTool::AdminAccountCreatedEmailWorker
 
     user.mailer_user.send_internal_tool_admin_account_created_email(school_name)
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::STAFF_CREATED_SCHOOL_ADMIN_ACCOUNT,
+      Analytics::SegmentIo::BackgroundEvents::STAFF_CREATED_SCHOOL_ADMIN_ACCOUNT,
       school_name,
-      SegmentIo::Properties::STAFF_USER
+      Analytics::SegmentIo::Properties::STAFF_USER
     )
   end
 end

--- a/services/QuillLMS/app/workers/internal_tool/district_admin_account_created_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/district_admin_account_created_email_worker.rb
@@ -11,11 +11,11 @@ class InternalTool::DistrictAdminAccountCreatedEmailWorker
 
     user.mailer_user.send_internal_tool_district_admin_account_created_email(district_name)
 
-    SegmentAnalytics.new.track_district_admin_user(
+    Analytics::SegmentAnalytics.new.track_district_admin_user(
       user,
-      SegmentIo::BackgroundEvents::STAFF_CREATED_DISTRICT_ADMIN_ACCOUNT,
+      Analytics::SegmentIo::BackgroundEvents::STAFF_CREATED_DISTRICT_ADMIN_ACCOUNT,
       district_name,
-      SegmentIo::Properties::STAFF_USER
+      Analytics::SegmentIo::Properties::STAFF_USER
     )
   end
 end

--- a/services/QuillLMS/app/workers/internal_tool/made_district_admin_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_district_admin_email_worker.rb
@@ -11,11 +11,11 @@ class InternalTool::MadeDistrictAdminEmailWorker
 
     user.mailer_user.send_internal_tool_made_district_admin_email(district_name)
 
-    SegmentAnalytics.new.track_district_admin_user(
+    Analytics::SegmentAnalytics.new.track_district_admin_user(
       user,
-      SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_DISTRICT_ADMIN,
+      Analytics::SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_DISTRICT_ADMIN,
       district_name,
-      SegmentIo::Properties::STAFF_USER
+      Analytics::SegmentIo::Properties::STAFF_USER
     )
   end
 end

--- a/services/QuillLMS/app/workers/internal_tool/made_school_admin_change_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_school_admin_change_school_email_worker.rb
@@ -14,11 +14,11 @@ class InternalTool::MadeSchoolAdminChangeSchoolEmailWorker
       user.mailer_user.send_internal_tool_made_school_admin_change_school_email(new_school, existing_school)
     end
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
+      Analytics::SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
       new_school.name,
-      SegmentIo::Properties::STAFF_USER
+      Analytics::SegmentIo::Properties::STAFF_USER
     )
   end
 end

--- a/services/QuillLMS/app/workers/internal_tool/made_school_admin_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_school_admin_email_worker.rb
@@ -13,11 +13,11 @@ class InternalTool::MadeSchoolAdminEmailWorker
       user.mailer_user.send_internal_tool_made_school_admin_email(school_name)
     end
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
+      Analytics::SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
       school_name,
-      SegmentIo::Properties::STAFF_USER
+      Analytics::SegmentIo::Properties::STAFF_USER
     )
   end
 end

--- a/services/QuillLMS/app/workers/internal_tool/made_school_admin_link_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/made_school_admin_link_school_email_worker.rb
@@ -13,11 +13,11 @@ class InternalTool::MadeSchoolAdminLinkSchoolEmailWorker
       user.mailer_user.send_internal_tool_made_school_admin_link_school_email(school)
     end
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
+      Analytics::SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
       school.name,
-      SegmentIo::Properties::STAFF_USER
+      Analytics::SegmentIo::Properties::STAFF_USER
     )
   end
 end

--- a/services/QuillLMS/app/workers/onboarding_checklist_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/onboarding_checklist_analytics_worker.rb
@@ -11,7 +11,7 @@ class OnboardingChecklistAnalyticsWorker
 
     return unless all_objectives_met
 
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.track_event_from_string("TEACHER_COMPLETED_ONBOARDING_CHECKLIST", user_id)
   end
 end

--- a/services/QuillLMS/app/workers/premium_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/premium_analytics_worker.rb
@@ -11,7 +11,7 @@ class PremiumAnalyticsWorker
     analytics = Analyzer.new
     analytics.track_with_attributes(
       @user,
-      SegmentIo::BackgroundEvents::TEACHER_BEGAN_PREMIUM,
+      Analytics::SegmentIo::BackgroundEvents::TEACHER_BEGAN_PREMIUM,
       properties: @user.segment_user.premium_params
     )
   end

--- a/services/QuillLMS/app/workers/premium_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/premium_analytics_worker.rb
@@ -8,7 +8,7 @@ class PremiumAnalyticsWorker
     @user = User.find_by_id(id)
     return unless @user
 
-    analytics = Analyzer.new
+    analytics = Analytics::Analyzer.new
     analytics.track_with_attributes(
       @user,
       Analytics::SegmentIo::BackgroundEvents::TEACHER_BEGAN_PREMIUM,

--- a/services/QuillLMS/app/workers/premium_hub/admin_account_created_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_hub/admin_account_created_email_worker.rb
@@ -12,9 +12,9 @@ class PremiumHub::AdminAccountCreatedEmailWorker
 
     user.mailer_user.send_premium_hub_admin_account_created_email(admin_name, school_name, is_reminder)
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::ADMIN_CREATED_SCHOOL_ADMIN_ACCOUNT,
+      Analytics::SegmentIo::BackgroundEvents::ADMIN_CREATED_SCHOOL_ADMIN_ACCOUNT,
       school_name,
       admin_name
     )

--- a/services/QuillLMS/app/workers/premium_hub/made_school_admin_change_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_hub/made_school_admin_change_school_email_worker.rb
@@ -15,9 +15,9 @@ class PremiumHub::MadeSchoolAdminChangeSchoolEmailWorker
       user.mailer_user.send_premium_hub_made_school_admin_change_school_email(admin_name, new_school, existing_school)
     end
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
+      Analytics::SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
       new_school.name,
       admin_name
     )

--- a/services/QuillLMS/app/workers/premium_hub/made_school_admin_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_hub/made_school_admin_email_worker.rb
@@ -14,9 +14,9 @@ class PremiumHub::MadeSchoolAdminEmailWorker
       user.mailer_user.send_premium_hub_made_school_admin_email(admin_name, school_name)
     end
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
+      Analytics::SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
       school_name,
       admin_name
     )

--- a/services/QuillLMS/app/workers/premium_hub/made_school_admin_link_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_hub/made_school_admin_link_school_email_worker.rb
@@ -14,9 +14,9 @@ class PremiumHub::MadeSchoolAdminLinkSchoolEmailWorker
       user.mailer_user.send_premium_hub_made_school_admin_link_school_email(admin_name, school)
     end
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
+      Analytics::SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
       school.name,
       admin_name
     )

--- a/services/QuillLMS/app/workers/premium_hub/teacher_account_created_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_hub/teacher_account_created_email_worker.rb
@@ -12,9 +12,9 @@ class PremiumHub::TeacherAccountCreatedEmailWorker
 
     user.mailer_user.send_premium_hub_teacher_account_created_email(admin_name, school_name, is_reminder)
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::ADMIN_CREATED_TEACHER_ACCOUNT,
+      Analytics::SegmentIo::BackgroundEvents::ADMIN_CREATED_TEACHER_ACCOUNT,
       school_name,
       admin_name
     )

--- a/services/QuillLMS/app/workers/premium_hub/teacher_link_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_hub/teacher_link_school_email_worker.rb
@@ -14,7 +14,7 @@ class PremiumHub::TeacherLinkSchoolEmailWorker
 
     SegmentAnalytics.new.track_school_admin_user(
       user,
-      SegmentIo::BackgroundEvents::ADMIN_SENT_LINK_REQUEST,
+      Analytics::SegmentIo::BackgroundEvents::ADMIN_SENT_LINK_REQUEST,
       school.name,
       admin_name
     )

--- a/services/QuillLMS/app/workers/premium_hub/teacher_link_school_email_worker.rb
+++ b/services/QuillLMS/app/workers/premium_hub/teacher_link_school_email_worker.rb
@@ -12,7 +12,7 @@ class PremiumHub::TeacherLinkSchoolEmailWorker
 
     user.mailer_user.send_premium_hub_teacher_link_school_email(admin_name, school)
 
-    SegmentAnalytics.new.track_school_admin_user(
+    Analytics::SegmentAnalytics.new.track_school_admin_user(
       user,
       Analytics::SegmentIo::BackgroundEvents::ADMIN_SENT_LINK_REQUEST,
       school.name,

--- a/services/QuillLMS/app/workers/previewed_activity_worker.rb
+++ b/services/QuillLMS/app/workers/previewed_activity_worker.rb
@@ -6,7 +6,7 @@ class PreviewedActivityWorker
   def perform(user_id, activity_id)
     return unless user_id
 
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.track_previewed_activity(user_id, activity_id)
   end
 end

--- a/services/QuillLMS/app/workers/student_joined_classroom_worker.rb
+++ b/services/QuillLMS/app/workers/student_joined_classroom_worker.rb
@@ -8,6 +8,6 @@ class StudentJoinedClassroomWorker
 
     # do in following order so we identify the teacher last
     analytics = Analyzer.new
-    analytics.track(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION) if teacher
+    analytics.track(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION) if teacher
   end
 end

--- a/services/QuillLMS/app/workers/student_joined_classroom_worker.rb
+++ b/services/QuillLMS/app/workers/student_joined_classroom_worker.rb
@@ -7,7 +7,7 @@ class StudentJoinedClassroomWorker
     teacher = User.find_by(id: teacher_id)
 
     # do in following order so we identify the teacher last
-    analytics = Analyzer.new
+    analytics = Analytics::Analyzer.new
     analytics.track(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION) if teacher
   end
 end

--- a/services/QuillLMS/app/workers/student_login_pdf_download_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/student_login_pdf_download_analytics_worker.rb
@@ -4,7 +4,7 @@ class StudentLoginPdfDownloadAnalyticsWorker
   include Sidekiq::Worker
 
   def perform(user_id, classroom_id)
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.track_student_login_pdf_download(user_id, classroom_id)
   end
 end

--- a/services/QuillLMS/app/workers/teacher_approved_to_become_admin_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_approved_to_become_admin_analytics_worker.rb
@@ -7,7 +7,7 @@ class TeacherApprovedToBecomeAdminAnalyticsWorker
     analyzer = Analyzer.new
     user = User.find_by_id(user_id)
 
-    event = new_user ? SegmentIo::BackgroundEvents::NEW_USER_APPROVED_TO_BECOME_ADMIN : SegmentIo::BackgroundEvents::TEACHER_APPROVED_TO_BECOME_ADMIN
+    event = new_user ? Analytics::SegmentIo::BackgroundEvents::NEW_USER_APPROVED_TO_BECOME_ADMIN : Analytics::SegmentIo::BackgroundEvents::TEACHER_APPROVED_TO_BECOME_ADMIN
     analyzer.track(user, event)
   end
 end

--- a/services/QuillLMS/app/workers/teacher_approved_to_become_admin_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_approved_to_become_admin_analytics_worker.rb
@@ -4,7 +4,7 @@ class TeacherApprovedToBecomeAdminAnalyticsWorker
   include Sidekiq::Worker
 
   def perform(user_id, new_user)
-    analyzer = Analyzer.new
+    analyzer = Analytics::Analyzer.new
     user = User.find_by_id(user_id)
 
     event = new_user ? Analytics::SegmentIo::BackgroundEvents::NEW_USER_APPROVED_TO_BECOME_ADMIN : Analytics::SegmentIo::BackgroundEvents::TEACHER_APPROVED_TO_BECOME_ADMIN

--- a/services/QuillLMS/app/workers/teacher_denied_to_become_admin_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_denied_to_become_admin_analytics_worker.rb
@@ -4,7 +4,7 @@ class TeacherDeniedToBecomeAdminAnalyticsWorker
   include Sidekiq::Worker
 
   def perform(user_id, new_user)
-    analyzer = Analyzer.new
+    analyzer = Analytics::Analyzer.new
     user = User.find_by_id(user_id)
 
     event = new_user ? Analytics::SegmentIo::BackgroundEvents::NEW_USER_DENIED_TO_BECOME_ADMIN : Analytics::SegmentIo::BackgroundEvents::TEACHER_DENIED_TO_BECOME_ADMIN

--- a/services/QuillLMS/app/workers/teacher_denied_to_become_admin_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_denied_to_become_admin_analytics_worker.rb
@@ -7,7 +7,7 @@ class TeacherDeniedToBecomeAdminAnalyticsWorker
     analyzer = Analyzer.new
     user = User.find_by_id(user_id)
 
-    event = new_user ? SegmentIo::BackgroundEvents::NEW_USER_DENIED_TO_BECOME_ADMIN : SegmentIo::BackgroundEvents::TEACHER_DENIED_TO_BECOME_ADMIN
+    event = new_user ? Analytics::SegmentIo::BackgroundEvents::NEW_USER_DENIED_TO_BECOME_ADMIN : Analytics::SegmentIo::BackgroundEvents::TEACHER_DENIED_TO_BECOME_ADMIN
     analyzer.track(user, event)
   end
 end

--- a/services/QuillLMS/app/workers/teacher_invited_admin_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_invited_admin_analytics_worker.rb
@@ -5,7 +5,7 @@ class TeacherInvitedAdminAnalyticsWorker
 
   def perform(teacher_id, admin_name, admin_email, note)
     teacher = User.find_by_id(teacher_id)
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     analytics.track_teacher_invited_admin(teacher, admin_name, admin_email, note)
   end
 end

--- a/services/QuillLMS/app/workers/teacher_requested_to_become_admin_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_requested_to_become_admin_analytics_worker.rb
@@ -7,7 +7,7 @@ class TeacherRequestedToBecomeAdminAnalyticsWorker
     analyzer = Analyzer.new
     user = User.find_by_id(user_id)
 
-    event = new_user ? SegmentIo::BackgroundEvents::NEW_USER_REQUESTED_TO_BECOME_ADMIN : SegmentIo::BackgroundEvents::TEACHER_REQUESTED_TO_BECOME_ADMIN
+    event = new_user ? Analytics::SegmentIo::BackgroundEvents::NEW_USER_REQUESTED_TO_BECOME_ADMIN : Analytics::SegmentIo::BackgroundEvents::TEACHER_REQUESTED_TO_BECOME_ADMIN
     analyzer.track(user, event)
   end
 end

--- a/services/QuillLMS/app/workers/teacher_requested_to_become_admin_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_requested_to_become_admin_analytics_worker.rb
@@ -4,7 +4,7 @@ class TeacherRequestedToBecomeAdminAnalyticsWorker
   include Sidekiq::Worker
 
   def perform(user_id, new_user)
-    analyzer = Analyzer.new
+    analyzer = Analytics::Analyzer.new
     user = User.find_by_id(user_id)
 
     event = new_user ? Analytics::SegmentIo::BackgroundEvents::NEW_USER_REQUESTED_TO_BECOME_ADMIN : Analytics::SegmentIo::BackgroundEvents::TEACHER_REQUESTED_TO_BECOME_ADMIN

--- a/services/QuillLMS/app/workers/track_unlisted_school_information_worker.rb
+++ b/services/QuillLMS/app/workers/track_unlisted_school_information_worker.rb
@@ -5,7 +5,7 @@ class TrackUnlistedSchoolInformationWorker
   sidekiq_options queue: SidekiqQueue::LOW
 
   def perform(user_id, school_name, school_zipcode)
-    analytics = SegmentAnalytics.new
+    analytics = Analytics::SegmentAnalytics.new
     user = User.find_by_id(user_id)
 
     return if user.nil? || school_name.nil?

--- a/services/QuillLMS/app/workers/user_login_worker.rb
+++ b/services/QuillLMS/app/workers/user_login_worker.rb
@@ -7,7 +7,7 @@ class UserLoginWorker
     @user = User.find_by(id: id)
     return unless @user
 
-    analytics = Analyzer.new
+    analytics = Analytics::Analyzer.new
     case @user.role
     when User::TEACHER, User::ADMIN
       TeacherActivityFeedRefillWorker.perform_async(@user.id)

--- a/services/QuillLMS/app/workers/user_login_worker.rb
+++ b/services/QuillLMS/app/workers/user_login_worker.rb
@@ -13,7 +13,7 @@ class UserLoginWorker
       TeacherActivityFeedRefillWorker.perform_async(@user.id)
       analytics.track_with_attributes(
         @user,
-        SegmentIo::BackgroundEvents::TEACHER_SIGNIN,
+        Analytics::SegmentIo::BackgroundEvents::TEACHER_SIGNIN,
         properties: @user&.segment_user&.common_params
       )
       record_user_login
@@ -23,7 +23,7 @@ class UserLoginWorker
       if teacher.present?
         analytics.track_with_attributes(
           teacher,
-          SegmentIo::BackgroundEvents::TEACHERS_STUDENT_SIGNIN,
+          Analytics::SegmentIo::BackgroundEvents::TEACHERS_STUDENT_SIGNIN,
           properties: {
             student_id: @user.id
           }

--- a/services/QuillLMS/config/initializers/segment_analytics.rb
+++ b/services/QuillLMS/config/initializers/segment_analytics.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'analytics/segment_io'
-
-if !Rails.env.test?
-  SegmentIo.configure do |c|
-    c.write_key = ENV['SEGMENT_WRITE_KEY']
-  end
-end

--- a/services/QuillLMS/config/initializers/segment_io.rb
+++ b/services/QuillLMS/config/initializers/segment_io.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Analytics::SegmentIo.configure { |c| c.write_key = ENV['SEGMENT_WRITE_KEY'] } unless Rails.env.test?

--- a/services/QuillLMS/spec/controllers/coteacher_classroom_invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/coteacher_classroom_invitations_controller_spec.rb
@@ -47,7 +47,7 @@ describe CoteacherClassroomInvitationsController, type: :controller do
         end
 
         it 'should track event' do
-          expect(analyzer).to receive(:track).with(invited_teacher, SegmentIo::BackgroundEvents::COTEACHER_ACCEPTANCE)
+          expect(analyzer).to receive(:track).with(invited_teacher, Analytics::SegmentIo::BackgroundEvents::COTEACHER_ACCEPTANCE)
           get :accept_pending_coteacher_invitations, params: { coteacher_invitation_ids: [invite_one.id, invite_two.id] }
         end
       end

--- a/services/QuillLMS/spec/controllers/coteacher_classroom_invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/coteacher_classroom_invitations_controller_spec.rb
@@ -33,7 +33,7 @@ describe CoteacherClassroomInvitationsController, type: :controller do
 
       context 'post' do
         before do
-          allow(Analyzer).to receive(:new) { analyzer }
+          allow(Analytics::Analyzer).to receive(:new) { analyzer }
         end
 
         it 'should accept one invitation' do

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -726,7 +726,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     before do
       allow(controller).to receive(:current_user) { teacher }
-      allow(Analyzer).to receive(:new) { analyzer }
+      allow(Analytics::Analyzer).to receive(:new) { analyzer }
     end
 
     it 'will call current_user_demo_id= if the demo account exists' do
@@ -816,7 +816,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     before do
       allow(controller).to receive(:current_user) { teacher }
-      allow(Analyzer).to receive(:new) { analyzer }
+      allow(Analytics::Analyzer).to receive(:new) { analyzer }
     end
 
     it 'will call preview_student_id= if the student exists and is in one of the teachers classrooms' do

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -754,7 +754,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
 
     it 'will track event' do
       expect(Demo::ResetAccountWorker).to receive(:perform_async).with(demo_teacher.id)
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::VIEWED_DEMO)
+      expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::VIEWED_DEMO)
 
       get :view_demo
     end
@@ -840,7 +840,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'will track event' do
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::VIEWED_AS_STUDENT)
+      expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::VIEWED_AS_STUDENT)
       get :preview_as_student, params: { student_id: student1.id }
     end
   end

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -174,7 +174,7 @@ describe Teachers::ClassroomsController, type: :controller do
       it 'should track the ownership transfer' do
         expect(analyzer).to receive(:track_with_attributes).with(
           current_owner,
-          SegmentIo::BackgroundEvents::TRANSFER_OWNERSHIP,
+          Analytics::SegmentIo::BackgroundEvents::TRANSFER_OWNERSHIP,
           { properties: { new_owner_id: subsequent_owner.id.to_s } }
         )
         session[:user_id] = current_owner.id

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -168,7 +168,7 @@ describe Teachers::ClassroomsController, type: :controller do
       let(:analyzer) { double(:analyzer, track_with_attributes: true) }
 
       before do
-        allow(Analyzer).to receive(:new) { analyzer }
+        allow(Analytics::Analyzer).to receive(:new) { analyzer }
       end
 
       it 'should track the ownership transfer' do

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -27,7 +27,6 @@
 require 'rails_helper'
 
 describe Classroom, type: :model do
-
   it { should validate_uniqueness_of(:code) }
   it { should validate_presence_of(:name) }
 

--- a/services/QuillLMS/spec/models/coteacher_classroom_invitation_spec.rb
+++ b/services/QuillLMS/spec/models/coteacher_classroom_invitation_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CoteacherClassroomInvitation, type: :model do
     let(:analyzer) { double(:analyzer, track_with_attributes: true) }
 
     before do
-      allow(Analyzer).to receive(:new) { analyzer }
+      allow(Analytics::Analyzer).to receive(:new) { analyzer }
     end
 
     it 'should track coteacher invitation' do

--- a/services/QuillLMS/spec/models/coteacher_classroom_invitation_spec.rb
+++ b/services/QuillLMS/spec/models/coteacher_classroom_invitation_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CoteacherClassroomInvitation, type: :model do
     it 'should track coteacher invitation' do
       expect(analyzer).to receive(:track_with_attributes).with(
         invite_one.invitation.inviter,
-        SegmentIo::BackgroundEvents::COTEACHER_INVITATION,
+        Analytics::SegmentIo::BackgroundEvents::COTEACHER_INVITATION,
         { properties: { invitee_email: invite_one.invitation.invitee_email } }
       )
       invite_one.save

--- a/services/QuillLMS/spec/models/referrals_user_spec.rb
+++ b/services/QuillLMS/spec/models/referrals_user_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ReferralsUser, type: :model do
   end
 
   context 'callbacks' do
-    let(:segment_analytics) { SegmentAnalytics.new }
+    let(:segment_analytics) { Analytics::SegmentAnalytics.new }
     let(:track_calls) { segment_analytics.backend.track_calls }
     let(:identify_calls) { segment_analytics.backend.identify_calls }
 
@@ -55,7 +55,7 @@ RSpec.describe ReferralsUser, type: :model do
       it 'triggers an invited event' do
         expect(identify_calls.size).to eq(1)
         expect(identify_calls[0][:user_id]).to be(referrals_user.referrer.id)
-        expect(track_calls[0][:event]).to be(SegmentIo::BackgroundEvents::REFERRAL_INVITED)
+        expect(track_calls[0][:event]).to be(Analytics::SegmentIo::BackgroundEvents::REFERRAL_INVITED)
         expect(track_calls[0][:user_id]).to be(referrals_user.referrer.id)
         expect(track_calls[0][:properties][:referral_id]).to be(referrals_user.referral.id)
       end
@@ -68,7 +68,7 @@ RSpec.describe ReferralsUser, type: :model do
         referrals_user.update(activated: true)
         expect(identify_calls.size).to eq(2)
         expect(identify_calls[1][:user_id]).to be(referrals_user.referrer.id)
-        expect(track_calls[1][:event]).to be(SegmentIo::BackgroundEvents::REFERRAL_ACTIVATED)
+        expect(track_calls[1][:event]).to be(Analytics::SegmentIo::BackgroundEvents::REFERRAL_ACTIVATED)
         expect(track_calls[1][:user_id]).to be(referrals_user.referrer.id)
         expect(track_calls[1][:properties][:referral_id]).to be(referrals_user.referral.id)
       end

--- a/services/QuillLMS/spec/models/segment_integration/user_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/user_spec.rb
@@ -65,15 +65,15 @@ RSpec.describe SegmentIntegration::User do
         active_students_at_school_this_year = 20
         total_activities_completed_by_students_at_school_this_year = 200
 
-        cache = CacheSegmentSchoolData.new(admin.school)
+        cache = Analytics::CacheSegmentSchoolData.new(admin.school)
 
         data = {
-          CacheSegmentSchoolData::TOTAL_TEACHERS_AT_SCHOOL => total_teachers_at_school,
-          CacheSegmentSchoolData::TOTAL_STUDENTS_AT_SCHOOL => total_students_at_school,
-          CacheSegmentSchoolData::TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL => total_activities_completed_by_students_at_school,
-          CacheSegmentSchoolData::ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR => active_teachers_at_school_this_year,
-          CacheSegmentSchoolData::ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR => active_students_at_school_this_year,
-          CacheSegmentSchoolData::TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR => total_activities_completed_by_students_at_school_this_year
+          Analytics::CacheSegmentSchoolData::TOTAL_TEACHERS_AT_SCHOOL => total_teachers_at_school,
+          Analytics::CacheSegmentSchoolData::TOTAL_STUDENTS_AT_SCHOOL => total_students_at_school,
+          Analytics::CacheSegmentSchoolData::TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL => total_activities_completed_by_students_at_school,
+          Analytics::CacheSegmentSchoolData::ACTIVE_TEACHERS_AT_SCHOOL_THIS_YEAR => active_teachers_at_school_this_year,
+          Analytics::CacheSegmentSchoolData::ACTIVE_STUDENTS_AT_SCHOOL_THIS_YEAR => active_students_at_school_this_year,
+          Analytics::CacheSegmentSchoolData::TOTAL_ACTIVITIES_COMPLETED_BY_STUDENTS_AT_SCHOOL_THIS_YEAR => total_activities_completed_by_students_at_school_this_year
         }
 
         cache.write(data)

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -77,7 +77,7 @@ RSpec.configure do |config|
   config.order = "random"
 
   config.before(:suite) { Rails.cache.clear }
-  config.before { SegmentAnalytics.backend = FakeSegmentBackend.new }
+  config.before { Analytics::SegmentAnalytics.backend = FakeSegmentBackend.new }
 
   config.infer_spec_type_from_file_location!
 

--- a/services/QuillLMS/spec/services/analytics/analyzer_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/analyzer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Analyzer do
+describe Analytics::Analyzer do
   let(:analyzer) { double(:analyzer, track: true, identify: true) }
   let(:user) { double(:user, id: "some_id", ip_address: "some_ip") }
 

--- a/services/QuillLMS/spec/services/analytics/cache_segment_school_data_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/cache_segment_school_data_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe CacheSegmentSchoolData do
+RSpec.describe Analytics::CacheSegmentSchoolData do
   let(:school) { create(:school) }
   let(:teacher1) { create(:teacher, last_sign_in: Time.zone.today - 366.days) }
   let(:teacher2) { create(:teacher, last_sign_in: Time.zone.today) }

--- a/services/QuillLMS/spec/services/analytics/error_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/error_analytics_spec.rb
@@ -13,7 +13,7 @@ describe ErrorAnalytics do
 
   describe '#track500' do
     it 'should track the error 500 event' do
-      expect(analyzer).to receive(:track).with({ event: SegmentIo::BackgroundEvents::ERROR_500, anonymous_id: "secure_random" })
+      expect(analyzer).to receive(:track).with({ event: Analytics::SegmentIo::BackgroundEvents::ERROR_500, anonymous_id: "secure_random" })
       subject.track500
     end
   end

--- a/services/QuillLMS/spec/services/analytics/error_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/error_analytics_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ErrorAnalytics do
+describe Analytics::ErrorAnalytics do
   let(:analyzer) { double(:analyzer, track: true) }
 
   subject { described_class.new(analyzer) }

--- a/services/QuillLMS/spec/services/analytics/referrer_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/referrer_analytics_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe 'ReferrerAnalytics' do
-  let(:analytics) { ReferrerAnalytics.new }
-  let(:segment_analytics) { SegmentAnalytics.new }
+describe Analytics::ReferrerAnalytics do
+  let(:analytics) { described_class.new }
+  let(:segment_analytics) { Analytics::SegmentAnalytics.new }
   let(:track_calls) { segment_analytics.backend.track_calls }
   let(:identify_calls) { segment_analytics.backend.identify_calls }
   let(:referrer) { create(:teacher) }
@@ -21,7 +21,7 @@ describe 'ReferrerAnalytics' do
     end
 
     it 'sends the event' do
-      expect(track_calls[0][:event]).to be(SegmentIo::BackgroundEvents::REFERRAL_INVITED)
+      expect(track_calls[0][:event]).to be(Analytics::SegmentIo::BackgroundEvents::REFERRAL_INVITED)
       expect(track_calls[0][:user_id]).to be(referrer.id)
       expect(track_calls[0][:properties][:referral_id]).to be(referral.id)
     end
@@ -38,7 +38,7 @@ describe 'ReferrerAnalytics' do
     end
 
     it 'sends the event' do
-      expect(track_calls[0][:event]).to be(SegmentIo::BackgroundEvents::REFERRAL_ACTIVATED)
+      expect(track_calls[0][:event]).to be(Analytics::SegmentIo::BackgroundEvents::REFERRAL_ACTIVATED)
       expect(track_calls[0][:user_id]).to be(referrer.id)
       expect(track_calls[0][:properties][:referral_id]).to be(referral.id)
     end

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -2,11 +2,8 @@
 
 require 'rails_helper'
 
-describe 'SegmentAnalytics' do
-
-  # TODO : arent tests of these behaviours duplicated in the tests of the Workers?
-
-  let(:analytics) { SegmentAnalytics.new }
+describe Analytics::SegmentAnalytics do
+  let(:analytics) { described_class.new }
   let(:track_calls) { analytics.backend.track_calls }
   let(:identify_calls) { analytics.backend.identify_calls }
 
@@ -18,9 +15,9 @@ describe 'SegmentAnalytics' do
       analytics.track_classroom_creation(classroom)
       expect(identify_calls.size).to eq(0)
       expect(track_calls.size).to eq(2)
-      expect(track_calls[0][:event]).to eq("#{SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | #{classroom.classroom_type_for_segment}")
+      expect(track_calls[0][:event]).to eq("#{Analytics::SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | #{classroom.classroom_type_for_segment}")
       expect(track_calls[0][:user_id]).to eq(classroom.owner.id)
-      expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::CLASSROOM_CREATION)
+      expect(track_calls[1][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::CLASSROOM_CREATION)
       expect(track_calls[1][:user_id]).to eq(classroom.owner.id)
       expect(track_calls[1][:properties][:classroom_type]).to eq(classroom.classroom_type_for_segment)
       expect(track_calls[1][:properties][:classroom_grade]).to eq(classroom.grade_as_integer)
@@ -43,11 +40,11 @@ describe 'SegmentAnalytics' do
         analytics.track_activity_assignment(teacher.id, activity.id)
         expect(identify_calls.size).to eq(0)
         expect(track_calls.size).to eq(2)
-        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
+        expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
         expect(track_calls[0][:user_id]).to eq(teacher.id)
         expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
         expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
-        expect(track_calls[1][:event]).to eq("#{SegmentIo::BackgroundEvents::DIAGNOSTIC_ASSIGNMENT} | #{activity.name}")
+        expect(track_calls[1][:event]).to eq("#{Analytics::SegmentIo::BackgroundEvents::DIAGNOSTIC_ASSIGNMENT} | #{activity.name}")
         expect(track_calls[1][:user_id]).to eq(teacher.id)
       end
     end
@@ -59,7 +56,7 @@ describe 'SegmentAnalytics' do
         analytics.track_activity_assignment(teacher.id, activity.id)
         expect(identify_calls.size).to eq(0)
         expect(track_calls.size).to eq(1)
-        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
+        expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ACTIVITY_ASSIGNMENT)
         expect(track_calls[0][:user_id]).to eq(teacher.id)
         expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
         expect(track_calls[0][:properties][:tool_name]).to eq('Connect')
@@ -78,7 +75,7 @@ describe 'SegmentAnalytics' do
       analytics.track_activity_completion(teacher, student.id, activity, activity_session)
       expect(identify_calls.size).to eq(0)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ACTIVITY_COMPLETION)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:activity_name]).to eq(activity.name)
       expect(track_calls[0][:properties][:tool_name]).to eq('Diagnostic')
@@ -97,7 +94,7 @@ describe 'SegmentAnalytics' do
       analytics.track_activity_pack_assignment(teacher.id, diagnostic_unit.id)
       expect(identify_calls.size).to eq(0)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:activity_pack_type]).to eq("Diagnostic")
       expect(track_calls[0][:properties][:activity_pack_name]).to eq(diagnostic_unit_template.name)
@@ -108,7 +105,7 @@ describe 'SegmentAnalytics' do
       analytics.track_activity_pack_assignment(teacher.id, unit.id)
       expect(identify_calls.size).to eq(0)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:activity_pack_type]).to eq("Custom")
       expect(track_calls[0][:properties][:activity_pack_name]).to eq(unit.name)
@@ -122,7 +119,7 @@ describe 'SegmentAnalytics' do
       analytics.track_activity_pack_assignment(teacher.id, unit.id)
       expect(identify_calls.size).to eq(0)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ACTIVITY_PACK_ASSIGNMENT)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:activity_pack_type]).to eq("Pre-made")
       expect(track_calls[0][:properties][:activity_pack_name]).to eq(unit_template.name)
@@ -138,17 +135,17 @@ describe 'SegmentAnalytics' do
     let!(:other_user_subscription) { create(:user_subscription, user: teacher, subscription: other_subscription)}
 
     it 'sends an event with information about the subscription for recurring subscriptions' do
-      analytics.track_teacher_subscription(subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
+      analytics.track_teacher_subscription(subscription, Analytics::SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(subscription.id)
     end
 
     it 'sends an event with information about the subscription for non-recurring subscriptions' do
-      analytics.track_teacher_subscription(other_subscription, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
+      analytics.track_teacher_subscription(other_subscription, Analytics::SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(other_subscription.id)
     end
@@ -162,24 +159,24 @@ describe 'SegmentAnalytics' do
     let!(:other_school_subscription) { create(:school_subscription, school: school, subscription: other_subscription)}
 
     it 'sends an event with information about the subscription for recurring subscriptions' do
-      analytics.track_school_subscription(subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
+      analytics.track_school_subscription(subscription, Analytics::SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
       expect(track_calls[0][:properties][:school_id]).to eq(school.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(subscription.id)
     end
 
     it 'sends an event with information about the subscription for nonrecurring subscriptions' do
-      analytics.track_school_subscription(other_subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
+      analytics.track_school_subscription(other_subscription, Analytics::SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
       expect(track_calls[0][:properties][:school_id]).to eq(school.id)
       expect(track_calls[0][:properties][:subscription_id]).to eq(other_subscription.id)
       expect(track_calls[0][:user_id]).to eq(other_subscription.purchaser_id)
     end
 
     it 'sends an event with anonymous ID if there is no purchaser id' do
-      analytics.track_school_subscription(subscription, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
+      analytics.track_school_subscription(subscription, Analytics::SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:user_id]).to eq(nil)
       expect(track_calls[0][:anonymous_id]).to be
@@ -194,7 +191,7 @@ describe 'SegmentAnalytics' do
       zipcode = 55555
       analytics.track_teacher_school_not_listed(teacher, 'Nonexistent', 55555)
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_SCHOOL_NOT_LISTED)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::TEACHER_SCHOOL_NOT_LISTED)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:school_name]).to eq(school_name)
       expect(track_calls[0][:properties][:zipcode]).to eq(zipcode)
@@ -208,9 +205,9 @@ describe 'SegmentAnalytics' do
     it 'sends an event with information about the new school admin user' do
       analytics.track_school_admin_user(
         teacher,
-        SegmentIo::BackgroundEvents::STAFF_CREATED_SCHOOL_ADMIN_ACCOUNT,
+        Analytics::SegmentIo::BackgroundEvents::STAFF_CREATED_SCHOOL_ADMIN_ACCOUNT,
         school.name,
-        SegmentIo::Properties::STAFF_USER
+        Analytics::SegmentIo::Properties::STAFF_USER
       )
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:event]).to eq('Quill team member created a school admin account')
@@ -230,9 +227,9 @@ describe 'SegmentAnalytics' do
     it 'sends an event with information about the new district admin user' do
       analytics.track_district_admin_user(
         teacher,
-        SegmentIo::BackgroundEvents::STAFF_CREATED_DISTRICT_ADMIN_ACCOUNT,
+        Analytics::SegmentIo::BackgroundEvents::STAFF_CREATED_DISTRICT_ADMIN_ACCOUNT,
         district.name,
-        SegmentIo::Properties::STAFF_USER
+        Analytics::SegmentIo::Properties::STAFF_USER
       )
       expect(track_calls.size).to eq(1)
       expect(track_calls[0][:event]).to eq('Quill team member created a district admin account')
@@ -305,7 +302,7 @@ describe 'SegmentAnalytics' do
       analytics.track_activity_completion(teacher, student.id, unit_activity2.activity, activity_session2)
       expect(identify_calls.size).to eq(0)
       expect(track_calls.size).to eq(2)
-      expect(track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::ACTIVITY_PACK_COMPLETION)
+      expect(track_calls[1][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ACTIVITY_PACK_COMPLETION)
       expect(track_calls[1][:user_id]).to eq(teacher.id)
       expect(track_calls[1][:properties][:activity_pack_name]).to eq(unit.name)
       expect(track_calls[1][:properties][:student_id]).to eq(student.id)
@@ -345,7 +342,7 @@ describe 'SegmentAnalytics' do
           reason,
           true
         )
-        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_NEW_USER)
+        expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_NEW_USER)
       end
     end
 
@@ -358,7 +355,7 @@ describe 'SegmentAnalytics' do
           reason,
           false
         )
-        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_TEACHER)
+        expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ADMIN_RECEIVED_ADMIN_UPGRADE_REQUEST_FROM_TEACHER)
       end
     end
 
@@ -380,7 +377,7 @@ describe 'SegmentAnalytics' do
           note
         )
         expect(track_calls.size).to eq(1)
-        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER)
+        expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER)
         expect(track_calls[0][:user_id]).to eq(admin.id)
         expect(track_calls[0][:properties][:admin_name]).to eq(admin.name)
         expect(track_calls[0][:properties][:admin_email]).to eq(admin.email)
@@ -405,7 +402,7 @@ describe 'SegmentAnalytics' do
           note
         )
         expect(track_calls.size).to eq(1)
-        expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER)
+        expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER)
         expect(track_calls[0][:anonymous_id]).to eq(admin_email)
         expect(track_calls[0][:properties][:admin_name]).to eq(admin_name)
         expect(track_calls[0][:properties][:admin_email]).to eq(admin_email)
@@ -434,7 +431,7 @@ describe 'SegmentAnalytics' do
         note
       )
       expect(track_calls.size).to eq(1)
-      expect(track_calls[0][:event]).to eq(SegmentIo::BackgroundEvents::TEACHER_INVITED_ADMIN)
+      expect(track_calls[0][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::TEACHER_INVITED_ADMIN)
       expect(track_calls[0][:user_id]).to eq(teacher.id)
       expect(track_calls[0][:properties][:admin_name]).to eq(admin_name)
       expect(track_calls[0][:properties][:admin_email]).to eq(admin_email)

--- a/services/QuillLMS/spec/services/clever_integration/creators/teacher_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/creators/teacher_spec.rb
@@ -48,7 +48,7 @@ describe CleverIntegration::Creators::Teacher do
 
 
 
-    before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
     context 'with no google_id' do
       let(:google_id) { nil }

--- a/services/QuillLMS/spec/workers/access_progress_report_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/access_progress_report_worker_spec.rb
@@ -7,9 +7,7 @@ describe AccessProgressReportWorker, type: :worker do
   let!(:teacher) { create(:teacher) }
   let(:analyzer) { double(:analyzer, track: true) }
 
-  before do
-    allow(Analyzer).to receive(:new) { analyzer }
-  end
+  before { allow(Analytics::Analyzer).to receive(:new) { analyzer } }
 
   it 'sends a segment.io event' do
     expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::ACCESS_PROGRESS_REPORT)

--- a/services/QuillLMS/spec/workers/access_progress_report_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/access_progress_report_worker_spec.rb
@@ -12,7 +12,7 @@ describe AccessProgressReportWorker, type: :worker do
   end
 
   it 'sends a segment.io event' do
-    expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::ACCESS_PROGRESS_REPORT)
+    expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::ACCESS_PROGRESS_REPORT)
     worker.perform(teacher.id)
   end
 end

--- a/services/QuillLMS/spec/workers/account_creation_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/account_creation_worker_spec.rb
@@ -7,7 +7,7 @@ describe AccountCreationWorker do
 
   subject { described_class.new }
 
-  before { allow(Analyzer).to receive(:new) { analyzer } }
+  before { allow(Analytics::Analyzer).to receive(:new) { analyzer } }
 
   describe '#perform' do
     context 'when user is a teacher' do

--- a/services/QuillLMS/spec/workers/account_creation_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/account_creation_worker_spec.rb
@@ -17,7 +17,7 @@ describe AccountCreationWorker do
         it 'should track the account creation' do
           expect(analyzer).to receive(:track_chain).with(
               teacher,
-              [SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION]
+              [Analytics::SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION]
           )
           subject.perform(teacher.id)
         end
@@ -30,8 +30,8 @@ describe AccountCreationWorker do
           expect(analyzer).to receive(:track_chain).with(
               teacher,
               [
-                SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION,
-                SegmentIo::BackgroundEvents::TEACHER_SIGNED_UP_FOR_NEWSLETTER
+                Analytics::SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION,
+                Analytics::SegmentIo::BackgroundEvents::TEACHER_SIGNED_UP_FOR_NEWSLETTER
               ]
           )
           subject.perform(teacher.id)

--- a/services/QuillLMS/spec/workers/activity_search_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/activity_search_analytics_worker_spec.rb
@@ -9,9 +9,7 @@ describe ActivitySearchAnalyticsWorker do
     let(:analytics) { double(:analytics) }
     let!(:user) { create(:user) }
 
-    before do
-      allow(SegmentAnalytics).to receive(:new) { analytics }
-    end
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analytics } }
 
     it 'should track the activity search' do
       expect(analytics).to receive(:track_activity_search).with(user.id, "query")

--- a/services/QuillLMS/spec/workers/admin_invited_by_teacher_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/admin_invited_by_teacher_analytics_worker_spec.rb
@@ -12,7 +12,7 @@ describe AdminInvitedByTeacherAnalyticsWorker do
     let(:admin_email) { 'admin@email.com' }
     let(:note) { 'Please' }
 
-    before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
     it 'should track the event' do
       expect(analyzer).to receive(:track_admin_invited_by_teacher).with(admin_name, admin_email, teacher, note)

--- a/services/QuillLMS/spec/workers/admin_received_admin_upgrade_request_from_teacher_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/admin_received_admin_upgrade_request_from_teacher_analytics_worker_spec.rb
@@ -11,7 +11,7 @@ describe AdminReceivedAdminUpgradeRequestFromTeacherAnalyticsWorker do
     let(:analyzer) { double(:analyzer) }
     let(:reason) { 'Please' }
 
-    before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
     it 'should track the event' do
       [true, false].each do |new_user|

--- a/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/alert_soon_to_expire_subscriptions_worker_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 describe AlertSoonToExpireSubscriptionsWorker do
   subject { described_class.new }
 
+  let(:background_events) { background_events = Analytics::SegmentIo::BackgroundEvents }
+
   describe '#perform' do
     let(:analytics) { double(:analytics).as_null_object }
     let!(:user) { create(:user) }
@@ -24,20 +26,18 @@ describe AlertSoonToExpireSubscriptionsWorker do
     let(:user_subscription_three) { create(:user_subscription, user: user, subscription: expiring_14_teacher_subscription)}
     let(:school_subscription_three) { create(:school_subscription, school: school, subscription: expiring_14_school_subscription)}
 
-    before do
-      allow(SegmentAnalytics).to receive(:new) { analytics }
-    end
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analytics } }
 
     it 'should trigger the teacher subscription will renew event in segment' do
-      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription30, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
-      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription30, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_30)
-      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription7, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_7)
-      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription7, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_RENEW_IN_7)
+      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription30, background_events::TEACHER_SUB_WILL_RENEW_IN_30)
+      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription30, background_events::SCHOOL_SUB_WILL_RENEW_IN_30)
+      expect(analytics).to receive(:track_teacher_subscription).with(renewing_teacher_subscription7, background_events::TEACHER_SUB_WILL_RENEW_IN_7)
+      expect(analytics).to receive(:track_school_subscription).with(renewing_school_subscription7, background_events::SCHOOL_SUB_WILL_RENEW_IN_7)
 
-      expect(analytics).to receive(:track_teacher_subscription).with(expiring_30_teacher_sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_30)
-      expect(analytics).to receive(:track_school_subscription).with(expiring_30_school_sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_30)
-      expect(analytics).to receive(:track_teacher_subscription).with(expiring_14_teacher_sub, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_EXPIRE_IN_14)
-      expect(analytics).to receive(:track_school_subscription).with(expiring_14_school_sub, SegmentIo::BackgroundEvents::SCHOOL_SUB_WILL_EXPIRE_IN_14)
+      expect(analytics).to receive(:track_teacher_subscription).with(expiring_30_teacher_sub, background_events::TEACHER_SUB_WILL_EXPIRE_IN_30)
+      expect(analytics).to receive(:track_school_subscription).with(expiring_30_school_sub, background_events::SCHOOL_SUB_WILL_EXPIRE_IN_30)
+      expect(analytics).to receive(:track_teacher_subscription).with(expiring_14_teacher_sub, background_events::TEACHER_SUB_WILL_EXPIRE_IN_14)
+      expect(analytics).to receive(:track_school_subscription).with(expiring_14_school_sub, background_events::SCHOOL_SUB_WILL_EXPIRE_IN_14)
       subject.perform
     end
 
@@ -53,7 +53,7 @@ describe AlertSoonToExpireSubscriptionsWorker do
     it 'should not trigger the event for subscriptions that are not paid for with credit card' do
       renewing_teacher_subscription30.update(payment_method: 'Invoice')
 
-      expect(analytics).not_to receive(:track_teacher_subscription).with(renewing_teacher_subscription30, SegmentIo::BackgroundEvents::TEACHER_SUB_WILL_RENEW_IN_30)
+      expect(analytics).not_to receive(:track_teacher_subscription).with(renewing_teacher_subscription30, background_events::TEACHER_SUB_WILL_RENEW_IN_30)
       subject.perform
     end
   end

--- a/services/QuillLMS/spec/workers/assign_activity_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_activity_worker_spec.rb
@@ -8,9 +8,7 @@ describe AssignActivityWorker, type: :worker do
   let(:teacher) { create(:teacher) }
   let(:unit) { create(:unit) }
 
-  before do
-    allow(SegmentAnalytics).to receive(:new) { analytics }
-  end
+  before { allow(Analytics::SegmentAnalytics).to receive(:new) { analytics } }
 
   it 'sends a segment.io event' do
     expect(analytics).to receive(:track_activity_pack_assignment).with(teacher.id, unit.id)

--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -124,14 +124,14 @@ describe AssignRecommendationsWorker do
   def should_track_that_all_recommendations_are_being_assigned
     expect(analyzer)
       .to receive(:track_with_attributes)
-      .with(teacher, SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS, properties)
+      .with(teacher, Analytics::SegmentIo::BackgroundEvents::ASSIGN_RECOMMENDATIONS, properties)
 
     subject
   end
 
 
   def should_not_track_that_all_recommendations_are_being_assigned
-    expect(analyzer).not_to receive(:track).with(teacher, SegmentIo::BackgroundEvents::ASSIGN_ALL_RECOMMENDATIONS)
+    expect(analyzer).not_to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::ASSIGN_ALL_RECOMMENDATIONS)
     subject
   end
 

--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -32,7 +32,7 @@ describe AssignRecommendationsWorker do
   end
 
   before do
-    allow(Analyzer).to receive(:new) { analyzer }
+    allow(Analytics::Analyzer).to receive(:new) { analyzer }
     allow(PusherRecommendationCompleted).to receive(:run)
   end
 

--- a/services/QuillLMS/spec/workers/calculate_and_cache_school_data_for_segment_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/calculate_and_cache_school_data_for_segment_worker_spec.rb
@@ -10,7 +10,7 @@ describe CalculateAndCacheSchoolDataForSegmentWorker do
 
     it 'should call calculate_and_set_cache on the CacheSegmentSchoolData instance' do
       cache = double(calculate_and_set_cache: nil)
-      expect(CacheSegmentSchoolData).to receive(:new).with(school).and_return(cache)
+      expect(Analytics::CacheSegmentSchoolData).to receive(:new).with(school).and_return(cache)
       expect(cache).to receive(:calculate_and_set_cache)
       subject.perform(school.id)
     end

--- a/services/QuillLMS/spec/workers/checkbox_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/checkbox_analytics_worker_spec.rb
@@ -10,7 +10,7 @@ describe CheckboxAnalyticsWorker do
     let!(:activity) { create(:activity) }
     let(:analyzer) { double(:analyzer) }
 
-    before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
     it 'should track the event' do
       expect(analyzer).to receive(:track_activity_assignment).with(user.id, activity.id)

--- a/services/QuillLMS/spec/workers/classroom_creation_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/classroom_creation_worker_spec.rb
@@ -4,14 +4,14 @@ require 'rails_helper'
 
 describe ClassroomCreationWorker, type: :worker do
   let(:worker) { ClassroomCreationWorker.new }
-  let(:analytics) { SegmentAnalytics.new }
+  let(:analytics) { Analytics::SegmentAnalytics.new }
   let(:classroom) { create(:classroom) }
 
   it 'sends a segment.io event' do
     worker.perform(classroom.id)
 
     expect(analytics.backend.track_calls.size).to eq(2)
-    expect(analytics.backend.track_calls[0][:event]).to eq("#{SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | Manual")
-    expect(analytics.backend.track_calls[1][:event]).to eq(SegmentIo::BackgroundEvents::CLASSROOM_CREATION)
+    expect(analytics.backend.track_calls[0][:event]).to eq("#{Analytics::SegmentIo::BackgroundEvents::CLASSROOM_CREATION} | Manual")
+    expect(analytics.backend.track_calls[1][:event]).to eq(Analytics::SegmentIo::BackgroundEvents::CLASSROOM_CREATION)
   end
 end

--- a/services/QuillLMS/spec/workers/credit_referring_accounts_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/credit_referring_accounts_worker_spec.rb
@@ -16,5 +16,3 @@ describe CreditReferringAccountsWorker, type: :worker do
     expect(referrals_user.user.credit_transactions.length).to eq(1)
   end
 end
-
-

--- a/services/QuillLMS/spec/workers/delete_student_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/delete_student_worker_spec.rb
@@ -7,9 +7,7 @@ describe DeleteStudentWorker do
 
   let(:analyzer) { double(:analyzer, track: true) }
 
-  before do
-    allow(Analyzer).to receive(:new) { analyzer }
-  end
+  before { allow(Analytics::Analyzer).to receive(:new) { analyzer } }
 
   describe '#perform' do
     let!(:teacher) { create(:teacher) }

--- a/services/QuillLMS/spec/workers/delete_student_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/delete_student_worker_spec.rb
@@ -16,14 +16,14 @@ describe DeleteStudentWorker do
 
     context 'if referred from class path' do
       it 'should track the delete student account' do
-        expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHER_DELETED_STUDENT_ACCOUNT)
+        expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHER_DELETED_STUDENT_ACCOUNT)
         subject.perform(teacher.id, true)
       end
     end
 
     context 'if not referred from class path' do
       it 'should track the mystery delete student' do
-        expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::MYSTERY_STUDENT_DELETION)
+        expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::MYSTERY_STUDENT_DELETION)
         subject.perform(teacher.id, false)
       end
     end

--- a/services/QuillLMS/spec/workers/error_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/error_worker_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 describe ErrorWorker, type: :worker do
-
   let!(:analytics) { Analytics::SegmentAnalytics.new }
 
   it 'sends a segment.io event' do

--- a/services/QuillLMS/spec/workers/error_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/error_worker_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe ErrorWorker, type: :worker do
 
-  let!(:analytics) { SegmentAnalytics.new }
+  let!(:analytics) { Analytics::SegmentAnalytics.new }
 
   it 'sends a segment.io event' do
     ErrorWorker.new.perform

--- a/services/QuillLMS/spec/workers/finish_activity_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/finish_activity_worker_spec.rb
@@ -10,9 +10,7 @@ describe FinishActivityWorker, type: :worker do
   let(:activity_session) { create(:activity_session,  classroom_unit: classroom_unit) }
   let(:analyzer) { double(:analyzer) }
 
-  before do
-    allow(SegmentAnalytics).to receive(:new) { analyzer }
-  end
+  before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
   it 'sends a segment.io event' do
     expect(analyzer).to receive(:track_activity_completion).with(activity_session.classroom_owner, activity_session.user_id, activity_session.activity, activity_session)

--- a/services/QuillLMS/spec/workers/identify_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_worker_spec.rb
@@ -7,7 +7,7 @@ describe IdentifyWorker do
 
   let(:analyzer) { double(:analyzer, track: true) }
 
-  before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
+  before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
   describe '#perform' do
     let!(:user) { create(:user) }

--- a/services/QuillLMS/spec/workers/internal_tool/admin_account_created_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/admin_account_created_email_worker_spec.rb
@@ -16,7 +16,7 @@ describe InternalTool::AdminAccountCreatedEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, school.name).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -50,9 +50,9 @@ describe InternalTool::AdminAccountCreatedEmailWorker, type: :worker do
     it 'should send a segment.io event' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::STAFF_CREATED_SCHOOL_ADMIN_ACCOUNT,
+        Analytics::SegmentIo::BackgroundEvents::STAFF_CREATED_SCHOOL_ADMIN_ACCOUNT,
         school.name,
-        SegmentIo::Properties::STAFF_USER
+        Analytics::SegmentIo::Properties::STAFF_USER
       )
       subject
     end

--- a/services/QuillLMS/spec/workers/internal_tool/district_admin_account_created_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/district_admin_account_created_email_worker_spec.rb
@@ -16,7 +16,7 @@ describe InternalTool::DistrictAdminAccountCreatedEmailWorker, type: :worker do
     allow(District).to receive(:find_by).and_return(district)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, district.name).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -50,9 +50,9 @@ describe InternalTool::DistrictAdminAccountCreatedEmailWorker, type: :worker do
     it 'should send a segment.io event' do
       expect(analytics).to receive(:track_district_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::STAFF_CREATED_DISTRICT_ADMIN_ACCOUNT,
+        Analytics::SegmentIo::BackgroundEvents::STAFF_CREATED_DISTRICT_ADMIN_ACCOUNT,
         district.name,
-        SegmentIo::Properties::STAFF_USER
+        Analytics::SegmentIo::Properties::STAFF_USER
       )
       subject
     end

--- a/services/QuillLMS/spec/workers/internal_tool/made_district_admin_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/made_district_admin_email_worker_spec.rb
@@ -16,7 +16,7 @@ describe InternalTool::MadeDistrictAdminEmailWorker, type: :worker do
     allow(District).to receive(:find_by).and_return(district)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, district.name).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -50,9 +50,9 @@ describe InternalTool::MadeDistrictAdminEmailWorker, type: :worker do
     it 'should send a segment.io event if user or district is nil' do
       expect(analytics).to receive(:track_district_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_DISTRICT_ADMIN,
+        Analytics::SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_DISTRICT_ADMIN,
         district.name,
-        SegmentIo::Properties::STAFF_USER
+        Analytics::SegmentIo::Properties::STAFF_USER
       )
       subject
     end

--- a/services/QuillLMS/spec/workers/internal_tool/made_school_admin_change_school_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/made_school_admin_change_school_email_worker_spec.rb
@@ -18,7 +18,7 @@ describe InternalTool::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(new_school, existing_school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, new_school, existing_school).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -54,9 +54,9 @@ describe InternalTool::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker do
     it 'should send a segment.io event' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
+        Analytics::SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
         new_school.name,
-        SegmentIo::Properties::STAFF_USER
+        Analytics::SegmentIo::Properties::STAFF_USER
       )
       subject
     end

--- a/services/QuillLMS/spec/workers/internal_tool/made_school_admin_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/made_school_admin_email_worker_spec.rb
@@ -17,7 +17,7 @@ describe InternalTool::MadeSchoolAdminEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, school.name).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -53,9 +53,9 @@ describe InternalTool::MadeSchoolAdminEmailWorker, type: :worker do
     it 'should send a segment.io event if user or school is nil' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
+        Analytics::SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
         school.name,
-        SegmentIo::Properties::STAFF_USER
+        Analytics::SegmentIo::Properties::STAFF_USER
       )
       subject
     end

--- a/services/QuillLMS/spec/workers/internal_tool/made_school_admin_link_school_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/internal_tool/made_school_admin_link_school_email_worker_spec.rb
@@ -17,7 +17,7 @@ describe InternalTool::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, school).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -53,9 +53,9 @@ describe InternalTool::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
     it 'should send a segment.io event if user or school is nil' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
+        Analytics::SegmentIo::BackgroundEvents::STAFF_MADE_EXISTING_USER_SCHOOL_ADMIN,
         school.name,
-        SegmentIo::Properties::STAFF_USER
+        Analytics::SegmentIo::Properties::STAFF_USER
       )
       subject
     end

--- a/services/QuillLMS/spec/workers/onboarding_checklist_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/onboarding_checklist_analytics_worker_spec.rb
@@ -13,9 +13,7 @@ describe OnboardingChecklistAnalyticsWorker do
     let!(:explore_our_diagnostics) { create(:explore_our_diagnostics)}
     let(:analyzer) { double(:analyzer) }
 
-    before do
-      allow(SegmentAnalytics).to receive(:new) { analyzer }
-    end
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
     it 'should track the event if there is a checkbox for that user and each of the onboarding objectives' do
       Checkbox.create(user: user, objective: create_a_classroom)

--- a/services/QuillLMS/spec/workers/premium_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_analytics_worker_spec.rb
@@ -14,21 +14,21 @@ describe PremiumAnalyticsWorker do
 
     context 'when account type is a teacher premium type' do
       it 'should track teacher began premium' do
-        expect(analyzer).to receive(:track_with_attributes).with(user, SegmentIo::BackgroundEvents::TEACHER_BEGAN_PREMIUM, properties: user.segment_user.premium_params)
+        expect(analyzer).to receive(:track_with_attributes).with(user, Analytics::SegmentIo::BackgroundEvents::TEACHER_BEGAN_PREMIUM, properties: user.segment_user.premium_params)
         subject.perform(user.id, Subscription::OFFICIAL_TEACHER_TYPES[0])
       end
     end
 
     context 'when account type is a school premium type' do
       it 'should track teacher began premium' do
-        expect(analyzer).to receive(:track_with_attributes).with(user, SegmentIo::BackgroundEvents::TEACHER_BEGAN_PREMIUM, properties: user.segment_user.premium_params)
+        expect(analyzer).to receive(:track_with_attributes).with(user, Analytics::SegmentIo::BackgroundEvents::TEACHER_BEGAN_PREMIUM, properties: user.segment_user.premium_params)
         subject.perform(user.id, Subscription::OFFICIAL_SCHOOL_TYPES[0])
       end
     end
 
     context 'when account type is a trial premium type' do
       it 'should track teacher began premium' do
-        expect(analyzer).to receive(:track_with_attributes).with(user, SegmentIo::BackgroundEvents::TEACHER_BEGAN_PREMIUM, properties: user.segment_user.premium_params)
+        expect(analyzer).to receive(:track_with_attributes).with(user, Analytics::SegmentIo::BackgroundEvents::TEACHER_BEGAN_PREMIUM, properties: user.segment_user.premium_params)
         subject.perform(user.id, Subscription::OFFICIAL_FREE_TYPES[0])
       end
     end

--- a/services/QuillLMS/spec/workers/premium_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_analytics_worker_spec.rb
@@ -7,7 +7,7 @@ describe PremiumAnalyticsWorker do
 
   let(:analyzer) { double(:analyzer, track: true) }
 
-  before { allow(Analyzer).to receive(:new) { analyzer } }
+  before { allow(Analytics::Analyzer).to receive(:new) { analyzer } }
 
   describe '#perform' do
     let!(:user) { create(:user) }

--- a/services/QuillLMS/spec/workers/premium_hub/admin_account_created_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_hub/admin_account_created_email_worker_spec.rb
@@ -18,7 +18,7 @@ describe PremiumHub::AdminAccountCreatedEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, referring_admin.name, school.name, is_reminder).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -52,7 +52,7 @@ describe PremiumHub::AdminAccountCreatedEmailWorker, type: :worker do
     it 'should send a segment.io event' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::ADMIN_CREATED_SCHOOL_ADMIN_ACCOUNT,
+        Analytics::SegmentIo::BackgroundEvents::ADMIN_CREATED_SCHOOL_ADMIN_ACCOUNT,
         school.name,
         referring_admin.name
       )

--- a/services/QuillLMS/spec/workers/premium_hub/made_school_admin_change_school_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_hub/made_school_admin_change_school_email_worker_spec.rb
@@ -19,7 +19,7 @@ describe PremiumHub::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(new_school, existing_school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, referring_admin.name, new_school, existing_school).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -55,7 +55,7 @@ describe PremiumHub::MadeSchoolAdminChangeSchoolEmailWorker, type: :worker do
     it 'should send a segment.io event' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
+        Analytics::SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
         new_school.name,
         referring_admin.name
       )

--- a/services/QuillLMS/spec/workers/premium_hub/made_school_admin_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_hub/made_school_admin_email_worker_spec.rb
@@ -18,7 +18,7 @@ describe PremiumHub::MadeSchoolAdminEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, referring_admin.name, school.name).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -54,7 +54,7 @@ describe PremiumHub::MadeSchoolAdminEmailWorker, type: :worker do
     it 'should send a segment.io event if user or school is nil' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
+        Analytics::SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
         school.name,
         referring_admin.name
       )

--- a/services/QuillLMS/spec/workers/premium_hub/made_school_admin_link_school_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_hub/made_school_admin_link_school_email_worker_spec.rb
@@ -18,7 +18,7 @@ describe PremiumHub::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, referring_admin.name, school).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -54,7 +54,7 @@ describe PremiumHub::MadeSchoolAdminLinkSchoolEmailWorker, type: :worker do
     it 'should send a segment.io event if user or school is nil' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
+        Analytics::SegmentIo::BackgroundEvents::ADMIN_MADE_EXISTING_USER_SCHOOL_ADMIN,
         school.name,
         referring_admin.name
       )

--- a/services/QuillLMS/spec/workers/premium_hub/teacher_account_created_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_hub/teacher_account_created_email_worker_spec.rb
@@ -18,7 +18,7 @@ describe PremiumHub::TeacherAccountCreatedEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, referring_admin.name, school.name, is_reminder).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -52,7 +52,7 @@ describe PremiumHub::TeacherAccountCreatedEmailWorker, type: :worker do
     it 'should send a segment.io event' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::ADMIN_CREATED_TEACHER_ACCOUNT,
+        Analytics::SegmentIo::BackgroundEvents::ADMIN_CREATED_TEACHER_ACCOUNT,
         school.name,
         referring_admin.name
       )

--- a/services/QuillLMS/spec/workers/premium_hub/teacher_link_school_email_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/premium_hub/teacher_link_school_email_worker_spec.rb
@@ -17,7 +17,7 @@ describe PremiumHub::TeacherLinkSchoolEmailWorker, type: :worker do
     allow(School).to receive(:find_by).and_return(school)
     allow(mailer_class).to receive(mailer_method).with(mailer_user, referring_admin.name, school).and_return(double(:email, deliver_now!: true))
     allow(teacher).to receive(:mailer_user).and_return(mailer_user)
-    allow(SegmentAnalytics).to receive(:new) { analytics }
+    allow(Analytics::SegmentAnalytics).to receive(:new) { analytics }
   end
 
   describe 'user is nil' do
@@ -51,7 +51,7 @@ describe PremiumHub::TeacherLinkSchoolEmailWorker, type: :worker do
     it 'should send a segment.io event if user or school is nil' do
       expect(analytics).to receive(:track_school_admin_user).with(
         teacher,
-        SegmentIo::BackgroundEvents::ADMIN_SENT_LINK_REQUEST,
+        Analytics::SegmentIo::BackgroundEvents::ADMIN_SENT_LINK_REQUEST,
         school.name,
         referring_admin.name
       )

--- a/services/QuillLMS/spec/workers/previewed_activity_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/previewed_activity_worker_spec.rb
@@ -10,9 +10,7 @@ describe PreviewedActivityWorker do
     let!(:activity) { create(:activity) }
     let(:analyzer) { double(:analyzer, track_previewed_activity: true) }
 
-    before do
-      allow(SegmentAnalytics).to receive(:new) { analyzer }
-    end
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
     it 'should track the previewed activity if there is a user id' do
       expect(analyzer).to receive(:track_previewed_activity).with(user.id, activity.id)

--- a/services/QuillLMS/spec/workers/student_joined_classroom_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/student_joined_classroom_worker_spec.rb
@@ -8,9 +8,7 @@ describe StudentJoinedClassroomWorker, type: :worker do
   let!(:student) { create(:student) }
   let!(:teacher) { create(:teacher) }
 
-  before do
-    allow(Analyzer).to receive(:new) { analyzer }
-  end
+  before { allow(Analytics::Analyzer).to receive(:new) { analyzer } }
 
   it 'results in the sending of 1 segment.io events' do
     expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION)

--- a/services/QuillLMS/spec/workers/student_joined_classroom_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/student_joined_classroom_worker_spec.rb
@@ -13,12 +13,12 @@ describe StudentJoinedClassroomWorker, type: :worker do
   end
 
   it 'results in the sending of 1 segment.io events' do
-    expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION)
+    expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION)
     worker.perform(teacher.id, student.id)
   end
 
   it 'in cases where no teacher is sent, it does not track teacher' do
-    expect(analyzer).not_to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION)
+    expect(analyzer).not_to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHERS_STUDENT_ACCOUNT_CREATION)
     worker.perform(nil, student.id)
   end
 end

--- a/services/QuillLMS/spec/workers/student_login_pdf_download_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/student_login_pdf_download_analytics_worker_spec.rb
@@ -10,9 +10,7 @@ describe StudentLoginPdfDownloadAnalyticsWorker do
     let!(:classroom) { create(:classroom) }
     let(:analyzer) { double(:analyzer, track_student_login_pdf_download: true) }
 
-    before do
-      allow(SegmentAnalytics).to receive(:new) { analyzer }
-    end
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
     it 'should track the student login pdf download' do
       expect(analyzer).to receive(:track_student_login_pdf_download).with(user.id, classroom.id)

--- a/services/QuillLMS/spec/workers/teacher_approved_to_become_admin_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_approved_to_become_admin_analytics_worker_spec.rb
@@ -9,7 +9,7 @@ describe TeacherApprovedToBecomeAdminAnalyticsWorker do
     let!(:teacher) { create(:teacher) }
     let(:analyzer) { double(:analyzer) }
 
-    before { allow(Analyzer).to receive(:new) { analyzer } }
+    before { allow(Analytics::Analyzer).to receive(:new) { analyzer } }
 
     it 'should track the new user event if new user is true' do
       expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::NEW_USER_APPROVED_TO_BECOME_ADMIN)

--- a/services/QuillLMS/spec/workers/teacher_approved_to_become_admin_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_approved_to_become_admin_analytics_worker_spec.rb
@@ -12,12 +12,12 @@ describe TeacherApprovedToBecomeAdminAnalyticsWorker do
     before { allow(Analyzer).to receive(:new) { analyzer } }
 
     it 'should track the new user event if new user is true' do
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::NEW_USER_APPROVED_TO_BECOME_ADMIN)
+      expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::NEW_USER_APPROVED_TO_BECOME_ADMIN)
       subject.perform(teacher.id, true)
     end
 
     it 'should track the teacher event if new user is false' do
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHER_APPROVED_TO_BECOME_ADMIN)
+      expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHER_APPROVED_TO_BECOME_ADMIN)
       subject.perform(teacher.id, false)
     end
   end

--- a/services/QuillLMS/spec/workers/teacher_denied_to_become_admin_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_denied_to_become_admin_analytics_worker_spec.rb
@@ -9,7 +9,7 @@ describe TeacherDeniedToBecomeAdminAnalyticsWorker do
     let!(:teacher) { create(:teacher) }
     let(:analyzer) { double(:analyzer) }
 
-    before { allow(Analyzer).to receive(:new) { analyzer } }
+    before { allow(Analytics::Analyzer).to receive(:new) { analyzer } }
 
     it 'should track the new user event if new user is true' do
       expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::NEW_USER_DENIED_TO_BECOME_ADMIN)

--- a/services/QuillLMS/spec/workers/teacher_denied_to_become_admin_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_denied_to_become_admin_analytics_worker_spec.rb
@@ -12,12 +12,12 @@ describe TeacherDeniedToBecomeAdminAnalyticsWorker do
     before { allow(Analyzer).to receive(:new) { analyzer } }
 
     it 'should track the new user event if new user is true' do
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::NEW_USER_DENIED_TO_BECOME_ADMIN)
+      expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::NEW_USER_DENIED_TO_BECOME_ADMIN)
       subject.perform(teacher.id, true)
     end
 
     it 'should track the teacher event if new user is false' do
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHER_DENIED_TO_BECOME_ADMIN)
+      expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHER_DENIED_TO_BECOME_ADMIN)
       subject.perform(teacher.id, false)
     end
   end

--- a/services/QuillLMS/spec/workers/teacher_invited_admin_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_invited_admin_analytics_worker_spec.rb
@@ -12,7 +12,7 @@ describe TeacherInvitedAdminAnalyticsWorker do
     let(:admin_email) { 'admin@email.com' }
     let(:note) { 'Please' }
 
-    before { allow(SegmentAnalytics).to receive(:new) { analyzer } }
+    before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }
 
     it 'should track the event' do
       expect(analyzer).to receive(:track_teacher_invited_admin).with(teacher, admin_name, admin_email, note)

--- a/services/QuillLMS/spec/workers/teacher_requested_to_become_admin_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_requested_to_become_admin_analytics_worker_spec.rb
@@ -12,12 +12,12 @@ describe TeacherRequestedToBecomeAdminAnalyticsWorker do
     before { allow(Analyzer).to receive(:new) { analyzer } }
 
     it 'should track the new user event if new user is true' do
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::NEW_USER_REQUESTED_TO_BECOME_ADMIN)
+      expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::NEW_USER_REQUESTED_TO_BECOME_ADMIN)
       subject.perform(teacher.id, true)
     end
 
     it 'should track the teacher event if new user is false' do
-      expect(analyzer).to receive(:track).with(teacher, SegmentIo::BackgroundEvents::TEACHER_REQUESTED_TO_BECOME_ADMIN)
+      expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHER_REQUESTED_TO_BECOME_ADMIN)
       subject.perform(teacher.id, false)
     end
   end

--- a/services/QuillLMS/spec/workers/teacher_requested_to_become_admin_analytics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_requested_to_become_admin_analytics_worker_spec.rb
@@ -9,7 +9,7 @@ describe TeacherRequestedToBecomeAdminAnalyticsWorker do
     let!(:teacher) { create(:teacher) }
     let(:analyzer) { double(:analyzer) }
 
-    before { allow(Analyzer).to receive(:new) { analyzer } }
+    before { allow(Analytics::Analyzer).to receive(:new) { analyzer } }
 
     it 'should track the new user event if new user is true' do
       expect(analyzer).to receive(:track).with(teacher, Analytics::SegmentIo::BackgroundEvents::NEW_USER_REQUESTED_TO_BECOME_ADMIN)

--- a/services/QuillLMS/spec/workers/track_unlisted_school_information_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/track_unlisted_school_information_worker_spec.rb
@@ -10,9 +10,7 @@ describe TrackUnlistedSchoolInformationWorker, type: :worker do
   school_name = 'Nonexistent'
   zipcode = 55555
 
-  before do
-    allow(SegmentAnalytics).to receive(:new) { analytics }
-  end
+  before { allow(Analytics::SegmentAnalytics).to receive(:new) { analytics } }
 
   it 'sends a segment.io event if there is a user and school name' do
     expect(analytics).to receive(:track_teacher_school_not_listed).with(teacher, school_name, zipcode)

--- a/services/QuillLMS/spec/workers/user_login_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/user_login_worker_spec.rb
@@ -9,7 +9,7 @@ describe UserLoginWorker, type: :worker do
   let(:teacher) { classroom.owner }
   let(:student) { create(:student, classrooms: [classroom]) }
 
-  before { allow(Analyzer).to receive(:new) { analyzer } }
+  before { allow(Analytics::Analyzer).to receive(:new) { analyzer } }
 
   context 'when a teacher logs in' do
     it 'track teacher sign in' do

--- a/services/QuillLMS/spec/workers/user_login_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/user_login_worker_spec.rb
@@ -13,7 +13,7 @@ describe UserLoginWorker, type: :worker do
 
   context 'when a teacher logs in' do
     it 'track teacher sign in' do
-      expect(analyzer).to receive(:track_with_attributes).with(teacher, SegmentIo::BackgroundEvents::TEACHER_SIGNIN, properties: teacher.segment_user.common_params)
+      expect(analyzer).to receive(:track_with_attributes).with(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHER_SIGNIN, properties: teacher.segment_user.common_params)
       worker.perform(teacher.id)
     end
 
@@ -28,7 +28,7 @@ describe UserLoginWorker, type: :worker do
 
   context 'when student with teacher logs in' do
     it 'track teacher student sign in' do
-      expect(analyzer).to receive(:track_with_attributes).with(teacher, SegmentIo::BackgroundEvents::TEACHERS_STUDENT_SIGNIN, properties: {student_id: student.id})
+      expect(analyzer).to receive(:track_with_attributes).with(teacher, Analytics::SegmentIo::BackgroundEvents::TEACHERS_STUDENT_SIGNIN, properties: {student_id: student.id})
       worker.perform(student.id)
     end
   end


### PR DESCRIPTION
## WHAT
FYI I'm tagging everyone on this PR so that going forward everyone is aware of the zeitwerk mode.

In preparation for Rails 7 upgrade, the LMS needs to be [zeitwerk](https://guides.rubyonrails.org/classic_to_zeitwerk_howto.html) compliant

For this PR, all files in the app/services/analytics folder (mainly Segment related services) need to be wrapped in 
```
module Analytics
end
```

## WHY
In order for zeitwerk autoloader to function properly, namespaces and subdirectory structure must be consistent.  This in turn facilitates more efficient autoloading of constants and files.

## HOW
1. Wrap the appropriate files in app/services/analytics with the proper module. 
2. Update the references to these files with `Analytics::`.  For example, `Analyzer` becomes `Analytics::Analyzer`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
