### PR TITLE
Fix activities all time query

### DIFF
--- a/services/QuillLMS/app/queries/impact_metrics/activities_all_time_query.rb
+++ b/services/QuillLMS/app/queries/impact_metrics/activities_all_time_query.rb
@@ -2,11 +2,6 @@
 
 module ImpactMetrics
   class ActivitiesAllTimeQuery < ::QuillBigQuery::Query
-
-    def initialize(options)
-      super(**options)
-    end
-
     def run
       run_query
     end


### PR DESCRIPTION
## WHAT
Fix a [bug](https://quillorg-5s.sentry.io/issues/4384788100/?project=11238&query=is%3Aunresolved&referrer=issue-stream&sort=user&statsPeriod=24h&stream_index=1) with ActivitiesAllTimeQuery

## WHY
Ruby3 changed how keyword arguments are handled.

## HOW
Remove initialize method since it's a pass through:
```
def initialize(**options)
  super(**options)
end
```
and Rubocop will complain.  Let the superclass handle it.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
