### PR TITLE
bring districts#show school query to parity with districts#new_subscr…

### DIFF
--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -161,7 +161,6 @@ class Cms::DistrictsController < Cms::CmsController
       .left_joins(:schools_users)
       .left_joins(:schools_admins)
       .left_joins(school_subscriptions: :subscription)
-      .where("subscriptions.expiration IS NULL OR subscriptions.expiration > ?", Date.current)
       .where("subscriptions.de_activated_date IS NULL")
       .group('schools.name, schools.id, subscriptions.account_type')
   end

--- a/services/QuillLMS/app/views/cms/districts/show.html.erb
+++ b/services/QuillLMS/app/views/cms/districts/show.html.erb
@@ -66,7 +66,7 @@
     <p><%= @district.grade_range || 'N/A' %></p>
     <br /> <br />
 
-    <h2>Schools</h2>
+    <h2>Schools (includes those with expired subscriptions)</h2>
 
     <table class='cms-results-table'>
       <thead>

--- a/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
@@ -105,7 +105,19 @@ describe Cms::DistrictsController do
         expect(assigns(:school_data)[0]).to eq(school)
         expect(assigns(:school_data).length).to eq(1)
       end
+
+      it 'should show a record if the only subscription is expired' do
+        school = create(:school, district: district)
+        expired_sub = create(:subscription, expiration: 15.days.ago.to_date)
+        create(:school_subscription, school: school, subscription: expired_sub)
+
+        get :show, params: { id: district.id }
+        expect(assigns(:school_data)[0]).to eq(school)
+        expect(assigns(:school_data).length).to eq(1)
+      end
     end
+
+
   end
 
   describe '#edit' do


### PR DESCRIPTION
## WHAT
bring districts#show school query to parity with districts#new_subscription 

## WHY
Quill staff are confused that the two views contain different logic.

## HOW
Remove expired subscription filter from query in `districts#show` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Cannot-see-full-list-of-schools-in-district-CMS-4171d7cfd2a34505b3cca377115eeb10

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
