### PR TITLE
add skill to question mapping csv and rake task

### DIFF
--- a/services/QuillLMS/lib/data/skill_to_question_mapping.csv
+++ b/services/QuillLMS/lib/data/skill_to_question_mapping.csv
@@ -1,0 +1,319 @@
+Question,Question ID,Skill Group Name,Skill Group ID,Skill Name
+She _____ want to go swimming. don't / doesn't,-LinooJU7h_BiASTmMFU,Subject-Verb Agreement,135,Starter Post Q1 - Basic Subject-verb Agreement
+The students in the class ___ the book. read / reads,-Linp1yljwuUFNcXjiaQ,Subject-Verb Agreement,135,Starter Post Q2 - Basic Subject-verb Agreement
+The buildings in Toronto ___ beautiful. are / is,-LinpE9ODZ5__Km8E4px,Subject-Verb Agreement,135,Starter Post Q3 - Basic Subject-verb Agreement
+the president gave a speech at the american museum of natural history to award the national medal of science.,-Linr1O9p3dRAfUvFnyS,Capitalization,134,Intermediate Post Q12 - Capitalization
+The city best restaurant opened twenty year ago.,-LinrO2cZGFlWXysOoVs,Plural and Possessive Nouns,124,Starter Post Q8 - Plural vs. Possessive Nouns
+The basketball player goal is to score point at all of her game this year.,-LinrV9paU5zGnUuAN9t,Plural and Possessive Nouns,124,Starter Post Q9 - Plural vs. Possessive Nouns
+The sailor breathes in the air. The air is salty.,-Lins3ua1sQQN6Tl7Q4h,Adjectives and Adverbs,125,Starter Post Q12 - Single Adjectives
+The wind blows and breaks two windows. It blows through the house.,-LinsaouHGCBKj2eprfC,Prepositional Phrases,126,Starter Post Q15 - Prepositional Phrases
+Lindsey eats an apple and throws it away. She eats quickly.,-LinsDnhwR8T0jLx3Ypp,Adjectives and Adverbs,125,Starter Post Q13 - Single Adverbs of Manner
+The ice melts in spring. The ice is white. The ice melts slowly.,-LinspkyKBeYdTTIn8Zc,Adjectives and Adverbs,125,Starter Post Q14 - Adjectives and Adverbs
+He is planting trees. He is planting them at a park. The park is large. The park is in California.,-Lint05rURFiNEg8K63T,Prepositional Phrases,126,Starter Post Q16 - Prepositional Phrases
+Runners stretch ___ legs while ___ waiting for the race to start.,-LKc-s1Gzbf6QiyHHRr-,Commonly Confused Words,128,Starter Pre Q5 - Commonly Confused Words (Their/There/They're)
+Runners stretch ___ legs while ___ waiting for the race to start.,-LKc-s1Gzbf6QiyHHRr-,Commonly Confused Words,159,SpringBoard Q24 - Commonly Confused Words (Their/There/They're)
+The athlete goal is to win medal at all of her competition this season.,-LKStUOiTFAuve_pUNNl,Plural and Possessive Nouns,124,Starter Pre Q9 - Plural vs. Possessive Nouns
+The family big house was built a hundred year ago.,-LKSuWT89unu5gJ2WRip,Plural and Possessive Nouns,124,Starter Pre Q8 - Plural vs. Possessive Nouns
+He ___ like to wake up early.,-LKT0cJcWANIOLWdxGDA,Subject-Verb Agreement,135,Starter Pre Q1 - Basic Subject-Verb Agreement
+The streets of Tokyo ___ bright.,-LKWlY_fa3JXEFzQO3I8,Subject-Verb Agreement,135,Starter Pre Q3 - Basic Subject-Verb Agreement
+Stars look ___ in the country than in the city.,-LKWu6ki2OHKFMAVZIko,Adjectives and Adverbs,125,Starter Pre Q7 - Comparative vs. Superlative Adjectives
+The stream floods during rainstorms. The stream is muddy. The stream floods easily.,-LKWyxEPkvcrETG1dVN3,Adjectives and Adverbs,125,Starter Pre Q14 - Adjectives and Adverbs
+He is going on vacation. He is going to a beach. The beach is beautiful. The beach is in San Diego.,-LKX1YDGP_nJ70U6_y-A,Prepositional Phrases,126,Starter Pre Q16 - Prepositional Phrases
+He is going on vacation.He is going to a beach.The beach is beautiful.The beach is in San Diego.,-LKX1YDGP_nJ70U6_y-A,Prepositional Phrases,156,SpringBoard Q11 - Prepositional Phrases
+Scorpions thrive in the desert. The desert is dry.,-LKX3Kput_ae17nDodqp,Adjectives and Adverbs,125,Starter Pre Q12 - Single Adjectives
+I’ll watch a movie at ___ house while ___ studying.,-LKXt53wwLoZW3EkmH_K,Commonly Confused Words,128,Starter Pre Q4 - Commonly Confused Words (Your/You're)
+I’ll watch a movie at ___ house while ___ studying.,-LKXt53wwLoZW3EkmH_K,Commonly Confused Words,159,SpringBoard Q23 - Commonly Confused Words (Your/You're)
+___ were soaked from the rain. Me and John / John and I,-LKXtrZuQbt-WpPJX6wP,"Nouns, Pronouns, and Verbs",136,Intermediate Pre Q1 - Pronouns in Subjects
+___ were soaked from the rain.,-LKXtrZuQbt-WpPJX6wP,Pronoun Case and Agreement,158,SpringBoard Q20 - Pronouns in Subjects
+Nelson Mandela won the Nobel Peace Prize. He brought South Africa together. unless / even though / because,-LKXzTjgc5wLmk4pNKGb,Complex Sentences,131,Intermediate Pre Q20 - Complex Sentences (Because)
+Nelson Mandela won the Nobel Peace Prize. He brought South Africa together.,-LKXzTjgc5wLmk4pNKGb,Complex Sentences,160,AP Q9 - Complex Sentences (Because) 
+Nelson Mandela won the Nobel Peace Prize. He brought South Africa together.,-LKXzTjgc5wLmk4pNKGb,Complex Sentences,147,PreAP1 Q8 - Complex Sentences (Because)
+I ___ the movie yesterday. saw / seen / have seen / had seen,-LKY9qcjbY_mXflblkVh,"Nouns, Pronouns, and Verbs",136,Intermediate Pre Q9 - Irregular Past Tense
+I ___ the movie yesterday.,-LKY9qcjbY_mXflblkVh,Verb Tense and Agreement,157,SpringBoard Q15 - Irregular Past Tense
+I ___ to California three times so far. went / been / had been / have been,-LKYE-fuDYeJEB4G_d5U,"Nouns, Pronouns, and Verbs",136,Intermediate Pre Q10 - Perfect Tense
+I ___ to California three times so far.,-LKYE-fuDYeJEB4G_d5U,Verb Tense and Agreement,157,SpringBoard Q16 - Perfect Tense
+"When I got home, I was excited to see that my new bike ___. was delivered / has been delivered / had been delivered",-LKYEJ7ZnM2dds1WqCSv,"Nouns, Pronouns, and Verbs",136,Intermediate Pre Q11 - Perfect Tense
+"When I got home, I was excited to see that my new bike ___.",-LKYEJ7ZnM2dds1WqCSv,Verb Tense and Agreement,157,SpringBoard Q17 - Perfect Tense
+Each of the soccer players ___ a green jersey. wears / wear,-LKYFOWVjMGfL292TOU-,Subject-Verb Agreement,135,Intermediate Pre Q4 - Subject-Verb Agreement
+Each of the soccer players ___ a green jersey.,-LKYFOWVjMGfL292TOU-,Verb Tense and Agreement,157,SpringBoard Q14 - Subject-Verb Agreement With Indefinite Pronouns
+Both ___ uniforms are purple and white. teams / teams' / team's,-LL-sMOL2wx5nAEMcyaN,"Nouns, Pronouns, and Verbs",136,Intermediate Pre Q6 - Plural Possessive
+I always borrow my two best ___ clothes. friends / friends' / friend's,-LL-wQK_WhlER6icDH2V,"Nouns, Pronouns, and Verbs",136,Intermediate Pre Q8 - Plural Possessive
+Traveling is ___ with a guide than without one.,-LL-z3Is5RTRvWyNZR6W,Adjectives and Adverbs,125,Starter Pre Q6 - Comparative vs. Superlative Adjectives
+Rico writes a letter and mails it. He writes quickly.,-LL03FB3y06qdXC7cEI_,Adjectives and Adverbs,125,Starter Pre Q13 - Single Adverbs of Manner
+A tree fell and blocked traffic. It fell onto the road.,-LL5ho_8jppZoOmjaubo,Prepositional Phrases,126,Starter Pre Q15 - Prepositional Phrases
+A tree fell and blocked traffic.It fell onto the road.,-LL5ho_8jppZoOmjaubo,Prepositional Phrases,156,SpringBoard Q10 - Prepositional Phrases
+The bad weather forced ___ to go inside. him and his dog / he and his dog,-LLAprmEAE3SUkJqdhm0,"Nouns, Pronouns, and Verbs",136,Intermediate Pre Q3 - Pronouns in Objects
+The bad weather forced ___ to go inside.,-LLAprmEAE3SUkJqdhm0,Pronoun Case and Agreement,158,SpringBoard Q21 - Pronouns in Objects
+The artist drew a picture of ___. Erica and me / Erica and I,-LLAqIXQyovkXmW5Cdze,"Nouns, Pronouns, and Verbs",136,Intermediate Pre Q2 - Pronouns in Objects
+The artist drew a picture of ___.,-LLAqIXQyovkXmW5Cdze,Pronoun Case and Agreement,158,SpringBoard Q22 - Pronouns in Objects
+Giraffes have long necks. They can reach leaves on tall trees.,-Lm6CCemZAGMrQBHIiXI,Complex Sentences,160,AP Q8 - Complex Sentences (Since)
+Giraffes have long necks. They can reach leaves on tall trees.,-Lm6CCemZAGMrQBHIiXI,Complex Sentences,155,SpringBoard Q5 - Complex Sentences (Since)
+Katherine Johnson helped launch the first American astronaut into orbit. She was one of the most trusted NASA mathematicians.,-Lmv3np1E3lCvmHWF06R,Appositive Phrases,138,Advanced Pre Q1 - Appositive Phrases
+Katherine Johnson helped launch the first American astronaut into orbit. She was one of the most trusted NASA mathematicians.,-Lmv3np1E3lCvmHWF06R,Appositive Phrases,162,AP Q3 - Appositive Phrases
+Katherine Johnson helped launch the first American astronaut into orbit. She was one of the most trusted NASA mathematicians.,-Lmv3np1E3lCvmHWF06R,Appositive Phrases,149,PreAP2 Q2 - Appositive Phrases
+Olympus Mons is the tallest mountain in our solar system. Olympus Mons is on Mars.,-LpAJDh8NspJ1O1ZAd7W,Relative Clauses,161,AP Q12 - Relative Clauses (Which)
+Olympus Mons is the tallest mountain in our solar system. Olympus Mons is on Mars.,-LpAJDh8NspJ1O1ZAd7W,Relative Clauses,150,PreAP2 Q8 - Relative Clauses (Which)
+the president visited jackson high school to honor the national teacher of the year.,-LQabYK1kSh4Dp5ZMtjB,Capitalization,134,Intermediate Pre Q12 - Capitalization
+I joined the soccer team. Joe tried out for the school play. and,-LQp53E7oNy-VXsYHQIL,Compound Sentences,130,Intermediate Pre Q17 - Compound Sentences (And)
+I joined the soccer team. Joe tried out for the school play.,-LQp53E7oNy-VXsYHQIL,Compound Sentences,154,SpringBoard Q1 - Compound Sentences (And)
+Tornadoes can pick up trees while they spin. Tornadoes can rip off roofs while they spin.,-LQtB2iMvevV1Bw7GoUH,"Compound Subjects, Objects, and Predicates",129,Intermediate Pre Q15 - Compound Predicates
+Tornadoes can pick up trees while they spin. Tornadoes can rip off roofs while they spin.,-LQtB2iMvevV1Bw7GoUH,"Compound Subjects, Objects, and Predicates",145,PreAP1 Q10 - Compound Predicates
+Tornadoes can pick up trees while they spin.Tornadoes can rip off roofs while they spin.,-LQtB2iMvevV1Bw7GoUH,"Compound Subjects, Objects, and Predicates",153,SpringBoard Q6 - Compound Predicates
+The cat is sleeping. The dog is sleeping.,-LQtdcqlCN1k2GA_pGNF,"Compound Subjects, Objects, and Predicates",127,Starter Pre Q20 - Compound Subjects
+Ostriches are the largest birds. Ostriches can grow over nine feet tall.,-LsrQRLNvYAJa6f0dqnC,Appositive Phrases,162,AP Q1 - Appositive Phrases
+The pressurized deep sea diving suit was invented in 1932. It led to the exploration of unknown parts of the ocean. who / that / which,-LVxfeBrdg3DAbGFl78t,Relative Clauses,139,Advanced Pre Q6 - Relative Clauses (Which)
+The pressurized deep sea diving suit was invented in 1932. It led to the exploration of unknown parts of the ocean.,-LVxfeBrdg3DAbGFl78t,Relative Clauses,161,AP Q11 - Relative Clauses (Which)
+The pressurized deep sea diving suit was invented in 1932.It led to the exploration of unknown parts of the ocean.,-LVxfeBrdg3DAbGFl78t,Relative Clauses,150,PreAP2 Q7 - Relative Clauses (Which)
+CNSA made history in 2019 by landing a rover on the far side of the moon. CNSA is China’s space agency.,-LVxg5EKmlyXaRLytaow,Appositive Phrases,138,Advanced Pre Q2 - Appositive Phrases
+CNSA made history in 2019 by landing a rover on the far side of the moon. CNSA is China's space agency.,-LVxg5EKmlyXaRLytaow,Appositive Phrases,162,AP Q5 - Appositive Phrases
+CNSA made history in 2019 by landing a rover on the far side of the moon. CNSA is China's space agency.,-LVxg5EKmlyXaRLytaow,Appositive Phrases,149,PreAP2 Q1 - Appositive Phrases
+Melipona bees produce a small amount of honey each year. Melipona bees are a type of stingless bee. They are native to the Americas.,-LVxi-9EJWhV1SjQOGvO,Advanced Combining,142,Advanced Pre Q12 - Appositive Phrases and Participial Phrases
+Melipona bees produce a small amount of honey each year. Melipona bees are a type of stingless bee. They are native to the Americas.,-LVxi-9EJWhV1SjQOGvO,Advanced Combining,166,AP Q6 - Appositive and Participial Phrases
+The wind lifted entire houses off the ground. The wind was blowing with incredible speed and force.,-LVxiL40aVUj3IMVlP7i,Participial Phrases,140,Advanced Pre Q4 - Participial Phrases
+The wind lifted entire houses off the ground. The wind was blowing with incredible speed and force.,-LVxiL40aVUj3IMVlP7i,Participial Phrases,163,AP Q4 - Paricipial Phrases
+The wind lifted entire houses off the ground. The wind was blowing with incredible speed and force.,-LVxiL40aVUj3IMVlP7i,Participial Phrases,151,PreAP2 Q5 - Participial Phrases
+The telephone was an exciting invention. It revolutionized communication. The telephone instantly connected people across the country for the first time. People were concerned there would be negative consequences.,-LVxjooFc8hOp5D5bxWv,Advanced Combining,142,Advanced Pre Q14 - Open Sentence Combining
+The light bulb was an invention. It brought electricity into homes. who / that / which,-LWHMaiB-Q1hNQvV7zZ9,Relative Clauses,139,Advanced Pre Q5 - Relative Clauses (That)
+The light bulb was an invention. It brought electricity into homes.,-LWHMaiB-Q1hNQvV7zZ9,Relative Clauses,161,AP Q10 - Relative Clauses (That)
+The light bulb was an invention.It brought electricity into homes.,-LWHMaiB-Q1hNQvV7zZ9,Relative Clauses,150,PreAP2 Q6 - Relative Clauses (That)
+I ___ a student. is / am / are / be,-LyFEjsE78Rzw1vlayfe,Sentences With To Be,167,ELL Starter Pre Q1 - Conjugating To Be
+They ___ students. is / am / are / be,-LyFEuupny5nwXv3ziLJ,Sentences With To Be,167,ELL Starter Pre Q2 - Conjugating To Be
+The girl ___ a student. is / am / are / be,-LyFF8JxR3s9Zb9nOWnC,Sentences With To Be,167,ELL Starter Pre Q3 - Conjugating To Be
+We are ___. student / students,-LyFFegKbXb80z-3oq6J,Sentences With To Be,167,ELL Starter Pre Q5 - Regular Plural Nouns
+It is ___ apple. a / an,-LyFFQi0LmCUGiGEB5xg,Sentences With To Be,167,ELL Starter Pre Q4 - A vs An
+You ___ student. are not a / are a not / not are a,-LyFGJixJXIFbHl2yOEG,Sentences With To Be,167,ELL Starter Pre Q6 - Word Order With Not
+He is ___. a teacher / teacher,-LyFGk8GydH3lttrSya0,Sentences With To Be,167,ELL Starter Pre Q7 - Using A & An Before A Noun
+She is a ___. happy student / student happy,-LyFGqSW7Wk1y41n8SlT,Sentences With To Be,167,ELL Starter Pre Q8 - Word Order With Adjectives
+I am ___ teacher. a kind / kind a / kind,-LyFH0E3EC-G47b37WH_,Sentences With To Be,167,ELL Starter Pre Q9 - Word Order With Adjectives
+He is ___. happy / a happy,-LyFHEF8vgYOMcCTDsi7,Sentences With To Be,167,ELL Starter Pre Q10 - Adjectives without Articles
+The boy is ___. a kind student / a student kind / kind a student / kind student,-LyFHr41C5VTamgYSwUl,Sentences With To Be,167,ELL Starter Pre Q12 - Word Order
+___ is happy. The dog / Dog,-LyFHXrgcOg2mcGfZ-Ab,Sentences With To Be,167,ELL Starter Pre Q11 - Starting Sentences with Nouns
+She ___ a book. want / wants,-LyFI-zYQhY9IeVi-n-i,Sentences With Want,169,ELL Starter Pre Q13 - Conjugating To Want
+I ___ a book. have / has,-LyFICBOb1865LsFQokV,Sentences With Have,168,ELL Starter Pre Q15 - Conjugating To Have
+We ___ a book. do not want / does not want / do not wants / does not wants / not want / not wants / want not / not want,-LyFISTQLjBRLLELy806,Sentences With Want,169,ELL Starter Pre Q14 - Conjugating To Want
+He ____ a book. do not have / does not have / do not has / does not has / not have / not has / has not / have not,-LyFKnkbD6GmYtPUE9Ah,Sentences With Have,168,ELL Starter Pre Q16 - Conjugating To Have
+___ a brown dog? Do you want / Does you want / Do you wants / Does you wants / You want / You wants,-LyFQn_9pqSLtU-Hmj-9,Writing Questions,171,ELL Starter Pre Q17 - Yes or No Questions with To Want
+___ friends? Are we / We are / Am we / We am / Is we / We is,-LyFQXXAsr-9V4_BSU3l,Writing Questions,171,ELL Starter Pre Q19 - Yes or No Questions with To Be
+___ black cats? Do he have / Does he have / Do he has / Does he has / He have / He has / Has he / Have he,-LyFQyhGGd3PBN-DMR-L,Writing Questions,171,ELL Starter Pre Q18 - Yes or No Questions with To Have
+Alpha wolves track the prey. The prey is also hunted by alpha wolves. Alpha wolves decide where to build the pack’s den. Producing pups for the pack is also something alpha wolves do.,-LYheTMlgFyHW-UKQQpe,Parallel Structure,141,Advanced Pre Q8 - Parallel Clauses
+Alpha wolves track the prey. The prey is also hunted by alpha wolves. Alpha wolves decide where to build the pack's den. Producing pups for the pack is also something alpha wolves do,-LYheTMlgFyHW-UKQQpe,Parallel Structure,164,AP Q15 - Parallel Clauses
+Just beyond the Great Barrier Reef _____ a whole new world of sea creatures yet to be studied.,-M2nQ6ISK8NuDAL0oci-,Subject-Verb Agreement,143,PreAP1 Q2 - Subject-Verb Agreement With Inversion
+Just beyond the Great Barrier Reef ___ a whole new world of sea creatures yet to be studied.,-M2nQ6ISK8NuDAL0oci-,Verb Tense and Agreement,157,SpringBoard Q13 - Subject-Verb Agreement With Inversion
+Each of the male wolves in the wolf pack has the chance to become the leader if _____ the current alpha male.,-M2nQhitkFFuphgKEi1h,Pronoun-Antecedent Agreement,144,PreAP1 Q4 - Pronoun Agreement With Indefinite Pronouns
+Each of the male wolves in the wolf pack has the chance to become the leader if ___ the current alpha male.,-M2nQhitkFFuphgKEi1h,Pronoun Case and Agreement,158,SpringBoard Q19 - Pronoun Agreement With Indefinite Pronouns
+"After discovering that Jupiter, Saturn, Uranus, and Neptune would soon align, NASA’s research team launched ___ first program to study planets in the outer Solar System.",-M2nZR4KVgOD61Dqtk_U,Pronoun Case and Agreement,158,SpringBoard Q18 - Pronoun Agreement
+The players on the field ___ the ball.,010d75a2-83e2-4329-95c0-0243a8a46151,Subject-Verb Agreement,135,Starter Pre Q2 - Basic Subject-Verb Agreement
+The players on the field ___ the ball.,010d75a2-83e2-4329-95c0-0243a8a46151,Verb Tense and Agreement,157,SpringBoard Q12 - Subject-Verb Agreement
+Do you already take out the trash?,03c4ee7d-7517-4e18-9c2b-912dd5f64978,Irregular Past Tense,179,ELL Advanced Pre Q7 - Past Tense (Do)
+Moss provides a habitat for insects. The soil is protected by moss. Releasing oxygen is also a thing that moss does.,05584cf5-33ef-4f87-988b-d09c36085ada,Parallel Structure,141,Advanced Post Q7 - Parallel Clauses
+Tiramisu is an Italian dessert with many layers. Trifle has many layers that can be made of cream or jelly. consequently / however / similarly / moreover,06583920-8654-4e56-ab5f-b9708450ac39,Conjunctive Adverbs,132,Intermediate Post Q22 - Conjunctive Adverbs (Similarly)
+Alligators and crocodiles are both large reptiles. Crocodiles are typically lighter in color. and / or / but / so,078ff29e-3fc9-41e8-b65e-871963ea0075,Compound Sentences,130,Intermediate Post Q18 - Compound Sentences (But)
+I ___ a teacher.,08bbc74a-d936-4d32-81de-387e439e6aa7,Sentences With To Be,167,ELL Starter Post Q1 - Conjugating To Be
+The first skateboards were developed in the 1950s. The first skateboard helped surfers practice without waves.,09c24ec7-f15f-451e-9993-28d69838ebb4,Participial Phrases,140,Advanced Post Q3 - Participial Phrases
+A huge flock of birds ___ right above us. is / are,0aff5857-33be-4b43-bf2b-b2bfc905e69c,Subject-Verb Agreement,135,Intermediate Pre Q5 - Subject-Verb Agreement
+A huge flock of birds ___ right above us.,0aff5857-33be-4b43-bf2b-b2bfc905e69c,Subject-Verb Agreement,143,PreAP1 Q1 - Subject-Verb Agreement With Collective Nouns
+I think you liked cats.,0b31c0b9-5fca-42ea-8680-21ae80a373af,Irregular Past Tense,179,ELL Advanced Pre Q5 - Past Tense (Think)
+He is ___.,0b8bb651-394c-449f-9d5b-f726c561298a,Sentences With To Be,167,ELL Starter Post Q7 - A & An Before A Noun
+"I have ___ computer, and ___ has my computer.",0c239173-cea8-45ad-bc7d-0a24fcacc66f,Possessive Nouns and Pronouns,173,ELL Intermediate Pre Q5 - Possessives
+Diana walks to school yesterday.,0e417ec6-ed87-46d6-bb99-627bf5c47d63,Regular Past Tense,178,ELL Advanced Post Q1 - Simple Past With -ed
+It is another warm day in July. It is another rainy day in July,0f5f7a4f-62f6-48f6-a459-6b5580fc242f,Adjectives and Adverbs,125,Starter Post Q17 - Coordinate Adjectives
+My sister ___ to school tomorrow morning.,1291b2d2-5272-453d-9ae2-5ad12963ac3a,Progressive Tenses,181,ELL Advanced Pre Q13 - Future Progressive
+A huge pack of wolves ___ right beside us. is / are,12a908ef-62d8-4983-a033-bebac6e9f25b,Subject-Verb Agreement,135,Intermediate Post Q5 - Subject-Verb Agreement
+The rolling thunder terrifies the sailors. The flashes of lightning terrify the sailors.,13e8a7b2-be2b-4828-a739-89ce10e0661a,"Compound Subjects, Objects, and Predicates",145,PreAP1 Q11 - Compound Subjects
+The rolling thunder terrifies the sailors. The flashes of lightning terrify the sailors.,13e8a7b2-be2b-4828-a739-89ce10e0661a,"Compound Subjects, Objects, and Predicates",153,SpringBoard Q8 - Compound Subjects
+Claudia talks to Gabby yesterday.,146db693-c491-4653-8faf-94349f462c69,Regular Past Tense,178,ELL Advanced Pre Q1 - Simple Past With -ed
+Addison cooks dinner right now.,179487bd-43da-40b4-b815-a2f57cb10ea8,Progressive Tenses,180,ELL Advanced Post Q11 - Postsent Progressive
+Kevin likes to swim. Alyssa likes to swim.,182ae667-a4f7-4c83-b4f9-b2c260ece786,"Compound Subjects, Objects, and Predicates",129,Intermediate Post Q16 - Compound Subjects
+"___ ___ ___ your homework, please?",1a7ac679-7e32-4bf3-96fa-fe7d7d15772e,Writing Questions,177,ELL Intermediate Post Q18 - Can Questions
+My brother ___ a test tomorrow morning.,1b62cd4d-878a-49fd-afdc-e2a2ac517015,Progressive Tenses,181,ELL Advanced Post Q13 - Future Progressive
+Eli eats a sandwich for lunch yesterday.,1d7b7f13-b91b-44d9-b4c9-4339b3f288db,Irregular Past Tense,179,ELL Advanced Post Q6 - Past Tense (Eat)
+He cleans up the ___ toys. childrens / children’s / childrens’,1ef645e1-d805-4447-b127-c11907976b9f,"Nouns, Pronouns, and Verbs",136,Intermediate Pre Q7 - Plural Possessive
+The scorpion has adapted to survive in a harsh desert climate. The rattlesnake has adapted to survive in a harsh desert climate.,1f76db0e-3b86-4bd2-aeab-fe031a5e15e1,"Compound Subjects, Objects, and Predicates",145,PreAP1 Q12 - Compound Subjects
+The scorpion has adapted to survive in a harsh desert climate. The rattlesnake has adapted to survive in a harsh desert climate.,1f76db0e-3b86-4bd2-aeab-fe031a5e15e1,"Compound Subjects, Objects, and Predicates",153,SpringBoard Q9 - Compound Subjects
+"in march, i went to florida.",235750e8-10e7-43a9-9b71-ed16c77f0a49,Capitalization,123,Starter Post Q11 - Capitalization (Basic)
+She wants a brown cat. She wants a black dog.,26bbbec6-8235-417c-95c2-de69c3310f63,Listing Adjectives and Nouns,170,ELL Starter Post Q21 - Combining Sentences with And
+Pho is a soup made with herbs. Pho is a soup made with bone broth. Pho is a soup made with noodles.,285424c5-0d38-46e3-b48e-6d1adc3bbe26,"Compound Subjects, Objects, and Predicates",127,Starter Pre Q21 - Listing Objects
+Are you ___ your birthday?,2855b1e0-5064-4804-a8f7-8e498576d556,Phrasal Verbs,181,ELL Advanced Pre Q16 - Phrasal Verbs
+___ ___ ___ best friend?,28bd411c-bd67-4306-af7e-950647ccf075,Writing Questions,177,ELL Intermediate Pre Q17 - Question Word Order
+Both ___ instruments are backstage. bands / band’s / bands’,28dcfd93-1422-4ba1-b39f-b5bdcb97200d,"Nouns, Pronouns, and Verbs",136,Intermediate Post Q6 - Plural Possessive
+They are kind. They are happy. and,28f7b400-c7a6-491d-9d07-a2294bb96be5,Listing Adjectives and Nouns,170,ELL Starter Pre Q20 - Combining Sentences with And
+Anthony wants to sing. Matthew wants to sing.,290850dc-0b90-41ff-bd52-99a89d690997,"Compound Subjects, Objects, and Predicates",129,Intermediate Pre Q16 - Compound Subjects
+The birds began to chirp. The birds were gathering outside my window. I knew it was time to wake up. when,2c770b7f-22fe-4127-8870-c3aebf65cd4c,Participial Phrases,140,Advanced Post Q11 - Complex Sentences with Participial Phrases
+We did not go outside because it rains.,2e95d850-631e-4fd4-97ea-ea72d685c917,Progressive Tenses,181,ELL Advanced Post Q12 - Past Progressive
+The sun provides energy for plants. Oceans are warmed by the sun. Impacting weather patterns is also a thing the sun does.,2eb6a78d-8e43-4b21-8109-7a4bb0ee7989,Parallel Structure,141,Advanced Pre Q7 - Parallel Clauses
+The sun provides energy for plants. Oceans are warmed by the sun. Impacting weather patterns is also a thing the sun does.,2eb6a78d-8e43-4b21-8109-7a4bb0ee7989,Parallel Structure,164,AP Q16 - Parallel Clauses
+The sun provides energy for plants. Oceans are warmed by the sun. Impacting weather patterns is also a thing the sun does.,2eb6a78d-8e43-4b21-8109-7a4bb0ee7989,Parallel Structure,152,PreAP2 Q12 - Parallel Clauses
+New York City's subway tunnels were built to withstand weather events. They were damaged by the extreme conditions of Hurricane Sandy. however / therefore / moreover / furthermore,2f7edef1-608f-4b1e-9a83-639845a6dd00,Conjunctive Adverbs,132,Intermediate Post Q21 - Conjunctive Adverbs (However)
+Do you ___ ___ ___ ___?,2f8fe1d8-3ec2-452c-8cd3-8cf47a401c88,Phrasal Verbs,181,ELL Advanced Post Q15 - Inseparable Phrasal Verbs
+She wants a big dog. She wants a small cat. and,30c92334-0eec-462b-855e-4f41174b329a,Listing Adjectives and Nouns,170,ELL Starter Pre Q21 - Combining Sentences with And
+The teacher is reading. The student is reading.,31986bb0-534b-4519-98b8-ff6ac1b334ad,"Compound Subjects, Objects, and Predicates",127,Starter Post Q20 - Compound Subjects
+We all go to Montana last summer.,34708cce-95ca-4848-8911-d648c8ffec67,Irregular Past Tense,179,ELL Advanced Pre Q10 - Past Tense (Go)
+This present is ___ my mother.,34b3e399-c860-48fc-8348-1f6a0e5e5cd4,Prepositions,174,ELL Intermediate Pre Q10 - For
+They are not strong swimmers. Chimpanzees often live close to large bodies of water. even though / since / until,36322c2b-656a-4e45-bce4-96a6d790a3c9,Complex Sentences,131,Intermediate Pre Q19 - Complex Sentences (Even Though)
+omar was born in denver on christmas.,36e7e144-9783-4c85-9eb6-847fc52eb1b2,Capitalization,123,Starter Post Q10 - Capitalization (Basic)
+Is she your friend? ___.,36f975b3-4d8f-489b-8a9e-af1f677e66af,ELL-Specific Skills,182,ELL Advanced Post Q20 - Responding to Questions
+I will go to my grandfather's house ___ school today.,392942c8-9460-4eee-afd1-1847c7fc1f5b,ELL-Specific Skills,182,ELL Advanced Pre Q19 - Prepositions
+Did you already ___ Jordan at the airport?,3a5b5881-c04d-4934-a8e2-2237ff0466c4,Phrasal Verbs,181,ELL Advanced Post Q17 - Phrasal Verbs
+We ___ sandwiches and apples.,3e83a55d-4594-403a-8e58-32ba8639eb47,Subject-Verb Agreement,172,ELL Intermediate Pre Q1 - Subject-Verb Agreement
+I want to make ___ today.,3e8d8833-8b3a-44ff-b4b7-1296a5bf1dfb,Articles,176,ELL Intermediate Pre Q14 - Articles
+Swimming is [harder] without goggles than with them. harder / more hard / more harder / hardest,411744f6-0a82-4570-8dec-06513342c838,Adjectives and Adverbs,125,Starter Post Q6 - Comparative vs. Superlative Adjectives
+___ teacher has ___ homework.,426eb422-52fd-4f14-a220-c698921db143,Possessive Nouns and Pronouns,173,ELL Intermediate Pre Q4 - Possessives
+This present is ___ my brother.,42f8172f-74d4-447c-b93b-59ecb3a08de1,Prepositions,174,ELL Intermediate Post Q10 - For
+Is she ___ her birthday?,4318987b-0064-4181-b372-335485bad16a,Phrasal Verbs,181,ELL Advanced Post Q16 - Phrasal Verbs
+We ___ ___ ___ a dog.,44252771-b016-4d58-970c-9f6aebd636b3,Sentences With Have,168,ELL Starter Post Q14 - Conjugating To Have
+"Two days after the aquarium's researchers received ___ first octopus, the octopus escaped through a grate in the floor and found its way back to the ocean.",46e12a6c-6741-41a9-9174-997d22f1b7bd,Pronoun-Antecedent Agreement,144,PreAP1 Q3 - Pronoun Agreement With Collective Nouns
+I carry our bags to the car last night.,48411cd6-3cc2-490f-8cce-7c71825f098e,Regular Past Tense,178,ELL Advanced Pre Q3 - Simple Past with -ied
+___ is happy.,486d277f-03f7-47e7-8368-d613424b079e,Sentences With To Be,167,ELL Starter Post Q11 - Starting Sentences with Nouns
+The Hubble Space Telescope was launched in 1990. It led to the discovery of galaxies far away from the earth. who / that / which,493ac0e7-457d-4164-9c97-33f350b3b595,Relative Clauses,139,Advanced Post Q6 - Relative Clauses (Which)
+I am __ student.,4c0c594c-4c7f-4225-9a71-3f3d0ad4c09b,Sentences With To Be,167,ELL Starter Post Q9 - Word Order With Adjectives
+I ___ four episodes of the show so far. saw / seen / have seen / had seen,4cc912f7-3a36-4627-afc0-4fc6cbcb071c,"Nouns, Pronouns, and Verbs",136,Intermediate Post Q10 - Perfect Tense
+When will you ___ ___ ___ from school?,4d95c78f-1a1d-4868-81f7-5d3bff59585c,Phrasal Verbs,181,ELL Advanced Post Q14 - Separable Phrasal Verbs
+They are at school at 10:30 yesterday.,52578f38-c455-4039-aeb3-27339a6d93ea,Irregular Past Tense,179,ELL Advanced Post Q4 - Past Tense (Be)
+___ time is your math test?,5315645e-fefd-402e-9e25-ced997910339,Writing Questions,177,ELL Intermediate Post Q19 - What Questions
+"Even though ___ cover is torn and ___ pages are yellowed, the book is very valuable because ___ three hundred years old and very rare.",532ed9e7-5830-4519-8fc5-8a40914aaa86,Commonly Confused Words,159,SpringBoard Q25 - Commonly Confused Words (Its/It's)
+Carlos wants to make ___ today.,53428cba-1976-4968-90d8-fe2878683da4,Articles,176,ELL Intermediate Post Q14 - Articles
+Sophia visits her grandmother ___ the summer.,54382c1c-ffbb-4c86-9462-9981b15e853f,Prepositions,174,ELL Intermediate Post Q13 - In (time)
+Eliza does her homework in ___.,55bd0014-f9a9-4691-a990-bdb3024a8f1e,Articles,176,ELL Intermediate Pre Q16 - Articles
+I was about to do my laundry when I noticed that all my clothes ___ by my brother. were washed / have been washed / had been washed,59b6aae8-b7a4-47f9-be7b-79f3da0deef3,"Nouns, Pronouns, and Verbs",136,Intermediate Post Q11 - Perfect Tense
+They are in class at 9:00 yesterday.,5a1d2ade-de6e-41d5-8eb2-c72f09b6ba2e,Irregular Past Tense,179,ELL Advanced Pre Q4 - Past Tense (Be)
+Do she already take out the trash?,5c5548ea-7aa3-4f0d-bf97-060aa9d2f1cc,Irregular Past Tense,179,ELL Advanced Post Q7 - Past Tense (Do)
+You have a brother. You have a sister. You have a father.,5dbf9d7c-02ab-4b15-b588-688fd4e0bf44,Listing Adjectives and Nouns,170,ELL Starter Post Q22 - Combining Sentences with And
+Levees were built to keep New Orleans from flooding. They were not strong enough to withstand Hurricane Katrina. however / therefore / moreover / furthermore,5ead7093-7586-4af0-8355-0b8ba427fd3a,Conjunctive Adverbs,132,Intermediate Pre Q21 - Conjunctive Adverbs (However)
+Levees were built to keep New Orleans from flooding.They were not strong enough to withstand Hurricane Katrina.,5ead7093-7586-4af0-8355-0b8ba427fd3a,Conjunctive Adverbs,148,PreAP2 Q9 - Conjunctive Adverbs (However)
+Flan is a dessert made with sugar. Flan is a dessert made with evaporated milk. Flan is a dessert made with eggs.,5ef3dca1-0ecd-4f39-bca0-dbc32725521d,"Compound Subjects, Objects, and Predicates",127,Starter Post Q21 - Listing Objects
+___ ___ ___ best friend?,608c0c28-9c8e-4186-86f9-23176a13b037,Writing Questions,177,ELL Intermediate Post Q17 - Question Word Order
+Franklin walks the dog later.,617e5326-8b84-4eb1-90fc-b7010d4b0d45,Future Tense,175,ELL Intermediate Pre Q22 - Simple Future Tense
+Yesterday she says that she wants a pet dog.,62a16c1c-f668-413b-a06e-130dad916d82,Irregular Past Tense,179,ELL Advanced Pre Q9 - Past Tense (Say)
+Is she ___ the plane?,638cd636-bf21-4470-9738-fadd12f7a237,Prepositions,174,ELL Intermediate Post Q12 - On (place)
+We ___ to our friends after school.,667f9386-7758-4400-8440-4ae982e64625,ELL-Specific Skills,182,"ELL Advanced Post Q21 - Say, Tell, Talk, and Ask"
+He shops for clothes earlier.,6b4435a6-741b-4d62-8c60-d513ee5637d5,Regular Past Tense,178,ELL Advanced Pre Q2 - Simple Past With Double Consonants
+She is a ___.,6b6413e6-92f8-41fd-82e3-22223c9d1b76,Sentences With To Be,167,ELL Starter Post Q8 - Word Order With Adjectives
+He ___ ___ ___ a dog.,6b84846b-390c-4b04-8849-a3db90a1f48e,Sentences With Have,168,ELL Starter Post Q16 - Conjugating To Have
+Ciera takes a test last Friday.,6d4fc862-6ec4-4027-aa4c-8b9589f32fc4,Irregular Past Tense,179,ELL Advanced Pre Q8 - Past Tense (Take)
+Who ___ ___ ___ ___?,6db9ff4e-3613-4450-9d51-ede834648b91,Phrasal Verbs,181,ELL Advanced Pre Q15 - Inseparable Phrasal Verbs
+Teagan eats cereal for breakfast yesterday.,6e403771-ece4-4fa5-8a04-5474f3002dbd,Irregular Past Tense,179,ELL Advanced Pre Q6 - Past Tense (Eat)
+My friend wants to play ___.,6f0973f6-422d-4193-b0c9-a8274019d0bf,Articles,176,ELL Intermediate Post Q15 - Articles
+The student ___ to school.,6f2e4f46-f0a3-46a5-a628-97447649b184,Subject-Verb Agreement,172,ELL Intermediate Post Q2 - Subject-Verb Agreement
+She will go to the park ___ work today.,6fa7448a-fa3f-457c-8013-fcbf9a304801,ELL-Specific Skills,182,ELL Advanced Post Q19 - Postpositions
+"___ ___ ___ this homework, please?",7009ed94-48fe-416e-a9aa-87d58757f6a9,Writing Questions,177,ELL Intermediate Pre Q18 - Can Questions
+"in january, i went to montana.",7091424b-b0d2-4e0d-b283-d45840a2f1ce,Capitalization,123,Starter Pre Q11 - Capitalization (Basic)
+My cousin is ___ the beach.,70a0fdc9-daf1-4ca6-b671-75e366e9e6df,Prepositions,174,ELL Intermediate Pre Q9 - At (place)
+She ___ a dog.,70a6891c-266d-46d7-8527-9fe0b4a57843,Sentences With Want,169,ELL Starter Post Q13 - Conjugating To Want
+The airplane was an invention. It made international travel much easier. who / that / which,70acbdeb-7225-407d-a9d2-6133b1016113,Relative Clauses,139,Advanced Post Q5 - Relative Clauses (That)
+We ___ to our friends during lunch.,71795dda-a403-4723-a510-1eb52e32812a,ELL-Specific Skills,182,"ELL Advanced Pre Q21 - Say, Tell, Talk, and Ask"
+Armadillos live for an average of 16 years in the wild. Armadillos are a type of hard-shelled mammal. They are native to Latin America.,741ac18f-22ac-4e04-b43d-f65a11c1e5e8,Advanced Combining,142,Advanced Post Q12 - Appositive Phrases and Participial Phrases
+___ computer is in ___ car.,7484ace1-8386-4e4e-9274-02daf8a7a465,Possessive Nouns and Pronouns,173,ELL Intermediate Post Q3 - Possessives
+Do we have a test ___ Wednesday?,74c2c0af-f83d-4992-9615-0a2638a2978d,Prepositions,174,ELL Intermediate Pre Q8 - On (time)
+Clarissa does not like chocolate cake ___ much.,74ec8408-cae8-4ed1-8e7e-5799fc25d7fd,ELL-Specific Skills,182,ELL Advanced Post Q23 - Very vs. Really
+The geese are searching for warmer weather.The geese fly south for the winter.,772ed640-182e-4111-addb-2c66b2a664e0,Participial Phrases,151,PreAP2 Q4 - Participial Phrases
+I like surfing. I like to skate. I like walks.,781a49db-4ca1-43f0-baf7-ad0f37dce41f,Parallel Structure,133,Intermediate Pre Q14 - Parallel Structure
+Chimpanzees often live close to large bodies of water. They are not strong swimmers.,78a22902-39df-4e5c-ad36-68daad4817ed,Complex Sentences,160,AP Q7 - Complex Sentences (Even Though)
+Chimpanzees often live close to large bodies of water. They are not strong swimmers.,78a22902-39df-4e5c-ad36-68daad4817ed,Complex Sentences,147,PreAP1 Q7 - Complex Sentences (Even Though)
+Chimpanzees often live close to large bodies of water. They are not strong swimmers.,78a22902-39df-4e5c-ad36-68daad4817ed,Complex Sentences,155,SpringBoard Q4 - Complex Sentences (Even Though)
+The tornado lifted full-grown trees into the air. The tornado was spinning with incredible power and speed.,7a51aeb6-5865-411a-936c-cc1909d98a49,Participial Phrases,140,Advanced Post Q4 - Participial Phrases
+"The earth and the moon have both been hit by asteroids. They've been hit throughout history. There are no craters on the earth's surface. Weather, water, and plants work together to erase craters from the earth's surface.",7be6a90d-b21a-4d1d-9d01-6dbff5eab04e,Advanced Combining,142,Advanced Pre Q15 - Open Sentence Combining
+"The earth and the moon have both been hit by asteroids. They've been hit throughout history. There are no craters on the earth's surface. Weather, water, and plants work together to erase craters from the earth's surface.",7be6a90d-b21a-4d1d-9d01-6dbff5eab04e,Advanced Combining,166,AP Q17 - Open Sentence Combining
+They live in the ocean. Dolphins breathe air like land mammals. even though / since / until,7ee0c1a4-7dae-4747-840e-61510c0b040d,Complex Sentences,131,Intermediate Post Q19 - Complex Sentences (Even Though)
+Lucy takes a test last Tuesday.,7fb826b3-552e-4289-8925-69e9648c064a,Irregular Past Tense,179,ELL Advanced Post Q8 - Past Tense (Take)
+Eagles can search for food while they fly. Eagles can carry small animals while they fly.,80aa1d57-d242-4a6e-ad95-263a432ded1d,"Compound Subjects, Objects, and Predicates",129,Intermediate Post Q15 - Compound Predicates
+When will you ___ ___ ___ at the airport?,8313038d-c4a1-401c-80dd-0a450a58f526,Phrasal Verbs,181,ELL Advanced Pre Q14 - Separable Phrasal Verbs
+School starts ___ 8:15.,8459dc3f-d681-43f1-b4b7-65283d61ef28,Prepositions,174,ELL Intermediate Post Q11 - At (time)
+Celeste visits her grandmother ___ the summer.,84f35b09-91cd-4beb-958b-99c51d3fef7e,Prepositions,174,ELL Intermediate Pre Q13 - In (time)
+Mr. Jenkins ___ to Mr. Brown tomorrow.,85294c46-6755-40d1-818b-36e37e839a87,Future Tense,175,ELL Intermediate Pre Q21 - Present vs. Future Tense
+She collects the ___ tickets. womens’ / women’s / womens,857b1eb8-2c04-4a38-b675-1f82e55e3b43,"Nouns, Pronouns, and Verbs",136,Intermediate Post Q7 - Plural Possessive
+Grass grows [taller] in the summer than in the winter. taller / more tall / more taller / tallest,87d6c318-8a55-4c68-8b61-c87561014491,Adjectives and Adverbs,125,Starter Post Q7 - Comparative vs. Superlative Adjectives
+___ friends?,87f137fd-1125-4500-a531-d938d676d79f,Writing Questions,171,ELL Starter Post Q19 - Yes or No Questions with To Be
+School starts ___ 7:45.,88a4b4ed-662a-4054-bd92-d2669c68ea4f,Prepositions,174,ELL Intermediate Pre Q11 - At (time)
+The ocean and the earth have both been explored. They have been explored throughout history. There is no complete map of the ocean floor. The immense water pressure at the bottom of the ocean makes it difficult to explore.,895e2920-3a1d-4cd2-87cf-4675c59e9485,Advanced Combining,142,Advanced Post Q15 - Open Sentence Combining
+Each of the band members ___ to the band director. listen / listens,8991f946-a846-40bb-8e17-b3d1bf5c9869,Subject-Verb Agreement,135,Intermediate Post Q4 - Subject-Verb Agreement
+The clouds turned stormy gray. The clouds were slowly moving across the sky. I knew it was time to head indoors. when,899edc9c-342e-4aa0-bc38-35f98292d91d,Participial Phrases,140,Advanced Pre Q11 - Complex Sentences with Participial Phrases
+Thousands of meteors hit the earth each day. Our planet is covered by more water than land. Most meteors fall in the water. even though / so,89ec718b-683d-4387-acb6-9730d015448b,Compound-Complex Sentences,137,Advanced Pre Q10 - Compound-Complex Sentences (Even Though & So)
+The teacher put hall passes on five ___ desks. students / students’ / student’s,8c9e86b5-1e23-4307-a082-ead8e6536f72,"Nouns, Pronouns, and Verbs",136,Intermediate Post Q8 - Plural Possessive
+"I have ___ phone, and ___ has my phone.",8ef4b110-e155-4108-b851-c88bd10f60e9,Possessive Nouns and Pronouns,173,ELL Intermediate Post Q5 - Possessives
+Did you already ___ Taylor from school?,903f989c-3a95-4c4e-b7d9-1ae843a152e3,Phrasal Verbs,181,ELL Advanced Pre Q17 - Phrasal Verbs
+Venus is not the closest planet to the sun. Its temperatures get hotter than any other planet. Humans could never live there. even though / so,90c7030f-11fb-4015-9f34-2cb68915f8f5,Compound-Complex Sentences,137,Advanced Post Q10 - Compound-Complex Sentences (Even Though & So)
+___ time is your basketball game?,9243eff3-db2c-462e-ad25-4262095fa83f,Writing Questions,177,ELL Intermediate Pre Q19 - What Questions
+You have a mother. You have a brother. You have a sister. and,9401625a-a904-4a2f-ba94-de4c86c59a8f,Listing Adjectives and Nouns,170,ELL Starter Pre Q22 - Combining Sentences with And
+Jasper does not like to play basketball ___ much.,9b3be418-3049-4ab3-82d0-894726e60de5,ELL-Specific Skills,182,ELL Advanced Pre Q23 - Very vs. Really
+My sister is ___ the beach.,9e12d315-7726-4779-a3ad-0c3dfc1c5bcc,Prepositions,174,ELL Intermediate Post Q9 - At (place)
+I ___ a dog.,9e931041-9b3f-4af1-8bb5-717bf7537f8e,Sentences With Want,169,ELL Starter Post Q15 - Conjugating To Want
+His mother is driving ___ the school.,a02edd7b-ba5e-4977-8918-fb78575018ed,ELL-Specific Skills,182,ELL Advanced Post Q18 - Postpositions
+I joined the math team. Parker tried out for the basketball team. and,a1daa28c-cb6a-4b14-a479-f22e5004cdf4,Compound Sentences,130,Intermediate Post Q17 - Compound Sentences (And)
+Piper swims in the ocean right now.,a2118630-2ddf-4c59-a3fb-7978cdf4d3dd,Progressive Tenses,180,ELL Advanced Pre Q11 - Present Progressive
+Guppies can live with other peaceful fish in aquariums. Piranhas should only be kept in tanks with other piranhas. Piranhas typically eat other fish. but / because,a470fc51-858e-42bc-9e24-672b36913c79,Compound-Complex Sentences,137,Advanced Pre Q9 - Compound-Complex Sentences (But & Because)
+Guppies can live with other peaceful fish in aquariums. Piranhas should only be kept in tanks with other piranhas. Piranhas typically eat other fish.,a470fc51-858e-42bc-9e24-672b36913c79,Compound-Complex Sentences,165,AP Q13 - Compound-Complex Sentences (But & Because)
+We are ___.,a4aac4d4-110c-435b-a2de-7cf4d7c144d6,Sentences With To Be,167,ELL Starter Post Q5 - Regular Plural Nouns
+Dominic went skiing for the first time. He was afraid to ski on the smallest slope. Now his friends watch him ski in competitions.,a4cdb989-dd89-4895-a37b-7025f07b2e98,Compound-Complex Sentences,165,AP Q14 - Compound-Complex Sentences (When & But)
+The nurse ___ to work.,a5841a6b-ea80-45f4-9b6c-398866b545b3,Subject-Verb Agreement,172,ELL Intermediate Pre Q2 - Subject-Verb Agreement
+Carpenter bees feed on plant pollen.Carpenter bees make nests in wood structures.,a660ad6c-b04b-478e-b083-52bf12d3c3b7,"Compound Subjects, Objects, and Predicates",145,PreAP1 Q9 - Compound Predicates
+Carpenter bees feed on plant pollen.Carpenter bees make nests in wood structures.,a660ad6c-b04b-478e-b083-52bf12d3c3b7,"Compound Subjects, Objects, and Predicates",153,SpringBoard Q7 - Compound Predicates
+"each winter, my mom teaches a biology class about sea lions in the arctic ocean.",a6b2d9f5-a743-44e0-8ad3-4876754cf964,Capitalization,134,Intermediate Post Q13 - Capitalization
+The heavy traffic made ___ late to school. her friend and she / her friend and her,a7be69e2-c32c-4c3c-a1ec-0f5949096881,"Nouns, Pronouns, and Verbs",136,Intermediate Post Q3 - Pronouns in Objects
+It is ___ orange.,a8c9d753-ddc8-43a9-aca8-a230f9b66c4b,Sentences With To Be,167,ELL Starter Post Q4 - A vs An
+A cello is a large instrument with four strings. A violin has four strings that can be played by hand or with a bow. consequently / however / similarly / moreover,aea16d60-861b-4a39-a98d-0fa09bb6c338,Conjunctive Adverbs,132,Intermediate Pre Q22 - Conjunctive Adverbs (Similarly)
+A cello is a large wooden instrument with four strings.A violin has four strings that can be played by hand or with a bow.,aea16d60-861b-4a39-a98d-0fa09bb6c338,Conjunctive Adverbs,148,PreAP2 Q10 - Conjunctive Adverbs (Similarly)
+Rosa Parks won the Presidential Medal of Freedom. She fought for equality. unless / even though / because,aeabdcf0-a076-45af-bafb-fc49e2a1e249,Complex Sentences,131,Intermediate Post Q20 - Complex Sentences (Because)
+Birria is a stew from Mexico. Birria is spicy. It is served at celebrations. It is served traditionally. Birria can eaten in many different ways.,b2d2231f-5225-4925-9288-e72bc06d074f,Advanced Combining,142,Advanced Post Q13 - Open Sentence Combining
+NASA made history in 1969 by landing a man on the moon. NASA is America's space agency.,b2fde2cb-53cc-4fff-a71a-c33530c04124,Appositive Phrases,138,Advanced Post Q2 - Appositive Phrases
+The swimmers hold ___ breath when ___ under water during the competition. they're / there / their,b64ed710-b18b-4079-84b2-0b72e7343f5e,Commonly Confused Words,128,Starter Post Q5 - Commonly Confused Words (Their/There/They're)
+She ___ the test yesterday. took / taken / had taken / have taken,b671f4ef-2489-4d9f-bbc6-0cc687f2276d,"Nouns, Pronouns, and Verbs",136,Intermediate Post Q9 - Irregular Past Tense
+Do you have a test ___ Friday?,b6f601c2-d774-455f-bd03-bcac47d0c254,Prepositions,174,ELL Intermediate Post Q8 - On (time)
+___ teacher has ___ books.,b74d00fd-4c89-4831-b4ae-f84cfdf497c7,Possessive Nouns and Pronouns,173,ELL Intermediate Post Q4 - Possessives
+Their friends are ___ the car.,b7cc274f-d90c-49f9-8223-21ab125dec26,Prepositions,174,ELL Intermediate Post Q6 - In (place)
+Mrs. Cole ___ to Mrs. Berry tomorrow.,b8339cc1-cd63-4862-ae68-5a2691bd6b00,Future Tense,175,ELL Intermediate Post Q21 - Present vs. Future Tense
+___ is our science classroom?,b9992407-47e5-4d77-9eb2-3c6f89d6b83d,Writing Questions,177,ELL Intermediate Post Q20 - Where Questions
+She likes to play ___.,b9bc0675-1c2d-4148-ab2c-b5b126260557,Articles,176,ELL Intermediate Pre Q15 - Articles
+She hugs her grandmother earlier.,baf07b7c-ab8c-4a8c-aa8d-99c8637e0371,Regular Past Tense,178,ELL Advanced Post Q2 - Simple Past With Double Consonants
+xavier was born in pittsburgh on halloween.,bb95f513-02b5-49e1-a1b3-48d9d1d2a9df,Capitalization,123,Starter Pre Q10 - Capitalization (Basic)
+The turtle swims in the water. The turtle is green. It is a sea turtle.,bca7e621-0576-4547-b13e-668e449a8705,Adjectives and Adverbs,125,Starter Post Q18 - Cumulative Adjectives
+"every summer, my dad teaches a biology class about sea turtles in the atlantic ocean.",bcded6f9-2969-4d6f-bf88-756e7a107dfc,Capitalization,134,Intermediate Pre Q13 - Capitalization
+The internet was an influential invention. It transformed the world. The internet helped people access a wide variety of resources for the first time. People were concerned that it did more harm than good.,c0511999-2b86-44e7-aecc-f0a33cd3199d,Advanced Combining,142,Advanced Post Q14 - Open Sentence Combining
+Are they ___ the plane?,c2892362-c2d4-44ab-a455-7548427492e3,Prepositions,174,ELL Intermediate Pre Q12 - On (place)
+Guinea pigs can live with other guinea pigs in peace. Hamsters should be kept in cages by themselves. Hamsters typically fight other hamsters. but / because,c41524a4-2270-42c0-9f0c-be6dd7bd48a7,Compound-Complex Sentences,137,Advanced Post Q9 - Compound-Complex Sentences (But & Because)
+Hummus is a dip made from chickpeas. Hummus is a healthy dip. Hummus can be made at home. It can be made easily. It can be eaten with many different things..,c52345b7-8544-412d-80a1-c6837c74eca0,Advanced Combining,142,Advanced Pre Q13 - Open Sentence Combining
+The chef chops the vegetables. The vegetables are also seasoned by the chef. The chef decides how to cook the steak. Placing the meal on a plate is also something the chef does.,c750e01b-35b6-4aef-ace8-e021f6746bda,Parallel Structure,141,Advanced Post Q8 - Parallel Clauses
+___ is our math classroom?,c986a947-dd31-46be-954a-990ee1db8fe7,Writing Questions,177,ELL Intermediate Pre Q20 - Where Questions
+Her father is driving ___ the school.,cb03d996-d998-461a-8693-457aa9e4368f,ELL-Specific Skills,182,ELL Advanced Pre Q18 - Prepositions
+Their sisters are ___ the car.,cb7e8a0c-18df-492c-9432-2fa5e1d53217,Prepositions,174,ELL Intermediate Pre Q6 - In (place)
+___ phone is in ___ car.,cd41c3ba-5f73-4778-94a9-df27d39b44ea,Possessive Nouns and Pronouns,173,ELL Intermediate Pre Q3 - Possessives
+You ___ ___ ___ doctor.,cd80223c-a090-4f63-97ad-5422cd8a0e46,Sentences With To Be,167,ELL Starter Post Q6 - Word Order With Not
+He is ___.,cdb9f78b-02fb-4fbb-b38e-a0d075b5117c,Sentences With To Be,167,ELL Starter Post Q10 - Adjectives Without Articles
+Jonah does his homework in ___.,cea5651f-1714-49d7-8b5f-b722993dfd7b,Articles,176,ELL Intermediate Post Q16 - Articles
+My friend took a photo of ___. Bianca and Me / Bianca and I,cebba199-e7f9-4426-8fe4-79aceea33b19,"Nouns, Pronouns, and Verbs",136,Intermediate Post Q2 - Pronouns in Objects
+Hazel visits her cousin later.,cf07285-5f64-42da-9299-57c752d8fa5c,Future Tense,175,ELL Intermediate Post Q22 - Simple Future Tense
+They all go to Taiwan last summer.,d0ee76f2-e9df-40cb-a87c-35e1eba5f0f2,Irregular Past Tense,179,ELL Advanced Post Q10 - Past Tense (Go)
+I do not eat cereal tomorrow morning.,d1ba3f1d-2b83-4625-9934-5e4c3175ccc5,Future Tense,175,ELL Intermediate Post Q23 - Negative Future Tense
+Exploring the ocean is difficult and expensive. Many parts of the ocean remain a mystery.,d2cfe62f-ad84-4dc1-b44f-75fe2ede75c1,Compound Sentences,146,PreAP1 Q6 - Compound Sentences (So)
+Exploring the ocean is difficult and expensive. Many parts of the ocean remain a mystery.,d2cfe62f-ad84-4dc1-b44f-75fe2ede75c1,Compound Sentences,154,SpringBoard Q3 - Compound Sentences (So)
+The bear stands on the ice. The bear is white. It is a polar bear.,d56040fb-8175-47c4-a522-7c07afa7629a,Adjectives and Adverbs,125,Starter Pre Q18 - Cumulative Adjectives
+What did you ___ to Rodrigo?,d8bc1fe7-890a-4146-b21f-f685b5dec0f9,ELL-Specific Skills,182,"ELL Advanced Pre Q22 - Say, Tell, Talk, and Ask"
+They ___ books and movies.,d9225907-fb87-4792-9281-cc19cfc7e3ab,Subject-Verb Agreement,172,ELL Intermediate Post Q1 - Subject-Verb Agreement
+Muhammad Ali donated millions of dollars to charity throughout his lifetime. He was one of the greatest boxers of all time.,dc99103a-4e6f-4e12-8c1d-45b8e94d4686,Appositive Phrases,138,Advanced Post Q1 - Appositive Phrases
+What did you ___ to Maya?,dd0b9c52-f93c-4ec1-b5fe-d2a49d54e775,ELL-Specific Skills,182,"ELL Advanced Post Q22 - Say, Tell, Talk, and Ask"
+We'll play soccer with ___ brother while ___ walking the dog. your / you're,dd6e3315-e738-4483-b7ad-ba2ed7b94e0e,Commonly Confused Words,128,Starter Post Q4 - Commonly Confused Words (Your/You're)
+I do not drink coffee tomorrow morning.,dea44ac9-34f6-4c0f-acb9-2a8c1a69f3ad,Future Tense,175,ELL Intermediate Pre Q23 - Negative Future Tense
+It is another cold day in Seattle. It is another windy day in Seattle.,df237870-b7ff-420c-887a-827f26c04042,Adjectives and Adverbs,125,Starter Pre Q17 - Coordinate Adjectives
+He cry during the movie last night.,e20ec74f-9555-465c-9473-4e406cf90ba0,Regular Past Tense,178,ELL Advanced Post Q3 - Simple Past with -ied
+Ants find food. Ants bring it back to the colony.,e2a70630-210a-4888-a284-6e5f0d6d28e2,"Compound Subjects, Objects, and Predicates",127,Starter Post Q19 - Compound Predicates
+I think you liked dogs.,e6c97d65-64f9-4608-ad86-e305dff61598,Irregular Past Tense,179,ELL Advanced Post Q5 - Past Tense (Think)
+The boy ___ a student.,ea8b6220-d682-4e0c-897e-4882da4d42be,Sentences With To Be,167,ELL Starter Post Q3 - Conjugating To Be
+The first successful airplane was invented in 1903. The first successful airplane stayed in flight for a few seconds.,ead64eba-adcd-494f-9317-0bd0a569c6f9,Participial Phrases,140,Advanced Pre Q3 - Particpial Phrases
+The first successful airplane was invented in 1903. The first successful airplane stayed in flight for a few seconds.,ead64eba-adcd-494f-9317-0bd0a569c6f9,Participial Phrases,163,AP Q2 - Paricipial Phrases
+The first successful airplane was invented in 1903.The first successful airplane stayed in flight for a few seconds.,ead64eba-adcd-494f-9317-0bd0a569c6f9,Participial Phrases,151,PreAP2 Q3 - Participial Phrases
+They are funny. They are kind.,eb4320c8-f0c0-40a0-b063-612058229a71,Listing Adjectives and Nouns,170,ELL Starter Post Q20 - Combining Sentences with And
+Eagles and hawks are both birds of prey. Eagles are typically larger in size. and / or / but / so,ebab97de-3145-41bc-9fac-6454f7f37d18,Compound Sentences,130,Intermediate Pre Q18 - Compound Sentences (But)
+___ were tired from playing kickball all day. Me and Tyrone / Tyrone and I,ee505700-8a15-4d0a-b32d-3236a898ba50,"Nouns, Pronouns, and Verbs",136,Intermediate Post Q1 - Pronouns in Subjects
+Yesterday you says that you want a pet cat.,f03f012c-2718-4777-9563-2b7ef61ad99f,Irregular Past Tense,179,ELL Advanced Post Q9 - Past Tense (Say)
+I did not go for a walk because it rains.,f0ec2f08-af00-409e-b896-a08d4f050a85,Progressive Tenses,181,ELL Advanced Pre Q12 - Past Progressive
+I like skiing. I like to swim. I like hikes.,f10a8656-5007-4292-a24b-c521a7487006,Parallel Structure,133,Intermediate Post Q14 - Parallel Structure
+I like skiing.I like to swim.I like hikes.,f10a8656-5007-4292-a24b-c521a7487006,Parallel Structure,152,PreAP2 Q11 - Parallel Structure
+Glass and metal are recyclable. Many towns cannot afford to recycle these materials.,f23a8272-e5b4-4d22-8e2d-e0ecf99a4733,Compound Sentences,146,PreAP1 Q5 - Compound Sentences (But)
+Glass and metal are recyclable.Many towns cannot afford to recycle these materials.,f23a8272-e5b4-4d22-8e2d-e0ecf99a4733,Compound Sentences,154,SpringBoard Q2 - Compound Sentences (But)
+Bees collect nectar. Bees carry it back to the hive.,f28332d4-634d-45a6-ad3e-e18d08e290a2,"Compound Subjects, Objects, and Predicates",127,Starter Pre Q19 - Compound Predicates
+The boy is ___ ___ ___.,f7438141-db58-4727-82ca-1dea48a700a2,Sentences With To Be,167,ELL Starter Post Q12 - Word Order
+___ ___ ___ a funny book?,fa9f4923-bcb4-4bf4-a180-963ea94bfe28,Writing Questions,171,ELL Starter Post Q17 - Yes or No Questions with To Want
+___ ___ ___ orange cats?,fc63a0e2-c647-4a9e-8387-0ca4465b0740,Writing Questions,171,ELL Starter Post Q18 - Yes or No Questions with To Have
+I need to go ___ the store later.,fd3d972e-a2a1-4639-8475-21e2d44846c6,Prepositions,174,ELL Intermediate Post Q7 - To
+Is he your brother? ___.,fda2f07f-aa83-4a67-937a-4f096d79d2dc,ELL-Specific Skills,182,ELL Advanced Pre Q20 - Responding to Questions
+We need to go ___ the store later.,fe2d1840-ca88-42f4-963f-63e7f85468b5,Prepositions,174,ELL Intermediate Pre Q7 - To
+They ___ teachers.,ff6fea38-cf55-449f-bf1c-d9a1df5a06c4,Sentences With To Be,167,ELL Starter Post Q2 - Conjugating To Be

--- a/services/QuillLMS/lib/tasks/populate_diagnostic_question_skills.rake
+++ b/services/QuillLMS/lib/tasks/populate_diagnostic_question_skills.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :diagnostic_question_skills do
+  desc 'Populate diagnostic question skills table'
+  task :populate => :environment do
+    skill_to_question_mapping = CSV.parse(File.read("lib/data/skill_to_question_mapping.csv"), headers: true)
+
+    ActiveRecord::Base.transaction do
+      skill_to_question_mapping.each do |row|
+        begin
+          question = Question.find_by_uid(row['Question ID'])
+          DiagnosticQuestionSkill.create(question: question, skill_group_id: row['Skill Group ID'], name: row['Skill Name'])
+        rescue => e
+          puts "ID:#{row['Question ID']}: #{e}"
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
## WHAT
Add a CSV with the data for the `diagnostic_question_skills` table, and add a rake task to store that data.

## WHY
We need these database links for the new scoring system.

## HOW
See "What".

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-script-to-upload-new-diagnostic-question-skills-ccd7ff27351443e893633d828670cb97?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - no tests for migrations
Have you deployed to Staging? | NO - ran locally, will run on staging once I have the full data
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A