### PR TITLE
Add back in missing params

### DIFF
--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -16,7 +16,7 @@ module Auth
       @auth_hash ||= request.env['omniauth.auth']
     end
 
-    private def district_success
+    private def district_success(_data, _redirect)
       redirect_to '/clever/district_success'
     end
 


### PR DESCRIPTION
## WHAT
Add back in params to Clever method

## WHY
They're actually [required](https://quillorg-5s.sentry.io/issues/4417837431/?environment=production&project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=3)

## HOW
Restore params.  They are actually a relic of the send method in line 9 of the auth clever controller.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
