### PR TITLE
lms/evidence-activities-load-timeout

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -7,7 +7,7 @@ module Evidence
 
     # GET /activities.json
     def index
-      @activities = Evidence::Activity.order(:title).map { |a| a.serializable_hash(include: []) }
+      @activities = Evidence::Activity.order(:title).map { |a| a.serializable_hash(include: [], methods: [:flag]) }
 
       render json: @activities
     end


### PR DESCRIPTION
## WHAT
Disable invalid_highlights in the all activities api call
## WHY
It's currently taking too long to do this calculation and making it impossible to load this through Heroku with a 30 second timeout.  Ultimately we do want this feature, but while we do a refactor that lets us do that, Curriculum would prefer that this page loads at all so that they can do their job by accessing Evidence activities
## HOW
Exclude `invalid_highlights` from the serialization of our Activities so that the function that's taking up all the time to load this API call doesn't run.  This does disable a key feature (flagging activities that have invalid highlights and thus need attention from developers), but we're willing to tolerate that temporarily.

### Notion Card Links
https://www.notion.so/quill/Very-long-internal-tool-loading-time-a98b11b3fa4b4c998bdee11caad45be5?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on this payload
Have you deployed to Staging? | Yes, but staging database is currently messed up so couldn't test (got someone else to test in their local: https://quill.slack.com/archives/C03UVPPNH/p1692299407542839)
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
