### PR TITLE
Fix bug with archive classrooms showing in active classrooms

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
@@ -72,7 +72,7 @@ const ActiveClassrooms = ({
     [googleProvider]: googleLink,
   }[provider]
 
-  const [classrooms, setClassrooms] = useState(initialClassrooms)
+  const [classrooms, setClassrooms] = useState(initialClassrooms.filter(classroom => classroom.visible))
   const [coteacherInvitations, setCoteacherInvitations] = useState(initialCoteacherInvitations)
   const [providerClassrooms, setProviderClassrooms] = useState([])
   const [providerClassroomsLoading, setProviderClassroomsLoading] = useState(false)


### PR DESCRIPTION
## WHAT
Fix a bug where archived classrooms are showing up in the ActiveClassrooms tab

## WHY
Having archived classrooms in the active classrooms tab is wrong, but also yields incorrect information about classroom ownership.

## HOW
Set only visible classrooms in the react hook initializer.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Classes-not-recognizing-teachers-as-owners-595bb061cad044a8b928958564f3f47f?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
