### PR TITLE
Fix Sentry coteacher invitation bug

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/classrooms.scss
@@ -121,6 +121,18 @@
         cursor: pointer;
         margin-left: 40px;
       }
+      .accept-or-decline {
+        display: flex;
+        button:first-of-type {
+          margin-right: 16px;
+        }
+        .spinner-container {
+          margin: 0;
+          .spinner {
+            height: 24px;
+          }
+        }
+      }
     }
   }
 

--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -937,6 +937,7 @@
 .invite-coteachers-modal {
   width: 560px;
   overflow: hidden;
+  max-height: 80vh;
   .invite-coteachers-modal-body {
     padding-top: 0px;
     p {
@@ -959,6 +960,13 @@
   }
   .invite-coteachers-modal-footer {
     justify-content: flex-end;
+    .quill-button {
+      .loading-spinner {
+        .spinner {
+          height: 24px;
+        }
+      }
+    }
   }
 
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/active_classrooms.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/active_classrooms.test.tsx.snap
@@ -715,13 +715,13 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
               className="accept-or-decline"
             >
               <button
-                className="quill-button secondary outlined small"
+                className="quill-button secondary outlined small focus-on-light"
                 onClick={[Function]}
               >
                 Decline
               </button>
               <button
-                className="quill-button primary contained small"
+                className="quill-button primary contained small focus-on-light"
                 onClick={[Function]}
               >
                 Accept
@@ -768,13 +768,13 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
               className="accept-or-decline"
             >
               <button
-                className="quill-button secondary outlined small"
+                className="quill-button secondary outlined small focus-on-light"
                 onClick={[Function]}
               >
                 Decline
               </button>
               <button
-                className="quill-button primary contained small"
+                className="quill-button primary contained small focus-on-light"
                 onClick={[Function]}
               >
                 Accept
@@ -821,13 +821,13 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
               className="accept-or-decline"
             >
               <button
-                className="quill-button secondary outlined small"
+                className="quill-button secondary outlined small focus-on-light"
                 onClick={[Function]}
               >
                 Decline
               </button>
               <button
-                className="quill-button primary contained small"
+                className="quill-button primary contained small focus-on-light"
                 onClick={[Function]}
               >
                 Accept
@@ -874,13 +874,13 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
               className="accept-or-decline"
             >
               <button
-                className="quill-button secondary outlined small"
+                className="quill-button secondary outlined small focus-on-light"
                 onClick={[Function]}
               >
                 Decline
               </button>
               <button
-                className="quill-button primary contained small"
+                className="quill-button primary contained small focus-on-light"
                 onClick={[Function]}
               >
                 Accept
@@ -927,13 +927,13 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
               className="accept-or-decline"
             >
               <button
-                className="quill-button secondary outlined small"
+                className="quill-button secondary outlined small focus-on-light"
                 onClick={[Function]}
               >
                 Decline
               </button>
               <button
-                className="quill-button primary contained small"
+                className="quill-button primary contained small focus-on-light"
                 onClick={[Function]}
               >
                 Accept
@@ -980,13 +980,13 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
               className="accept-or-decline"
             >
               <button
-                className="quill-button secondary outlined small"
+                className="quill-button secondary outlined small focus-on-light"
                 onClick={[Function]}
               >
                 Decline
               </button>
               <button
-                className="quill-button primary contained small"
+                className="quill-button primary contained small focus-on-light"
                 onClick={[Function]}
               >
                 Accept
@@ -1033,13 +1033,13 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
               className="accept-or-decline"
             >
               <button
-                className="quill-button secondary outlined small"
+                className="quill-button secondary outlined small focus-on-light"
                 onClick={[Function]}
               >
                 Decline
               </button>
               <button
-                className="quill-button primary contained small"
+                className="quill-button primary contained small focus-on-light"
                 onClick={[Function]}
               >
                 Accept
@@ -1086,13 +1086,13 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
               className="accept-or-decline"
             >
               <button
-                className="quill-button secondary outlined small"
+                className="quill-button secondary outlined small focus-on-light"
                 onClick={[Function]}
               >
                 Decline
               </button>
               <button
-                className="quill-button primary contained small"
+                className="quill-button primary contained small focus-on-light"
                 onClick={[Function]}
               >
                 Accept
@@ -1139,13 +1139,13 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
               className="accept-or-decline"
             >
               <button
-                className="quill-button secondary outlined small"
+                className="quill-button secondary outlined small focus-on-light"
                 onClick={[Function]}
               >
                 Decline
               </button>
               <button
-                className="quill-button primary contained small"
+                className="quill-button primary contained small focus-on-light"
                 onClick={[Function]}
               >
                 Accept

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/active_classrooms.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/active_classrooms.test.tsx.snap
@@ -714,16 +714,18 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
             <div
               className="accept-or-decline"
             >
-              <span
+              <button
+                className="quill-button secondary outlined small"
                 onClick={[Function]}
               >
                 Decline
-              </span>
-              <span
+              </button>
+              <button
+                className="quill-button primary contained small"
                 onClick={[Function]}
               >
                 Accept
-              </span>
+              </button>
             </div>
           </div>
         </div>
@@ -765,16 +767,18 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
             <div
               className="accept-or-decline"
             >
-              <span
+              <button
+                className="quill-button secondary outlined small"
                 onClick={[Function]}
               >
                 Decline
-              </span>
-              <span
+              </button>
+              <button
+                className="quill-button primary contained small"
                 onClick={[Function]}
               >
                 Accept
-              </span>
+              </button>
             </div>
           </div>
         </div>
@@ -816,16 +820,18 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
             <div
               className="accept-or-decline"
             >
-              <span
+              <button
+                className="quill-button secondary outlined small"
                 onClick={[Function]}
               >
                 Decline
-              </span>
-              <span
+              </button>
+              <button
+                className="quill-button primary contained small"
                 onClick={[Function]}
               >
                 Accept
-              </span>
+              </button>
             </div>
           </div>
         </div>
@@ -867,16 +873,18 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
             <div
               className="accept-or-decline"
             >
-              <span
+              <button
+                className="quill-button secondary outlined small"
                 onClick={[Function]}
               >
                 Decline
-              </span>
-              <span
+              </button>
+              <button
+                className="quill-button primary contained small"
                 onClick={[Function]}
               >
                 Accept
-              </span>
+              </button>
             </div>
           </div>
         </div>
@@ -918,16 +926,18 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
             <div
               className="accept-or-decline"
             >
-              <span
+              <button
+                className="quill-button secondary outlined small"
                 onClick={[Function]}
               >
                 Decline
-              </span>
-              <span
+              </button>
+              <button
+                className="quill-button primary contained small"
                 onClick={[Function]}
               >
                 Accept
-              </span>
+              </button>
             </div>
           </div>
         </div>
@@ -969,16 +979,18 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
             <div
               className="accept-or-decline"
             >
-              <span
+              <button
+                className="quill-button secondary outlined small"
                 onClick={[Function]}
               >
                 Decline
-              </span>
-              <span
+              </button>
+              <button
+                className="quill-button primary contained small"
                 onClick={[Function]}
               >
                 Accept
-              </span>
+              </button>
             </div>
           </div>
         </div>
@@ -1020,16 +1032,18 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
             <div
               className="accept-or-decline"
             >
-              <span
+              <button
+                className="quill-button secondary outlined small"
                 onClick={[Function]}
               >
                 Decline
-              </span>
-              <span
+              </button>
+              <button
+                className="quill-button primary contained small"
                 onClick={[Function]}
               >
                 Accept
-              </span>
+              </button>
             </div>
           </div>
         </div>
@@ -1071,16 +1085,18 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
             <div
               className="accept-or-decline"
             >
-              <span
+              <button
+                className="quill-button secondary outlined small"
                 onClick={[Function]}
               >
                 Decline
-              </span>
-              <span
+              </button>
+              <button
+                className="quill-button primary contained small"
                 onClick={[Function]}
               >
                 Accept
-              </span>
+              </button>
             </div>
           </div>
         </div>
@@ -1122,16 +1138,18 @@ exports[`ActiveClassrooms component with classrooms should render with classroom
             <div
               className="accept-or-decline"
             >
-              <span
+              <button
+                className="quill-button secondary outlined small"
                 onClick={[Function]}
               >
                 Decline
-              </span>
-              <span
+              </button>
+              <button
+                className="quill-button primary contained small"
                 onClick={[Function]}
               >
                 Accept
-              </span>
+              </button>
             </div>
           </div>
         </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/coteacher_invitation.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/coteacher_invitation.test.jsx.snap
@@ -21,16 +21,18 @@ exports[`CoteacherInvitation component should render CoteacherInvitation 1`] = `
     <div
       className="accept-or-decline"
     >
-      <span
+      <button
+        className="quill-button secondary outlined small"
         onClick={[Function]}
       >
         Decline
-      </span>
-      <span
+      </button>
+      <button
+        className="quill-button primary contained small"
         onClick={[Function]}
       >
         Accept
-      </span>
+      </button>
     </div>
   </div>
 </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/coteacher_invitation.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/coteacher_invitation.test.jsx.snap
@@ -22,13 +22,13 @@ exports[`CoteacherInvitation component should render CoteacherInvitation 1`] = `
       className="accept-or-decline"
     >
       <button
-        className="quill-button secondary outlined small"
+        className="quill-button secondary outlined small focus-on-light"
         onClick={[Function]}
       >
         Decline
       </button>
       <button
-        className="quill-button primary contained small"
+        className="quill-button primary contained small focus-on-light"
         onClick={[Function]}
       >
         Accept

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/invite_coteachers_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/invite_coteachers_modal.test.jsx.snap
@@ -90,18 +90,16 @@ exports[`InviteCoteacherModal component if a coteacher does not get passed shoul
         className="buttons"
       >
         <button
-          className="quill-button outlined secondary medium disabled"
-          disabled={true}
+          className="quill-button outlined secondary medium"
           onClick={[Function]}
         >
           Cancel
         </button>
         <button
           className="quill-button contained primary medium disabled"
-          disabled={true}
           onClick={[Function]}
         >
-          <Spinner />
+          Invite
         </button>
       </div>
     </div>
@@ -192,18 +190,16 @@ exports[`InviteCoteacherModal component if a coteacher gets passed should render
         className="buttons"
       >
         <button
-          className="quill-button outlined secondary medium disabled"
-          disabled={true}
+          className="quill-button outlined secondary medium"
           onClick={[Function]}
         >
           Cancel
         </button>
         <button
-          className="quill-button contained primary medium disabled"
-          disabled={true}
+          className="quill-button contained primary medium"
           onClick={[Function]}
         >
-          <Spinner />
+          Invite
         </button>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/invite_coteachers_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/invite_coteachers_modal.test.jsx.snap
@@ -90,13 +90,13 @@ exports[`InviteCoteacherModal component if a coteacher does not get passed shoul
         className="buttons"
       >
         <button
-          className="quill-button outlined secondary medium"
+          className="quill-button outlined secondary medium focus-on-light"
           onClick={[Function]}
         >
           Cancel
         </button>
         <button
-          className="quill-button contained primary medium disabled"
+          className="quill-button contained primary medium focus-on-light disabled"
           onClick={[Function]}
         >
           Invite
@@ -190,13 +190,13 @@ exports[`InviteCoteacherModal component if a coteacher gets passed should render
         className="buttons"
       >
         <button
-          className="quill-button outlined secondary medium"
+          className="quill-button outlined secondary medium focus-on-light"
           onClick={[Function]}
         >
           Cancel
         </button>
         <button
-          className="quill-button contained primary medium"
+          className="quill-button contained primary medium focus-on-light"
           onClick={[Function]}
         >
           Invite

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/invite_coteachers_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/invite_coteachers_modal.test.jsx.snap
@@ -90,16 +90,18 @@ exports[`InviteCoteacherModal component if a coteacher does not get passed shoul
         className="buttons"
       >
         <button
-          className="quill-button outlined secondary medium"
+          className="quill-button outlined secondary medium disabled"
+          disabled={true}
           onClick={[Function]}
         >
           Cancel
         </button>
         <button
           className="quill-button contained primary medium disabled"
+          disabled={true}
           onClick={[Function]}
         >
-          Invite
+          <Spinner />
         </button>
       </div>
     </div>
@@ -190,16 +192,18 @@ exports[`InviteCoteacherModal component if a coteacher gets passed should render
         className="buttons"
       >
         <button
-          className="quill-button outlined secondary medium"
+          className="quill-button outlined secondary medium disabled"
+          disabled={true}
           onClick={[Function]}
         >
           Cancel
         </button>
         <button
-          className="quill-button contained primary medium"
+          className="quill-button contained primary medium disabled"
+          disabled={true}
           onClick={[Function]}
         >
-          Invite
+          <Spinner />
         </button>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/invite_coteachers_modal.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/invite_coteachers_modal.test.jsx
@@ -58,12 +58,5 @@ describe('InviteCoteacherModal component', () => {
     it('should render a datatable', () => {
       expect(wrapper.find(DataTable).exists()).toBe(true)
     })
-
-    it('should trim trailing whitespace for coteacher email after submission', () => {
-      wrapper.setState({ email: "test-user@gmail.com "})
-      wrapper.instance().inviteCoteachers()
-      expect(requestPost).toHaveBeenCalledWith("/invitations/create_coteacher_invitation", {classroom_ids: [285383], invitee_email: "test-user@gmail.com"}, expect.any(Function))
-    })
   })
-
 })

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/coteacher_invitation.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/coteacher_invitation.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { requestPost } from '../../../../modules/request/index';
+import { Spinner } from '../../../Shared';
 
 interface CoteacherInvitationProps {
   getClassroomsAndCoteacherInvitations: () => void;
@@ -8,46 +9,67 @@ interface CoteacherInvitationProps {
   coteacherInvitation: any;
 }
 
-export default class CoteacherInvitation extends React.Component<CoteacherInvitationProps, {}> {
-  constructor(props) {
-    super(props)
+const ACCEPT = 'accept'
+const REJECT = 'reject'
 
-    this.acceptInvitation = this.acceptInvitation.bind(this)
-    this.rejectInvitation = this.rejectInvitation.bind(this)
-  }
+export const CoteacherInvitation = ({ getClassroomsAndCoteacherInvitations, showSnackbar, coteacherInvitation }: CoteacherInvitationProps) => {
 
-  acceptInvitation() {
-    const { getClassroomsAndCoteacherInvitations, coteacherInvitation, showSnackbar, } = this.props
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [action, setAction] = React.useState<string>('')
+
+  function acceptInvitation() {
     const dataForInvite = { coteacher_invitation_ids: [coteacherInvitation.id] }
+    setAction(ACCEPT)
+    setLoading(true)
     requestPost('/coteacher_classroom_invitations/accept_pending_coteacher_invitations', dataForInvite, (body) => {
       getClassroomsAndCoteacherInvitations()
       showSnackbar('Invitation accepted')
+      setAction('')
+      setLoading(false)
     })
   }
 
-  rejectInvitation() {
-    const { getClassroomsAndCoteacherInvitations, coteacherInvitation, showSnackbar, } = this.props
+  function rejectInvitation() {
     const dataForInvite = { coteacher_invitation_ids: [coteacherInvitation.id] }
+    setAction(REJECT)
+    setLoading(true)
     requestPost('/coteacher_classroom_invitations/reject_pending_coteacher_invitations', dataForInvite, (body) => {
       getClassroomsAndCoteacherInvitations()
       showSnackbar('Invitation declined')
+      setAction('')
+      setLoading(false)
     })
   }
 
-  render() {
-    const { coteacherInvitation } = this.props
-    const { classroom_name, inviter_name, inviter_email } = coteacherInvitation
-    return (
-      <div className="coteacher-invitation">
-        <h2>Invitation to co-teach "{classroom_name}"</h2>
-        <div className="coteacher-invitation-content">
-          <p>{inviter_name} ({inviter_email}) invited you to co-teach.</p>
-          <div className="accept-or-decline">
-            <span onClick={this.rejectInvitation}>Decline</span>
-            <span onClick={this.acceptInvitation}>Accept</span>
-          </div>
+  function renderButtons() {
+    if(loading) {
+      const isAccepting = action === ACCEPT
+      const acceptElement = isAccepting ? <Spinner/> : 'Accept'
+      const declineElement = !isAccepting ? <Spinner/> : 'Decline'
+      return(
+        <div className="accept-or-decline">
+          <button className="quill-button secondary outlined small disabled" disabled={true} onClick={rejectInvitation}>{declineElement}</button>
+          <button className="quill-button primary contained small disabled" disabled={true} onClick={acceptInvitation}>{acceptElement}</button>
         </div>
+      )
+    }
+    return(
+      <div className="accept-or-decline">
+        <button className="quill-button secondary outlined small" onClick={rejectInvitation}>Decline</button>
+        <button className="quill-button primary contained small" onClick={acceptInvitation}>Accept</button>
       </div>
     )
   }
+
+  return (
+    <div className="coteacher-invitation">
+      <h2>Invitation to co-teach "{coteacherInvitation.classroom_name}"</h2>
+      <div className="coteacher-invitation-content">
+        <p>{coteacherInvitation.inviter_name} ({coteacherInvitation.inviter_email}) invited you to co-teach.</p>
+        {renderButtons()}
+      </div>
+    </div>
+  )
 }
+
+export default CoteacherInvitation

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/coteacher_invitation.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/coteacher_invitation.tsx
@@ -55,8 +55,8 @@ export const CoteacherInvitation = ({ getClassroomsAndCoteacherInvitations, show
     }
     return(
       <div className="accept-or-decline">
-        <button className="quill-button secondary outlined small" onClick={rejectInvitation}>Decline</button>
-        <button className="quill-button primary contained small" onClick={acceptInvitation}>Accept</button>
+        <button className="quill-button secondary outlined small focus-on-light" onClick={rejectInvitation}>Decline</button>
+        <button className="quill-button primary contained small focus-on-light" onClick={acceptInvitation}>Accept</button>
       </div>
     )
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/coteacher_invitation.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/coteacher_invitation.tsx
@@ -44,8 +44,8 @@ export const CoteacherInvitation = ({ getClassroomsAndCoteacherInvitations, show
   function renderButtons() {
     if(loading) {
       const isAccepting = action === ACCEPT
-      const acceptElement = isAccepting ? <Spinner/> : 'Accept'
-      const declineElement = !isAccepting ? <Spinner/> : 'Decline'
+      const acceptElement = isAccepting ? <Spinner /> : 'Accept'
+      const declineElement = !isAccepting ? <Spinner /> : 'Decline'
       return(
         <div className="accept-or-decline">
           <button className="quill-button secondary outlined small disabled" disabled={true} onClick={rejectInvitation}>{declineElement}</button>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
@@ -143,7 +143,7 @@ export const InviteCoteachersModal = ({ close, onSuccess, classrooms, classroom,
   }
 
   function renderButtons() {
-    if(!loading) {
+    if(loading) {
       return(
         <div className="buttons">
           <button className="quill-button outlined secondary medium disabled" disabled={true} onClick={close}>Cancel</button>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
@@ -30,7 +30,7 @@ export const InviteCoteachersModal = ({ close, onSuccess, classrooms, classroom,
   const [loading, setLoading] = React.useState<boolean>(false);
 
   function footerButtonClass() {
-    let buttonClass = 'quill-button contained primary medium';
+    let buttonClass = 'quill-button contained primary medium focus-on-light';
     if (!selectedClassroomIds.length || !email) {
       buttonClass += ' disabled';
     }
@@ -155,7 +155,7 @@ export const InviteCoteachersModal = ({ close, onSuccess, classrooms, classroom,
     }
     return(
       <div className="buttons">
-        <button className="quill-button outlined secondary medium" onClick={close}>Cancel</button>
+        <button className="quill-button outlined secondary medium focus-on-light" onClick={close}>Cancel</button>
         <button className={footerButtonClass()} onClick={inviteCoteachers}>Invite</button>
       </div>
     )

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
@@ -2,7 +2,7 @@ import * as moment from 'moment';
 import * as React from 'react';
 
 import { requestPost, } from '../../../../modules/request/index';
-import { ButtonLoadingSpinner, DataTable, Input, Spinner, } from '../../../Shared/index';
+import { DataTable, Input, Spinner, } from '../../../Shared/index';
 
 interface InviteCoteachersModalProps {
   close: () => void;
@@ -148,7 +148,7 @@ export const InviteCoteachersModal = ({ close, onSuccess, classrooms, classroom,
         <div className="buttons">
           <button className="quill-button outlined secondary medium disabled" disabled={true} onClick={close}>Cancel</button>
           <button className="quill-button contained primary medium disabled" disabled={true} onClick={inviteCoteachers}>
-            <Spinner/>
+            <Spinner />
           </button>
         </div>
       )

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/invite_coteachers_modal.tsx
@@ -2,7 +2,7 @@ import * as moment from 'moment';
 import * as React from 'react';
 
 import { requestPost, } from '../../../../modules/request/index';
-import { DataTable, Input, } from '../../../Shared/index';
+import { ButtonLoadingSpinner, DataTable, Input, Spinner, } from '../../../Shared/index';
 
 interface InviteCoteachersModalProps {
   close: () => void;
@@ -10,11 +10,6 @@ interface InviteCoteachersModalProps {
   classrooms: Array<any>;
   classroom: any;
   coteacher: any;
-}
-
-interface InviteCoteachersModalState {
-  selectedClassroomIds: Array<string|number>;
-  email: string;
 }
 
 const headers = [
@@ -29,25 +24,12 @@ const headers = [
   }
 ]
 
-export default class InviteCoteachersModal extends React.Component<InviteCoteachersModalProps, InviteCoteachersModalState> {
-  constructor(props) {
-    super(props)
+export const InviteCoteachersModal = ({ close, onSuccess, classrooms, classroom, coteacher }: InviteCoteachersModalProps) => {
+  const [email, setEmail] = React.useState<string>(coteacher && coteacher.email ? coteacher.email : '');
+  const [selectedClassroomIds, setSelectedClassroomIds] = React.useState<number[]>([classroom.id]);
+  const [loading, setLoading] = React.useState<boolean>(false);
 
-    this.state = {
-      email: props.coteacher ? props.coteacher.email : '',
-      selectedClassroomIds: [props.classroom.id]
-    }
-
-    this.inviteCoteachers = this.inviteCoteachers.bind(this)
-    this.handleEmailChange = this.handleEmailChange.bind(this)
-    this.checkRow = this.checkRow.bind(this)
-    this.uncheckRow = this.uncheckRow.bind(this)
-    this.checkAllRows = this.checkAllRows.bind(this)
-    this.uncheckAllRows = this.uncheckAllRows.bind(this)
-  }
-
-  footerButtonClass() {
-    const { selectedClassroomIds, email } = this.state
+  function footerButtonClass() {
     let buttonClass = 'quill-button contained primary medium';
     if (!selectedClassroomIds.length || !email) {
       buttonClass += ' disabled';
@@ -55,45 +37,42 @@ export default class InviteCoteachersModal extends React.Component<InviteCoteach
     return buttonClass;
   }
 
-  handleEmailChange(event) {
-    this.setState({ email: event.target.value })
+  function handleEmailChange(event) {
+    const { target } = event
+    const { value } = target
+    setEmail(value)
   }
 
-  checkRow(id) {
-    const { selectedClassroomIds } = this.state
+  function checkRow(id) {
     const newSelectedClassroomIds = selectedClassroomIds.concat(id)
-    this.setState({ selectedClassroomIds: newSelectedClassroomIds })
+    setSelectedClassroomIds(newSelectedClassroomIds)
   }
 
-  uncheckRow(id) {
-    const { selectedClassroomIds } = this.state
+  function uncheckRow(id) {
     const newSelectedClassroomIds = selectedClassroomIds.filter(selectedId => selectedId !== id)
-    this.setState({ selectedClassroomIds: newSelectedClassroomIds })
+    setSelectedClassroomIds(newSelectedClassroomIds)
   }
 
-  checkAllRows() {
-    const { classrooms } = this.props
+  function checkAllRows() {
     const newSelectedClassroomIds = classrooms.map(classroom => classroom.id)
-    this.setState({ selectedClassroomIds: newSelectedClassroomIds })
+    setSelectedClassroomIds(newSelectedClassroomIds)
   }
 
-  uncheckAllRows() {
-    this.setState({ selectedClassroomIds: [] })
+  function uncheckAllRows() {
+    setSelectedClassroomIds([])
   }
 
-  inviteCoteachers() {
-    const { onSuccess, close, } = this.props
-    const { email, selectedClassroomIds } = this.state
+  function inviteCoteachers() {
     const dataForInvite = { classroom_ids: selectedClassroomIds, invitee_email: email.trim() }
+    setLoading(true)
     requestPost('/invitations/create_coteacher_invitation', dataForInvite, (body) => {
       onSuccess('Co-teacher invited')
+      setLoading(false)
       close()
     })
   }
 
-  renderEmailInput() {
-    const { coteacher } = this.props
-    const { email } = this.state
+  function renderEmailInput() {
     if (coteacher) {
       return (
         <Input
@@ -108,7 +87,7 @@ export default class InviteCoteachersModal extends React.Component<InviteCoteach
       return (
         <Input
           className="email"
-          handleChange={this.handleEmailChange}
+          handleChange={handleEmailChange}
           label="Co-teacher email"
           placeholder="teacher@example.edu"
           type="text"
@@ -118,19 +97,17 @@ export default class InviteCoteachersModal extends React.Component<InviteCoteach
     }
   }
 
-  renderModalContent() {
+  function renderModalContent() {
     return (
       <div className="invite-coteachers-modal-content">
         <p>Co-teachers can do everything you can except move or merge students, archive classes, edit activity packs, and access your Premium features.</p>
-        {this.renderEmailInput()}
-        {this.renderDataTable()}
+        {renderEmailInput()}
+        {renderDataTable()}
       </div>
     )
   }
 
-  renderDataTable() {
-    const { classrooms, coteacher, } = this.props
-    const { selectedClassroomIds, } = this.state
+  function renderDataTable() {
 
     let possibleClassrooms = classrooms
 
@@ -154,41 +131,55 @@ export default class InviteCoteachersModal extends React.Component<InviteCoteach
 
     return (
       <DataTable
-        checkAllRows={this.checkAllRows}
-        checkRow={this.checkRow}
+        checkAllRows={checkAllRows}
+        checkRow={checkRow}
         headers={headers}
         rows={rows}
         showCheckboxes={true}
-        uncheckAllRows={this.uncheckAllRows}
-        uncheckRow={this.uncheckRow}
+        uncheckAllRows={uncheckAllRows}
+        uncheckRow={uncheckRow}
       />
     )
   }
 
-  render() {
-    const { close } = this.props
-    return (
-      <div className="modal-container invite-coteachers-modal-container">
-        <div className="modal-background" />
-        <div className="invite-coteachers-modal quill-modal">
-
-          <div className="invite-coteachers-modal-header">
-            <h3 className="title">Invite co-teachers</h3>
-          </div>
-
-          <div className="invite-coteachers-modal-body modal-body">
-            {this.renderModalContent()}
-          </div>
-
-          <div className="invite-coteachers-modal-footer">
-            <div className="buttons">
-              <button className="quill-button outlined secondary medium" onClick={close}>Cancel</button>
-              <button className={this.footerButtonClass()} onClick={this.inviteCoteachers}>Invite</button>
-            </div>
-          </div>
-
+  function renderButtons() {
+    if(!loading) {
+      return(
+        <div className="buttons">
+          <button className="quill-button outlined secondary medium disabled" disabled={true} onClick={close}>Cancel</button>
+          <button className="quill-button contained primary medium disabled" disabled={true} onClick={inviteCoteachers}>
+            <Spinner/>
+          </button>
         </div>
+      )
+    }
+    return(
+      <div className="buttons">
+        <button className="quill-button outlined secondary medium" onClick={close}>Cancel</button>
+        <button className={footerButtonClass()} onClick={inviteCoteachers}>Invite</button>
       </div>
     )
   }
+
+  return (
+    <div className="modal-container invite-coteachers-modal-container">
+      <div className="modal-background" />
+      <div className="invite-coteachers-modal quill-modal">
+
+        <div className="invite-coteachers-modal-header">
+          <h3 className="title">Invite co-teachers</h3>
+        </div>
+
+        <div className="invite-coteachers-modal-body modal-body">
+          {renderModalContent()}
+        </div>
+
+        <div className="invite-coteachers-modal-footer">
+          {renderButtons()}
+        </div>
+      </div>
+    </div>
+  )
 }
+
+export default InviteCoteachersModal

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
@@ -6,7 +6,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
   defaultText="No date selected"
   handleClickCopyToAll={[Function]}
   icon={null}
-  initialValue={"2022-11-10T05:00:00.000Z"}
+  initialValue={"2022-11-10T03:00:00.000Z"}
   rowIndex={0}
 >
   <div
@@ -21,7 +21,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
         closeOnSelect={false}
         closeOnTab={true}
         dateFormat="MMM D"
-        initialValue={"2022-11-10T05:00:00.000Z"}
+        initialValue={"2022-11-10T03:00:00.000Z"}
         initialViewDate={2022-11-10T09:00:00.000Z}
         input={true}
         inputProps={Object {}}
@@ -85,7 +85,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       "onFocus": [Function],
                       "onKeyDown": [Function],
                       "type": "text",
-                      "value": "Nov 10 5:00 am",
+                      "value": "Nov 10 3:00 am",
                     }
                   }
                 >
@@ -102,7 +102,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       onKeyDown={[Function]}
                       placeholder="No date selected"
                       type="text"
-                      value="Nov 10 5:00 am"
+                      value="Nov 10 3:00 am"
                     />
                     <img
                       alt="dropdown indicator"
@@ -120,7 +120,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                   moment={[Function]}
                   navigate={[Function]}
                   renderDay={[Function]}
-                  selectedDate={"2022-11-10T05:00:00.000Z"}
+                  selectedDate={"2022-11-10T03:00:00.000Z"}
                   showView={[Function]}
                   timeFormat="h:mm a"
                   updateDate={[Function]}


### PR DESCRIPTION
## WHAT
fix Sentry coteacher invitation bug by adding a loading indicator and disabling buttons while the request is processing

## WHY
if a user clicks the button multiple times, multiple requests are sent which yields this particular Sentry error

## HOW
add logic to check for loading state, render loading indicator and disable button to prevent multiple request being executed. I also took the chance to refactor these two files into functional components

note: I checked in with Jack about the design changes and he approved them

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="782" alt="Screen Shot 2023-08-21 at 2 43 19 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/ff24f9b6-ef06-47be-aad6-32c316b92ee3">
<img width="785" alt="Screen Shot 2023-08-21 at 2 42 51 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/4765d94d-4571-4cf5-bb5e-60d3021e154c">
<img width="1378" alt="Screen Shot 2023-08-21 at 3 46 47 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/7b398a55-5e8c-42c9-afdf-85f2264cb9fa">
<img width="1360" alt="Screen Shot 2023-08-21 at 3 46 00 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/9a914c12-598d-4458-a6e7-798feca29194">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Coteacher-invitation-acceptance-triggers-duplicate-key-violation-914f5a52b7564a3ca993a386c6ecff78

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
