### PR TITLE
lms/zero-not-null-for-query

### DIFF
--- a/services/QuillLMS/app/queries/snapshots/student_learning_hours_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/student_learning_hours_query.rb
@@ -4,7 +4,7 @@ module Snapshots
   class StudentLearningHoursQuery < ActivitySessionCountQuery
     def select_clause
       # timespent stores seconds
-      "SELECT SUM(activity_sessions.timespent) / 3600.0 AS count"
+      "SELECT IFNULL(SUM(activity_sessions.timespent), 0) / 3600.0 AS count"
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/student_learning_hours_query_spec.rb
@@ -10,6 +10,16 @@ module Snapshots
       let(:total_timespent) { activity_sessions.sum(&:timespent) / 3600.0 }
 
       it { expect(results).to eq(count: total_timespent) }
+
+      context 'null total timespent' do
+        let(:activity_sessions) do
+          classroom_units.map do |classroom_unit|
+            create(:activity_session, classroom_unit: classroom_unit, timespent: nil)
+          end
+        end
+
+        it { expect(results).to eq(count: 0) }
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
If no existing data for learning hours is in place, return 0 not null
## WHY
Because the front-end interprets null as 'N/A', but we want empty results for this query to display as 0
## HOW
Wrap the `SELECT` value in an `IFNULL` so that we treat null sums as 0

### Notion Card Links
https://www.notion.so/quill/Admin-Usage-Snapshot-Report-QA-Week-of-July-17-767225ae4fd74382bfed44861d36f589?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
