### PR TITLE
lms/suppress-empty-snackbar

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/activity_pack.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/activity_pack.tsx
@@ -67,7 +67,7 @@ const ActivityPack = ({
   function onSuccess(snackbarCopy) {
     getUnits()
     closeModal()
-    showSnackbar(snackbarCopy)
+    if (snackbarCopy) showSnackbar(snackbarCopy)
   }
 
   function getActivityPackData() {


### PR DESCRIPTION
## WHAT
Only open the Snackbar if there is content to show in it
## WHY
We don't want to confuse users into thinking that there's a message for them when there isn't
## HOW
Just add an `if` before the `showSnackbar` call to confirm that there's actually something to show

### Notion Card Links
https://www.notion.so/quill/Setting-publish-dates-or-due-dates-for-activities-shows-an-empty-snackbar-844d1270e0b14268859a90474fc23b05?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage for this behavior
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
