### PR TITLE
Update hover states for tertiary navigation

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
@@ -409,6 +409,10 @@
           margin: 0px 0px 2px 8px;
         }
       }
+      a:hover {
+        background-color: rgba(255, 255, 255, 0.50);
+        text-decoration: none;
+      }
     }
   }
 }

--- a/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
@@ -241,10 +241,10 @@
       background-image: url("https://assets.quill.org/images/icons/white-diamond.svg");
     }
 
-    &:hover {
-      text-decoration: none;
-      background-color: rgba(255, 255, 255, 0.5);
-    }
+  }
+  a:hover {
+    text-decoration: none;
+    background-color: rgba(255, 255, 255, 0.5);
   }
 
   li a img {

--- a/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
@@ -28,11 +28,12 @@ function getIcon(activeTab: string, tabLabel: string) {
 
 function renderListItem({ tabs, activeStates, handleLinkClick, tabLabel, i }) {
   const onMobile = window.innerWidth <= MAX_VIEW_WIDTH_FOR_MOBILE_NAVBAR;
-
+  const premiumClass = premiumHubReportingTabs.includes(tabLabel) ? 'premium' : ''
+  const linkClass = `${activeStates[i]} ${premiumClass}`
   if (onMobile) {
     return(
       <li>
-        <Link className={activeStates[i]} onClick={handleLinkClick} to={tabs[tabLabel].url}>
+        <Link className={`${activeStates[i]} ${premiumClass}`} onClick={handleLinkClick} to={tabs[tabLabel].url}>
           {tabLabel}
         </Link>
         <div className={`checkmark-icon ${activeStates[i]}`} />
@@ -41,7 +42,7 @@ function renderListItem({ tabs, activeStates, handleLinkClick, tabLabel, i }) {
   }
   return (
     <li>
-      <Link className={activeStates[i]} onClick={handleLinkClick} to={tabs[tabLabel].url}>
+      <Link className={linkClass} onClick={handleLinkClick} to={tabs[tabLabel].url}>
         {tabLabel}
         {getIcon(activeStates[i], tabLabel)}
       </Link>


### PR DESCRIPTION
## WHAT
update hover states for tertiary navigation in the My Reports and Premium Hub tabs

## WHY
these somehow lost their styling

## HOW
just update some CSS and conditionally render `premium` class 

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1357" alt="Screen Shot 2023-08-14 at 1 29 02 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/4142e6fc-5983-44cb-a5e3-02ecf74ec975">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/UI-Fix-Global-Header-Tertiary-Level-Navigation-on-Premium-Tab-i-e-Maroon-colored-needs-to-dis-66e2c6bd819f4a4c97a3d3d18a95a932

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- small CSS change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
