### PR TITLE
Get rid of .html.erb references in code

### DIFF
--- a/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
@@ -8,16 +8,11 @@ class Cms::BlogPostsController < Cms::CmsController
 
   def index
     @blog_posts_name_and_id = BlogPost.all.map{|bp| bp.attributes.merge({'rating' => bp.average_rating})}
-    #cms/blog_posts/index.html.erb
   end
 
-  def new
-    #cms/blog_posts/new.html.erb
-  end
+  def new; end
 
-  def edit
-    #cms/blog_posts/edit.html.erb
-  end
+  def edit; end
 
   def create
     blog_post = BlogPost.create(blog_post_params)

--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -92,7 +92,7 @@ class SchoolsController < ApplicationController
 
   def select_school
     respond_to do |format|
-      format.html # select_school.html.erb
+      format.html
       format.json {
         @js_file = 'session'
         #if the school does not specifically have a name, we send the type (e.g. not listed, international, etc..)

--- a/services/QuillLMS/app/views/teachers/classroom_manager/dashboard.html.erb
+++ b/services/QuillLMS/app/views/teachers/classroom_manager/dashboard.html.erb
@@ -14,5 +14,5 @@
 }) %>
 
 <% if current_user.show_satismeter? %>
-  <%= render partial: 'application/satismeter.html.erb' %>
+  <%= render partial: 'application/satismeter' %>
 <% end %>


### PR DESCRIPTION
## WHAT
Fix a Rails 7 [regression](https://quillorg-5s.sentry.io/issues/4357388277/?project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0) involving rendering a template

## WHY
Rails 7 doesn't like file references in code that include extensions like `.html.erb`

## HOW
Remove the extension

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
