### PR TITLE
add migration and model files for diagnostic question skills

### DIFF
--- a/services/QuillLMS/app/models/diagnostic_question_skill.rb
+++ b/services/QuillLMS/app/models/diagnostic_question_skill.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: diagnostic_question_skills
+#
+#  id             :bigint           not null, primary key
+#  name           :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  question_id    :bigint           not null
+#  skill_group_id :bigint           not null
+#
+# Indexes
+#
+#  index_diagnostic_question_skills_on_question_id     (question_id)
+#  index_diagnostic_question_skills_on_skill_group_id  (skill_group_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (question_id => questions.id)
+#  fk_rails_...  (skill_group_id => skill_groups.id)
+#
+class DiagnosticQuestionSkill < ApplicationRecord
+  belongs_to :skill_group
+  belongs_to :question
+
+  validates_presence_of :skill_group_id
+  validates_presence_of :question_id
+  validates_presence_of :name
+end

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -50,6 +50,8 @@ class Question < ApplicationRecord
     TYPE_GRAMMAR_QUESTION => 'grammar_questions',
   }
 
+  has_many :diagnostic_question_skills
+
   validates :data, presence: true
   validates :question_type, presence: true, inclusion: {in: TYPES}
   validates :uid, presence: true, uniqueness: true

--- a/services/QuillLMS/app/models/skill_group.rb
+++ b/services/QuillLMS/app/models/skill_group.rb
@@ -15,6 +15,7 @@ class SkillGroup < ApplicationRecord
   has_many :skill_group_activities
   has_many :activities, through: :skill_group_activities
   has_many :skills
+  has_many :diagnostic_question_skills
 
   validates_presence_of :name
 end

--- a/services/QuillLMS/db/migrate/20230731184420_create_diagnostic_question_skills.rb
+++ b/services/QuillLMS/db/migrate/20230731184420_create_diagnostic_question_skills.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateDiagnosticQuestionSkills < ActiveRecord::Migration[6.1]
+  def change
+    create_table :diagnostic_question_skills do |t|
+      t.string :name, null: false
+      t.references :question, index: true, foreign_key: true, null: false
+      t.references :skill_group, index: true, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2380,6 +2380,39 @@ ALTER SEQUENCE public.csv_exports_id_seq OWNED BY public.csv_exports.id;
 
 
 --
+-- Name: diagnostic_question_skills; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.diagnostic_question_skills (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    question_id bigint NOT NULL,
+    skill_group_id bigint NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: diagnostic_question_skills_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.diagnostic_question_skills_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: diagnostic_question_skills_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.diagnostic_question_skills_id_seq OWNED BY public.diagnostic_question_skills.id;
+
+
+--
 -- Name: district_admins; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5717,6 +5750,13 @@ ALTER TABLE ONLY public.csv_exports ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
+-- Name: diagnostic_question_skills id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.diagnostic_question_skills ALTER COLUMN id SET DEFAULT nextval('public.diagnostic_question_skills_id_seq'::regclass);
+
+
+--
 -- Name: district_admins id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6784,6 +6824,14 @@ ALTER TABLE ONLY public.criteria
 
 ALTER TABLE ONLY public.csv_exports
     ADD CONSTRAINT csv_exports_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: diagnostic_question_skills diagnostic_question_skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.diagnostic_question_skills
+    ADD CONSTRAINT diagnostic_question_skills_pkey PRIMARY KEY (id);
 
 
 --
@@ -8137,6 +8185,20 @@ CREATE INDEX index_criteria_on_recommendation_id ON public.criteria USING btree 
 
 
 --
+-- Name: index_diagnostic_question_skills_on_question_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_diagnostic_question_skills_on_question_id ON public.diagnostic_question_skills USING btree (question_id);
+
+
+--
+-- Name: index_diagnostic_question_skills_on_skill_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_diagnostic_question_skills_on_skill_group_id ON public.diagnostic_question_skills USING btree (skill_group_id);
+
+
+--
 -- Name: index_district_admins_on_district_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9266,6 +9328,14 @@ ALTER TABLE ONLY public.canvas_instance_auth_credentials
 
 
 --
+-- Name: diagnostic_question_skills fk_rails_30c45cabf6; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.diagnostic_question_skills
+    ADD CONSTRAINT fk_rails_30c45cabf6 FOREIGN KEY (skill_group_id) REFERENCES public.skill_groups(id);
+
+
+--
 -- Name: teacher_notification_settings fk_rails_3291865e04; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9599,6 +9669,14 @@ ALTER TABLE ONLY public.third_party_user_ids
 
 ALTER TABLE ONLY public.criteria
     ADD CONSTRAINT fk_rails_ada79930c6 FOREIGN KEY (concept_id) REFERENCES public.concepts(id);
+
+
+--
+-- Name: diagnostic_question_skills fk_rails_ae69c93feb; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.diagnostic_question_skills
+    ADD CONSTRAINT fk_rails_ae69c93feb FOREIGN KEY (question_id) REFERENCES public.questions(id);
 
 
 --
@@ -10341,4 +10419,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230706155155'),
 ('20230710144829'),
 ('20230725175024'),
-('20230728183700');
+('20230728183700'),
+('20230731184420');
+
+

--- a/services/QuillLMS/spec/factories/diagnostic_question_skill.rb
+++ b/services/QuillLMS/spec/factories/diagnostic_question_skill.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :diagnostic_question_skill do
+    sequence(:name) { |n| "Skill-#{n}" }
+    skill_group { create(:skill_group) }
+    question { create(:question) }
+  end
+end

--- a/services/QuillLMS/spec/models/diagnostic_question_skill_spec.rb
+++ b/services/QuillLMS/spec/models/diagnostic_question_skill_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: diagnostic_question_skills
+#
+#  id             :bigint           not null, primary key
+#  name           :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  question_id    :bigint           not null
+#  skill_group_id :bigint           not null
+#
+# Indexes
+#
+#  index_diagnostic_question_skills_on_question_id     (question_id)
+#  index_diagnostic_question_skills_on_skill_group_id  (skill_group_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (question_id => questions.id)
+#  fk_rails_...  (skill_group_id => skill_groups.id)
+#
+describe DiagnosticQuestionSkill, type: :model do
+  context 'validations' do
+    it { should belong_to(:skill_group) }
+    it { should belong_to(:question) }
+
+    it { should validate_presence_of(:skill_group_id) }
+    it { should validate_presence_of(:question_id) }
+    it { should validate_presence_of(:name) }
+  end
+end


### PR DESCRIPTION
## WHAT
Add migration and model file updates for the new `diagnostic_question_skills` table.

## WHY
This is the table we're using to replace `skills` for the new diagnostic scoring logic.

## HOW
Just generate the migration, build a very simple model file, and add tests.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Spec-Base-the-Diagnostic-Scoring-on-the-Question-ID-not-the-Concept-Result-82251d621dcb4411996830ec37d154d6?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? |  NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A