### PR TITLE
Add error handling for Google::Apis::ClientError

### DIFF
--- a/services/QuillLMS/app/services/google_integration/rest_client.rb
+++ b/services/QuillLMS/app/services/google_integration/rest_client.rb
@@ -4,8 +4,11 @@ module GoogleIntegration
   class RestClient
     ACTIVE_STATE = 'ACTIVE'
     ARCHIVED_STATE = 'ARCHIVED'
+    ME = 'me'
 
     attr_reader :google_auth_credential, :user_external_id
+
+    delegate :user_id, to: :google_auth_credential
 
     def initialize(google_auth_credential)
       @google_auth_credential = google_auth_credential
@@ -15,23 +18,26 @@ module GoogleIntegration
     end
 
     def classroom_students(course_id)
-      CourseStudentsAggregator
-        .run(api, course_id)
-        .map { |student_data| StudentDataAdapter.run(student_data) }
+      handle_client_errors do
+        CourseStudentsAggregator
+          .run(api, course_id)
+          .map { |student_data| StudentDataAdapter.run(student_data) }
+      end
     end
 
     def student_classrooms
-      student_classrooms_data.map { |classroom_data| { classroom_external_id: classroom_data.id } }
+      handle_client_errors do
+        student_classrooms_data.map { |classroom_data| { classroom_external_id: classroom_data.id } }
+      end
     end
 
     def teacher_classrooms
-      [].tap do |classrooms_data|
-        teacher_courses_data.each do |course_data|
-          student_count = CourseStudentsAggregator.run(api, course_data.id).count
-          classrooms_data << ClassroomDataAdapter.run(course_data, student_count)
-        rescue => e
-          ::ErrorNotifier.report(e, course_id: course_data.id, user_id: google_auth_credential.user_id)
-          next
+      handle_client_errors do
+        [].tap do |classrooms_data|
+          teacher_courses_data.each do |course_data|
+            student_count = CourseStudentsAggregator.run(api, course_data.id).count
+            classrooms_data << ClassroomDataAdapter.run(course_data, student_count)
+          end
         end
       end
     end
@@ -40,16 +46,22 @@ module GoogleIntegration
       @api ||= ::Google::Apis::ClassroomV1::ClassroomService.new
     end
 
+    private def handle_client_errors
+      yield
+    rescue Google::Apis::ClientError => e
+      e.status_code == 403 ? [] : ErrorNotifier.report(e, user_id: user_id)
+    end
+
     private def student_classrooms_data
       api
-        .list_courses(course_states: [ACTIVE_STATE, ARCHIVED_STATE])
+        .list_courses(student_id: ME, course_states: [ACTIVE_STATE, ARCHIVED_STATE])
         &.courses
         &.select { |course_data| course_data.owner_id != user_external_id } || []
     end
 
     private def teacher_courses_data
       api
-        .list_courses(course_states: [ACTIVE_STATE, ARCHIVED_STATE])
+        .list_courses(teacher_id: ME, course_states: [ACTIVE_STATE, ARCHIVED_STATE])
         &.courses
         &.select { |course_data| TeacherCourseDataValidator.run(course_data, user_external_id) } || []
     end


### PR DESCRIPTION
## WHAT
With the upgrade to Google Client, there is a new error popping up `Google::Apis::ClientError`.  This code handles those errors while reporting new ones that might pop-up in the future.

## WHY
Inspecting the payload shows:
```
@ClassroomDisabled The user is not permitted to access Classroom. \, In \"status\": \ "PERMISSION DENIED
```
Some teachers apparently do not have access to this API

## HOW
Add a wrapper that catches these errors and returns an empty array

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
