### PR TITLE
Fix Sentry error for Diagnostic Reports

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -58,7 +58,10 @@ module ResultsSummary
       correct_skill_ids = correct_skills.map { |s| s[:id] }
       correct_skill_number = correct_skills.count
       proficiency_text = summarize_student_proficiency_for_skill_per_activity(present_skill_number, correct_skill_number)
-      average_proficiency_score = skills.reduce(0) { |sum, skill| sum += skill[:proficiency_score] } / skills.length.to_f
+      average_proficiency_score = skills.reduce(0) do |sum, skill|
+        score = skill[:proficiency_score].is_a?(Integer) ? skill[:proficiency_score] : skill[:proficiency_score].to_i
+        sum += score
+      end / skills.length.to_f
       skill_group_summary_index = @skill_group_summaries.find_index { |sg| sg[:name] == skill_group.name }
       @skill_group_summaries[skill_group_summary_index][:proficiency_scores_by_student][student_name] = average_proficiency_score
       unless proficiency_text == PROFICIENCY

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -86,7 +86,7 @@ describe ResultsSummary do
                     skill: skill.name,
                     number_correct: 1,
                     number_incorrect: 0,
-                    proficiency_score: 1.0,
+                    proficiency_score: "1.0",
                     summary: ResultsSummary::FULLY_CORRECT,
                   }
                 ],
@@ -181,7 +181,7 @@ describe ResultsSummary do
               skill: skill.name,
               number_correct: 1,
               number_incorrect: 1,
-              proficiency_score: 0,
+              proficiency_score: "0",
               summary: ResultsSummary::PARTIALLY_CORRECT,
             }
           ],

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -86,7 +86,7 @@ describe ResultsSummary do
                     skill: skill.name,
                     number_correct: 1,
                     number_incorrect: 0,
-                    proficiency_score: "1.0",
+                    proficiency_score: 1.0,
                     summary: ResultsSummary::FULLY_CORRECT,
                   }
                 ],
@@ -181,7 +181,7 @@ describe ResultsSummary do
               skill: skill.name,
               number_correct: 1,
               number_incorrect: 1,
-              proficiency_score: "0",
+              proficiency_score: 0,
               summary: ResultsSummary::PARTIALLY_CORRECT,
             }
           ],


### PR DESCRIPTION
## WHAT
fix Sentry error happening for certain users in Diagnostic Reports where a string value is being coerced into an integer

## WHY
it's causing some user's reports to not display

## HOW
a few users have string values stored for the `proficiency_score` value of a skill object so just add a check for this and convert to an integer if this is the case

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://quillorg-5s.sentry.io/issues/4357387725/?project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=1

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
