### PR TITLE
Sidekiq/TeacherActivityFeedBatchRefillWorker string-to-integer conversion error fix

### DIFF
--- a/services/QuillLMS/app/workers/teacher_activity_feed_batch_refill_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_activity_feed_batch_refill_worker.rb
@@ -3,7 +3,7 @@
 class TeacherActivityFeedBatchRefillWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
-  DELAY = 3.seconds
+  DELAY = 3.seconds.to_i
 
   def perform(start_date, end_date, delay = DELAY)
     teachers = User

--- a/services/QuillLMS/spec/workers/teacher_activity_feed_batch_refill_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_activity_feed_batch_refill_worker_spec.rb
@@ -12,7 +12,7 @@ describe TeacherActivityFeedBatchRefillWorker, type: :worker do
     expect(TeacherActivityFeedRefillWorker).to receive(:perform_in).with(0, teacher_in_window1.id)
     expect(TeacherActivityFeedRefillWorker).to receive(:perform_in).with(7, teacher_in_window2.id)
 
-    run_delay = 7
+    run_delay = 7.seconds.to_i
 
     worker.perform('2020-01-01', '2020-01-31', run_delay)
   end


### PR DESCRIPTION
## WHAT
fix string-to-integer conversion error in `TeacherActivityFeedBatchRefillWorker`

## WHY
we don't want this operation to error out

## HOW
just add a `.to_i` call to the `delay` time variable so that it can be multiplied with the index of that iteration

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Sidekiq-TeacherActivityFeedBatchRefillWorker-string-to-integer-conversion-error-b665b07f8f874cb8a66060ccca2f7e0c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | deploying tomorrow
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
