### PR TITLE
Change School Name to flexibly accomodate the entire school name

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
@@ -291,13 +291,20 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    .school, .not-a-password {
+    .not-a-password {
       input {
         border-bottom: none;
       }
     }
-    .school input {
-      width: max-content;
+    .school-name-container {
+      width: 80%;
+    }
+    .school-name-label {
+      font-size: 12px;
+      font-weight: 600;
+      color: #7f7f7f;
+      display: flex;
+      margin-bottom: 5px;
     }
     .not-a-password input {
       max-width: 300px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
@@ -287,6 +287,9 @@
       margin-bottom: 71px;
     }
   }
+  .school-container {
+    margin-bottom: 40px;
+  }
   .school-container, .inactive-password-container {
     display: flex;
     align-items: center;
@@ -306,6 +309,9 @@
       display: flex;
       margin-bottom: 5px;
     }
+    .school-name {
+      font-size: 16px;
+    }
     .not-a-password input {
       max-width: 300px;
       width: 100%;
@@ -319,6 +325,9 @@
       cursor: pointer;
       background-color: transparent;
       border: none;
+    }
+    .change-school {
+      margin-top: 27px;
     }
   }
   .school-search-container {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_general.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_general.jsx
@@ -233,13 +233,10 @@ export default class TeacherGeneralAccountInfo extends React.Component {
         schoolContainerClass += schoolSelectionReminderVisible && (!school || school.name === NO_SCHOOL_SELECTED) ? ' show-notification-badges' : ''
         return (
           <div className={schoolContainerClass}>
-            <Input
-              className="school"
-              disabled={true}
-              label="School"
-              type="text"
-              value={schoolNameValue}
-            />
+            <div className="school-name-container">
+              <label className="school-name-label">School</label>
+              <p className="school-name">{schoolNameValue}</p>
+            </div>
             <button className="change-school notification-badge-relative interactive-wrapper" onClick={this.showSchoolSelector} type="button">{buttonCopy}</button>
           </div>
         )


### PR DESCRIPTION
## WHAT
A lot of schools names are getting cut off in the current School Name Display on My Account. This change allows school names to display fully on this page. 

## WHY
So teachers can see their full school name.

## HOW
Just replace the input element with a paragraph element here, because paragraph elements will widen to accommodate the length of the content.

### Screenshots
<img width="670" alt="Screenshot 2023-07-31 at 2 44 33 PM" src="https://github.com/empirical-org/Empirical-Core/assets/57366100/7e7dcdc7-e9fd-4bd2-9c22-a935c56264f6">


### Notion Card Links
https://www.notion.so/quill/Ensure-long-school-names-do-not-get-cut-off-in-settings-7951973565f54b09b2294baffdc448ac?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes