### PR TITLE
User Rails.cache wrapper over $redis

### DIFF
--- a/services/QuillLMS/app/controllers/admins_controller.rb
+++ b/services/QuillLMS/app/controllers/admins_controller.rb
@@ -29,7 +29,7 @@ class AdminsController < ApplicationController
     }
 
   def show
-    serialized_admin_users_json = $redis.get("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{current_user.id}")
+    serialized_admin_users_json = Rails.cache.read("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{current_user.id}")
     if serialized_admin_users_json
       serialized_admin_users = JSON.parse(serialized_admin_users_json)
     end
@@ -217,7 +217,7 @@ class AdminsController < ApplicationController
   end
 
   private def reset_admin_users_cache
-    $redis.del("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{current_user.id}")
+    Rails.cache.delete("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{current_user.id}")
     FindAdminUsersWorker.perform_async(current_user.id)
   end
 

--- a/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::ConceptFeedbackController < Api::ApiController
   before_action :concept_feedback_by_uid, except: [:index, :create, :update]
 
   caches_action :index, format: 'json', expires_in: 1.hour
+
   def index
     all_concept_feedbacks = ConceptFeedback
       .where(activity_type: params[:activity_type])

--- a/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/progress_reports_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::ProgressReportsController < Api::ApiController
   def district_activity_scores
     return unless current_user&.admin?
 
-    serialized_district_activity_scores_json = $redis.get("#{SchoolsAdmins::DISTRICT_ACTIVITY_SCORES_CACHE_KEY_STEM}#{current_user.id}")
+    serialized_district_activity_scores_json = Rails.cache.read("#{SchoolsAdmins::DISTRICT_ACTIVITY_SCORES_CACHE_KEY_STEM}#{current_user.id}")
     if serialized_district_activity_scores_json
       serialized_district_activity_scores = JSON.parse(serialized_district_activity_scores_json)
     end
@@ -32,7 +32,7 @@ class Api::V1::ProgressReportsController < Api::ApiController
   def district_concept_reports
     return unless current_user&.admin?
 
-    serialized_district_concept_reports_json = $redis.get("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{current_user.id}")
+    serialized_district_concept_reports_json = Rails.cache.read("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{current_user.id}")
     if serialized_district_concept_reports_json
       serialized_district_concept_reports = JSON.parse(serialized_district_concept_reports_json)
     end

--- a/services/QuillLMS/app/controllers/api/v1/shared_cache_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/shared_cache_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::SharedCacheController < Api::ApiController
   before_action :set_custom_cache_key
 
   BASE_SHARED_CACHE_KEY = 'SHARED_CACHE'
-  SHARED_CACHE_EXPIRY = 300
+  SHARED_CACHE_EXPIRY = 5.minutes
 
   def show
     cached_data = Rails.cache.read(cache_key)
@@ -17,7 +17,7 @@ class Api::V1::SharedCacheController < Api::ApiController
 
   def update
     data = params[:data]
-    Rails.cache.write(cache_key, data.to_json, {ex: SHARED_CACHE_EXPIRY})
+    Rails.cache.write(cache_key, data.to_json, expires_in: SHARED_CACHE_EXPIRY)
     render(json: data)
   end
 

--- a/services/QuillLMS/app/controllers/api/v1/shared_cache_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/shared_cache_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::SharedCacheController < Api::ApiController
   SHARED_CACHE_EXPIRY = 300
 
   def show
-    cached_data = $redis.get(cache_key)
+    cached_data = Rails.cache.read(cache_key)
     if !cached_data
       return not_found
     end
@@ -17,12 +17,12 @@ class Api::V1::SharedCacheController < Api::ApiController
 
   def update
     data = params[:data]
-    $redis.set(cache_key, data.to_json, {ex: SHARED_CACHE_EXPIRY})
+    Rails.cache.write(cache_key, data.to_json, {ex: SHARED_CACHE_EXPIRY})
     render(json: data)
   end
 
   def destroy
-    $redis.del(cache_key)
+    Rails.cache.delete(cache_key)
     render(plain: 'OK')
   end
 

--- a/services/QuillLMS/app/controllers/cms/concepts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/concepts_controller.rb
@@ -22,7 +22,7 @@ class Cms::ConceptsController < Cms::CmsController
   end
 
   def concepts_in_use
-    stored_concepts_in_use = $redis.get('CONCEPTS_IN_USE')
+    stored_concepts_in_use = Rails.cache.read('CONCEPTS_IN_USE')
     return unless stored_concepts_in_use
 
     concepts_in_use = JSON.parse(stored_concepts_in_use)

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -37,8 +37,8 @@ class PagesController < ApplicationController
     @title = 'Quill.org | Interactive Writing and Grammar'
     @description = 'Quill provides free writing and grammar activities for middle and high school students.'
     # default numbers are current as of 03/12/19
-    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 252000000
-    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 2100000
+    @number_of_sentences = Rails.cache.read(NUMBER_OF_SENTENCES) || 252000000
+    @number_of_students = Rails.cache.read(NUMBER_OF_STUDENTS) || 2100000
 
     if request.env['affiliate.tag']
       name = ReferrerUser.find_by(referral_code: request.env['affiliate.tag'])&.user&.name
@@ -344,11 +344,11 @@ class PagesController < ApplicationController
   end
 
   def impact
-    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 2100000
-    @number_of_schools = $redis.get(NUMBER_OF_SCHOOLS) || 14651
-    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 252000000
-    @number_of_low_income_schools = $redis.get(NUMBER_OF_LOW_INCOME_SCHOOLS) || 8911
-    @number_of_teachers = $redis.get(NUMBER_OF_TEACHERS) || 44100
+    @number_of_students = Rails.cache.read(NUMBER_OF_STUDENTS) || 2100000
+    @number_of_schools = Rails.cache.read(NUMBER_OF_SCHOOLS) || 14651
+    @number_of_sentences = Rails.cache.read(NUMBER_OF_SENTENCES) || 252000000
+    @number_of_low_income_schools = Rails.cache.read(NUMBER_OF_LOW_INCOME_SCHOOLS) || 8911
+    @number_of_teachers = Rails.cache.read(NUMBER_OF_TEACHERS) || 44100
   end
 
   def team

--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -64,9 +64,13 @@ class SchoolsController < ApplicationController
          "lower(name) LIKE :prefix", prefix: "%#{@prefix.downcase}%"
          ).group("schools.id")
          .limit(@limit)
-        Rails.cache.write("#{cache_id}_RADIUS_TO_SCHOOL_#{@lat}_#{@lng}_#{@radius}", @schools.map {|s| s.id}.to_json)
+
          # short cache, highly specific
-        $redis.expire("#{cache_id}_RADIUS_TO_SCHOOL_#{@lat}_#{@lng}_#{@radius}", 60*5)
+        Rails.cache.write(
+          "#{cache_id}_RADIUS_TO_SCHOOL_#{@lat}_#{@lng}_#{@radius}",
+          @schools.map {|s| s.id}.to_json,
+          expires_in: 5.minutes
+        )
       end
     end
 
@@ -79,9 +83,13 @@ class SchoolsController < ApplicationController
          "lower(name) LIKE :prefix", prefix: "%#{@prefix.downcase}%"
        ).group("schools.id")
        .limit(@limit)
-      Rails.cache.write("PREFIX_TO_SCHOOL_#{@prefix}", @schools.map {|s| s.id}.to_json)
+
       # longer cache, more general
-      $redis.expire("PREFIX_TO_SCHOOL_#{@prefix}", 60*60)
+      Rails.cache.write(
+        "PREFIX_TO_SCHOOL_#{@prefix}",
+        @schools.map {|s| s.id}.to_json,
+        expires_in: 60.minutes
+      )
     end
 
   end

--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -25,7 +25,7 @@ class StatusesController < ApplicationController
   end
 
   def redis_cache
-    $redis.info
+    Rails.cache.redis.info
     render plain: 'OK'
   end
 

--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -25,7 +25,7 @@ class StatusesController < ApplicationController
   end
 
   def redis_cache
-    Rails.cache.redis.info
+    $redis.info
     render plain: 'OK'
   end
 

--- a/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_units_controller.rb
@@ -112,7 +112,7 @@ class Teachers::ClassroomUnitsController < ApplicationController
   end
 
   private def lessons_cache
-    lessons_cache = $redis.get("user_id:#{current_user.id}_lessons_array")
+    lessons_cache = Rails.cache.read("user_id:#{current_user.id}_lessons_array")
     if lessons_cache
       JSON.parse(lessons_cache)
     else

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -384,7 +384,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
   end
 
   private def set_lesson_diagnostic_recommendations_start_time
-    $redis.set("user_id:#{current_user.id}_lesson_diagnostic_recommendations_start_time", Time.current)
+    Rails.cache.write("user_id:#{current_user.id}_lesson_diagnostic_recommendations_start_time", Time.current)
   end
 
 end

--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -108,7 +108,7 @@ class Teachers::UnitTemplatesController < ApplicationController
 
   private def cached_formatted_unit_templates
     ut_cache_name = "#{related_models_flag}_unit_templates"
-    cached = $redis.get(ut_cache_name)
+    cached = Rails.cache.read(ut_cache_name)
     set_cache_if_necessary_and_return(cached, ut_cache_name)
   end
 
@@ -118,7 +118,7 @@ class Teachers::UnitTemplatesController < ApplicationController
       ut_cache
     else
       uts = unit_templates_by_user_testing_flag
-      $redis.set(ut_cache_name, uts.to_json)
+      Rails.cache.write(ut_cache_name, uts.to_json)
       uts
     end
   end

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -103,10 +103,10 @@ class UserMailer < ActionMailer::Base
   end
 
   def recommendations_assignment_report_email
-    @independent_less_than_ten_seconds = $redis.get("diagnostic_recommendations_under_ten_seconds_count") || 0
-    @group_less_than_ten_seconds = $redis.get("lesson_diagnostic_recommendations_under_ten_seconds_count") || 0
-    @independent_more_than_ten_seconds = $redis.get("diagnostic_recommendations_over_ten_seconds_count") || 0
-    @group_more_than_ten_seconds = $redis.get("lesson_diagnostic_recommendations_over_ten_seconds_count") || 0
+    @independent_less_than_ten_seconds = Rails.cache.read("diagnostic_recommendations_under_ten_seconds_count") || 0
+    @group_less_than_ten_seconds = Rails.cache.read("lesson_diagnostic_recommendations_under_ten_seconds_count") || 0
+    @independent_more_than_ten_seconds = Rails.cache.read("diagnostic_recommendations_over_ten_seconds_count") || 0
+    @group_more_than_ten_seconds = Rails.cache.read("lesson_diagnostic_recommendations_over_ten_seconds_count") || 0
     independent_total_recommendations = @independent_more_than_ten_seconds.to_i + @independent_less_than_ten_seconds.to_i
     group_total_recommendations = @group_more_than_ten_seconds.to_i + @group_less_than_ten_seconds.to_i
     @percentage_of_independent_less_than_ten_seconds = independent_total_recommendations > 0 ? (@independent_less_than_ten_seconds.to_f/independent_total_recommendations) * 100 : 100

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -225,7 +225,7 @@ class Activity < ApplicationRecord
   end
 
   def self.set_activity_search_cache
-    Rails.cache.set(
+    Rails.cache.write(
       UserFlagset::DEFAULT_ACTIVITY_SEARCH_CACHE_KEY,
       ActivitySearchWrapper.new(PRODUCTION).search.to_json
     )

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -96,6 +96,8 @@ class Activity < ApplicationRecord
 
   FLAGS_ATTRIBUTE = 'flags'
 
+  DEFAULT_ACTIVITY_SEARCH_CACHE_KEY = 'default_activity_search'
+
   scope :gamma_user, -> { where("'#{GAMMA}' = ANY(activities.flags) OR '#{BETA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
   scope :beta_user, -> { where("'#{BETA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
   scope :alpha_user, -> { where("'#{ALPHA}' = ANY(activities.flags) OR '#{BETA}' = ANY(activities.flags) OR '#{GAMMA}' = ANY(activities.flags) OR '#{PRODUCTION}' = ANY(activities.flags)")}
@@ -226,7 +228,7 @@ class Activity < ApplicationRecord
 
   def self.set_activity_search_cache
     Rails.cache.write(
-      UserFlagset::DEFAULT_ACTIVITY_SEARCH_CACHE_KEY,
+      DEFAULT_ACTIVITY_SEARCH_CACHE_KEY,
       ActivitySearchWrapper.new(PRODUCTION).search.to_json
     )
   end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -374,7 +374,7 @@ class ActivitySession < ApplicationRecord
     classroom_id = classroom_unit&.classroom_id
     return unless state == 'finished' && classroom_id
 
-    $redis.del("classroom_id:#{classroom_id}_completed_activity_count")
+    Rails.cache.delete("classroom_id:#{classroom_id}_completed_activity_count")
   end
 
   def self.save_concept_results(activity_sessions, concept_results)

--- a/services/QuillLMS/app/models/classrooms_teacher.rb
+++ b/services/QuillLMS/app/models/classrooms_teacher.rb
@@ -34,7 +34,7 @@ class ClassroomsTeacher < ApplicationRecord
 
   private def delete_classroom_minis_cache_for_each_teacher_of_this_classroom
     Classroom.unscoped.find(classroom_id).teachers.ids.each do |id|
-      $redis.del("user_id:#{id}_classroom_minis")
+      Rails.cache.delete("user_id:#{id}_classroom_minis")
     end
   end
 

--- a/services/QuillLMS/app/models/concerns/lessons_cache.rb
+++ b/services/QuillLMS/app/models/concerns/lessons_cache.rb
@@ -43,7 +43,7 @@ module LessonsCache
       else
         lessons_cache = format_initial_lessons_cache(teacher)
       end
-      $redis.set("user_id:#{user_id}_lessons_array", lessons_cache.to_json)
+      Rails.cache.write("user_id:#{user_id}_lessons_array", lessons_cache.to_json)
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -248,7 +248,7 @@ module Teacher
 
 
   def classroom_minis_cache
-    cache = $redis.get("user_id:#{id}_classroom_minis")
+    cache = Rails.cache.read("user_id:#{id}_classroom_minis")
     cache ? JSON.parse(cache) : nil
   end
 
@@ -258,7 +258,7 @@ module Teacher
   end
 
   def self.clear_classrooms_minis_cache(teacher_id)
-    $redis.del("user_id:#{teacher_id}_classroom_minis")
+    Rails.cache.delete("user_id:#{teacher_id}_classroom_minis")
   end
 
   def classroom_minis_info

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -6,6 +6,7 @@ module Teacher
   include CheckboxCallback
   include LessonsCache
 
+  MINIS_CACHE_EXPIRATION_TIME = 16.hours
   TRIAL_LIMIT = 250
   TRIAL_START_DATE = Date.parse('1-9-2015') # September 1st 2015
 
@@ -254,7 +255,7 @@ module Teacher
 
   def classroom_minis_cache=(info)
     # TODO: move this to background worker
-    Rails.cache.write("user_id:#{id}_classroom_minis", info.to_json, {ex: 16.hours} )
+    Rails.cache.write("user_id:#{id}_classroom_minis", info.to_json, expires_in: MINIS_CACHE_EXPIRATION_TIME)
   end
 
   def self.clear_classrooms_minis_cache(teacher_id)

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -254,7 +254,7 @@ module Teacher
 
   def classroom_minis_cache=(info)
     # TODO: move this to background worker
-    $redis.set("user_id:#{id}_classroom_minis", info.to_json, {ex: 16.hours} )
+    Rails.cache.write("user_id:#{id}_classroom_minis", info.to_json, {ex: 16.hours} )
   end
 
   def self.clear_classrooms_minis_cache(teacher_id)
@@ -542,7 +542,7 @@ module Teacher
     if !lessons_data
       lessons_data = data_for_lessons_cache
     end
-    $redis.set("user_id:#{id}_lessons_array", lessons_data.to_json)
+    Rails.cache.write("user_id:#{id}_lessons_array", lessons_data.to_json)
   end
 
   def data_for_lessons_cache

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -72,8 +72,6 @@ module UserFlagset
       },
     }
 
-    DEFAULT_ACTIVITY_SEARCH_CACHE_KEY = 'default_activity_search'
-
     validates :flagset, inclusion: { in: FLAGSETS.keys.map(&:to_s) }
   end
 

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -6,7 +6,6 @@ module UserFlagset
 
   included do
     FLAGSETS = {
-
       production: {
         display_name: 'production',
         flags: {
@@ -71,8 +70,9 @@ module UserFlagset
           Flags::PRIVATE =>           { display_name: 'Private' }
         }
       },
-
     }
+
+    DEFAULT_ACTIVITY_SEARCH_CACHE_KEY = 'default_activity_search'
 
     validates :flagset, inclusion: { in: FLAGSETS.keys.map(&:to_s) }
   end
@@ -85,6 +85,10 @@ module UserFlagset
     return nil unless flagset
 
     FLAGSETS[flagset.to_sym][:flags].keys.map{|k| "'#{k}'"}.join(',')
+  end
+
+  def self.default_flagset_cache_key(flagset)
+    "default_#{flagset}activity_search"
   end
 
   def activity_viewable?(activity)

--- a/services/QuillLMS/app/models/redis_feed.rb
+++ b/services/QuillLMS/app/models/redis_feed.rb
@@ -55,7 +55,7 @@ class RedisFeed
 
   def reset!
     temp_ids = ids
-    Rails.cache.delete(redis_key)
+    $redis.del(redis_key)
     temp_ids
   end
 
@@ -80,6 +80,6 @@ class RedisFeed
 
   # used for testing
   private def delete_all
-    Rails.cache.delete(redis_key)
+    $redis.del(redis_key)
   end
 end

--- a/services/QuillLMS/app/models/redis_feed.rb
+++ b/services/QuillLMS/app/models/redis_feed.rb
@@ -55,7 +55,7 @@ class RedisFeed
 
   def reset!
     temp_ids = ids
-    $redis.del(redis_key)
+    Rails.cache.delete(redis_key)
     temp_ids
   end
 
@@ -80,6 +80,6 @@ class RedisFeed
 
   # used for testing
   private def delete_all
-    $redis.del(redis_key)
+    Rails.cache.delete(redis_key)
   end
 end

--- a/services/QuillLMS/app/models/students_classrooms.rb
+++ b/services/QuillLMS/app/models/students_classrooms.rb
@@ -79,6 +79,6 @@ class StudentsClassrooms < ApplicationRecord
   private def invalidate_classroom_minis
     return unless classroom&.owner.present?
 
-    $redis.del("user_id:#{classroom.owner.id}_classroom_minis")
+    Rails.cache.delete("user_id:#{classroom.owner.id}_classroom_minis")
   end
 end

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -142,7 +142,7 @@ class UnitTemplate < ApplicationRecord
     unless serialized_unit_template
       serializable_unit_template = UnitTemplatePseudoSerializer.new(self, flag)
       serialized_unit_template = serializable_unit_template.data
-      $redis.set("unit_template_id:#{id}_serialized", serialized_unit_template.to_json, {ex: cache_expiration_time})
+      Rails.cache.write("unit_template_id:#{id}_serialized", serialized_unit_template.to_json, {ex: cache_expiration_time})
     end
     serialized_unit_template
   end

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -147,7 +147,7 @@ class UnitTemplate < ApplicationRecord
       Rails.cache.write(
         "unit_template_id:#{id}_serialized",
         serialized_unit_template.to_json,
-        expires_in: CACHE_EXPIRATION_TIME
+        expires_in: CACHED_EXPIRATION_TIME
       )
     end
     serialized_unit_template

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -659,15 +659,15 @@ class User < ApplicationRecord
   end
 
   def delete_classroom_minis_cache
-    $redis.del("user_id:#{id}_classroom_minis")
+    Rails.cache.delete("user_id:#{id}_classroom_minis")
   end
 
   def delete_struggling_students_cache
-    $redis.del("user_id:#{id}_struggling_students")
+    Rails.cache.delete("user_id:#{id}_struggling_students")
   end
 
   def delete_difficult_concepts_cache
-    $redis.del("user_id:#{id}_difficult_concepts")
+    Rails.cache.delete("user_id:#{id}_difficult_concepts")
   end
 
   def coteacher_invitations

--- a/services/QuillLMS/app/services/activity_search_wrapper.rb
+++ b/services/QuillLMS/app/services/activity_search_wrapper.rb
@@ -33,7 +33,7 @@ class ActivitySearchWrapper
   def self.search_cache_data(flagset = nil)
     substring = flagset ? "#{flagset}_" : ""
     activity_search_json = ActivitySearchWrapper.new(flagset).search.to_json
-    $redis.set("default_#{substring}activity_search", activity_search_json)
+    Rails.cache.write("default_#{substring}activity_search", activity_search_json)
     activity_search_json
   end
 

--- a/services/QuillLMS/app/services/independent_practice_packs_assigner.rb
+++ b/services/QuillLMS/app/services/independent_practice_packs_assigner.rb
@@ -81,7 +81,7 @@ class IndependentPracticePacksAssigner < ApplicationService
   end
 
   private def set_diagnostic_recommendations_start_time
-    $redis.set("user_id:#{user.id}_diagnostic_recommendations_start_time", Time.current)
+    Rails.cache.write("user_id:#{user.id}_diagnostic_recommendations_start_time", Time.current)
   end
 
   private def staggered_release?

--- a/services/QuillLMS/app/services/vitally_integration/cache_vitally_school_data.rb
+++ b/services/QuillLMS/app/services/vitally_integration/cache_vitally_school_data.rb
@@ -15,7 +15,7 @@ module VitallyIntegration
     end
 
     def self.set(school_id, year, data)
-      Rails.cache.write(cache_key(school_id, year), data, {ex: 1.year})
+      Rails.cache.write(cache_key(school_id, year), data, expires_in: 1.year)
     end
   end
 end

--- a/services/QuillLMS/app/services/vitally_integration/cache_vitally_school_data.rb
+++ b/services/QuillLMS/app/services/vitally_integration/cache_vitally_school_data.rb
@@ -7,7 +7,7 @@ module VitallyIntegration
     end
 
     def self.get(school_id, year)
-      $redis.get(cache_key(school_id, year))
+      Rails.cache.read(cache_key(school_id, year))
     end
 
     def self.del(school_id, year)
@@ -15,7 +15,7 @@ module VitallyIntegration
     end
 
     def self.set(school_id, year, data)
-      $redis.set(cache_key(school_id, year), data, {ex: 1.year})
+      Rails.cache.write(cache_key(school_id, year), data, {ex: 1.year})
     end
   end
 end

--- a/services/QuillLMS/app/services/vitally_integration/cache_vitally_school_data.rb
+++ b/services/QuillLMS/app/services/vitally_integration/cache_vitally_school_data.rb
@@ -11,7 +11,7 @@ module VitallyIntegration
     end
 
     def self.del(school_id, year)
-      $redis.del(cache_key(school_id, year))
+      Rails.cache.delete(cache_key(school_id, year))
     end
 
     def self.set(school_id, year, data)

--- a/services/QuillLMS/app/services/vitally_integration/cache_vitally_teacher_data.rb
+++ b/services/QuillLMS/app/services/vitally_integration/cache_vitally_teacher_data.rb
@@ -15,7 +15,7 @@ module VitallyIntegration
     end
 
     def self.set(teacher_id, year, data)
-      $redis.set(cache_key(teacher_id, year), data, {ex: 1.year})
+      Rails.cache.write(cache_key(teacher_id, year), data, {ex: 1.year})
     end
   end
 end

--- a/services/QuillLMS/app/services/vitally_integration/cache_vitally_teacher_data.rb
+++ b/services/QuillLMS/app/services/vitally_integration/cache_vitally_teacher_data.rb
@@ -7,11 +7,11 @@ module VitallyIntegration
     end
 
     def self.get(teacher_id, year)
-      $redis.get(cache_key(teacher_id, year))
+      Rails.cache.read(cache_key(teacher_id, year))
     end
 
     def self.del(teacher_id, year)
-      $redis.del(cache_key(teacher_id, year))
+      Rails.cache.delete(cache_key(teacher_id, year))
     end
 
     def self.set(teacher_id, year, data)

--- a/services/QuillLMS/app/services/vitally_integration/cache_vitally_teacher_data.rb
+++ b/services/QuillLMS/app/services/vitally_integration/cache_vitally_teacher_data.rb
@@ -2,6 +2,8 @@
 
 module VitallyIntegration
   class CacheVitallyTeacherData
+    EXPIRATION = 1.year
+
     def self.cache_key(teacher_id, year)
       "teacher_id:#{teacher_id}_vitally_stats_for_year_#{year}"
     end
@@ -15,7 +17,7 @@ module VitallyIntegration
     end
 
     def self.set(teacher_id, year, data)
-      Rails.cache.write(cache_key(teacher_id, year), data, {ex: 1.year})
+      Rails.cache.write(cache_key(teacher_id, year), data, expires_in: EXPIRATION)
     end
   end
 end

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -67,9 +67,9 @@ class AssignRecommendationsWorker
     if elapsed_time > 10
       diagnostic_recommendations_over_ten_seconds_count = $redis.get("#{lesson_text}diagnostic_recommendations_over_ten_seconds_count")
       if diagnostic_recommendations_over_ten_seconds_count
-        $redis.set("#{lesson_text}diagnostic_recommendations_over_ten_seconds_count", diagnostic_recommendations_over_ten_seconds_count.to_i + 1)
+        Rails.cache.write("#{lesson_text}diagnostic_recommendations_over_ten_seconds_count", diagnostic_recommendations_over_ten_seconds_count.to_i + 1)
       else
-        $redis.set("#{lesson_text}diagnostic_recommendations_over_ten_seconds_count", 1)
+        Rails.cache.write("#{lesson_text}diagnostic_recommendations_over_ten_seconds_count", 1)
       end
       begin
         raise "#{elapsed_time} seconds for user #{teacher_id} to assign #{lesson_text} recommendations"
@@ -79,9 +79,9 @@ class AssignRecommendationsWorker
     else
       diagnostic_recommendations_under_ten_seconds_count = $redis.get("diagnostic_recommendations_under_ten_seconds_count")
       if diagnostic_recommendations_under_ten_seconds_count
-        $redis.set("#{lesson_text}diagnostic_recommendations_under_ten_seconds_count", diagnostic_recommendations_under_ten_seconds_count.to_i + 1)
+        Rails.cache.write("#{lesson_text}diagnostic_recommendations_under_ten_seconds_count", diagnostic_recommendations_under_ten_seconds_count.to_i + 1)
       else
-        $redis.set("#{lesson_text}diagnostic_recommendations_under_ten_seconds_count", 1)
+        Rails.cache.write("#{lesson_text}diagnostic_recommendations_under_ten_seconds_count", 1)
       end
     end
     $redis.del("user_id:#{teacher_id}_#{lesson_text}diagnostic_recommendations_start_time")

--- a/services/QuillLMS/app/workers/assign_recommendations_worker.rb
+++ b/services/QuillLMS/app/workers/assign_recommendations_worker.rb
@@ -60,12 +60,12 @@ class AssignRecommendationsWorker
 
   def handle_error_tracking_for_diagnostic_recommendation_assignment_time(teacher_id, lesson)
     lesson_text = lesson ? "lesson_" : ''
-    start_time = $redis.get("user_id:#{teacher_id}_#{lesson_text}diagnostic_recommendations_start_time")
+    start_time = Rails.cache.read("user_id:#{teacher_id}_#{lesson_text}diagnostic_recommendations_start_time")
     return unless start_time
 
     elapsed_time = Time.current - start_time.to_time
     if elapsed_time > 10
-      diagnostic_recommendations_over_ten_seconds_count = $redis.get("#{lesson_text}diagnostic_recommendations_over_ten_seconds_count")
+      diagnostic_recommendations_over_ten_seconds_count = Rails.cache.read("#{lesson_text}diagnostic_recommendations_over_ten_seconds_count")
       if diagnostic_recommendations_over_ten_seconds_count
         Rails.cache.write("#{lesson_text}diagnostic_recommendations_over_ten_seconds_count", diagnostic_recommendations_over_ten_seconds_count.to_i + 1)
       else
@@ -77,13 +77,13 @@ class AssignRecommendationsWorker
         NewRelic::Agent.notice_error(e)
       end
     else
-      diagnostic_recommendations_under_ten_seconds_count = $redis.get("diagnostic_recommendations_under_ten_seconds_count")
+      diagnostic_recommendations_under_ten_seconds_count = Rails.cache.read("diagnostic_recommendations_under_ten_seconds_count")
       if diagnostic_recommendations_under_ten_seconds_count
         Rails.cache.write("#{lesson_text}diagnostic_recommendations_under_ten_seconds_count", diagnostic_recommendations_under_ten_seconds_count.to_i + 1)
       else
         Rails.cache.write("#{lesson_text}diagnostic_recommendations_under_ten_seconds_count", 1)
       end
     end
-    $redis.del("user_id:#{teacher_id}_#{lesson_text}diagnostic_recommendations_start_time")
+    Rails.cache.delete("user_id:#{teacher_id}_#{lesson_text}diagnostic_recommendations_start_time")
   end
 end

--- a/services/QuillLMS/app/workers/find_admin_users_worker.rb
+++ b/services/QuillLMS/app/workers/find_admin_users_worker.rb
@@ -10,7 +10,7 @@ class FindAdminUsersWorker
 
     serialized_admin_users_cache_life = 60*60*25
     serialized_admin_users = UserAdminSerializer.new(user).to_json(root: false)
-    $redis.set("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{admin_id}", serialized_admin_users)
+    Rails.cache.write("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{admin_id}", serialized_admin_users)
     $redis.expire("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{admin_id}", serialized_admin_users_cache_life)
     PusherAdminUsersCompleted.run(admin_id)
   end

--- a/services/QuillLMS/app/workers/find_admin_users_worker.rb
+++ b/services/QuillLMS/app/workers/find_admin_users_worker.rb
@@ -4,7 +4,7 @@ class FindAdminUsersWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
-  SERIALIZED_ADMIN_USERS_CACHE_LIFE = 25.hours.to_i
+  SERIALIZED_ADMIN_USERS_CACHE_LIFE = 25.hours
 
   def perform(admin_id)
     user = User.find_by_id(admin_id)

--- a/services/QuillLMS/app/workers/find_admin_users_worker.rb
+++ b/services/QuillLMS/app/workers/find_admin_users_worker.rb
@@ -4,14 +4,20 @@ class FindAdminUsersWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
+  SERIALIZED_ADMIN_USERS_CACHE_LIFE = 25.hours.to_i
+
   def perform(admin_id)
     user = User.find_by_id(admin_id)
     return unless user
 
-    serialized_admin_users_cache_life = 60*60*25
     serialized_admin_users = UserAdminSerializer.new(user).to_json(root: false)
-    Rails.cache.write("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{admin_id}", serialized_admin_users)
-    $redis.expire("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{admin_id}", serialized_admin_users_cache_life)
+
+    Rails.cache.write(
+      "#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{admin_id}",
+      serialized_admin_users,
+      expires_in: SERIALIZED_ADMIN_USERS_CACHE_LIFE
+    )
+
     PusherAdminUsersCompleted.run(admin_id)
   end
 end

--- a/services/QuillLMS/app/workers/find_district_activity_scores_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_activity_scores_worker.rb
@@ -7,7 +7,7 @@ class FindDistrictActivityScoresWorker
   def perform(admin_id)
     serialized_district_activity_scores_cache_life = 60*60*25
     serialized_district_activity_scores = ProgressReports::DistrictActivityScores.new(admin_id).results.to_json
-    $redis.set("#{SchoolsAdmins::DISTRICT_ACTIVITY_SCORES_CACHE_KEY_STEM}#{admin_id}", serialized_district_activity_scores)
+    Rails.cache.write("#{SchoolsAdmins::DISTRICT_ACTIVITY_SCORES_CACHE_KEY_STEM}#{admin_id}", serialized_district_activity_scores)
     $redis.expire("#{SchoolsAdmins::DISTRICT_ACTIVITY_SCORES_CACHE_KEY_STEM}#{admin_id}", serialized_district_activity_scores_cache_life)
     PusherDistrictActivityScoresCompleted.run(admin_id)
   end

--- a/services/QuillLMS/app/workers/find_district_activity_scores_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_activity_scores_worker.rb
@@ -4,11 +4,17 @@ class FindDistrictActivityScoresWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
+  SERIALIZED_DISTRICT_ACTIVITY_SCORES_CACHE_LIFE = 25.hours.to_i
+
   def perform(admin_id)
-    serialized_district_activity_scores_cache_life = 60*60*25
     serialized_district_activity_scores = ProgressReports::DistrictActivityScores.new(admin_id).results.to_json
-    Rails.cache.write("#{SchoolsAdmins::DISTRICT_ACTIVITY_SCORES_CACHE_KEY_STEM}#{admin_id}", serialized_district_activity_scores)
-    $redis.expire("#{SchoolsAdmins::DISTRICT_ACTIVITY_SCORES_CACHE_KEY_STEM}#{admin_id}", serialized_district_activity_scores_cache_life)
+
+    Rails.cache.write(
+      "#{SchoolsAdmins::DISTRICT_ACTIVITY_SCORES_CACHE_KEY_STEM}#{admin_id}",
+      serialized_district_activity_scores,
+      expires_in: SERIALIZED_DISTRICT_ACTIVITY_SCORES_CACHE_LIFE
+    )
+
     PusherDistrictActivityScoresCompleted.run(admin_id)
   end
 end

--- a/services/QuillLMS/app/workers/find_district_activity_scores_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_activity_scores_worker.rb
@@ -4,7 +4,7 @@ class FindDistrictActivityScoresWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
-  SERIALIZED_DISTRICT_ACTIVITY_SCORES_CACHE_LIFE = 25.hours.to_i
+  SERIALIZED_DISTRICT_ACTIVITY_SCORES_CACHE_LIFE = 25.hours
 
   def perform(admin_id)
     serialized_district_activity_scores = ProgressReports::DistrictActivityScores.new(admin_id).results.to_json

--- a/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
@@ -4,7 +4,7 @@ class FindDistrictConceptReportsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL, retry: 2
 
-  SERIALIZED_DISTRICT_CONCEPT_REPORTS_CACHE_LIFE = 25.hours.to_i
+  SERIALIZED_DISTRICT_CONCEPT_REPORTS_CACHE_LIFE = 25.hours
 
   def perform(admin_id)
     return unless admin_id

--- a/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
@@ -4,13 +4,18 @@ class FindDistrictConceptReportsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL, retry: 2
 
+  SERIALIZED_DISTRICT_CONCEPT_REPORTS_CACHE_LIFE = 25.hours.to_i
+
   def perform(admin_id)
     return unless admin_id
 
-    serialized_district_concept_reports_cache_life = 60*60*25
     serialized_district_concept_reports = ProgressReports::DistrictConceptReports.new(admin_id).results.to_json
-    Rails.cache.write("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_concept_reports)
-    $redis.expire("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_concept_reports_cache_life)
+    Rails.cache.write(
+      "#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}",
+      serialized_district_concept_reports,
+      expires_in: SERIALIZED_DISTRICT_CONCEPT_REPORTS_CACHE_LIFE
+    )
+
     PusherDistrictConceptReportsCompleted.run(admin_id)
   end
 end

--- a/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
+++ b/services/QuillLMS/app/workers/find_district_concept_reports_worker.rb
@@ -9,7 +9,7 @@ class FindDistrictConceptReportsWorker
 
     serialized_district_concept_reports_cache_life = 60*60*25
     serialized_district_concept_reports = ProgressReports::DistrictConceptReports.new(admin_id).results.to_json
-    $redis.set("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_concept_reports)
+    Rails.cache.write("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_concept_reports)
     $redis.expire("#{SchoolsAdmins::DISTRICT_CONCEPT_REPORTS_CACHE_KEY_STEM}#{admin_id}", serialized_district_concept_reports_cache_life)
     PusherDistrictConceptReportsCompleted.run(admin_id)
   end

--- a/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
+++ b/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
@@ -39,13 +39,13 @@ class GenerateConceptsInUseArrayWorker
   end
 
   private def set_concepts_in_use
-    $redis.set("CONCEPTS_IN_USE", CONCEPTS_IN_USE)
-    $redis.set("NUMBER_OF_CONCEPTS_IN_USE_LAST_SET", Time.current)
+    Rails.cache.write("CONCEPTS_IN_USE", CONCEPTS_IN_USE)
+    Rails.cache.write("NUMBER_OF_CONCEPTS_IN_USE_LAST_SET", Time.current)
   end
 
   private def set_question_types
     REDIS_KEY_QUESTION_TYPES.each_pair do |redis_key, question_type|
-      $redis.set(redis_key, question_response(question_type))
+      Rails.cache.write(redis_key, question_response(question_type))
     end
   end
 end

--- a/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
+++ b/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
@@ -173,15 +173,15 @@ class GetConceptsInUseIndividualConceptWorker
   end
 
   def set_concepts_in_use_cache
-    Rails.cache.redis.watch('CONCEPTS_IN_USE') do
-      concepts_in_use = JSON.parse(Rails.cache.read('CONCEPTS_IN_USE'))
-      @organized_concepts.each do |oc|
-        concepts_in_use << CONCEPTS_IN_USE_HEADERS.map do |attr|
-          oc[attr].is_a?(Array) ? oc[attr].flatten.uniq.join(', ') : oc[attr]
-        end
+    $redis.watch('CONCEPTS_IN_USE')
+    concepts_in_use = JSON.parse(Rails.cache.read('CONCEPTS_IN_USE'))
+    @organized_concepts.each do |oc|
+      concepts_in_use << CONCEPTS_IN_USE_HEADERS.map do |attr|
+        oc[attr].is_a?(Array) ? oc[attr].flatten.uniq.join(', ') : oc[attr]
       end
-      Rails.cache.write("CONCEPTS_IN_USE", concepts_in_use.to_json)
     end
+    Rails.cache.write("CONCEPTS_IN_USE", concepts_in_use.to_json)
+    $redis.unwatch('CONCEPTS_IN_USE')
   rescue => e
     set_concepts_in_use_cache
   end

--- a/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
+++ b/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
@@ -173,7 +173,7 @@ class GetConceptsInUseIndividualConceptWorker
           end
         end
       end
-      $redis.set("CONCEPTS_IN_USE", concepts_in_use.to_json)
+      Rails.cache.write("CONCEPTS_IN_USE", concepts_in_use.to_json)
       $redis.unwatch
     rescue => e
       set_concepts_in_use_cache

--- a/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
+++ b/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
@@ -14,7 +14,7 @@ class QuillStaffAccountsChangedWorker
     current_staff_accounts = current_staff_account_data
     previous_staff_accounts = cached_staff_account_data
     notify_staff(current_staff_accounts, previous_staff_accounts) unless current_staff_accounts == previous_staff_accounts
-    Rails.cache.write(STAFF_ACCOUNTS_CACHE_KEY, current_staff_accounts.to_json, ex: 25.hours.to_i)
+    Rails.cache.write(STAFF_ACCOUNTS_CACHE_KEY, current_staff_accounts.to_json, expires_in: 25.hours)
   end
 
   def current_staff_account_data
@@ -28,7 +28,7 @@ class QuillStaffAccountsChangedWorker
   end
 
   def cached_staff_account_data
-    JSON.parse($redis.get(STAFF_ACCOUNTS_CACHE_KEY) || '[]')
+    JSON.parse(Rails.cache.read(STAFF_ACCOUNTS_CACHE_KEY) || '[]')
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
+++ b/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
@@ -14,7 +14,7 @@ class QuillStaffAccountsChangedWorker
     current_staff_accounts = current_staff_account_data
     previous_staff_accounts = cached_staff_account_data
     notify_staff(current_staff_accounts, previous_staff_accounts) unless current_staff_accounts == previous_staff_accounts
-    $redis.set(STAFF_ACCOUNTS_CACHE_KEY, current_staff_accounts.to_json, ex: 25.hours.to_i)
+    Rails.cache.write(STAFF_ACCOUNTS_CACHE_KEY, current_staff_accounts.to_json, ex: 25.hours.to_i)
   end
 
   def current_staff_account_data

--- a/services/QuillLMS/app/workers/reset_lesson_cache_worker.rb
+++ b/services/QuillLMS/app/workers/reset_lesson_cache_worker.rb
@@ -5,7 +5,7 @@ class ResetLessonCacheWorker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
   def perform(id)
-    $redis.del("user_id:#{id}_lessons_array")
+    Rails.cache.delete("user_id:#{id}_lessons_array")
     @user = User.find(id)
     @user.set_lessons_cache
   end

--- a/services/QuillLMS/app/workers/set_impact_metrics_worker.rb
+++ b/services/QuillLMS/app/workers/set_impact_metrics_worker.rb
@@ -21,15 +21,15 @@ class SetImpactMetricsWorker
     low_income_schools = schools.select { |school| (school["free_lunches"] || 0) > FREE_LUNCH_MINIMUM}
 
     number_of_sentences = self.class.round_to_ten_thousands(finished_activity_sessions_count) * SENTENCES_PER_ACTIVITY_SESSION
-    $redis.set(PagesController::NUMBER_OF_SENTENCES, number_of_sentences)
+    Rails.cache.write(PagesController::NUMBER_OF_SENTENCES, number_of_sentences)
     number_of_students = self.class.round_to_ten_thousands(active_students_count)
-    $redis.set(PagesController::NUMBER_OF_STUDENTS, number_of_students)
+    Rails.cache.write(PagesController::NUMBER_OF_STUDENTS, number_of_students)
     number_of_teachers = self.class.round_to_hundreds(teacher_ids.size)
-    $redis.set(PagesController::NUMBER_OF_TEACHERS, number_of_teachers)
+    Rails.cache.write(PagesController::NUMBER_OF_TEACHERS, number_of_teachers)
     number_of_schools = schools.length
-    $redis.set(PagesController::NUMBER_OF_SCHOOLS, number_of_schools)
+    Rails.cache.write(PagesController::NUMBER_OF_SCHOOLS, number_of_schools)
     number_of_low_income_schools = low_income_schools.length
-    $redis.set(PagesController::NUMBER_OF_LOW_INCOME_SCHOOLS, number_of_low_income_schools)
+    Rails.cache.write(PagesController::NUMBER_OF_LOW_INCOME_SCHOOLS, number_of_low_income_schools)
   end
 
   def self.round_to_ten_thousands(number)

--- a/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
@@ -34,11 +34,11 @@ module Evidence
     end
 
     private def optimal_rule_hash
-      cached = $redis.get(OPTIMAL_RULE_KEY)
+      cached = Rails.cache.read(OPTIMAL_RULE_KEY)
       serialized_optimal_rule = cached.nil? || cached&.blank? ? nil : JSON.parse(cached)
       unless serialized_optimal_rule
         serialized_optimal_rule = Evidence::Rule.find_by(optimal: true, rule_type: Rule::TYPE_PLAGIARISM).to_json
-        $redis.set(OPTIMAL_RULE_KEY, serialized_optimal_rule)
+        Rails.cache.write(OPTIMAL_RULE_KEY, serialized_optimal_rule)
       end
       serialized_optimal_rule || {}
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/regex_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/regex_check.rb
@@ -27,11 +27,11 @@ module Evidence
     end
 
     private def optimal_rule_uid
-      cached = $redis.get(OPTIMAL_RULE_KEY)
+      cached = Rails.cache.read(OPTIMAL_RULE_KEY)
       optimal_rule_uid = cached.nil? || cached&.blank? ? nil : cached
       unless optimal_rule_uid
         optimal_rule_uid = Evidence::Rule.find_by(optimal: true, rule_type: @rule_type)&.uid
-        $redis.set(OPTIMAL_RULE_KEY, optimal_rule_uid)
+        Rails.cache.write(OPTIMAL_RULE_KEY, optimal_rule_uid)
       end
       optimal_rule_uid || ''
     end

--- a/services/QuillLMS/engines/evidence/spec/lib/plagiarism_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/plagiarism_check_spec.rb
@@ -9,7 +9,7 @@ module Evidence
     context 'should #feedback_object' do
 
       it 'should return appropriate feedback attributes if there is plagiarism' do
-        $redis.redis.flushdb
+        Rails.cache.redis.flushdb
         entry = "these are s'',ome! r''esponse words to plagiarize and this is plagiarism"
         passage = "these are some res,,,,ponse,,,, words to plagiarize and this is plagiarism"
         feedback = "this is some standard plagiarism feedback"

--- a/services/QuillLMS/engines/evidence/spec/lib/plagiarism_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/plagiarism_check_spec.rb
@@ -9,7 +9,7 @@ module Evidence
     context 'should #feedback_object' do
 
       it 'should return appropriate feedback attributes if there is plagiarism' do
-        Rails.cache.redis.flushdb
+        Rails.cache.clear
         entry = "these are s'',ome! r''esponse words to plagiarize and this is plagiarism"
         passage = "these are some res,,,,ponse,,,, words to plagiarize and this is plagiarism"
         feedback = "this is some standard plagiarism feedback"

--- a/services/QuillLMS/engines/evidence/spec/lib/regex_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/regex_check_spec.rb
@@ -21,7 +21,7 @@ module Evidence
     context 'should #feedback_object' do
 
       it 'should return optimal blank feedback when there is no regex match' do
-        $redis.redis.flushdb
+        Rails.cache.redis.flushdb
         optimal_rule = create(:evidence_rule, :rule_type => "rules-based-1", :optimal => true)
         entry = "this is not a good regex match"
         regex_check = Evidence::RegexCheck.new(entry, prompt, optimal_rule.rule_type)

--- a/services/QuillLMS/engines/evidence/spec/lib/regex_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/regex_check_spec.rb
@@ -21,7 +21,7 @@ module Evidence
     context 'should #feedback_object' do
 
       it 'should return optimal blank feedback when there is no regex match' do
-        Rails.cache.redis.flushdb
+        Rails.cache.clear
         optimal_rule = create(:evidence_rule, :rule_type => "rules-based-1", :optimal => true)
         entry = "this is not a good regex match"
         regex_check = Evidence::RegexCheck.new(entry, prompt, optimal_rule.rule_type)

--- a/services/QuillLMS/lib/tasks/concepts_in_use.rake
+++ b/services/QuillLMS/lib/tasks/concepts_in_use.rake
@@ -2,7 +2,7 @@
 
 namespace :concepts_in_use do
   task get: :environment do
-    last_set = $redis.get("NUMBER_OF_CONCEPTS_IN_USE_LAST_SET")
+    last_set = Rails.cache.read("NUMBER_OF_CONCEPTS_IN_USE_LAST_SET")
     if !last_set || 7.days.ago >= Date.parse(last_set, "%d-%m-%Y")
       GenerateConceptsInUseArrayWorker.perform_async
     end

--- a/services/QuillLMS/lib/tasks/redis.rake
+++ b/services/QuillLMS/lib/tasks/redis.rake
@@ -2,9 +2,9 @@
 
 namespace :redis do
   task :delete_keys => :environment do
-    Rails.cache.keys.each do |k|
-      puts "deleting key #{k}"
-      Rails.cache.delete k
+    Rails.cache.redis.keys("*").each do |key|
+      puts "deleting key #{key}"
+      Rails.cache.delete(key)
     end
     puts 'finished'
   end

--- a/services/QuillLMS/lib/tasks/redis.rake
+++ b/services/QuillLMS/lib/tasks/redis.rake
@@ -2,7 +2,7 @@
 
 namespace :redis do
   task :delete_keys => :environment do
-    $redis.keys.each do |k|
+    Rails.cache.keys.each do |k|
       puts "deleting key #{k}"
       Rails.cache.delete k
     end

--- a/services/QuillLMS/lib/tasks/redis.rake
+++ b/services/QuillLMS/lib/tasks/redis.rake
@@ -2,7 +2,7 @@
 
 namespace :redis do
   task :delete_keys => :environment do
-    $redis.keys("*").each do |key|
+    $redis.keys.each do |key|
       puts "deleting key #{key}"
       Rails.cache.delete(key)
     end

--- a/services/QuillLMS/lib/tasks/redis.rake
+++ b/services/QuillLMS/lib/tasks/redis.rake
@@ -4,7 +4,7 @@ namespace :redis do
   task :delete_keys => :environment do
     $redis.keys.each do |k|
       puts "deleting key #{k}"
-      $redis.del k
+      Rails.cache.delete k
     end
     puts 'finished'
   end

--- a/services/QuillLMS/lib/tasks/redis.rake
+++ b/services/QuillLMS/lib/tasks/redis.rake
@@ -2,12 +2,10 @@
 
 namespace :redis do
   task :delete_keys => :environment do
-    Rails.cache.redis.keys("*").each do |key|
+    $redis.keys("*").each do |key|
       puts "deleting key #{key}"
       Rails.cache.delete(key)
     end
     puts 'finished'
   end
-
-
 end

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
 
     it "should include the response from the db" do
       get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
-      expect(JSON.parse(response.body).keys.first).to eq(concept_feedback.uid)
+      expect(JSON.parse(response.body).keys).to include(concept_feedback.uid)
     end
   end
 

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
 
     it "should include the response from the db" do
       get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
-      expect(JSON.parse(response.body).keys).to include(concept_feedback.uid)
+      expect(JSON.parse(response.body).keys.first).to eq(concept_feedback.uid)
     end
   end
 

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -6,6 +6,8 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
   let!(:concept_feedback) { create(:concept_feedback) }
 
   describe "#index" do
+    after { Rails.cache.clear } # index is cached
+
     it "should return a list of ConceptFeedbacks" do
       get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
       expect(JSON.parse(response.body).keys.length).to eq(1)

--- a/services/QuillLMS/spec/controllers/api/v1/shared_cache_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/shared_cache_controller_spec.rb
@@ -2,43 +2,44 @@
 
 require 'rails_helper'
 
-describe Api::V1::SharedCacheController, type: :controller do
-  KEY = "test_shared_cache_key"
-  COMBINED_KEY = "#{Api::V1::SharedCacheController::BASE_SHARED_CACHE_KEY}_#{KEY}"
+RSpec.describe Api::V1::SharedCacheController, type: :controller do
+  let(:key) { 'test_shared_cache_key' }
+  let(:combined_key) { "#{Api::V1::SharedCacheController::BASE_SHARED_CACHE_KEY}_#{key}" }
 
   describe "#show" do
+    let(:cached_data) { {foo: 'bar'} }
+
     it "should return a 404 if the custom cache key isn't set" do
-      expect($redis).to receive(:get).with(COMBINED_KEY).and_return(nil)
-      get :show, params: { id: KEY }, as: :json
+      expect(Rails.cache).to receive(:read).with(combined_key).and_return(nil)
+      get :show, params: { id: key }, as: :json
       expect(response.status).to eq(404)
       expect(response.body).to include("The resource you were looking for does not exist")
     end
 
     it "should return the data in the cache if it is set" do
-      CACHED_DATA = {
-        foo: 'bar'
-      }
-      expect($redis).to receive(:get).with(COMBINED_KEY).and_return(CACHED_DATA.to_json)
-      get :show, params: { id: KEY, data: CACHED_DATA }, as: :json
+      expect(Rails.cache).to receive(:read).with(combined_key).and_return(cached_data.to_json)
+      get :show, params: { id: key, data: cached_data }, as: :json
       expect(response.status).to eq(200)
-      expect(response.body).to eq(CACHED_DATA.to_json)
+      expect(response.body).to eq(cached_data.to_json)
     end
   end
 
   describe "#update" do
+    let(:set_data) { {foo: 'bar'} }
+    let(:expires_in) { Api::V1::SharedCacheController::SHARED_CACHE_EXPIRY }
+
     it "should set the cache for the specified key" do
-      SET_DATA = {"foo" => "bar"}
-      expect($redis).to receive(:set).with(COMBINED_KEY, SET_DATA.to_json, {ex: Api::V1::SharedCacheController::SHARED_CACHE_EXPIRY})
-      put :update, params: { id: KEY, data: SET_DATA }, as: :json
+      expect(Rails.cache).to receive(:write).with(combined_key, set_data.to_json, expires_in: expires_in)
+      put :update, params: { id: key, data: set_data }, as: :json
       expect(response.status).to eq(200)
-      expect(response.body).to eq(SET_DATA.to_json)
+      expect(response.body).to eq(set_data.to_json)
     end
   end
 
   describe "#destroy" do
     it "should delete the existing record" do
-      expect($redis).to receive(:del).with(COMBINED_KEY)
-      delete :destroy, params: { id: KEY }, as: :json
+      expect(Rails.cache).to receive(:delete).with(combined_key)
+      delete :destroy, params: { id: key }, as: :json
       expect(response.status).to eq(200)
       expect(response.body).to eq("OK")
     end

--- a/services/QuillLMS/spec/controllers/teachers/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_units_controller_spec.rb
@@ -76,7 +76,7 @@ describe Teachers::ClassroomUnitsController, type: :controller do
       before { allow(teacher).to receive(:set_and_return_lessons_cache_data) { { id: "not 10" } } }
 
       context 'when value is present in the cache' do
-        before { $redis.set("user_id:#{teacher.id}_lessons_array", { id: 10 }.to_json) }
+        before { Rails.cache.write("user_id:#{teacher.id}_lessons_array", { id: 10 }.to_json) }
 
         it 'should render the redis cache' do
           get :lessons_activities_cache, as: :json
@@ -92,7 +92,7 @@ describe Teachers::ClassroomUnitsController, type: :controller do
 
     describe '#lessons_units_and_activities' do
       before do
-        $redis.set("user_id:#{teacher.id}_lessons_array", [
+        Rails.cache.write("user_id:#{teacher.id}_lessons_array", [
           { activity_id: 10, activity_name: "some name", completed: false, visible: true },
           { activity_id: 11, activity_name: "bater papo", completed: false, visible: false }
         ].to_json)

--- a/services/QuillLMS/spec/controllers/teachers/unit_templates_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/unit_templates_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Teachers::UnitTemplatesController, type: :controller do
+RSpec.describe Teachers::UnitTemplatesController, type: :controller do
   before do
     session[:user_id] = teacher.id
   end

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -38,9 +38,7 @@
 #
 require 'rails_helper'
 
-
-describe ActivitySession, type: :model, redis: true do
-
+RSpec.describe ActivitySession, type: :model, redis: true do
   it { should belong_to(:classroom_unit).touch(true) }
   it { should belong_to(:activity) }
   it { should have_one(:classification).through(:activity) }
@@ -295,13 +293,13 @@ describe ActivitySession, type: :model, redis: true do
       it "deletes redis cache when an activity with a classroom's state is finished" do
         activity_session.update(state: 'finished')
         activity_session.invalidate_activity_session_count_if_completed
-        expect($redis.get("classroom_id:#{student.classrooms.first.id}_completed_activity_count")).not_to be
+        expect(Rails.cache.read("classroom_id:#{student.classrooms.first.id}_completed_activity_count")).not_to be
       end
 
       it "does nothing to redis cache when any other classroom attribute changes" do
         activity_session.update(visible: false)
         activity_session.invalidate_activity_session_count_if_completed
-        expect($redis.get("classroom_id:#{student.classrooms.first.id}_completed_activity_count")).to eq('10')
+        expect(Rails.cache.read("classroom_id:#{student.classrooms.first.id}_completed_activity_count")).to eq(10)
       end
 
     end

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -289,7 +289,7 @@ describe ActivitySession, type: :model, redis: true do
       let!(:activity_session){   create(:activity_session, classroom_unit: classroom_unit, state: 'not validated')}
 
       before do
-        $redis.set("classroom_id:#{student.classrooms.first.id}_completed_activity_count", 10)
+        Rails.cache.write("classroom_id:#{student.classrooms.first.id}_completed_activity_count", 10)
       end
 
       it "deletes redis cache when an activity with a classroom's state is finished" do

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -408,9 +408,9 @@ describe Activity, type: :model, redis: true do
     let!(:cache_activity) { create(:activity, :production) }
 
     it 'sets the default_activity_search for the cache' do
-      $redis.redis.flushdb
+      Rails.cache.redis.flushdb
       Activity.set_activity_search_cache
-      expect(JSON.parse($redis.get('default_activity_search'))['activities'].first['uid']).to eq(cache_activity.uid)
+      expect(JSON.parse(Rails.cache.read('default_activity_search'))['activities'].first['uid']).to eq(cache_activity.uid)
     end
   end
 
@@ -464,7 +464,7 @@ describe Activity, type: :model, redis: true do
     let!(:cache_activity) { create(:activity, :production) }
 
     it 'when cache is empty the result is the value of the search results' do
-      $redis.redis.flushdb
+      Rails.cache.redis.flushdb
       search_results = Activity.search_results(nil)
       results = ActivitySearchWrapper.search_cache_data(nil)
       expect(search_results).to eq(JSON.parse(results))

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -408,7 +408,7 @@ describe Activity, type: :model, redis: true do
     let!(:cache_activity) { create(:activity, :production) }
 
     it 'sets the default_activity_search for the cache' do
-      Rails.cache.redis.flushdb
+      Rails.cache.clear
       Activity.set_activity_search_cache
       expect(JSON.parse(Rails.cache.read('default_activity_search'))['activities'].first['uid']).to eq(cache_activity.uid)
     end
@@ -464,7 +464,7 @@ describe Activity, type: :model, redis: true do
     let!(:cache_activity) { create(:activity, :production) }
 
     it 'when cache is empty the result is the value of the search results' do
-      Rails.cache.redis.flushdb
+      Rails.cache.clear
       search_results = Activity.search_results(nil)
       results = ActivitySearchWrapper.search_cache_data(nil)
       expect(search_results).to eq(JSON.parse(results))

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -381,9 +381,9 @@ describe Activity, type: :model, redis: true do
     let(:activity) { create(:activity) }
 
     it 'deletes the default_activity_search from the cache' do
-      Rails.cache.write(UserFlagset::DEFAULT_ACTIVITY_SEARCH_CACHE_KEY, something: 'something')
+      Rails.cache.write(described_class::DEFAULT_ACTIVITY_SEARCH_CACHE_KEY, something: 'something')
       Activity.clear_activity_search_cache
-      expect(Rails.cache.read(UserFlagset::DEFAULT_ACTIVITY_SEARCH_CACHE_KEY)).to eq nil
+      expect(Rails.cache.read(described_class::DEFAULT_ACTIVITY_SEARCH_CACHE_KEY)).to eq nil
     end
 
     it 'deletes all redis keys as defined in UserFlagset' do

--- a/services/QuillLMS/spec/models/author_spec.rb
+++ b/services/QuillLMS/spec/models/author_spec.rb
@@ -10,7 +10,7 @@
 #
 require 'rails_helper'
 
-describe Author, type: :model, redis: true do
+RSpec.describe Author, type: :model, redis: true do
   it { should have_many(:unit_templates) }
   it { is_expected.to callback(:delete_relevant_caches).after(:commit) }
 

--- a/services/QuillLMS/spec/models/author_spec.rb
+++ b/services/QuillLMS/spec/models/author_spec.rb
@@ -29,10 +29,10 @@ describe Author, type: :model, redis: true do
     it 'should clear the unit templates' do
       template.get_cached_serialized_unit_template
       author.run_callbacks(:commit)
-      expect($redis.get("unit_template_id:#{template.id}_serialized")).to eq nil
-      expect($redis.get('production_unit_templates')).to eq nil
-      expect($redis.get('beta_unit_templates')).to eq nil
-      expect($redis.get('alpha_unit_templates')).to eq nil
+      expect(Rails.cache.read("unit_template_id:#{template.id}_serialized")).to eq nil
+      expect(Rails.cache.read('production_unit_templates')).to eq nil
+      expect(Rails.cache.read('beta_unit_templates')).to eq nil
+      expect(Rails.cache.read('alpha_unit_templates')).to eq nil
     end
   end
 

--- a/services/QuillLMS/spec/models/classroom_unit_activity_state_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_activity_state_spec.rb
@@ -68,7 +68,7 @@ describe ClassroomUnitActivityState, type: :model, redis: true do
 
   describe 'caching lessons upon assignemnt' do
     before do
-      $redis.redis.flushdb
+      Rails.cache.redis.flushdb
       cua.save
     end
 

--- a/services/QuillLMS/spec/models/classroom_unit_activity_state_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_activity_state_spec.rb
@@ -73,7 +73,7 @@ describe ClassroomUnitActivityState, type: :model, redis: true do
     end
 
     it "creates a redis key for the user if there isn't one" do
-      expect($redis.get("user_id:#{classroom_unit.classroom.owner.id}_lessons_array")).to be
+      expect(Rails.cache.read("user_id:#{classroom_unit.classroom.owner.id}_lessons_array")).to be
     end
 
     it "caches data about the assignment" do
@@ -84,7 +84,7 @@ describe ClassroomUnitActivityState, type: :model, redis: true do
         "unit_id" => cua.classroom_unit.unit_id,
         "completed" => cua.completed,
         "visible" => cua.unit_activity.visible}
-      expect($redis.get("user_id:#{classroom_unit.classroom.owner.id}_lessons_array")).to eq([lesson_data].to_json)
+      expect(Rails.cache.read("user_id:#{classroom_unit.classroom.owner.id}_lessons_array")).to eq([lesson_data].to_json)
     end
 
     it "caches data about subsequent assignment" do
@@ -111,7 +111,7 @@ describe ClassroomUnitActivityState, type: :model, redis: true do
         "unit_id" => cua2.classroom_unit.unit_id,
         "completed" => cua2.completed,
         "visible" => unit_activity.visible}
-      expect($redis.get("user_id:#{classroom_unit2.classroom.owner.id}_lessons_array")).to eq([lesson_data, lesson2_data].to_json)
+      expect(Rails.cache.read("user_id:#{classroom_unit2.classroom.owner.id}_lessons_array")).to eq([lesson_data, lesson2_data].to_json)
     end
   end
 

--- a/services/QuillLMS/spec/models/classroom_unit_activity_state_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_activity_state_spec.rb
@@ -68,7 +68,7 @@ describe ClassroomUnitActivityState, type: :model, redis: true do
 
   describe 'caching lessons upon assignemnt' do
     before do
-      Rails.cache.redis.flushdb
+      Rails.cache.clear
       cua.save
     end
 

--- a/services/QuillLMS/spec/models/classrooms_teacher_spec.rb
+++ b/services/QuillLMS/spec/models/classrooms_teacher_spec.rb
@@ -63,10 +63,9 @@ RSpec.describe ClassroomsTeacher, type: :model, redis: true do
     let(:teacher) { classrooms_teacher.teacher }
 
     it 'should delete_classroom_minis_cache on create' do
-      $redis.set("user_id:#{teacher.id}_classroom_minis", {something: 'something'})
+      Rails.cache.write("user_id:#{teacher.id}_classroom_minis", something: 'something')
       classrooms_teacher.save
-      expect($redis.get("user_id:#{teacher.id}_classroom_minis")).to eq nil
+      expect(Rails.cache.read("user_id:#{teacher.id}_classroom_minis")).to eq nil
     end
   end
-
 end

--- a/services/QuillLMS/spec/models/redis_feed_spec.rb
+++ b/services/QuillLMS/spec/models/redis_feed_spec.rb
@@ -88,7 +88,7 @@ describe RedisFeed, type: :model do
         end
 
         def delete_all
-          $redis.del(redis_key)
+          Rails.cache.delete(redis_key)
         end
       end
     end

--- a/services/QuillLMS/spec/models/students_classrooms_spec.rb
+++ b/services/QuillLMS/spec/models/students_classrooms_spec.rb
@@ -80,7 +80,7 @@ describe StudentsClassrooms, type: :model, redis: true do
       let(:classrooms) { create(:students_classrooms) }
 
       it "should invalidate the classroom minis" do
-        $redis.set("user_id:#{classrooms.classroom.owner.id}_classroom_minis", "something")
+        Rails.cache.write("user_id:#{classrooms.classroom.owner.id}_classroom_minis", "something")
         classrooms.run_callbacks(:commit)
         expect($redis.get("user_id:#{classrooms.classroom.owner.id}_classroom_minis")).to eq nil
       end

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -24,7 +24,7 @@
 #
 require 'rails_helper'
 
-describe UnitTemplate, redis: true, type: :model do
+RSpec.describe UnitTemplate, redis: true, type: :model do
   let!(:unit_template) {create(:unit_template)}
 
   it { should belong_to(:unit_template_category) }

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -229,7 +229,7 @@ describe UnitTemplate, redis: true, type: :model do
 
     it 'should save the serialized hash to the db and returns it' do
       unit_template1.get_cached_serialized_unit_template
-      serialized_template_from_db = JSON.parse($redis.get("unit_template_id:#{unit_template1.id}_serialized"))
+      serialized_template_from_db = JSON.parse(Rails.cache.read("unit_template_id:#{unit_template1.id}_serialized"))
       JSON.parse(json).each do |k, v|
         expect(serialized_template_from_db).to include(k)
         expect(serialized_template_from_db[k]).to eq(v)
@@ -327,36 +327,39 @@ describe UnitTemplate, redis: true, type: :model do
   describe '#around_save callback' do
 
     before do
-      $redis.redis.flushdb
-      $redis.multi{
-        Rails.cache.write('beta_unit_templates', 'a')
-        Rails.cache.write('production_unit_templates', 'a')
-        Rails.cache.write('gamma_unit_templates', 'a')
-        Rails.cache.write('alpha_unit_templates', 'a')
-      }
+      Rails.cache.redis.flushdb
+
+      Rails.cache.redis.multi do |multi|
+        multi.set('beta_unit_templates', 'a')
+        multi.set('production_unit_templates', 'a')
+        multi.set('gamma_unit_templates', 'a')
+        multi.set('alpha_unit_templates', 'a')
+      end
     end
 
     def exist_count
       flag_types = ['beta_unit_templates', 'production_unit_templates', 'gamma_unit_templates', 'alpha_unit_templates']
       exist_count = 0
       flag_types.each do |flag|
-        exist_count += $redis.exists(flag) == 1 ? 1 : 0
+        exist_count += Rails.cache.exist?(flag) ? 1 : 0
       end
       exist_count
     end
 
     it "deletes the cache of the saved unit" do
-      Rails.cache.write("unit_template_id:#{unit_template.id}_serialized", 'something')
-      expect($redis.exists("unit_template_id:#{unit_template.id}_serialized")).to eq(1)
+      cache_key = "unit_template_id:#{unit_template.id}_serialized"
+
+      Rails.cache.write(cache_key, 'something')
+      expect(Rails.cache.exist?(cache_key)).to eq true
       unit_template.update(name: 'something else')
-      expect($redis.exists("unit_template_id:#{unit_template.id}_serialized")).to eq(0)
+      expect(Rails.cache.exist?(cache_key)).to eq false
     end
 
     it "deletes the cache of all flags before and after save" do
       expect(exist_count).to eq(4)
       unit_template.update(flag: 'beta')
       expect(exist_count).to eq(0)
-      expect($redis.exists('alpha_unit_templates')).to eq(0)
+      expect(Rails.cache.exists?('alpha_unit_templates')).to eq false
       Rails.cache.write('alpha_unit_templates', 'some test nonsense')
       unit_template.update(flag: 'alpha')
       expect(exist_count).to eq(0)
@@ -398,12 +401,12 @@ describe UnitTemplate, redis: true, type: :model do
       Rails.cache.write('private_unit_templates', "data")
       Rails.cache.write('gamma_unit_templates', "same")
       UnitTemplate.delete_all_caches
-      expect($redis.get("unit_template_id:#{template.id}_serialized")).to eq nil
-      expect($redis.get('production_unit_templates')).to eq nil
-      expect($redis.get('gamma_unit_templates')).to eq nil
-      expect($redis.get('beta_unit_templates')).to eq nil
-      expect($redis.get('alpha_unit_templates')).to eq nil
-      expect($redis.get('private_unit_templates')).to eq nil
+      expect(Rails.cache.read("unit_template_id:#{template.id}_serialized")).to eq nil
+      expect(Rails.cache.read('production_unit_templates')).to eq nil
+      expect(Rails.cache.read('gamma_unit_templates')).to eq nil
+      expect(Rails.cache.read('beta_unit_templates')).to eq nil
+      expect(Rails.cache.read('alpha_unit_templates')).to eq nil
+      expect(Rails.cache.read('private_unit_templates')).to eq nil
     end
 
   end

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -329,10 +329,10 @@ describe UnitTemplate, redis: true, type: :model do
     before do
       $redis.redis.flushdb
       $redis.multi{
-        $redis.set('beta_unit_templates', 'a')
-        $redis.set('production_unit_templates', 'a')
-        $redis.set('gamma_unit_templates', 'a')
-        $redis.set('alpha_unit_templates', 'a')
+        Rails.cache.write('beta_unit_templates', 'a')
+        Rails.cache.write('production_unit_templates', 'a')
+        Rails.cache.write('gamma_unit_templates', 'a')
+        Rails.cache.write('alpha_unit_templates', 'a')
       }
     end
 
@@ -346,7 +346,7 @@ describe UnitTemplate, redis: true, type: :model do
     end
 
     it "deletes the cache of the saved unit" do
-      $redis.set("unit_template_id:#{unit_template.id}_serialized", 'something')
+      Rails.cache.write("unit_template_id:#{unit_template.id}_serialized", 'something')
       expect($redis.exists("unit_template_id:#{unit_template.id}_serialized")).to eq(1)
       unit_template.update(name: 'something else')
       expect($redis.exists("unit_template_id:#{unit_template.id}_serialized")).to eq(0)
@@ -357,7 +357,7 @@ describe UnitTemplate, redis: true, type: :model do
       unit_template.update(flag: 'beta')
       expect(exist_count).to eq(0)
       expect($redis.exists('alpha_unit_templates')).to eq(0)
-      $redis.set('alpha_unit_templates', 'some test nonsense')
+      Rails.cache.write('alpha_unit_templates', 'some test nonsense')
       unit_template.update(flag: 'alpha')
       expect(exist_count).to eq(0)
     end
@@ -391,12 +391,12 @@ describe UnitTemplate, redis: true, type: :model do
     let(:template) { create(:unit_template) }
 
     it 'should clear the unit templates' do
-      $redis.set("unit_template_id:#{template.id}_serialized", "pretend")
-      $redis.set('production_unit_templates', "this")
-      $redis.set('beta_unit_templates', "is")
-      $redis.set('alpha_unit_templates', "real")
-      $redis.set('private_unit_templates', "data")
-      $redis.set('gamma_unit_templates', "same")
+      Rails.cache.write("unit_template_id:#{template.id}_serialized", "pretend")
+      Rails.cache.write('production_unit_templates', "this")
+      Rails.cache.write('beta_unit_templates', "is")
+      Rails.cache.write('alpha_unit_templates', "real")
+      Rails.cache.write('private_unit_templates', "data")
+      Rails.cache.write('gamma_unit_templates', "same")
       UnitTemplate.delete_all_caches
       expect($redis.get("unit_template_id:#{template.id}_serialized")).to eq nil
       expect($redis.get('production_unit_templates')).to eq nil

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -327,7 +327,7 @@ describe UnitTemplate, redis: true, type: :model do
   describe '#around_save callback' do
 
     before do
-      Rails.cache.redis.flushdb
+      Rails.cache.clear
 
       Rails.cache.redis.multi do |multi|
         multi.set('beta_unit_templates', 'a')

--- a/services/QuillLMS/spec/models/unit_template_spec.rb
+++ b/services/QuillLMS/spec/models/unit_template_spec.rb
@@ -328,13 +328,10 @@ describe UnitTemplate, redis: true, type: :model do
 
     before do
       Rails.cache.clear
-
-      Rails.cache.redis.multi do |multi|
-        multi.set('beta_unit_templates', 'a')
-        multi.set('production_unit_templates', 'a')
-        multi.set('gamma_unit_templates', 'a')
-        multi.set('alpha_unit_templates', 'a')
-      end
+      Rails.cache.write('beta_unit_templates', 'a')
+      Rails.cache.write('production_unit_templates', 'a')
+      Rails.cache.write('gamma_unit_templates', 'a')
+      Rails.cache.write('alpha_unit_templates', 'a')
     end
 
     def exist_count
@@ -359,7 +356,7 @@ describe UnitTemplate, redis: true, type: :model do
       expect(exist_count).to eq(4)
       unit_template.update(flag: 'beta')
       expect(exist_count).to eq(0)
-      expect(Rails.cache.exists?('alpha_unit_templates')).to eq false
+      expect(Rails.cache.exist?('alpha_unit_templates')).to eq false
       Rails.cache.write('alpha_unit_templates', 'some test nonsense')
       unit_template.update(flag: 'alpha')
       expect(exist_count).to eq(0)

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -482,7 +482,7 @@ describe User, type: :model do
     let(:user) { create(:user) }
 
     it 'should clear the class_room_minis cache' do
-      $redis.set("user_id:#{user.id}_classroom_minis", "anything")
+      Rails.cache.write("user_id:#{user.id}_classroom_minis", "anything")
       user.delete_classroom_minis_cache
       expect($redis.get("user_id:#{user.id}_classroom_minis")).to eq(nil)
     end
@@ -492,7 +492,7 @@ describe User, type: :model do
     let(:user) { create(:user) }
 
     it 'should clear the class_room_minis cache' do
-      $redis.set("user_id:#{user.id}_struggling_students", "anything")
+      Rails.cache.write("user_id:#{user.id}_struggling_students", "anything")
       user.delete_struggling_students_cache
       expect($redis.get("user_id:#{user.id}_struggling_students")).to eq(nil)
     end
@@ -573,7 +573,7 @@ describe User, type: :model do
     let(:user) { create(:user) }
 
     it 'should clear the class_room_minis cache' do
-      $redis.set("user_id:#{user.id}_difficult_concepts", "anything")
+      Rails.cache.write("user_id:#{user.id}_difficult_concepts", "anything")
       user.delete_difficult_concepts_cache
       expect($redis.get("user_id:#{user.id}_difficult_concepts")).to eq(nil)
     end

--- a/services/QuillLMS/spec/services/vitally_integration/cache_vitally_school_data_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/cache_vitally_school_data_spec.rb
@@ -2,29 +2,28 @@
 
 require 'rails_helper'
 
-describe VitallyIntegration::CacheVitallySchoolData do
+RSpec.describe VitallyIntegration::CacheVitallySchoolData do
   subject { described_class }
 
   let(:school_id) { 1 }
   let(:year) { 2000 }
+  let(:cache_key) { "school_id:#{school_id}_vitally_stats_for_year_#{year}" }
 
-  it '#cache_key' do
-    expect(subject.cache_key(school_id, year)).to eq("school_id:#{school_id}_vitally_stats_for_year_#{year}")
-  end
+  it { expect(subject.cache_key(school_id, year)).to eq(cache_key) }
 
   it '#set' do
     data = {test: 1}
-    expect($redis).to receive(:set).with("school_id:#{school_id}_vitally_stats_for_year_#{year}", data.to_json, {ex: 1.year})
+    expect(Rails.cache).to receive(:write).with(cache_key, data.to_json, expires_in: 1.year)
     subject.set(school_id, year, data.to_json)
   end
 
   it '#del' do
-    expect($redis).to receive(:del).with("school_id:#{school_id}_vitally_stats_for_year_#{year}")
+    expect(Rails.cache).to receive(:delete).with(cache_key)
     subject.del(school_id, year)
   end
 
   it '#get' do
-    expect($redis).to receive(:get).with("school_id:#{school_id}_vitally_stats_for_year_#{year}")
+    expect(Rails.cache).to receive(:read).with(cache_key)
     subject.get(school_id, year)
   end
 end

--- a/services/QuillLMS/spec/services/vitally_integration/cache_vitally_teacher_data_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/cache_vitally_teacher_data_spec.rb
@@ -7,24 +7,23 @@ describe VitallyIntegration::CacheVitallyTeacherData do
 
   let(:teacher_id) { 1 }
   let(:year) { 2000 }
+  let(:cache_key) { "teacher_id:#{teacher_id}_vitally_stats_for_year_#{year}" }
 
-  it '#cache_key' do
-    expect(subject.cache_key(teacher_id, year)).to eq("teacher_id:#{teacher_id}_vitally_stats_for_year_#{year}")
-  end
+  it { expect(subject.cache_key(teacher_id, year)).to eq(cache_key) }
 
   it '#set' do
     data = {test: 1}
-    expect($redis).to receive(:set).with("teacher_id:#{teacher_id}_vitally_stats_for_year_#{year}", data.to_json, {ex: 1.year})
+    expect(Rails.cache).to receive(:write).with(cache_key, data.to_json, expires_in: 1.year)
     subject.set(teacher_id, year, data.to_json)
   end
 
   it '#del' do
-    expect($redis).to receive(:del).with("teacher_id:#{teacher_id}_vitally_stats_for_year_#{year}")
+    expect(Rails.cache).to receive(:delete).with(cache_key)
     subject.del(teacher_id, year)
   end
 
   it '#get' do
-    expect($redis).to receive(:get).with("teacher_id:#{teacher_id}_vitally_stats_for_year_#{year}")
+    expect(Rails.cache).to receive(:read).with(cache_key)
     subject.get(teacher_id, year)
   end
 end

--- a/services/QuillLMS/spec/workers/quill_staff_accounts_changed_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/quill_staff_accounts_changed_worker_spec.rb
@@ -14,7 +14,7 @@ describe QuillStaffAccountsChangedWorker, type: :worker do
       expect(worker).to receive(:current_staff_account_data).and_return([staff_json])
       expect(worker).to receive(:cached_staff_account_data).and_return({})
       expect(worker).to receive(:notify_staff)
-      expect($redis).to receive(:set).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY, [staff_json].to_json, ex: 25.hours.to_i)
+      expect(Rails.cache).to receive(:write).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY, [staff_json].to_json, expires_in: 25.hours)
       worker.perform
     end
 
@@ -22,7 +22,7 @@ describe QuillStaffAccountsChangedWorker, type: :worker do
       expect(worker).to receive(:current_staff_account_data).and_return([staff_json])
       expect(worker).to receive(:cached_staff_account_data).and_return([staff_json])
       expect(worker).not_to receive(:notify_staff)
-      expect($redis).to receive(:set).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY, [staff_json].to_json, ex: 25.hours.to_i)
+      expect(Rails.cache).to receive(:write).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY, [staff_json].to_json, expires_in: 25.hours)
       worker.perform
     end
 
@@ -39,8 +39,8 @@ describe QuillStaffAccountsChangedWorker, type: :worker do
   end
 
   describe "#cached_staff_account_data" do
-    it "retrieves cached data from Redis" do
-      expect($redis).to receive(:get).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY)
+    it "retrieves cached data" do
+      expect(Rails.cache).to receive(:read).with(QuillStaffAccountsChangedWorker::STAFF_ACCOUNTS_CACHE_KEY)
       worker.cached_staff_account_data
     end
   end

--- a/services/QuillLMS/spec/workers/reset_lesson_cache_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/reset_lesson_cache_worker_spec.rb
@@ -9,13 +9,13 @@ describe ResetLessonCacheWorker do
     let!(:user) { create(:user) }
 
     before do
-      $redis.set("user_id:#{user.id}_lessons_array", ["something"])
+      Rails.cache.write("user_id:#{user.id}_lessons_array", ["something"])
     end
 
     it 'should delete the redis cache and set lesson cache for user' do
       expect_any_instance_of(User).to receive(:set_lessons_cache)
       subject.perform(user.id)
-      expect($redis.get("user_id:#{user.id}_lessons_array")).to eq nil
+      expect(Rails.cache.read("user_id:#{user.id}_lessons_array")).to eq nil
     end
   end
 end

--- a/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
@@ -37,27 +37,27 @@ describe SetImpactMetricsWorker do
 
     it 'should set the NUMBER_OF_SENTENCES redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_SENTENCES)).to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.size) * SetImpactMetricsWorker::SENTENCES_PER_ACTIVITY_SESSION).to_s)
+      expect(Rails.cache.read(PagesController::NUMBER_OF_SENTENCES)).to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.size) * SetImpactMetricsWorker::SENTENCES_PER_ACTIVITY_SESSION).to_s)
     end
 
     it 'should set the NUMBER_OF_STUDENTS redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_STUDENTS)).to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.count('DISTINCT(user_id)'))).to_s)
+      expect(Rails.cache.read(PagesController::NUMBER_OF_STUDENTS)).to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.count('DISTINCT(user_id)'))).to_s)
     end
 
     it 'should set the NUMBER_OF_TEACHERS redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_TEACHERS)).to eq(SetImpactMetricsWorker.round_to_hundreds(teachers.length).to_s)
+      expect(Rails.cache.read(PagesController::NUMBER_OF_TEACHERS)).to eq(SetImpactMetricsWorker.round_to_hundreds(teachers.length).to_s)
     end
 
     it 'should set the NUMBER_OF_SCHOOLS redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_SCHOOLS)).to eq(schools_payload.length.to_s)
+      expect(Rails.cache.read(PagesController::NUMBER_OF_SCHOOLS)).to eq(schools_payload.length.to_s)
     end
 
     it 'should set the NUMBER_OF_LOW_INCOME_SCHOOLS redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_LOW_INCOME_SCHOOLS)).to eq(schools_payload.filter { |s| s["free_lunches"] > SetImpactMetricsWorker::FREE_LUNCH_MINIMUM}.length.to_s)
+      expect(Rails.cache.read(PagesController::NUMBER_OF_LOW_INCOME_SCHOOLS)).to eq(schools_payload.filter { |s| s["free_lunches"] > SetImpactMetricsWorker::FREE_LUNCH_MINIMUM}.length.to_s)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe SetImpactMetricsWorker do
+RSpec.describe SetImpactMetricsWorker do
   subject { described_class.new }
 
   context '#perform' do
@@ -37,27 +37,35 @@ describe SetImpactMetricsWorker do
 
     it 'should set the NUMBER_OF_SENTENCES redis value' do
       subject.perform
-      expect(Rails.cache.read(PagesController::NUMBER_OF_SENTENCES)).to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.size) * SetImpactMetricsWorker::SENTENCES_PER_ACTIVITY_SESSION).to_s)
+
+      expect(Rails.cache.read(PagesController::NUMBER_OF_SENTENCES))
+        .to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.size) * SetImpactMetricsWorker::SENTENCES_PER_ACTIVITY_SESSION))
     end
 
     it 'should set the NUMBER_OF_STUDENTS redis value' do
       subject.perform
-      expect(Rails.cache.read(PagesController::NUMBER_OF_STUDENTS)).to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.count('DISTINCT(user_id)'))).to_s)
+
+      expect(Rails.cache.read(PagesController::NUMBER_OF_STUDENTS))
+        .to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.count('DISTINCT(user_id)'))))
     end
 
     it 'should set the NUMBER_OF_TEACHERS redis value' do
       subject.perform
-      expect(Rails.cache.read(PagesController::NUMBER_OF_TEACHERS)).to eq(SetImpactMetricsWorker.round_to_hundreds(teachers.length).to_s)
+
+      expect(Rails.cache.read(PagesController::NUMBER_OF_TEACHERS))
+        .to eq(SetImpactMetricsWorker.round_to_hundreds(teachers.length))
     end
 
     it 'should set the NUMBER_OF_SCHOOLS redis value' do
       subject.perform
-      expect(Rails.cache.read(PagesController::NUMBER_OF_SCHOOLS)).to eq(schools_payload.length.to_s)
+      expect(Rails.cache.read(PagesController::NUMBER_OF_SCHOOLS)).to eq(schools_payload.length)
     end
 
     it 'should set the NUMBER_OF_LOW_INCOME_SCHOOLS redis value' do
       subject.perform
-      expect(Rails.cache.read(PagesController::NUMBER_OF_LOW_INCOME_SCHOOLS)).to eq(schools_payload.filter { |s| s["free_lunches"] > SetImpactMetricsWorker::FREE_LUNCH_MINIMUM}.length.to_s)
+
+      expect(Rails.cache.read(PagesController::NUMBER_OF_LOW_INCOME_SCHOOLS))
+        .to eq(schools_payload.filter { |s| s["free_lunches"] > SetImpactMetricsWorker::FREE_LUNCH_MINIMUM}.length)
     end
   end
 end


### PR DESCRIPTION
## WHAT
Make the following replacements:
 `$redis.set` -> `Rails.cache.write`
 `$redis.get` -> `Rails.cache.read`
 `$redis.del` -> `Rails.cache.delete`
 `$redis.flushdb` -> `Rails.cache.clear`
 `$redis.exists` -> `Rails.cache.exists?`

Also, fold in `$redis.expire` with `Rails.cache.write(key, value, expires_in: [expiry])` 


## WHY
[Calls](https://github.com/empirical-org/Empirical-Core/blob/c920c57566ee6cf5eeae0e266178058ef429228b/services/QuillLMS/app/models/concerns/teacher.rb#L257) to `$redis.set` with positional and keyword arguments no longer work in Ruby 3

It's also better if we have an agnostic wrapper `Rails.cache` vs the global variable `$redis`

## HOW
Find and replace

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
