### PR TITLE
lms/premium-hub-overview-copy

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/adminsTeachers.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/adminsTeachers.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`AdminsTeachers component should match snapshot 1`] = `
     </span>
      Any changes you make when you access a teacher account will impact the teacher and student facing dashboards. This list provides you with the ability to sign in to all of the teacher accounts for the schools you have admin access.
     <strong>
-      The data below represents usage from this school year, beginning July 1st.
+      The data above represents usage from this school year, beginning July 1st.
     </strong>
   </p>
 </div>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/adminsTeachers.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/adminsTeachers.tsx
@@ -268,7 +268,7 @@ export const AdminsTeachers: React.SFC<AdminsTeachersProps> = ({
         access a teacher account will impact the teacher and student facing
         dashboards. This list provides you with the ability to sign in to all of the
         teacher accounts for the schools you have admin access.
-        <strong>The data below represents usage from this school year, beginning July 1st.</strong>
+        <strong>The data above represents usage from this school year, beginning July 1st.</strong>
       </p>
     </React.Fragment>
   )


### PR DESCRIPTION
## WHAT
Small copy tweak so that the copy matches new layout
## WHY
The data is no longer "below" the text block, but is now "above" it
## HOW
Just update the copy and then rebuild the jest snapshot

### Screenshots
<img width="1206" alt="image" src="https://github.com/empirical-org/Empirical-Core/assets/331565/d62b36aa-a4a3-4c29-975e-719d3b27da3d">

### Notion Card Links
https://www.notion.so/quill/Minor-copy-change-on-the-Overview-page-for-the-Premium-Hub-704149d7e5ba45ad877530ae60115c14

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
