### PR TITLE
Intermittent spec capitalize names

### DIFF
--- a/services/QuillLMS/spec/services/canvas_integration/student_creator_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/student_creator_spec.rb
@@ -9,7 +9,7 @@ describe CanvasIntegration::StudentCreator do
   let(:canvas_instance) { create(:canvas_instance) }
   let(:external_id) { Faker::Number.number.to_s }
   let(:email) { Faker::Internet.email }
-  let(:name) { Faker::Name.custom_name }
+  let(:name) { 'Canvas Student' }
 
   let(:data) do
     {

--- a/services/QuillLMS/spec/services/clever_integration/teacher_creator_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_creator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CleverIntegration::TeacherCreator do
   subject { described_class.run(data) }
 
   let(:email) { Faker::Internet.email }
-  let(:name) { Faker::Name.custom_name }
+  let(:name) { 'Clever Teacher' }
   let(:user_external_id) { SecureRandom.hex(12) }
   let(:username) { Faker::Internet.user_name }
 


### PR DESCRIPTION
## WHAT
Fix some spec failures involving capitalized names

## WHY
For some cases Faker::Name.custom_name generates names with capitalization different than CapitalizeName gem.  

## HOW
Hard code the name for these specs to avoid weird cases where Faker has something capitalized and the gem thinks otherwise.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | No.  Non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
