### PR TITLE
Fix name on SegmentIO class

### DIFF
--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Analytics
-  module Analytics::SegmentIo
+  module SegmentIo
     class << self
       attr_accessor :configuration
     end


### PR DESCRIPTION
## WHAT
Fix a bug involving the SegmentIO classname

## WHY
There's an error  `NoMethodError: undefined method `write_key' for nil:NilClass` when attempting to run `Analytics::SegmentAnalytics.new`

This was a find/replace Fail with the zeitwerk work.

## HOW
Fix the find and replace error.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Verified locally.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
