### PR TITLE
Fix provider log in method bug

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -227,7 +227,11 @@ class Teachers::ClassroomsController < ApplicationController
     return students unless classroom.provider?
 
     provider_classroom_delegator = ProviderClassroomDelegator.new(classroom)
-    students.map { |student| student.merge(synced: provider_classroom_delegator.synced_status(student)) }
+
+    students
+      .map { |student| student.merge(synced: provider_classroom_delegator.synced_status(student)) }
+      .map { |student| student.merge(provider: User.find(student['id']).provider) }
+
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -10423,3 +10423,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230731184420'),
 ('20230801140455'),
 ('20230801140522');
+
+


### PR DESCRIPTION
## WHAT
Fix a bug where logInMethod is not rendering properly for GoogleClassroom and Clever students

## WHY
The current display says `username` which is wrong.

## HOW
Add in a 'provider' key to the student payload .

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/GC-linked-and-Clever-linked-student-accounts-labeled-with-the-Log-in-Method-Username-1b5448e1fc3444039592062f67a73606?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? |  YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
