### PR TITLE
Update concept for uncued questions

### DIFF
--- a/services/QuillLMS/lib/tasks/update_uncued_question_concept.rake
+++ b/services/QuillLMS/lib/tasks/update_uncued_question_concept.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :update_uncued_question_concept do
+  desc 'Update uncued question concept from Joining Sentences to Open Sentence Combining'
+  task :run => :environment do
+    joining_sentences_concept_uid = 'us2_ksblSRRVRIXantRiNg'
+    open_sentence_concept_uid = 'V9ytDF4ljU-AsisRCF7qdw'
+    sql = <<-SQL
+      SELECT id
+      FROM questions
+      WHERE
+          questions.data->>'flag' != 'archived'
+          AND (questions.data->>'concept_uid' = '#{joining_sentences_concept_uid}' OR questions.data->>'conceptID' = '#{joining_sentences_concept_uid}')
+    SQL
+    question_ids = RawSqlRunner.execute(sql).values.flatten
+    question_ids.each do |id|
+      question = Question.find(id)
+      question.data["concept_uid"] = open_sentence_concept_uid if question.data["concept_uid"]
+      question.data["conceptID"] = open_sentence_concept_uid if question.data["conceptID"]
+      question.save(validate: false)
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/update_uncued_question_concept.rake
+++ b/services/QuillLMS/lib/tasks/update_uncued_question_concept.rake
@@ -18,6 +18,8 @@ namespace :update_uncued_question_concept do
       question.data["concept_uid"] = open_sentence_concept_uid if question.data["concept_uid"]
       question.data["conceptID"] = open_sentence_concept_uid if question.data["conceptID"]
       question.save(validate: false)
+      puts "Updating concept attached to Question #{question.id}"
     end
+    puts "Updated question IDs: #{question_ids}"
   end
 end


### PR DESCRIPTION
## WHAT
update the concept for uncued questions

## WHY
this was requested by Curriculum as part of the target skills project

## HOW
add a rake task that gets all the IDs for questions that match the old concept UID and replace it with the new one

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Mass-Data-Request-Change-the-question-concept-for-prompts-f06badf034a842629ff77077933556a5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  rake task-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
