### PR TITLE
Turn off UpdateStudentImportedClassroomsWorker

### DIFF
--- a/services/QuillLMS/app/controllers/auth/google_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/google_controller.rb
@@ -48,11 +48,9 @@ class Auth::GoogleController < ApplicationController
   end
 
   private def run_background_jobs
-    if @user.teacher?
-      GoogleIntegration::UpdateTeacherImportedClassroomsWorker.perform_async(@user.id)
-    elsif @user.student?
-      GoogleIntegration::UpdateStudentImportedClassroomsWorker.perform_async(@user.id)
-    end
+    return unless @user.teacher?
+
+    GoogleIntegration::UpdateTeacherImportedClassroomsWorker.perform_async(@user.id)
   end
 
   private def follow_google_redirect


### PR DESCRIPTION
## WHAT
Turn off a background job

## WHY
There's a client [error](https://quillorg-5s.sentry.io/issues/4380192200/?project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=5) that is not allowing this endpoint to be accessed.

Students will still get pulled into classrooms via the teacher.  This was a redundancy worker.

## HOW
Remove from google controller flow.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
