### PR TITLE
Fix nil students data value

### DIFF
--- a/services/QuillLMS/app/services/clever_integration/district_classroom_data_adapter.rb
+++ b/services/QuillLMS/app/services/clever_integration/district_classroom_data_adapter.rb
@@ -14,7 +14,7 @@ module CleverIntegration
         classroom_external_id: classroom_external_id,
         grade: data.grade,
         name: data.name,
-        studentCount: data.students.count
+        studentCount: data.students&.count || 0
       }
     end
 

--- a/services/QuillLMS/app/services/clever_integration/library_classroom_data_adapter.rb
+++ b/services/QuillLMS/app/services/clever_integration/library_classroom_data_adapter.rb
@@ -14,7 +14,7 @@ module CleverIntegration
         classroom_external_id: classroom_external_id,
         grade: data[:grade],
         name: data[:name],
-        studentCount: data[:students].count
+        studentCount: data[:students]&.count || 0,
       }
     end
 


### PR DESCRIPTION
## WHAT
Fix nil value for students key with Clever classroom importing

## WHY
This is a regression from standardizing imports with google.  Prior, Clever just had a students key, but in transitioning to studentCount, I added a bug when students is nil.

## HOW
Add safe navigation with `.count` and default to 0.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  will add later.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
