### PR TITLE
Fix non-downcased emails in teacher_fix#google_unsync

### DIFF
--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -47,18 +47,18 @@ class TeacherFixController < ApplicationController
   end
 
   def recover_unit_activities
-    user = User.find_by_email(params['email'])
+    user = User.find_by(email: params_email)
     if user&.teacher?
       units = Unit.where(user_id: user.id)
       TeacherFixes::recover_unit_activities_for_units(units)
       render json: {}, status: 200
     else
-      render json: {error: "Cannot find a teacher with the email #{params['email']}."}
+      render json: {error: "Cannot find a teacher with the email #{params_email}."}
     end
   end
 
   def recover_activity_sessions
-    user = User.find_by_email(params['email'])
+    user = User.find_by(email: params_email)
     if user&.teacher?
       unit = Unit.find_by(name: params['unit_name'], user_id: user.id)
       if unit
@@ -69,7 +69,7 @@ class TeacherFixController < ApplicationController
         render json: {error: "The user with the email #{user.email} does not have a unit named #{params['unit_name']}"}
       end
     else
-      render json: {error: "Cannot find a teacher with the email #{params['email']}."}
+      render json: {error: "Cannot find a teacher with the email #{params_email}."}
     end
   end
 
@@ -151,8 +151,8 @@ class TeacherFixController < ApplicationController
   end
 
   def google_unsync_account
-    original_email = params['original_email']
-    user = User.find_by_email(original_email)
+    original_email = params['original_email'].downcase
+    user = User.find_by(email: original_email)
     if user
       new_email = params['new_email']
       if new_email == ''
@@ -259,6 +259,10 @@ class TeacherFixController < ApplicationController
     teacher.classrooms_i_teach.each(&:save_user_pack_sequence_items)
 
     render json: {}, status: 200
+  end
+
+  private def params_email
+    params['email'].downcase
   end
 
   private def set_user

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -338,8 +338,9 @@ describe TeacherFixController do
 
   describe '#google_unsync_account' do
     context 'when user exists' do
+      let(:user) { create(:student, :signed_up_with_google) }
+
       context 'when new email is not given' do
-        let!(:user) { create(:student, :signed_up_with_google) }
 
         it 'should reset the google id and set the signed up with google flag' do
           post :google_unsync_account, params: { original_email: user.email, password: "test123" }
@@ -349,14 +350,22 @@ describe TeacherFixController do
       end
 
       context 'when new email is given' do
-        let!(:user) { create(:student, :signed_up_with_google) }
-
         it 'should update the email, reset the google id and set the signed up with google flag' do
           post :google_unsync_account, params: { original_email: user.email, password: "test123", new_email: "new@email.com" }
           expect(user.reload.email).to eq "new@email.com"
           expect(user.reload.signed_up_with_google).to eq false
           expect(user.reload.google_id).to eq nil
         end
+      end
+
+      context 'when email is not downcased' do
+        it 'should update the email, reset the google id and set the signed up with google flag' do
+          post :google_unsync_account, params: { original_email: user.email.upcase, password: "test123", new_email: "new@email.com" }
+          expect(user.reload.email).to eq "new@email.com"
+          expect(user.reload.signed_up_with_google).to eq false
+          expect(user.reload.google_id).to eq nil
+        end
+
       end
     end
 


### PR DESCRIPTION
## WHAT
Fix a teacher fix issue where emails entered in as params are not downcased

## WHY
The subsequent param is passed to `User.find_by_email` which expects downcased emails

## HOW
Call `.downcase` on the email params.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Unsync-user-with-GC-teacher-fix-doesn-t-work-issues-with-Google-email-c382bfd56ae7410d95eb3a712bf135b0?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
