### PR TITLE
Filter out failed credit card from SalesOps daily emails

### DIFF
--- a/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions_worker.rb
@@ -8,13 +8,13 @@ class IdentifyStripeInvoicesWithoutSubscriptionsWorker
   RELEVANT_INVOICE_STATUSES = ['open', 'paid']
 
   def perform
-    invoice_payloads = map_invoices_for_template(relevant_stripe_invoices)
-
-    StripeIntegration::Mailer.invoices_without_subscriptions(invoice_payloads).deliver_now!
+    StripeIntegration::Mailer
+      .invoices_without_subscriptions(invoice_payloads)
+      .deliver_now!
   end
 
-  private def map_invoices_for_template(invoices)
-    invoices.map do |invoice|
+  private def invoice_payloads
+    relevant_stripe_invoices.map do |invoice|
       {
         id: invoice.id,
         created: Time.at(invoice.created).getlocal.to_datetime,
@@ -36,7 +36,10 @@ class IdentifyStripeInvoicesWithoutSubscriptionsWorker
   end
 
   private def invoice_ids_with_subscriptions
-    @invoice_ids_with_subscriptions ||= Subscription.where(stripe_invoice_id: stripe_invoice_ids).pluck(:stripe_invoice_id)
+    @invoice_ids_with_subscriptions ||=
+      Subscription
+        .where(stripe_invoice_id: stripe_invoice_ids)
+        .pluck(:stripe_invoice_id)
   end
 
   private def invoice_refunded?(invoice)

--- a/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_worker_spec.rb
@@ -9,7 +9,7 @@ describe IdentifyStripeInvoicesWithoutSubscriptionsWorker do
 
   describe '#perform' do
     let(:mailer_double) { double(deliver_now!: nil) }
-    let(:charge_double) { double(amount: 100, amount_refunded: 0) }
+    let(:charge_double) { double(amount: 100, amount_refunded: 0, status: nil) }
 
     before do
       list_double = double
@@ -58,6 +58,14 @@ describe IdentifyStripeInvoicesWithoutSubscriptionsWorker do
 
     it 'should send an email that does not include invoices that have been refunded' do
       expect(charge_double).to receive(:amount_refunded).and_return(100)
+
+      expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([]).and_return(mailer_double)
+
+      subject.perform
+    end
+
+    it 'should send an email that does not include invoices that have failed charges' do
+      expect(charge_double).to receive(:status).and_return(described_class::FAILED_CHARGE)
 
       expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([]).and_return(mailer_double)
 


### PR DESCRIPTION
## WHAT
SalesOps gets a daily email with a listing of potentially relevant Stripe Invoices.  This PR removes invoices that have failed credit card charges

## WHY
Those invoices can't be fixed by the Sales/Ops since it's likely an issue with the CreditCard number, expiration date, etc.

## HOW
Add a clause that checks to see if the Stripe:Charge has status 'failed'.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Filter-failed-credit-card-subscriptions-out-of-daily-emails-to-sales-ops-bbaecd356bf24520919828fc221b2e78?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
