### PR TITLE
Fix failing specs, add ability to pass hash through query subclasses

### DIFF
--- a/services/QuillLMS/app/queries/impact_metrics/active_students_all_time_query.rb
+++ b/services/QuillLMS/app/queries/impact_metrics/active_students_all_time_query.rb
@@ -3,6 +3,10 @@
 module ImpactMetrics
   class ActiveStudentsAllTimeQuery < ::QuillBigQuery::Query
 
+    def initialize(options: {})
+      super(options)
+    end
+
     def run
       run_query
     end

--- a/services/QuillLMS/app/queries/impact_metrics/active_teachers_all_time_query.rb
+++ b/services/QuillLMS/app/queries/impact_metrics/active_teachers_all_time_query.rb
@@ -4,6 +4,10 @@ module ImpactMetrics
   class ActiveTeachersAllTimeQuery < ::QuillBigQuery::Query
     ACTIVITY_SESSION_MINIMUM = 9
 
+    def initialize(options: {})
+      super(options)
+    end
+
     def run
       run_query
     end

--- a/services/QuillLMS/app/queries/impact_metrics/activities_all_time_query.rb
+++ b/services/QuillLMS/app/queries/impact_metrics/activities_all_time_query.rb
@@ -3,6 +3,10 @@
 module ImpactMetrics
   class ActivitiesAllTimeQuery < ::QuillBigQuery::Query
 
+    def initialize(options: {})
+      super(options)
+    end
+
     def run
       run_query
     end

--- a/services/QuillLMS/app/queries/impact_metrics/schools_containing_certain_teachers_query.rb
+++ b/services/QuillLMS/app/queries/impact_metrics/schools_containing_certain_teachers_query.rb
@@ -3,7 +3,7 @@
 module ImpactMetrics
   class SchoolsContainingCertainTeachersQuery < ::QuillBigQuery::Query
 
-    def initialize(teacher_ids, options = {})
+    def initialize(teacher_ids:, options: {})
       @teacher_ids = teacher_ids
 
       super(options)

--- a/services/QuillLMS/spec/queries/impact_metrics/active_students_all_time_query_spec.rb
+++ b/services/QuillLMS/spec/queries/impact_metrics/active_students_all_time_query_spec.rb
@@ -11,7 +11,7 @@ module ImpactMetrics
       let(:inactive_students) { create_list(:student, 10)}
       let(:activity_sessions) { students.map { |s| create(:activity_session, :finished, user: s) }}
       let(:unfinished_activity_sessions) { inactive_students.map { |s| create(:activity_session, state: "started", user: s) }}
-      let(:query_args) { [] }
+      let(:query_args) { {} }
 
       let(:cte_records) {
         [

--- a/services/QuillLMS/spec/queries/impact_metrics/active_teachers_all_time_query_spec.rb
+++ b/services/QuillLMS/spec/queries/impact_metrics/active_teachers_all_time_query_spec.rb
@@ -14,7 +14,7 @@ module ImpactMetrics
       let(:activity_sessions) { classroom_units.map { |classroom_unit| create_list(:activity_session, 10, classroom_unit: classroom_unit) } }
 
       let(:cte_records) { [users, units, classroom_units, activity_sessions] }
-      let(:query_args) { [] }
+      let(:query_args) { {} }
 
       it { expect(results).to match_array(users.map { |u| {"id" => u.id}}) }
 

--- a/services/QuillLMS/spec/queries/impact_metrics/activities_all_time_query_spec.rb
+++ b/services/QuillLMS/spec/queries/impact_metrics/activities_all_time_query_spec.rb
@@ -9,7 +9,7 @@ module ImpactMetrics
 
       let(:activity_sessions) { create_list(:activity_session, 20, :finished) }
       let(:unfinished_activity_sessions) { create_list(:activity_session, 10, state: 'started') }
-      let(:query_args) { [] }
+      let(:query_args) { {} }
 
       let(:cte_records) {
         [

--- a/services/QuillLMS/spec/queries/impact_metrics/schools_containing_certain_teachers_query_spec.rb
+++ b/services/QuillLMS/spec/queries/impact_metrics/schools_containing_certain_teachers_query_spec.rb
@@ -16,7 +16,12 @@ module ImpactMetrics
       let(:schools_user_two) { create(:schools_users, user: second_teacher, school: chosen_school_two) }
       let(:excluded_school) { create(:school) }
 
-      let(:query_args) { [[teacher.id, second_teacher.id]] }
+      let(:query_args) do
+        {
+          teacher_ids: [teacher.id, second_teacher.id]
+        }
+      end
+
       let(:cte_records) {
         [
           schools,


### PR DESCRIPTION
## WHAT
These specs were failing because I hadn't fully understood how to properly subclass the `QuillBigQuery::Query` superclass. It turns out your need to have each subclass accept a hash object as its initial parameter and then pass that hash through to the superclass initializer. 

## WHY
Fix failing tests on develop.

## HOW
Add an initializer function on each subclass that passes a hash to its superclass initializer. We need to do this because the testing setup accepts a Runner object as an argument in a hash.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
