### PR TITLE
Remove users with duplicate emails that have no activity sessions and no classrooms

### DIFF
--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -50,6 +50,7 @@ namespace :users do
               FROM users
               WHERE email IS NOT NULL
               AND TRIM(email) != ''
+              AND role = 'student'
               GROUP BY email
               HAVING COUNT(email) > 1
           ),

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -81,6 +81,13 @@ namespace :users do
         SQL
       ).first['ids'].split(',')
 
+    puts "#{user_ids.count} users to delete"
+    misses = User.where(id: user_ids).select { |u| !u.student? || u.activity_sessions.count != 0 || u.classrooms.count != 0 || User.where(email: u.email).count <  2;  }.map { |u| [u.id, u.activity_sessions.count, u.classrooms.count, User.where(email: u.email).count] }
+    return if misses.count > 0
+
+    puts "Going to delete #{user_ids.count} users"
+    puts "Deleting #{user_ids.count} users"
     User.where(id: user_ids).destroy_all
+    puts "Deleted #{user_ids.count} users"
   end
 end


### PR DESCRIPTION
## WHAT
Add rake task to remove users with duplicate emails that have no activity sessions and no classrooms

## WHY
Users exists that share emails since email uniqueness has not always been enforced.
This causes opaque [bugs](https://quillorg-5s.sentry.io/issues/4386194670/?project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=16) where a student update is attempted but it cannot go through since we now do enforce email uniqueness.

Let's just remove users with no classrooms and no activity sessions that also have an email that another users has.

## HOW
Find the duplicates and partition by id, and delete the first row ( just in case both users with duplicate emails fit the criteria, we don't want to delete both of them).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Verified on staging.
Have you deployed to Staging? | No.  Ran query in staging console.
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A