### PR TITLE
Fix signet:authorization error

### DIFF
--- a/services/QuillLMS/app/models/google_integration/teacher_classrooms_data.rb
+++ b/services/QuillLMS/app/models/google_integration/teacher_classrooms_data.rb
@@ -17,7 +17,7 @@ module GoogleIntegration
 
     private def classrooms_data
       JSON
-        .parse(serialized_classrooms_data)
+        .parse(serialized_classrooms_data || [].to_json)
         .map(&:deep_symbolize_keys)
         .map { |data| data.merge(teacher_id: user.id) }
     end

--- a/services/QuillLMS/app/services/google_integration/authorization_client_fetcher.rb
+++ b/services/QuillLMS/app/services/google_integration/authorization_client_fetcher.rb
@@ -2,8 +2,6 @@
 
 module GoogleIntegration
   class AuthorizationClientFetcher < ::ApplicationService
-    TOKEN_CREDENTIAL_URI = 'https://oauth2.googleapis.com/token'
-
     attr_reader :auth_credential
 
     def initialize(auth_credential)
@@ -11,24 +9,28 @@ module GoogleIntegration
     end
 
     def run
+      validate_refresh_token
       refresh_access_token
-      client
+      fetch_signet_client
     end
 
-    private def client
-      @client ||=
-        Signet::OAuth2::Client.new(
-          client_id: Auth::Google::CLIENT_ID,
-          client_secret: Auth::Google::CLIENT_SECRET,
-          refresh_token: auth_credential.refresh_token,
-          token_credential_uri: TOKEN_CREDENTIAL_URI
-        )
+    private def fetch_signet_client
+      SignetClientFetcher.run(refresh_token)
     end
 
     private def refresh_access_token
       return unless auth_credential.access_token_expired?
 
-      AccessTokenRefresher.run(auth_credential, client)
+      AccessTokenRefresher.run(auth_credential)
+    end
+
+    private def refresh_token
+      # reload in case the AccessTokenRefresher updated the refresh_token
+      auth_credential.reload.refresh_token
+    end
+
+    private def validate_refresh_token
+      RefreshTokenValidator.run(auth_credential)
     end
   end
 end

--- a/services/QuillLMS/app/services/google_integration/refresh_token_validator.rb
+++ b/services/QuillLMS/app/services/google_integration/refresh_token_validator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module GoogleIntegration
+  class RefreshTokenValidator < ::ApplicationService
+    class ClientFetchAccessTokenError < ::StandardError; end
+
+    MINIMUM_ACCESS_SCOPE = ['openid'].freeze
+
+    attr_reader :auth_credential
+
+    delegate :refresh_token, to: :auth_credential
+
+    def initialize(auth_credential)
+      @auth_credential = auth_credential
+    end
+
+    def run
+      client.fetch_access_token!
+    rescue ::Signet::AuthorizationError => e
+      auth_credential.destroy!
+      raise ClientFetchAccessTokenError, e
+    end
+
+    private def client
+      SignetClientFetcher.run(refresh_token, scope: MINIMUM_ACCESS_SCOPE)
+    end
+  end
+end

--- a/services/QuillLMS/app/services/google_integration/signet_client_fetcher.rb
+++ b/services/QuillLMS/app/services/google_integration/signet_client_fetcher.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module GoogleIntegration
+  class SignetClientFetcher < ::ApplicationService
+    class NilRefreshTokenError < ::StandardError; end
+
+    TOKEN_CREDENTIAL_URI = 'https://oauth2.googleapis.com/token'
+
+    attr_reader :refresh_token, :options
+
+    def initialize(refresh_token, **options)
+      @refresh_token = refresh_token
+      @options = options
+    end
+
+    def run
+      raise NilRefreshTokenError if refresh_token.nil?
+
+      ::Signet::OAuth2::Client.new(client_args)
+    end
+
+    private def base_args
+      {
+        client_id: ::Auth::Google::CLIENT_ID,
+        client_secret: ::Auth::Google::CLIENT_SECRET,
+        refresh_token: refresh_token,
+        token_credential_uri: TOKEN_CREDENTIAL_URI
+      }
+    end
+
+    private def client_args
+      base_args.merge(**options)
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/google_integration/teacher_classrooms_data_spec.rb
+++ b/services/QuillLMS/spec/models/google_integration/teacher_classrooms_data_spec.rb
@@ -8,6 +8,12 @@ module GoogleIntegration
 
     subject { described_class.new(teacher, serialized_classrooms_data) }
 
+    context 'nil serialized_classrooms_data' do
+      let(:serialized_classrooms_data) { nil }
+
+      it { expect(subject.count).to eq 0 }
+    end
+
     context 'no classrooms' do
       let(:serialized_classrooms_data) { [].to_json }
 

--- a/services/QuillLMS/spec/services/google_integration/access_token_refresher_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/access_token_refresher_spec.rb
@@ -4,26 +4,43 @@ require 'rails_helper'
 
 module GoogleIntegration
   RSpec.describe AccessTokenRefresher do
-    subject { described_class.run(auth_credential, authorization_client) }
+    subject { described_class.run(auth_credential) }
 
     let(:auth_credential) { create(:google_auth_credential) }
-
-    let(:authorization_client) do
-      instance_double(
-        Signet::OAuth2::Client,
-        refresh!: nil,
-        access_token: access_token,
-        refresh_token: refresh_token,
-        expires_at: expires_at
-      )
-    end
+    let(:signet_authorization_error) { ::Signet::AuthorizationError.new('error') }
 
     let(:access_token) { 'access_token' }
     let(:refresh_token) { 'refresh_token' }
     let(:expires_at) { 1.hour.from_now }
 
-    it { expect { subject }.to change(auth_credential, :access_token).to(access_token) }
-    it { expect { subject }.to change(auth_credential, :refresh_token).to(refresh_token) }
-    it { expect { subject }.to change(auth_credential, :expires_at).to(be_within(1.second).of(1.hour.from_now)) }
+    let(:client) do
+      double(
+        Signet::OAuth2::Client,
+        access_token: access_token,
+        expires_at: expires_at,
+        refresh!: nil,
+        refresh_token: refresh_token
+      )
+    end
+
+    before { allow(SignetClientFetcher).to receive(:run).with(auth_credential.refresh_token).and_return(client) }
+
+    context 'when the refresh token is invalid' do
+      before { allow(client).to receive(:refresh!).and_raise(signet_authorization_error) }
+
+      it { expect { subject }.to raise_error(described_class::ClientRefreshError) }
+
+      it 'destroys auth credential if token cannot be refreshed' do
+        subject
+      rescue described_class::ClientRefreshError
+        expect(auth_credential).not_to be_persisted
+      end
+    end
+
+    context 'when the refresh token is valid' do
+      it { expect { subject }.to change { auth_credential.reload.access_token }.to(access_token) }
+      it { expect { subject }.to change { auth_credential.reload.expires_at }.to(expires_at) }
+      it { expect { subject }.to change { auth_credential.reload.refresh_token }.to(refresh_token) }
+    end
   end
 end

--- a/services/QuillLMS/spec/services/google_integration/access_token_refresher_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/access_token_refresher_spec.rb
@@ -39,7 +39,7 @@ module GoogleIntegration
 
     context 'when the refresh token is valid' do
       it { expect { subject }.to change { auth_credential.reload.access_token }.to(access_token) }
-      it { expect { subject }.to change { auth_credential.reload.expires_at }.to(expires_at) }
+      it { expect { subject }.to change { auth_credential.reload.expires_at }.to(be_within(1.second).of(expires_at)) }
       it { expect { subject }.to change { auth_credential.reload.refresh_token }.to(refresh_token) }
     end
   end

--- a/services/QuillLMS/spec/services/google_integration/refresh_token_validator_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/refresh_token_validator_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module GoogleIntegration
+  RSpec.describe RefreshTokenValidator do
+    subject { described_class.run(auth_credential) }
+
+    let(:auth_credential) { create(:google_auth_credential) }
+    let(:signet_authorization_error) { Signet::AuthorizationError.new('error') }
+
+    let(:client) { double(Signet::OAuth2::Client, fetch_access_token!: nil) }
+    let(:options) { { scope: described_class::MINIMUM_ACCESS_SCOPE } }
+
+    before do
+      allow(SignetClientFetcher)
+        .to receive(:run)
+        .with(auth_credential.refresh_token, **options)
+        .and_return(client)
+    end
+
+    it { expect { subject }.not_to raise_error }
+
+    context 'when the refresh token is invalid' do
+      before { allow(client).to receive(:fetch_access_token!).and_raise(signet_authorization_error) }
+
+      it { expect { subject }.to raise_error(described_class::ClientFetchAccessTokenError) }
+
+      it 'destroys auth credential if token cannot be refreshed' do
+        subject
+      rescue described_class::ClientFetchAccessTokenError
+        expect(auth_credential).not_to be_persisted
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/google_integration/signet_client_fetcher_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/signet_client_fetcher_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module GoogleIntegration
+  RSpec.describe SignetClientFetcher do
+    subject { described_class.run(refresh_token) }
+
+    let(:refresh_token) { 'refresh_token' }
+    let(:client_id) { 'client_id' }
+    let(:client_secret) { 'client_secret' }
+
+    before do
+      stub_const('Auth::Google::CLIENT_ID', client_id)
+      stub_const('Auth::Google::CLIENT_SECRET', client_secret)
+    end
+
+    it { expect(subject).to be_a(Signet::OAuth2::Client) }
+    it { expect(subject.client_id).to eq client_id }
+    it { expect(subject.client_secret).to eq client_secret }
+    it { expect(subject.refresh_token).to eq refresh_token }
+
+    context 'nil refresh token' do
+      let(:refresh_token) { nil }
+
+      it { expect { subject }.to raise_error(SignetClientFetcher::NilRefreshTokenError) }
+    end
+
+    context 'scope option provided' do
+      subject { described_class.run(refresh_token, **options) }
+
+      let(:scope) { RefreshTokenValidator::MINIMUM_ACCESS_SCOPE }
+      let(:options) { { scope: scope } }
+
+      it { expect(subject.scope).to eq scope }
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Fix state where user has auth credential but the refresh_token is not valid.

## WHY
Instead of trying to refresh with a bad refresh token, we need to just delete the auth_credential and force the user to reauthorize when they attempt to do any importing or refreshing of GoogleClassrooms

## HOW
Add a new class `SignetClientFetcher` which takes a refresh token and optional scope.
The minimal scope is passed to this class when we want to do a minimal test that the access and refresh token.
If the tokens are valid, proceed with returning a client to make subsequent api calls.  
If the tokens are not valid, destroy the auth_credential so that the next attempt at import will redirect the user for reauthorization.  To be honest, I'm not actually sure where in the flow this happening, so this is an attempt to narrow down these edge cases.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
