### PR TITLE
Fix capitalize_names logic so that it only runs if name is changed

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -115,7 +115,10 @@ class User < ApplicationRecord
 
   SCHOOL_CHANGELOG_ATTRIBUTE = 'school_id'
 
-  attr_accessor :validate_username, :require_password_confirmation_when_password_present, :newsletter
+  attr_accessor :newsletter,
+    :require_password_confirmation_when_password_present,
+    :skip_capitalize_names_callback,
+    :validate_username
 
   has_secure_password validations: false
   has_one :admin_info, dependent: :destroy
@@ -231,7 +234,7 @@ class User < ApplicationRecord
 
   before_validation :generate_student_username_if_absent
   before_validation :prep_authentication_terms
-  before_save :capitalize_name
+  before_save :capitalize_name, if: proc { will_save_change_to_name? && !skip_capitalize_names_callback }
   before_save :set_time_zone, unless: :time_zone
   after_save  :update_invitee_email_address, if: proc { saved_change_to_email? }
   after_save :check_for_school

--- a/services/QuillLMS/lib/tasks/progress_bar.rb
+++ b/services/QuillLMS/lib/tasks/progress_bar.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProgessBar
+class ProgressBar
   def initialize(total)
     @total = total
     @counter = 1

--- a/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
+++ b/services/QuillLMS/lib/tasks/temporary/remove_student_duplicates_with_same_email.rake
@@ -7,7 +7,7 @@ namespace :students do
 
     duplicate_emails = User.student.where.not(email: [nil, ""]).group(:email).having("count(email) > 1").pluck(:email)
 
-    progress_bar = ProgessBar.new(duplicate_emails.size)
+    progress_bar = ProgressBar.new(duplicate_emails.size)
 
     duplicate_emails.each do |email|
       User.find_by(email: email).duplicate_empty_student_accounts.destroy_all

--- a/services/QuillLMS/lib/tasks/users.rake
+++ b/services/QuillLMS/lib/tasks/users.rake
@@ -6,7 +6,7 @@ namespace :users do
   task clear_data_on_deleted_users: :environment do
     deleted_users = User.deleted_users
 
-    progress_bar = ProgessBar.new(deleted_users.size)
+    progress_bar = ProgressBar.new(deleted_users.size)
 
     deleted_users.find_each do |user|
       user.clear_data

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -352,6 +352,38 @@ describe User, type: :model do
     end
   end
 
+  context 'capitalize_name callback' do
+    subject { user.save }
+
+    let!(:user) { create(:user) }
+
+    context 'name not changed' do
+      it do
+        expect(user).not_to receive(:capitalize_name)
+        subject
+      end
+    end
+
+    context 'name changed' do
+      before { user.name = 'Ronald Macdonald' }
+
+      it do
+        expect(user).to receive(:capitalize_name)
+        subject
+      end
+
+      context 'skip_capitalize_names_callback is true' do
+        before { user.skip_capitalize_names_callback = true }
+
+        it do
+          expect(user).not_to receive(:capitalize_name)
+          subject
+        end
+      end
+    end
+
+  end
+
   describe '#admin?' do
     let!(:user) { create(:admin) }
 

--- a/services/QuillLMS/spec/services/canvas_integration/student_creator_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/student_creator_spec.rb
@@ -9,7 +9,7 @@ describe CanvasIntegration::StudentCreator do
   let(:canvas_instance) { create(:canvas_instance) }
   let(:external_id) { Faker::Number.number.to_s }
   let(:email) { Faker::Internet.email }
-  let(:name) { Faker::Name.custom_name }
+  let(:name) { 'Canvas Student' }
 
   let(:data) do
     {

--- a/services/QuillLMS/spec/services/clever_integration/teacher_creator_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_creator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CleverIntegration::TeacherCreator do
   subject { described_class.run(data) }
 
   let(:email) { Faker::Internet.email }
-  let(:name) { Faker::Name.custom_name }
+  let(:name) { 'Clever Teacher' }
   let(:user_external_id) { SecureRandom.hex(12) }
   let(:username) { Faker::Internet.user_name }
 


### PR DESCRIPTION
## WHAT
1. Fix the `capitalize_names` callback on the User model so that it only is called when the name has changed
2. Add a virtual attribute to skip the capitalize names attribute
 
## WHY
1. It's unnecessary to call this every time a User object is saved
2. There are exceptions where the a user's preferred capitalization is different than the norm: (e.g. MacDonald vs Macdonald).  In these cases we should allow for an ad hoc update.

## HOW
1. Add a condition to the before_save callback
2. While there is a `skip_callback` construction that would also work, it is not [thread-safe](https://thelazylog.com/skip-activerecord-callbacks/).  A virtual attribute ensures this is only performed on one user record.Add `attr_accessor :skip_capitalize_name_callback`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/A-teacher-s-name-is-auto-correcting-to-be-incorrectly-capitalized-MacDonald-instead-of-Macdonald--bc2b1990f9c14b84966a374854169e17?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
