### PR TITLE
Fix off-by-one error with subscription expiration

### DIFF
--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -463,11 +463,11 @@ module Teacher
   end
 
   def subscription_is_expired?
-    subscription && subscription.expiration < Date.current
+    subscription && subscription.expired?
   end
 
   def subscription_is_valid?
-    subscription && subscription.expiration > Date.current
+    subscription && !subscription.expired?
   end
 
   def teachers_activity_sessions_since_trial_start_date

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -177,7 +177,7 @@ class Subscription < ApplicationRecord
   end
 
   def expired?
-    expiration <= Date.current
+    expiration < Date.current
   end
 
   def check_if_purchaser_email_is_in_database


### PR DESCRIPTION
## WHAT
Fix a bug where subscriptions are expiring at beginning of day

## WHY
Expiration is given as a day but we'd like it to expire at end of day.

## HOW
Update expired? check from `<=` to `<`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Premium-subscriptions-expiring-at-start-of-day-7e6fd81c712f462e878ab1602480073c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
