### PR TITLE
update scoring names around the site

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
@@ -430,7 +430,7 @@ $lightgray: #cecece;
   display: inline-block;
   margin-top: 15px;
   margin-right: 15px;
-  width: 193px;
+  width: min-content;
   padding: 10px;
   h3 {
     font-size: 20px;
@@ -441,8 +441,6 @@ $lightgray: #cecece;
   }
 }
 #individual-classroom-view {
-  margin: auto;
-  max-width: 950px;
   th, td {
     text-align: left;
     &:first-of-type {

--- a/services/QuillLMS/app/assets/stylesheets/pages/student_results.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_results.scss
@@ -13,7 +13,7 @@
       margin: 16px;
     }
     .results-icon-container {
-      width: 96px;
+      width: min-content;
       padding: 8px;
       border-radius: 8px;
       border: solid 1px #c1c1c1;

--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/activity_feed.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/activity_feed.scss
@@ -28,13 +28,13 @@
   .score-tag {
     border-radius: 4px;
     padding: 0 6px;
-    &.proficient {
+    &.frequently-demonstrated-skill {
       background-color: #dcedcc;
     }
-    &.nearly-proficient {
+    &.sometimes-demonstrated-skill {
       background-color: #ffeccc;
     }
-    &.not-yet-proficient {
+    &.rarely-demonstrated-skill {
       background-color: #ffe0e3;
     }
     &.completed {

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -59,6 +59,10 @@ class ActivitySession < ApplicationRecord
   NOT_YET_PROFICIENT = 'Not yet proficient'
   PROFICIENT = 'Proficient'
 
+  SOMETIMES_DEMONSTRATED_SKILL = 'Sometimes demonstrated skill'
+  RARELY_DEMONSTRATED_SKILL = 'Rarely demonstrated skill'
+  FREQUENTLY_DEMONSTRATED_SKILL = 'Frequently demonstrated skill'
+
   RESULTS_PER_PAGE = 25
 
   STATE_UNSTARTED = 'unstarted'

--- a/services/QuillLMS/app/models/teacher_activity_feed.rb
+++ b/services/QuillLMS/app/models/teacher_activity_feed.rb
@@ -54,11 +54,11 @@ class TeacherActivityFeed < RedisFeed
     return '' unless percentage
 
     if percentage >= ProficiencyEvaluator.proficiency_cutoff
-      ActivitySession::PROFICIENT
+      ActivitySession::FREQUENTLY_DEMONSTRATED_SKILL
     elsif percentage >= ProficiencyEvaluator.nearly_proficient_cutoff
-      ActivitySession::NEARLY_PROFICIENT
+      ActivitySession::SOMETIMES_DEMONSTRATED_SKILL
     else
-      ActivitySession::NOT_YET_PROFICIENT
+      ActivitySession::RARELY_DEMONSTRATED_SKILL
     end
   end
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/activities/results_page/results_icon.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/activities/results_page/results_icon.jsx
@@ -8,7 +8,7 @@ export default class ResultsIcon extends React.Component {
     let color = '#4ea500';
     if (scoreColor === 'red-score-color') {
       color = '#e73030';
-    } else if (scoreColor === 'yellow-score-color') {
+    } else if (scoreColor === 'orange-score-color') {
       color = '#eb9911';
     }
     return { backgroundColor: color };
@@ -37,12 +37,12 @@ export default class ResultsIcon extends React.Component {
 
   text = () => {
     const { percentage, } = this.props
-    let text = 'Not yet proficient'
+    let text = 'Rarely demonstrated skill'
 
-    if (percentage > 0.8) {
-      text = 'Proficient'
-    } else if (percentage > 0.6) {
-      text = 'Nearly proficient'
+    if (percentage >= 0.83) {
+      text = 'Frequently demonstrated skill'
+    } else if (percentage >= 0.32) {
+      text = 'Sometimes demonstrated skill'
     }
 
     return text

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
@@ -147,12 +147,12 @@ exports[`ActivityFeed component not on mobile should render when there are activ
           Object {
             "attribute": "activityName",
             "name": "Activity",
-            "width": "380px",
+            "width": "296px",
           },
           Object {
             "attribute": "scoreTag",
             "name": "Score",
-            "width": "124px",
+            "width": "210px",
           },
           Object {
             "attribute": "completed",
@@ -336,9 +336,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             scope="col"
             style={
               Object {
-                "minWidth": "380px",
+                "minWidth": "296px",
                 "textAlign": "left",
-                "width": "380px",
+                "width": "296px",
               }
             }
           >
@@ -349,9 +349,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             scope="col"
             style={
               Object {
-                "minWidth": "124px",
+                "minWidth": "210px",
                 "textAlign": "left",
-                "width": "124px",
+                "width": "210px",
               }
             }
           >
@@ -398,9 +398,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-33"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -411,9 +411,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-33"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -457,27 +457,79 @@ exports[`ActivityFeed component not on mobile should render when there are activ
               >
                 Angie Thomas
               </td>
-              <td
-                className="data-table-row-section undefined"
-                key="activityName-32"
-                style={
-                  Object {
-                    "minWidth": "380px",
-                    "textAlign": "left",
-                    "width": "380px",
+              <td>
+                <Tooltip
+                  isTabbable={true}
+                  key="activityName-32"
+                  tooltipText="Capitalize Names of People and the Pronoun \\"I\\""
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "296px",
+                      "textAlign": "left",
+                      "width": "296px",
+                    }
                   }
-                }
-              >
-                Capitalize Names of People and the Pronoun "I"
+                  tooltipTriggerText="Capitalize Names of People and the Pronoun \\"I\\""
+                  tooltipTriggerTextClass="data-table-row-section undefined"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "296px",
+                      "textAlign": "left",
+                      "width": "296px",
+                    }
+                  }
+                >
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "296px",
+                        "textAlign": "left",
+                        "width": "296px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section undefined"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "296px",
+                          "textAlign": "left",
+                          "width": "296px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      Capitalize Names of People and the Pronoun "I"
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section undefined"
                 key="scoreTag-32"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -526,9 +578,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-29"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -539,9 +591,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-29"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -590,9 +642,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-28"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -603,9 +655,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-28"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -654,9 +706,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-27"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -667,9 +719,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-27"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -718,9 +770,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-26"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -731,9 +783,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-26"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -782,9 +834,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-25"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -795,9 +847,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-25"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -846,9 +898,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-24"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -859,9 +911,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-24"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -910,9 +962,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-23"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -923,9 +975,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-23"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -974,9 +1026,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-3"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -987,9 +1039,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-3"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >
@@ -1038,9 +1090,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="activityName-2"
                 style={
                   Object {
-                    "minWidth": "380px",
+                    "minWidth": "296px",
                     "textAlign": "left",
-                    "width": "380px",
+                    "width": "296px",
                   }
                 }
               >
@@ -1051,9 +1103,9 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 key="scoreTag-2"
                 style={
                   Object {
-                    "minWidth": "124px",
+                    "minWidth": "210px",
                     "textAlign": "left",
-                    "width": "124px",
+                    "width": "210px",
                   }
                 }
               >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/activity_feed.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/activity_feed.tsx
@@ -10,11 +10,11 @@ const headers = [
     name: 'Student',
     attribute: 'studentName',
   }, {
-    width: '380px',
+    width: '296px',
     name: 'Activity',
     attribute: 'activityName',
   }, {
-    width: '124px',
+    width: '210px',
     name: 'Score',
     attribute: 'scoreTag',
   }, {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/class_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/class_report.jsx
@@ -121,7 +121,7 @@ export default class ClassReport extends React.Component {
     const overviewBoxes = students ? <OverviewBoxes data={students} /> : null
 
     return (
-      <div id='individual-classroom-view'>
+      <div className="container" id='individual-classroom-view'>
         {overviewBoxes}
         <div>
           <ProgressReport

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/overview_boxes.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/overview_boxes.jsx
@@ -23,13 +23,13 @@ export default class OverviewBoxes extends React.Component {
       proficiency
     if (group === 'red-score-color') {
       range = '0 - 31%';
-      proficiency = 'Not yet proficient'
+      proficiency = 'Rarely demonstrated skill'
     } else if (group === 'yellow-score-color') {
       range = '32 - 82%';
-      proficiency = 'Nearly proficient'
+      proficiency = 'Sometimes demonstrated skill'
     } else {
       range = '83 - 100%';
-      proficiency = 'Proficient'
+      proficiency = 'Frequently demonstrated skill'
     }
     return (
       <div className={'student-groupings ' + group} key={group}>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
@@ -19,12 +19,12 @@ exports[`ScoreLegend component should render 1`] = `
         <p
           className="title"
         >
-          Proficient
+          Frequently demonstrated skill
         </p>
         <p
           className="explanation"
         >
-          83-100%
+          100%-83% of prompts
         </p>
       </div>
     </div>
@@ -40,12 +40,12 @@ exports[`ScoreLegend component should render 1`] = `
         <p
           className="title"
         >
-          Nearly proficient
+          Sometimes demonstrated skill
         </p>
         <p
           className="explanation"
         >
-          32-82%
+          83%-31% of prompts
         </p>
       </div>
     </div>
@@ -61,12 +61,12 @@ exports[`ScoreLegend component should render 1`] = `
         <p
           className="title"
         >
-          Not yet proficient
+          Rarely demonstrated skill
         </p>
         <p
           className="explanation"
         >
-          0-31%
+          31%-0% of prompts
         </p>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
@@ -1,4 +1,3 @@
-'use strict';
 import React from 'react';
 
 import { proficiencyCutoffsAsPercentage } from '../../../../modules/proficiency_cutoffs.js';
@@ -13,22 +12,22 @@ export default class ScoreLegend extends React.Component {
           <div className="icon">
             <div className="icon-wrapper icon-green" />
             <div className="icons-description-wrapper">
-              <p className="title">Proficient</p>
-              <p className="explanation">{`${cutOff.proficient}-100%`}</p>
+              <p className="title">Frequently demonstrated skill</p>
+              <p className="explanation">{`100%-${cutOff.proficient}% of prompts`}</p>
             </div>
           </div>
           <div className="icon">
             <div className="icon-wrapper icon-orange" />
             <div className="icons-description-wrapper">
-              <p className="title">Nearly proficient</p>
-              <p className="explanation">{`${cutOff.nearlyProficient}-${cutOff.proficient - 1}%`}</p>
+              <p className="title">Sometimes demonstrated skill</p>
+              <p className="explanation">{`${cutOff.proficient}%-${cutOff.nearlyProficient - 1}% of prompts`}</p>
             </div>
           </div>
           <div className="icon">
             <div className="icon-wrapper icon-red" />
             <div className="icons-description-wrapper">
-              <p className="title">Not yet proficient</p>
-              <p className="explanation">{`0-${cutOff.nearlyProficient - 1}%`}</p>
+              <p className="title">Rarely demonstrated skill</p>
+              <p className="explanation">{`${cutOff.nearlyProficient - 1}%-0% of prompts`}</p>
             </div>
           </div>
           <Tooltip

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
@@ -961,7 +961,7 @@ exports[`StudentProfileUnit component should render 1`] = `
               "headerClassName": "name-section",
               "name": "Activity",
               "rowSectionClassName": "name-section",
-              "width": "560px",
+              "width": "474px",
             },
             Object {
               "attribute": "score",
@@ -969,7 +969,7 @@ exports[`StudentProfileUnit component should render 1`] = `
               "name": "Score",
               "noTooltip": true,
               "rowSectionClassName": "score-section tooltip-section",
-              "width": "144px",
+              "width": "230px",
             },
             Object {
               "attribute": "tool",
@@ -1026,7 +1026,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                   className="proficient"
                 />
                 <span>
-                  Proficient
+                  Frequently demonstrated skill
                 </span>
               </div>,
               "tool": undefined,
@@ -1050,7 +1050,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                   className="nearly-proficient"
                 />
                 <span>
-                  Nearly proficient
+                  Sometimes demonstrated skill
                 </span>
               </div>,
               "tool": undefined,
@@ -1069,9 +1069,9 @@ exports[`StudentProfileUnit component should render 1`] = `
               scope="col"
               style={
                 Object {
-                  "minWidth": "560px",
+                  "minWidth": "474px",
                   "textAlign": "left",
-                  "width": "560px",
+                  "width": "474px",
                 }
               }
             >
@@ -1082,9 +1082,9 @@ exports[`StudentProfileUnit component should render 1`] = `
               scope="col"
               style={
                 Object {
-                  "minWidth": "144px",
+                  "minWidth": "230px",
                   "textAlign": "left",
-                  "width": "144px",
+                  "width": "230px",
                 }
               }
             >
@@ -1153,9 +1153,9 @@ exports[`StudentProfileUnit component should render 1`] = `
                 key="name-9"
                 style={
                   Object {
-                    "minWidth": "560px",
+                    "minWidth": "474px",
                     "textAlign": "left",
-                    "width": "560px",
+                    "width": "474px",
                   }
                 }
               >
@@ -1166,9 +1166,9 @@ exports[`StudentProfileUnit component should render 1`] = `
                 key="score-9"
                 style={
                   Object {
-                    "minWidth": "144px",
+                    "minWidth": "230px",
                     "textAlign": "left",
-                    "width": "144px",
+                    "width": "230px",
                   }
                 }
               >
@@ -1179,7 +1179,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                     className="proficient"
                   />
                   <span>
-                    Proficient
+                    Frequently demonstrated skill
                   </span>
                 </div>
               </td>
@@ -1247,9 +1247,9 @@ exports[`StudentProfileUnit component should render 1`] = `
                 key="name-5"
                 style={
                   Object {
-                    "minWidth": "560px",
+                    "minWidth": "474px",
                     "textAlign": "left",
-                    "width": "560px",
+                    "width": "474px",
                   }
                 }
               >
@@ -1260,9 +1260,9 @@ exports[`StudentProfileUnit component should render 1`] = `
                 key="score-5"
                 style={
                   Object {
-                    "minWidth": "144px",
+                    "minWidth": "230px",
                     "textAlign": "left",
-                    "width": "144px",
+                    "width": "230px",
                   }
                 }
               >
@@ -1273,7 +1273,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                     className="nearly-proficient"
                   />
                   <span>
-                    Nearly proficient
+                    Sometimes demonstrated skill
                   </span>
                 </div>
               </td>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
@@ -3977,7 +3977,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                   "headerClassName": "name-section",
                   "name": "Activity",
                   "rowSectionClassName": "name-section",
-                  "width": "560px",
+                  "width": "474px",
                 },
                 Object {
                   "attribute": "score",
@@ -3985,7 +3985,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                   "name": "Score",
                   "noTooltip": true,
                   "rowSectionClassName": "score-section tooltip-section",
-                  "width": "144px",
+                  "width": "230px",
                 },
                 Object {
                   "attribute": "tool",
@@ -4042,7 +4042,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                       className="proficient"
                     />
                     <span>
-                      Proficient
+                      Frequently demonstrated skill
                     </span>
                   </div>,
                   "tool": undefined,
@@ -4066,7 +4066,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                       className="nearly-proficient"
                     />
                     <span>
-                      Nearly proficient
+                      Sometimes demonstrated skill
                     </span>
                   </div>,
                   "tool": undefined,
@@ -4085,9 +4085,9 @@ exports[`StudentProfileUnits component should render only completed activities i
                   scope="col"
                   style={
                     Object {
-                      "minWidth": "560px",
+                      "minWidth": "474px",
                       "textAlign": "left",
-                      "width": "560px",
+                      "width": "474px",
                     }
                   }
                 >
@@ -4098,9 +4098,9 @@ exports[`StudentProfileUnits component should render only completed activities i
                   scope="col"
                   style={
                     Object {
-                      "minWidth": "144px",
+                      "minWidth": "230px",
                       "textAlign": "left",
-                      "width": "144px",
+                      "width": "230px",
                     }
                   }
                 >
@@ -4169,9 +4169,9 @@ exports[`StudentProfileUnits component should render only completed activities i
                     key="name-9"
                     style={
                       Object {
-                        "minWidth": "560px",
+                        "minWidth": "474px",
                         "textAlign": "left",
-                        "width": "560px",
+                        "width": "474px",
                       }
                     }
                   >
@@ -4182,9 +4182,9 @@ exports[`StudentProfileUnits component should render only completed activities i
                     key="score-9"
                     style={
                       Object {
-                        "minWidth": "144px",
+                        "minWidth": "230px",
                         "textAlign": "left",
-                        "width": "144px",
+                        "width": "230px",
                       }
                     }
                   >
@@ -4195,7 +4195,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                         className="proficient"
                       />
                       <span>
-                        Proficient
+                        Frequently demonstrated skill
                       </span>
                     </div>
                   </td>
@@ -4263,9 +4263,9 @@ exports[`StudentProfileUnits component should render only completed activities i
                     key="name-5"
                     style={
                       Object {
-                        "minWidth": "560px",
+                        "minWidth": "474px",
                         "textAlign": "left",
-                        "width": "560px",
+                        "width": "474px",
                       }
                     }
                   >
@@ -4276,9 +4276,9 @@ exports[`StudentProfileUnits component should render only completed activities i
                     key="score-5"
                     style={
                       Object {
-                        "minWidth": "144px",
+                        "minWidth": "230px",
                         "textAlign": "left",
-                        "width": "144px",
+                        "width": "230px",
                       }
                     }
                   >
@@ -4289,7 +4289,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                         className="nearly-proficient"
                       />
                       <span>
-                        Nearly proficient
+                        Sometimes demonstrated skill
                       </span>
                     </div>
                   </td>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -64,13 +64,13 @@ const incompleteHeaders = [
 
 const completeHeaders = [
   {
-    width: '560px',
+    width: '474px',
     name: 'Activity',
     attribute: 'name',
     headerClassName: 'name-section',
     rowSectionClassName: 'name-section'
   }, {
-    width: '144px',
+    width: '230px',
     name: 'Score',
     attribute: 'score',
     noTooltip: true,
@@ -191,14 +191,14 @@ export default class StudentProfileUnit extends React.Component {
     }
 
     if (maxPercentage >= PROFICIENT_CUTOFF) {
-      return (<div className="score"><div className="proficient" /><span>Proficient</span></div>)
+      return (<div className="score"><div className="proficient" /><span>Frequently demonstrated skill</span></div>)
     }
 
     if (maxPercentage >= NEARLY_PROFICIENT_CUTOFF) {
-      return (<div className="score"><div className="nearly-proficient" /><span>Nearly proficient</span></div>)
+      return (<div className="score"><div className="nearly-proficient" /><span>Sometimes demonstrated skill</span></div>)
     }
 
-    return (<div className="score"><div className="not-yet-proficient" /><span>Not yet proficient</span></div>)
+    return (<div className="score"><div className="not-yet-proficient" /><span>Rarely demonstrated skill</span></div>)
   }
 
   toolIcon = (key) => {

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/ResultsPage.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/ResultsPage.jsx
@@ -15,18 +15,6 @@ export default class ResultsPage extends React.Component {
     )
   }
 
-  coloredSquareClassName = (category) => {
-    const { resultCategoryNames, } = this.props
-    switch(category) {
-      case resultCategoryNames.PROFICIENT:
-        return 'proficient'
-      case resultCategoryNames.NEARLY_PROFICIENT:
-        return 'nearly-proficient'
-      default:
-        return 'not-yet-proficient'
-    }
-  }
-
   headerButton = () => {
     const { integrationPartnerName, integrationPartnerSessionId, anonymous, classroomId, } = this.props
     const buttonClassName = 'quill-button primary contained large focus-on-light'
@@ -82,10 +70,6 @@ export default class ResultsPage extends React.Component {
 
     return (
       <div className="result-section" key={category}>
-        <div className="result-section-header">
-          <div className={`colored-square ${this.coloredSquareClassName(category)}`} />
-          <span>{category}</span>
-        </div>
         <h2>{this.resultSectionDescription(category)}</h2>
         <ul>{results}</ul>
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/ResultsPage.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/ResultsPage.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`ResultsPage container anonymous should render 1`] = `
             className="icon"
             style={
               Object {
-                "backgroundColor": "#4ea500",
+                "backgroundColor": "#eb9911",
               }
             }
           >
@@ -57,7 +57,7 @@ exports[`ResultsPage container anonymous should render 1`] = `
             />
           </div>
           <span>
-            Nearly proficient
+            Sometimes demonstrated skill
           </span>
         </div>
       </ResultsIcon>
@@ -85,16 +85,6 @@ exports[`ResultsPage container anonymous should render 1`] = `
           className="result-section"
           key="Nearly proficient"
         >
-          <div
-            className="result-section-header"
-          >
-            <div
-              className="colored-square nearly-proficient"
-            />
-            <span>
-              Nearly proficient
-            </span>
-          </div>
           <h2>
             Concepts you have almost mastered. Keep practicing!
           </h2>
@@ -110,16 +100,6 @@ exports[`ResultsPage container anonymous should render 1`] = `
           className="result-section"
           key="Not yet proficient"
         >
-          <div
-            className="result-section-header"
-          >
-            <div
-              className="colored-square not-yet-proficient"
-            />
-            <span>
-              Not yet proficient
-            </span>
-          </div>
           <h2>
             Concepts you have not mastered yet. Try again!
           </h2>
@@ -135,16 +115,6 @@ exports[`ResultsPage container anonymous should render 1`] = `
           className="result-section"
           key="Proficient"
         >
-          <div
-            className="result-section-header"
-          >
-            <div
-              className="colored-square proficient"
-            />
-            <span>
-              Proficient
-            </span>
-          </div>
           <h2>
             Concepts you have mastered. Good work!
           </h2>
@@ -220,7 +190,7 @@ exports[`ResultsPage container integration should render 1`] = `
             className="icon"
             style={
               Object {
-                "backgroundColor": "#4ea500",
+                "backgroundColor": "#eb9911",
               }
             }
           >
@@ -230,7 +200,7 @@ exports[`ResultsPage container integration should render 1`] = `
             />
           </div>
           <span>
-            Nearly proficient
+            Sometimes demonstrated skill
           </span>
         </div>
       </ResultsIcon>
@@ -258,16 +228,6 @@ exports[`ResultsPage container integration should render 1`] = `
           className="result-section"
           key="Nearly proficient"
         >
-          <div
-            className="result-section-header"
-          >
-            <div
-              className="colored-square nearly-proficient"
-            />
-            <span>
-              Nearly proficient
-            </span>
-          </div>
           <h2>
             Concepts you have almost mastered. Keep practicing!
           </h2>
@@ -283,16 +243,6 @@ exports[`ResultsPage container integration should render 1`] = `
           className="result-section"
           key="Not yet proficient"
         >
-          <div
-            className="result-section-header"
-          >
-            <div
-              className="colored-square not-yet-proficient"
-            />
-            <span>
-              Not yet proficient
-            </span>
-          </div>
           <h2>
             Concepts you have not mastered yet. Try again!
           </h2>
@@ -308,16 +258,6 @@ exports[`ResultsPage container integration should render 1`] = `
           className="result-section"
           key="Proficient"
         >
-          <div
-            className="result-section-header"
-          >
-            <div
-              className="colored-square proficient"
-            />
-            <span>
-              Proficient
-            </span>
-          </div>
           <h2>
             Concepts you have mastered. Good work!
           </h2>
@@ -391,7 +331,7 @@ exports[`ResultsPage container not anonymous should render 1`] = `
             className="icon"
             style={
               Object {
-                "backgroundColor": "#4ea500",
+                "backgroundColor": "#eb9911",
               }
             }
           >
@@ -401,7 +341,7 @@ exports[`ResultsPage container not anonymous should render 1`] = `
             />
           </div>
           <span>
-            Nearly proficient
+            Sometimes demonstrated skill
           </span>
         </div>
       </ResultsIcon>
@@ -429,16 +369,6 @@ exports[`ResultsPage container not anonymous should render 1`] = `
           className="result-section"
           key="Nearly proficient"
         >
-          <div
-            className="result-section-header"
-          >
-            <div
-              className="colored-square nearly-proficient"
-            />
-            <span>
-              Nearly proficient
-            </span>
-          </div>
           <h2>
             Concepts you have almost mastered. Keep practicing!
           </h2>
@@ -454,16 +384,6 @@ exports[`ResultsPage container not anonymous should render 1`] = `
           className="result-section"
           key="Not yet proficient"
         >
-          <div
-            className="result-section-header"
-          >
-            <div
-              className="colored-square not-yet-proficient"
-            />
-            <span>
-              Not yet proficient
-            </span>
-          </div>
           <h2>
             Concepts you have not mastered yet. Try again!
           </h2>
@@ -479,16 +399,6 @@ exports[`ResultsPage container not anonymous should render 1`] = `
           className="result-section"
           key="Proficient"
         >
-          <div
-            className="result-section-header"
-          >
-            <div
-              className="colored-square proficient"
-            />
-            <span>
-              Proficient
-            </span>
-          </div>
           <h2>
             Concepts you have mastered. Good work!
           </h2>

--- a/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_activity_feed_spec.rb
@@ -21,11 +21,11 @@ describe TeacherActivityFeed, type: :model do
 
         expect(feed.first[:id]).to eq(activity_session2.id)
         expect(feed.first[:completed]).to eq("2 mins ago")
-        expect(feed.first[:score]).to eq("Nearly proficient")
+        expect(feed.first[:score]).to eq(ActivitySession::SOMETIMES_DEMONSTRATED_SKILL)
 
         expect(feed.last[:id]).to eq(activity_session.id)
         expect(feed.last[:completed]).to eq("5 mins ago")
-        expect(feed.last[:score]).to eq("Proficient")
+        expect(feed.last[:score]).to eq(ActivitySession::FREQUENTLY_DEMONSTRATED_SKILL)
       end
     end
 
@@ -44,7 +44,7 @@ describe TeacherActivityFeed, type: :model do
 
         expect(feed.first[:id]).to eq(activity_session.id)
         expect(feed.first[:completed]).to eq("5 mins ago")
-        expect(feed.first[:score]).to eq("Proficient")
+        expect(feed.first[:score]).to eq(ActivitySession::FREQUENTLY_DEMONSTRATED_SKILL)
       end
     end
   end
@@ -117,26 +117,26 @@ describe TeacherActivityFeed, type: :model do
     end
 
     context 'when the activity session percentage is at or above the proficiency cutoff' do
-      it "returns #{ActivitySession::PROFICIENT}" do
+      it "returns #{ActivitySession::FREQUENTLY_DEMONSTRATED_SKILL}" do
         text = feed.send(:text_for_score, proficient_activity_session.classification.key, proficient_activity_session.percentage)
 
-        expect(text).to eq(ActivitySession::PROFICIENT)
+        expect(text).to eq(ActivitySession::FREQUENTLY_DEMONSTRATED_SKILL)
       end
     end
 
     context 'when the activity session percentage is at or above the nearly proficient cutoff' do
-      it "returns #{ActivitySession::NEARLY_PROFICIENT}" do
+      it "returns #{ActivitySession::SOMETIMES_DEMONSTRATED_SKILL}" do
         text = feed.send(:text_for_score, nearly_proficient_activity_session.classification.key, nearly_proficient_activity_session.percentage)
 
-        expect(text).to eq(ActivitySession::NEARLY_PROFICIENT)
+        expect(text).to eq(ActivitySession::SOMETIMES_DEMONSTRATED_SKILL)
       end
     end
 
     context 'when the activity session percentage is below the nearly proficient cutoff' do
-      it "returns #{ActivitySession::NOT_YET_PROFICIENT}" do
+      it "returns #{ActivitySession::RARELY_DEMONSTRATED_SKILL}" do
         text = feed.send(:text_for_score, not_yet_proficient_activity_session.classification.key, not_yet_proficient_activity_session.percentage)
 
-        expect(text).to eq(ActivitySession::NOT_YET_PROFICIENT)
+        expect(text).to eq(ActivitySession::RARELY_DEMONSTRATED_SKILL)
       end
     end
 


### PR DESCRIPTION
## WHAT
Update language we use around the site to say "Frequently/sometimes/rarely demonstrated skill" rather than "Proficient/Nearly proficient/Not yet proficient".

## WHY
This is a follow-up to the scoring changes we've made recently.

## HOW
Find the places identified in the spec and update them. Note: the code itself still largely uses the language of proficiency; I made a follow-up card to clean that up but wanted to get this out sooner so teachers are less likely to be confused by a change.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-Names-of-Scoring-Explanation-of-Frequently-Sometimes-Rarely-Demonstrated-Skill-a439297c7de4473fbb2a4481e202b78c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES