### PR TITLE
Tweak count logic for Diagnostic reports student results

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/results.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/results.test.jsx.snap
@@ -8579,6 +8579,7 @@ exports[`Results component should render when there are results 1`] = `
                      of 
                     11
                      Student
+                    s
                      Proficient
                   </span>
                 </th>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
@@ -1703,7 +1703,6 @@ exports[`StudentResultsTable component should render when there is student data 
                  of 
                 1
                  Student
-                s
                  Improved or Maintained Skill
               </span>
               <div
@@ -1785,7 +1784,6 @@ exports[`StudentResultsTable component should render when there is student data 
                  of 
                 1
                  Student
-                s
                  Improved or Maintained Skill
               </span>
               <div
@@ -1867,7 +1865,6 @@ exports[`StudentResultsTable component should render when there is student data 
                  of 
                 1
                  Student
-                s
                  Improved or Maintained Skill
               </span>
               <div
@@ -1949,7 +1946,6 @@ exports[`StudentResultsTable component should render when there is student data 
                  of 
                 1
                  Student
-                s
                  Improved or Maintained Skill
               </span>
               <div
@@ -2031,7 +2027,6 @@ exports[`StudentResultsTable component should render when there is student data 
                  of 
                 1
                  Student
-                s
                  Improved or Maintained Skill
               </span>
               <div
@@ -2113,7 +2108,6 @@ exports[`StudentResultsTable component should render when there is student data 
                  of 
                 1
                  Student
-                s
                  Improved or Maintained Skill
               </span>
               <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
@@ -228,12 +228,12 @@ const StudentResultsTable = ({ isPreTest, skillGroupSummaries, studentResults, o
     if (!completedStudentCount) { return }
 
     if (isPreTest) {
-      return <span className="label">{proficientStudentCount} of {completedStudentCount} Student{proficientStudentCount === 1 ? '' : 's'}{' Proficient'}</span>
+      return <span className="label">{proficientStudentCount} of {completedStudentCount} Student{completedStudentCount === 1 ? '' : 's'}{' Proficient'}</span>
     }
 
     return (
       <div className="student-proficiency-data-container">
-        <span className="label">{proficientStudentCount} of {completedStudentCount} Student{proficientStudentCount === 1 ? '' : 's'}{' Improved or Maintained Skill'}</span>
+        <span className="label">{proficientStudentCount} of {completedStudentCount} Student{completedStudentCount === 1 ? '' : 's'}{' Improved or Maintained Skill'}</span>
         {renderDelta(proficientStudentCount)}
       </div>
     )

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
@@ -6,7 +6,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
   defaultText="No date selected"
   handleClickCopyToAll={[Function]}
   icon={null}
-  initialValue={"2022-11-10T05:00:00.000Z"}
+  initialValue={"2022-11-10T03:00:00.000Z"}
   rowIndex={0}
 >
   <div
@@ -21,7 +21,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
         closeOnSelect={false}
         closeOnTab={true}
         dateFormat="MMM D"
-        initialValue={"2022-11-10T05:00:00.000Z"}
+        initialValue={"2022-11-10T03:00:00.000Z"}
         initialViewDate={2022-11-10T09:00:00.000Z}
         input={true}
         inputProps={Object {}}
@@ -85,7 +85,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       "onFocus": [Function],
                       "onKeyDown": [Function],
                       "type": "text",
-                      "value": "Nov 10 5:00 am",
+                      "value": "Nov 10 3:00 am",
                     }
                   }
                 >
@@ -102,7 +102,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       onKeyDown={[Function]}
                       placeholder="No date selected"
                       type="text"
-                      value="Nov 10 5:00 am"
+                      value="Nov 10 3:00 am"
                     />
                     <img
                       alt="dropdown indicator"
@@ -120,7 +120,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                   moment={[Function]}
                   navigate={[Function]}
                   renderDay={[Function]}
-                  selectedDate={"2022-11-10T05:00:00.000Z"}
+                  selectedDate={"2022-11-10T03:00:00.000Z"}
                   showView={[Function]}
                   timeFormat="h:mm a"
                   updateDate={[Function]}


### PR DESCRIPTION
## WHAT
tweak count logic for Diagnostic reports student results "Students Proficient/ Students Improved or Maintained Skill"

## WHY
we want this to use the total count of students assigned the Diagnostic

## HOW
just swap `proficientStudentCount` with `completedStudentCount`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small change-- manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
