### PR TITLE
Fix invite students bug

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/active_classrooms.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/active_classrooms.test.tsx.snap
@@ -6117,20 +6117,15 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
                                   Students
                                 </h3>
                                 <div
-                                  className="invite-provider-classroom-students"
+                                  className="invite-quill-classroom-students"
                                 >
                                   <button
                                     className="quill-button primary outlined small"
                                     onClick={[Function]}
                                     type="button"
                                   >
-                                    Import 
-                                     students
+                                    Invite students
                                   </button>
-                                  <span>
-                                    Last imported 
-                                    Invalid date
-                                  </span>
                                 </div>
                               </div>
                               <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
@@ -176,6 +176,8 @@ const ActiveClassrooms = ({
   }
 
   const importProviderClassroomStudents = () => {
+    if (!provider) { return }
+
     requestGet(providerConfig.retrieveClassroomsPath, (body) => {
       if (body.reauthorization_required) {
         openModal(reauthorizeProviderModal)

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -572,11 +572,11 @@ const ClassroomStudentSection = ({
   }
 
   const renderInviteStudents = () => {
-    const { classroomProvider } = classroom
-
     if (!classroom.visible) { return null }
 
-    if (importProviderClassroomStudents) {
+    const { classroomProvider } = classroom
+
+    if (classroomProvider) {
       const lastUpdatedDate = moment(classroom.updated_at).format('MMM D, YYYY')
       return (
         <div className="invite-provider-classroom-students">


### PR DESCRIPTION
## WHAT
Fix a bug with invite students button

## WHY
We need this button for teachers to add students to a classroom

## HOW
Fix a check to see if there is a classroom provider.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Import-students-button-on-the-My-Classes-page-2776042c37074867a8a99a493c09b22f?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Manual check
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
