### PR TITLE
Upgrade Raven to Sentry

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -140,7 +140,9 @@ gem 'rack-host-redirect'
 gem 'rack-affiliates', '= 0.4.0'
 
 # DEPLOYMENT
-gem 'sentry-raven', '>= 0.12.2'
+gem 'sentry-ruby'
+gem 'sentry-rails'
+gem 'sentry-sidekiq'
 gem 'rack-heartbeat'
 
 # INTEGRATIONS

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -702,8 +702,14 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (2.9.0)
-      faraday (>= 0.7.6, < 1.0)
+    sentry-rails (5.10.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.10.0)
+    sentry-ruby (5.10.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.10.0)
+      sentry-ruby (~> 5.10.0)
+      sidekiq (>= 3.0)
     shellany (0.0.1)
     shoulda-callback-matchers (1.1.4)
       activesupport (>= 3)
@@ -911,7 +917,9 @@ DEPENDENCIES
   scout_apm
   secure_headers (= 6.3.2)
   selenium-webdriver (~> 3)
-  sentry-raven (>= 0.12.2)
+  sentry-rails
+  sentry-ruby
+  sentry-sidekiq
   shoulda-callback-matchers (~> 1.1.1)
   shoulda-matchers (~> 4)
   sidekiq (~> 5.2.10)

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
 
   helper SegmentioHelper
 
-  before_action :set_raven_context
+  before_action :set_sentry_context
   before_action :check_staff_for_extended_session
   before_action :confirm_valid_session
   before_action :set_default_cache_security_headers
@@ -152,9 +152,9 @@ class ApplicationController < ActionController::Base
     response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
   end
 
-  protected def set_raven_context
-    Raven.user_context(id: session[:current_user_id])
-    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  protected def set_sentry_context
+    Sentry.set_user(id: session[:current_user_id])
+    Sentry.set_extras(params: params.to_unsafe_h, url: request.url)
   end
 
   protected def confirm_valid_session

--- a/services/QuillLMS/app/lib/error_notifier.rb
+++ b/services/QuillLMS/app/lib/error_notifier.rb
@@ -3,7 +3,7 @@
 module ErrorNotifier
   # pass an exception
   def self.report(error, options = {})
-    Raven.capture_exception(error, extra: options)
+    Sentry.capture_exception(error, extra: options)
     NewRelic::Agent.notice_error(error, options)
   end
 end

--- a/services/QuillLMS/config/initializers/sentry.rb
+++ b/services/QuillLMS/config/initializers/sentry.rb
@@ -3,4 +3,6 @@
 Sentry.init do |config|
   config.enabled_environments = %W(staging production)
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+
+  config.dsn = ENV['SENTRY_DSN'] if ENV['SENTRY_DSN'].present?
 end

--- a/services/QuillLMS/config/initializers/sentry.rb
+++ b/services/QuillLMS/config/initializers/sentry.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
-Raven.configure do |config|
-  config.environments = %W(staging production)
+Sentry.init do |config|
+  config.enabled_environments = %W(staging production)
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 end

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -181,7 +181,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
           }
         }
 
-        expect(Raven).to_not receive(:capture_exception)
+        expect(Sentry).to_not receive(:capture_exception)
 
         put :update, params: { id: activity_session.uid, data: data }, as: :json
         activity_session.reload

--- a/services/QuillLMS/spec/lib/error_notifier_spec.rb
+++ b/services/QuillLMS/spec/lib/error_notifier_spec.rb
@@ -7,15 +7,15 @@ describe ErrorNotifier do
     let(:error) { StandardError }
     let(:key_values) { {key: 'value', key2: 'value2'}}
 
-    it 'should notify Sentry (Raven) and New Relic' do
-      expect(Raven).to receive(:capture_exception).with(error, extra: {}).once
+    it 'should notify Sentry and New Relic' do
+      expect(Sentry).to receive(:capture_exception).with(error, extra: {}).once
       expect(NewRelic::Agent).to receive(:notice_error).with(error, {}).once
 
       ErrorNotifier.report(error)
     end
 
-    it 'should notify Sentry (Raven) and New Relic with additional context' do
-      expect(Raven).to receive(:capture_exception).with(error, extra: key_values).once
+    it 'should notify Sentry and New Relic with additional context' do
+      expect(Sentry).to receive(:capture_exception).with(error, extra: key_values).once
       expect(NewRelic::Agent).to receive(:notice_error).with(error, key_values).once
 
       ErrorNotifier.report(error, key_values)


### PR DESCRIPTION
## WHAT
Remove sentry-raven gem 
Add sentry-ruby gem
Add sentry-rails gem
Add sentry-sidekiq gem

## WHY
sentry-raven 0.12.2 is from 2014.

Also, Rails 7 upgrade requires it.

## HOW
Following the [migration guide](https://docs.sentry.io/platforms/ruby/migration/), update Raven methods and initializer with Sentry. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manual checks via examples [here](https://github.com/getsentry/sentry-ruby/tree/master/sentry-rails/examples/rails-6.0)
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
