### PR TITLE
Convert snapshot payload type to array

### DIFF
--- a/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
@@ -12,7 +12,7 @@ module Snapshots
 
     def perform(cache_key, query, user_id, timeframe, school_ids, filters)
       payload = generate_payload(query, timeframe, school_ids, filters)
-      Rails.cache.write(cache_key, payload, expires_in: cache_expiry)
+      Rails.cache.write(cache_key, payload.to_a, expires_in: cache_expiry)
 
       PusherTrigger.run(user_id, PUSHER_EVENT,
         {

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -19,7 +19,7 @@ module Snapshots
     def perform(cache_key, query, user_id, timeframe, school_ids, filters)
       payload = generate_payload(query, timeframe, school_ids, filters)
 
-      Rails.cache.write(cache_key, payload, expires_in: cache_expiry)
+      Rails.cache.write(cache_key, payload.to_a, expires_in: cache_expiry)
 
       PusherTrigger.run(user_id, PUSHER_EVENT,
         {


### PR DESCRIPTION
## WHAT
Fix a [couple](https://quillorg-5s.sentry.io/issues/4380605319/?project=11238&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=1) of [regressions](https://quillorg-5s.sentry.io/issues/4381057874/?project=11238&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=0) involving snapshots worker calls

## WHY
With the update of the bigquery gem, the return type of some of the queries is `Google::Cloud::Bigquery::Data` which Rails.cache.write doesn't know how to handle.

## HOW
Just do a `payload.to_a` so that the cache store can handle it properly.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Verified manually.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
