### PR TITLE
Fix Sidekiq/PopulateEvidenceActivityHealthWorker error

### DIFF
--- a/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
@@ -38,7 +38,10 @@ class SerializeEvidenceActivityHealth
     num_final_attempt_optimal = prompt_feedback_history[prompt.id]["num_final_attempt_optimal"]
     num_final_attempt_not_optimal = prompt_feedback_history[prompt.id]["num_final_attempt_not_optimal"]
     num_final_attempts = num_final_attempt_optimal + num_final_attempt_not_optimal
-
+    puts "num_final_attempt_optimal: #{num_final_attempt_optimal}"
+    puts "num_final_attempt_optimal.to_f: #{num_final_attempt_optimal.to_f }"
+    puts "num_final_attempts: #{num_final_attempts}"
+    puts "num_final_attempt_optimal.to_f / num_final_attempts: #{num_final_attempt_optimal.to_f / num_final_attempts}"
     return nil if !num_final_attempt_optimal || !num_final_attempts
 
     ((num_final_attempt_optimal.to_f / num_final_attempts) * 100).round

--- a/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
@@ -35,9 +35,13 @@ class SerializeEvidenceActivityHealth
     prompt = activity.prompts.find_by(conjunction: conjunction)
     return nil unless prompt && prompt_feedback_history[prompt.id]
 
+    num_final_attempt_optimal = prompt_feedback_history[prompt.id]["num_final_attempt_optimal"]
+    num_final_attempt_not_optimal = prompt_feedback_history[prompt.id]["num_final_attempt_not_optimal"]
+    num_final_attempts = num_final_attempt_optimal + num_final_attempt_not_optimal
 
-    num_final_attempts = prompt_feedback_history[prompt.id]["num_final_attempt_optimal"] + prompt_feedback_history[prompt.id]["num_final_attempt_not_optimal"]
-    ((prompt_feedback_history[prompt.id]["num_final_attempt_optimal"].to_f / num_final_attempts) * 100).round
+    return nil if !num_final_attempt_optimal || !num_final_attempts
+
+    ((num_final_attempt_optimal.to_f / num_final_attempts) * 100).round
   end
 
   private def activity_feedback_history

--- a/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
@@ -38,11 +38,8 @@ class SerializeEvidenceActivityHealth
     num_final_attempt_optimal = prompt_feedback_history[prompt.id]["num_final_attempt_optimal"]
     num_final_attempt_not_optimal = prompt_feedback_history[prompt.id]["num_final_attempt_not_optimal"]
     num_final_attempts = num_final_attempt_optimal + num_final_attempt_not_optimal
-    puts "num_final_attempt_optimal: #{num_final_attempt_optimal}"
-    puts "num_final_attempt_optimal.to_f: #{num_final_attempt_optimal.to_f }"
-    puts "num_final_attempts: #{num_final_attempts}"
-    puts "num_final_attempt_optimal.to_f / num_final_attempts: #{num_final_attempt_optimal.to_f / num_final_attempts}"
-    return nil if !num_final_attempt_optimal || !num_final_attempts
+
+    return 0 if num_final_attempt_optimal.zero? || num_final_attempts.zero?
 
     ((num_final_attempt_optimal.to_f / num_final_attempts) * 100).round
   end


### PR DESCRIPTION
## WHAT
fix Sidekiq/PopulateEvidenceActivityHealthWorker Sentry error

## WHY
we don't want these errors to happen

## HOW
add a `.zero?` check and early return before trying to do float conversion

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Sidekiq-PopulateEvidenceActivityHealthWorker-FloatDomainError-a6082f32a4574efdba431619b3eed106

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
