### PR TITLE
Fix clever integration cache hydration auth

### DIFF
--- a/services/QuillLMS/app/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker.rb
+++ b/services/QuillLMS/app/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker.rb
@@ -5,10 +5,13 @@ module CanvasIntegration
     include Sidekiq::Worker
     sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
+    class UserNotFoundError < StandardError; end
+
     def perform(user_id)
       user = ::User.find_by(id: user_id)
 
-      return if user.nil?
+      return ErrorNotifier.report(UserNotFoundError, user_id: user_id) if user.nil?
+      return unless user.canvas_authorized?
 
       TeacherClassroomsCacheHydrator.run(user)
     end

--- a/services/QuillLMS/app/workers/clever_integration/hydrate_teacher_classrooms_cache_worker.rb
+++ b/services/QuillLMS/app/workers/clever_integration/hydrate_teacher_classrooms_cache_worker.rb
@@ -5,10 +5,13 @@ module CleverIntegration
     include Sidekiq::Worker
     sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
+    class UserNotFoundError < StandardError; end
+
     def perform(user_id)
       user = ::User.find_by(id: user_id)
 
-      return if user.nil?
+      return ErrorNotifier.report(UserNotFoundError, user_id: user_id) if user.nil?
+      return unless user.clever_authorized?
 
       TeacherClassroomsCacheHydrator.run(user)
     end

--- a/services/QuillLMS/spec/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/canvas_integration/hydrate_teacher_classrooms_cache_worker_spec.rb
@@ -2,34 +2,49 @@
 
 require 'rails_helper'
 
-describe CanvasIntegration::HydrateTeacherClassroomsCacheWorker do
-  subject { described_class.new.perform(user_id) }
+module CanvasIntegration
+  RSpec.describe HydrateTeacherClassroomsCacheWorker do
+    subject { described_class.new.perform(user_id) }
 
-  context 'nil user_id' do
-    let(:user_id) { nil }
+    context 'nil user_id' do
+      let(:user_id) { nil }
 
-    it do
-      expect(CanvasIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
-      subject
+      it do
+        expect(ErrorNotifier).to receive(:report).with(described_class::UserNotFoundError, user_id: user_id)
+        expect(TeacherClassroomsCacheHydrator).not_to receive(:run)
+        subject
+      end
     end
-  end
 
-  context 'user does not exist' do
-    let(:user_id) { 0 }
+    context 'user does not exist' do
+      let(:user_id) { 0 }
 
-    it do
-      expect(CanvasIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
-      subject
+      it do
+        expect(ErrorNotifier).to receive(:report).with(described_class::UserNotFoundError, user_id: user_id)
+        expect(TeacherClassroomsCacheHydrator).not_to receive(:run)
+        subject
+      end
     end
-  end
 
-  context 'user exists' do
-    let(:user) { create(:teacher) }
-    let(:user_id) { user.id }
+    context 'user exists' do
+      let(:user) { create(:teacher, :with_canvas_account) }
+      let(:user_id) { user.id }
 
-    it do
-      expect(CanvasIntegration::TeacherClassroomsCacheHydrator).to receive(:run).with(user)
-      subject
+      it do
+        expect(ErrorNotifier).not_to receive(:report)
+        expect(TeacherClassroomsCacheHydrator).not_to receive(:run)
+        subject
+      end
+
+      context 'is clever_authorized' do
+        before { create(:canvas_auth_credential, user: user) }
+
+        it do
+          expect(ErrorNotifier).not_to receive(:report)
+          expect(TeacherClassroomsCacheHydrator).to receive(:run).with(user)
+          subject
+        end
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/workers/clever_integration/hydrate_teacher_classrooms_cache_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/clever_integration/hydrate_teacher_classrooms_cache_worker_spec.rb
@@ -2,34 +2,49 @@
 
 require 'rails_helper'
 
-describe CleverIntegration::HydrateTeacherClassroomsCacheWorker do
-  subject { described_class.new.perform(user_id) }
+module CleverIntegration
+  RSpec.describe HydrateTeacherClassroomsCacheWorker do
+    subject { described_class.new.perform(user_id) }
 
-  context 'nil user_id' do
-    let(:user_id) { nil }
+    context 'nil user_id' do
+      let(:user_id) { nil }
 
-    it do
-      expect(CleverIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
-      subject
+      it do
+        expect(ErrorNotifier).to receive(:report).with(described_class::UserNotFoundError, user_id: user_id)
+        expect(TeacherClassroomsCacheHydrator).not_to receive(:run)
+        subject
+      end
     end
-  end
 
-  context 'user does not exist' do
-    let(:user_id) { 0 }
+    context 'user does not exist' do
+      let(:user_id) { 0 }
 
-    it do
-      expect(CleverIntegration::TeacherClassroomsCacheHydrator).not_to receive(:run)
-      subject
+      it do
+        expect(ErrorNotifier).to receive(:report).with(described_class::UserNotFoundError, user_id: user_id)
+        expect(TeacherClassroomsCacheHydrator).not_to receive(:run)
+        subject
+      end
     end
-  end
 
-  context 'user exists' do
-    let(:user) { create(:teacher) }
-    let(:user_id) { user.id }
+    context 'user exists' do
+      let(:user) { create(:teacher, :signed_up_with_clever) }
+      let(:user_id) { user.id }
 
-    it do
-      expect(CleverIntegration::TeacherClassroomsCacheHydrator).to receive(:run).with(user)
-      subject
+      it do
+        expect(ErrorNotifier).not_to receive(:report)
+        expect(TeacherClassroomsCacheHydrator).not_to receive(:run)
+        subject
+      end
+
+      context 'is clever_authorized' do
+        before { create(:clever_library_auth_credential, user: user) }
+
+        it do
+          expect(ErrorNotifier).not_to receive(:report)
+          expect(TeacherClassroomsCacheHydrator).to receive(:run).with(user)
+          subject
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Add an authorization check for `{Clever,Canvas}Integration::TeacherClassroomsCacheHydrator`

## WHY
The hydrator should not be called if the user's auth credential has expired

## HOW
Add a guard clause that checks for authorization before attempting to hydrate the cache.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sidekiq-CleverIntegration-HydrateTeacherClassroomsCacheWorker-nil-error-daefd6b00bc84c5e89bff86f3a891803?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
