### PR TITLE
make sure to create/update admin info record when making users admins from cms

### DIFF
--- a/services/QuillLMS/app/controllers/cms/district_admins_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/district_admins_controller.rb
@@ -52,6 +52,9 @@ class Cms::DistrictAdminsController < Cms::CmsController
     district_admin = @district.district_admins.build(user_id: user.id)
 
     if district_admin.save!
+      admin_info = AdminInfo.find_or_create_by!(user: user)
+      admin_info.update(approver_role: User::STAFF, approval_status: AdminInfo::APPROVED)
+
       determine_district_admin_worker(user.id, @district.id, new_user)
       returned_message = new_user ? t('district_admin.new_account') : t('district_admin.existing_account')
       render json: { message: returned_message }, status: 200

--- a/services/QuillLMS/app/controllers/cms/school_admins_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/school_admins_controller.rb
@@ -72,6 +72,9 @@ class Cms::SchoolAdminsController < Cms::CmsController
     new_school_admin = user.schools_admins.build(school_id: school_id)
 
     if new_school_admin.save!
+      admin_info = AdminInfo.find_or_create_by!(user: user)
+      admin_info.update(approver_role: User::STAFF, approval_status: AdminInfo::APPROVED)
+
       handle_school_admin_save(user, school_id, new_user)
     else
       render json: { error: new_school_admin.errors.messages }

--- a/services/QuillLMS/spec/controllers/cms/school_admins_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/school_admins_controller_spec.rb
@@ -15,69 +15,103 @@ describe Cms::SchoolAdminsController do
   end
 
   describe '#create' do
-    it 'creates a new user account and school admin for a new user and sends the expected email' do
-      Sidekiq::Testing.inline! do
-        post :create, params: { school_id: school1.id, email: 'test@email.com', first_name: 'Test', last_name: 'User' }
+    describe 'for a new user' do
+      it 'creates the user admin info record as staff approved' do
+        post :create, params: { school_id: school1.id, email: new_user_email, first_name: 'Test', last_name: 'User' }
 
         new_user = User.find_by(email: 'test@email.com')
-        expect(new_user).to be
-        expect(SchoolsAdmins.find_by_user_id(new_user.id)).to be
-        expect(school1.users.last).to eq(new_user)
-        expect(ActionMailer::Base.deliveries.last.subject).to eq('[Action Required] Test, a Quill school admin account was created for you')
-        expect(ActionMailer::Base.deliveries.last.to).to eq(['test@email.com'])
+        expect(new_user.admin_info.approver_role).to eq(User::STAFF)
+        expect(new_user.admin_info.approval_status).to eq(AdminInfo::APPROVED)
+      end
+
+      it 'creates a new user account and school admin and sends the expected email' do
+        Sidekiq::Testing.inline! do
+          post :create, params: { school_id: school1.id, email: 'test@email.com', first_name: 'Test', last_name: 'User' }
+
+          new_user = User.find_by(email: 'test@email.com')
+          expect(new_user).to be
+          expect(SchoolsAdmins.find_by_user_id(new_user.id)).to be
+          expect(school1.users.last).to eq(new_user)
+          expect(ActionMailer::Base.deliveries.last.subject).to eq('[Action Required] Test, a Quill school admin account was created for you')
+          expect(ActionMailer::Base.deliveries.last.to).to eq(['test@email.com'])
+        end
       end
     end
 
-    it 'creates a new school admin for an existing user with no linked school and sends the expected email' do
-      Sidekiq::Testing.inline! do
-        post :create, params: { school_id: school1.id, email: admin1.email}
+    describe 'for an existing admin user' do
+      describe 'who already has an admin info record' do
+        let!(:admin_info) { create(:admin_info, user: admin1, approval_status: AdminInfo::PENDING, approver_role: User::ADMIN )}
 
-        body_contains_expected_content = ActionMailer::Base.deliveries.last.encoded.include?("To receive access to premium features, please link your account")
+        it 'updates the admin info record to be staff approved' do
+          post :create, params: { school_id: school1.id, email: admin1.email}
 
-        expect(SchoolsAdmins.find_by_user_id(admin1.id)).to be
-        expect(ActionMailer::Base.deliveries.last.subject).to eq("#{admin1.first_name}, you are now a Quill admin for #{school1.name}")
-        expect(ActionMailer::Base.deliveries.last.to).to eq([admin1.email])
-        expect(body_contains_expected_content).to be true
+          expect(admin1.admin_info.reload.approver_role).to eq(User::STAFF)
+          expect(admin1.admin_info.reload.approval_status).to eq(AdminInfo::APPROVED)
+        end
       end
+
+      describe 'who does not already have an admin info record' do
+        it 'creates the admin info record as staff approved' do
+          post :create, params: { school_id: school1.id, email: admin1.email}
+
+          expect(admin1.admin_info.approver_role).to eq(User::STAFF)
+          expect(admin1.admin_info.approval_status).to eq(AdminInfo::APPROVED)
+        end
+      end
+
+      it 'creates a new school admin with no linked school and sends the expected email' do
+        Sidekiq::Testing.inline! do
+          post :create, params: { school_id: school1.id, email: admin1.email}
+
+          body_contains_expected_content = ActionMailer::Base.deliveries.last.encoded.include?("To receive access to premium features, please link your account")
+
+          expect(SchoolsAdmins.find_by_user_id(admin1.id)).to be
+          expect(ActionMailer::Base.deliveries.last.subject).to eq("#{admin1.first_name}, you are now a Quill admin for #{school1.name}")
+          expect(ActionMailer::Base.deliveries.last.to).to eq([admin1.email])
+          expect(body_contains_expected_content).to be true
+        end
+      end
+
+      it 'creates a new school admin linked to school and sends the expected email' do
+        Sidekiq::Testing.inline! do
+          school1.users.push(admin1)
+          admin1.reload
+          post :create, params: { school_id: school1.id, email: admin1.email}
+
+          body_contains_expected_content = !ActionMailer::Base.deliveries.last.encoded.include?("To receive access to premium features, please link your account")
+          expect(SchoolsAdmins.find_by_user_id(admin1.id)).to be
+          expect(ActionMailer::Base.deliveries.last.subject).to eq("#{admin1.first_name}, you are now a Quill admin for #{school1.name}")
+          expect(ActionMailer::Base.deliveries.last.to).to eq([admin1.email])
+          expect(body_contains_expected_content).to be true
+        end
+      end
+
+      it 'creates a new school admin linked to a different school and sends the expected email' do
+        Sidekiq::Testing.inline! do
+          school2.users.push(admin2)
+          admin2.reload
+          post :create, params: { school_id: school1.id, email: admin2.email}
+
+          body_contains_expected_content = ActionMailer::Base.deliveries.last.encoded.include?("Your account is currently linked to #{school2.name}")
+          expect(SchoolsAdmins.find_by_user_id(admin2.id)).to be
+          expect(ActionMailer::Base.deliveries.last.subject).to eq("#{admin2.first_name}, you are now a Quill admin for #{school1.name}")
+          expect(ActionMailer::Base.deliveries.last.to).to eq([admin2.email])
+          expect(body_contains_expected_content).to be true
+        end
+      end
+
+      it 'creates a new school admin for an existing admin user and does not send an additional email' do
+        Sidekiq::Testing.inline! do
+          school2.users.push(admin2)
+          admin2.reload
+          post :create, params: { school_id: school1.id, email: admin2.email}
+          post :create, params: { school_id: school2.id, email: admin2.email}
+
+          expect(ActionMailer::Base.deliveries.count).to eq(1)
+        end
+      end
+
     end
 
-    it 'creates a new school admin for an existing user linked to school and sends the expected email' do
-      Sidekiq::Testing.inline! do
-        school1.users.push(admin1)
-        admin1.reload
-        post :create, params: { school_id: school1.id, email: admin1.email}
-
-        body_contains_expected_content = !ActionMailer::Base.deliveries.last.encoded.include?("To receive access to premium features, please link your account")
-        expect(SchoolsAdmins.find_by_user_id(admin1.id)).to be
-        expect(ActionMailer::Base.deliveries.last.subject).to eq("#{admin1.first_name}, you are now a Quill admin for #{school1.name}")
-        expect(ActionMailer::Base.deliveries.last.to).to eq([admin1.email])
-        expect(body_contains_expected_content).to be true
-      end
-    end
-
-    it 'creates a new school admin for an existing user linked to a different school and sends the expected email' do
-      Sidekiq::Testing.inline! do
-        school2.users.push(admin2)
-        admin2.reload
-        post :create, params: { school_id: school1.id, email: admin2.email}
-
-        body_contains_expected_content = ActionMailer::Base.deliveries.last.encoded.include?("Your account is currently linked to #{school2.name}")
-        expect(SchoolsAdmins.find_by_user_id(admin2.id)).to be
-        expect(ActionMailer::Base.deliveries.last.subject).to eq("#{admin2.first_name}, you are now a Quill admin for #{school1.name}")
-        expect(ActionMailer::Base.deliveries.last.to).to eq([admin2.email])
-        expect(body_contains_expected_content).to be true
-      end
-    end
-
-    it 'creates a new school admin for an existing admin user and does not send an additional email' do
-      Sidekiq::Testing.inline! do
-        school2.users.push(admin2)
-        admin2.reload
-        post :create, params: { school_id: school1.id, email: admin2.email}
-        post :create, params: { school_id: school2.id, email: admin2.email}
-
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-      end
-    end
   end
 end


### PR DESCRIPTION
## WHAT
When making a user an admin for a school from the School or District CMS, create or update their `AdminInfo` record to be staff approved.

## WHY
We were running into weird bugs where staff members would make someone an admin, but they'd have an existing pending request to other admins in their school, making it so that they still couldn't actually access premium features.

## HOW
Just do a lookup after saving the record.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/The-Make-Admin-link-in-a-school-s-profile-in-the-CMS-does-not-lead-to-an-admin-verification-request--5d5c30ef7293438d9b024db7c71b67a1?pvs=4
https://www.notion.so/268fb61789c541f9975d1b46b955fc48?pvs=25

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A