### PR TITLE
fix completed_at date for tooltip

### DIFF
--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -46,7 +46,7 @@ class GradesController < ApplicationController
       percentage: activity_session.percentage,
       description: activity_session.activity.description,
       due_date: unit_activity.due_date,
-      completed_at: Time.at(activity_session.completed_at.to_i + current_user.utc_offset.seconds),
+      completed_at: activity_session.completed_at + current_user.utc_offset.seconds,
       grouped_key_target_skill_concepts: format_grouped_key_target_skill_concepts(key_target_skill_concepts),
       number_of_questions: questions.length,
       number_of_correct_questions: correct_key_target_skill_concepts.length

--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -46,7 +46,7 @@ class GradesController < ApplicationController
       percentage: activity_session.percentage,
       description: activity_session.activity.description,
       due_date: unit_activity.due_date,
-      completed_at: activity_session.completed_at.to_i + current_user.utc_offset.seconds,
+      completed_at: Time.at(activity_session.completed_at.to_i + current_user.utc_offset.seconds),
       grouped_key_target_skill_concepts: format_grouped_key_target_skill_concepts(key_target_skill_concepts),
       number_of_questions: questions.length,
       number_of_correct_questions: correct_key_target_skill_concepts.length

--- a/services/QuillLMS/spec/controllers/grades_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/grades_controller_spec.rb
@@ -29,8 +29,6 @@ describe GradesController do
 
       json_response = JSON.parse(response.body).deep_symbolize_keys
 
-      # Due to time-precision rounding on strings, we have to do this comparison
-      # in a convoluted way
       expect(json_response[:sessions].first).to include(
         percentage: activity_session.percentage,
         id: activity_session.id,
@@ -40,8 +38,11 @@ describe GradesController do
         number_of_questions: 2,
         number_of_correct_questions: 1
       )
-      expect(json_response[:sessions].first[:completed_at])
-        .to eq((activity_session.reload.completed_at + teacher.utc_offset.seconds).to_s)
+
+      # Due to time-precision rounding on strings, we have to do this comparison
+      # in a convoluted way
+      expect(json_response[:sessions].first[:completed_at].to_datetime.to_i)
+        .to eq((activity_session.reload.completed_at + teacher.utc_offset.seconds).to_datetime.to_i)
 
     end
   end

--- a/services/QuillLMS/spec/controllers/grades_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/grades_controller_spec.rb
@@ -41,7 +41,7 @@ describe GradesController do
         number_of_correct_questions: 1
       )
       expect(json_response[:sessions].first[:completed_at])
-        .to eq(Time.at(activity_session.reload.completed_at.to_i + teacher.utc_offset))
+        .to eq(activity_session.reload.completed_at + teacher.utc_offset.seconds)
 
     end
   end

--- a/services/QuillLMS/spec/controllers/grades_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/grades_controller_spec.rb
@@ -41,7 +41,7 @@ describe GradesController do
         number_of_correct_questions: 1
       )
       expect(json_response[:sessions].first[:completed_at])
-        .to eq(activity_session.reload.completed_at.to_i + teacher.utc_offset.seconds)
+        .to eq(Time.at(activity_session.reload.completed_at.to_i + teacher.utc_offset))
 
     end
   end

--- a/services/QuillLMS/spec/controllers/grades_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/grades_controller_spec.rb
@@ -41,7 +41,7 @@ describe GradesController do
         number_of_correct_questions: 1
       )
       expect(json_response[:sessions].first[:completed_at])
-        .to eq(activity_session.reload.completed_at + teacher.utc_offset.seconds)
+        .to eq((activity_session.reload.completed_at + teacher.utc_offset.seconds).to_s)
 
     end
   end


### PR DESCRIPTION
## WHAT
Send back `completed_at` as datetime rather than integer so frontend can handle it correctly.

## WHY
We want users to see accurate information.

## HOW
Just wrap the time definition in a `Time.at` call.

### Screenshots
<img width="333" alt="Screen Shot 2023-07-25 at 1 05 51 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/92d03997-e2a0-4845-be2a-d2be1299b0d1">

### Notion Card Links
https://www.notion.so/quill/Completed-date-and-target-skills-displaying-incorrect-info-cf955d7f14734e3a9095558a3320f626?d=7d620c9da0d24ccca659c1069c0e85c8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A