### PR TITLE
Add padding around quill academy button

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/quill_academy.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/quill_academy.scss
@@ -39,6 +39,7 @@
       flex-direction: column;
       align-items: center;
       text-decoration: none;
+      padding: 32px;
       &.premium-user {
         box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
         border-radius: 30px;


### PR DESCRIPTION
## WHAT
Add 32px padding around the Quill academy button

## WHY
The button needs to breathe

## HOW
Update the scss file

### Screenshots
![Screenshot 2023-08-09 at 8 10 42 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/fa40452e-f8f3-40c6-b90a-87a73e8b7cd3)


### Notion Card Links
https://www.notion.so/quill/UI-Layout-Bug-in-Quill-Academy-Landing-Page-1049fcdc75e444f5b8f8f07c5ecc3675?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Manual check for styling change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
