### PR TITLE
adjust displayed scoring bands

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
@@ -45,7 +45,7 @@ exports[`ScoreLegend component should render 1`] = `
         <p
           className="explanation"
         >
-          83%-31% of prompts
+          82%-32% of prompts
         </p>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
@@ -20,7 +20,7 @@ export default class ScoreLegend extends React.Component {
             <div className="icon-wrapper icon-orange" />
             <div className="icons-description-wrapper">
               <p className="title">Sometimes demonstrated skill</p>
-              <p className="explanation">{`${cutOff.proficient}%-${cutOff.nearlyProficient - 1}% of prompts`}</p>
+              <p className="explanation">{`${cutOff.proficient - 1}%-${cutOff.nearlyProficient}% of prompts`}</p>
             </div>
           </div>
           <div className="icon">


### PR DESCRIPTION
## WHAT
Adjust the scoring bands we display on the Activity Summary.

## WHY
So there's no overlap.

## HOW
Just modify how the middle band is displayed.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Percentage-scores-in-student-reports-848596c0a8cb42c0b68e97de96372b2d?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES