### PR TITLE
Fix Diagnostic Report Student Results popover layout

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_results_summary.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_results_summary.scss
@@ -352,8 +352,10 @@
         max-height: 100vh;
         overflow: scroll;
         header {
+          width: 512px;
           padding: 0px 20px;
           display: flex;
+          flex-direction: row;
           justify-content: space-between;
           align-items: center;
           h3 {


### PR DESCRIPTION
## WHAT
Fix Diagnostic Report popover layout for Student Results

## WHY
we don't want this to be scrollable

## HOW
just tweak the CSS

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Layout-issue-on-the-Growth-Diagnostic-Student-Results-report-1152163430ab43589efa5a31b6b491ed

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- small CSS change
Have you deployed to Staging? | no-- small CSS change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
