### PR TITLE
Fix bug with cms/user#show template

### DIFF
--- a/services/QuillLMS/app/views/cms/users/show.html.erb
+++ b/services/QuillLMS/app/views/cms/users/show.html.erb
@@ -82,7 +82,7 @@
       <br />
 
       <p style='font-weight: 700;'>Email verification status</p>
-      <p><%= @user.email_verification_status || N/A %></p>
+      <p><%= @user.email_verification_status || 'N/A' %></p>
       <br />
     <% end %>
 


### PR DESCRIPTION
## WHAT
There's an [bug](https://quillorg-5s.sentry.io/issues/4361121501/?project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=0) in a template with a string not being surrounded by quotes.

## WHY
The lack of quotes prevents the page from rending

## HOW
Wrap the string in quotes.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
