### PR TITLE
Add guard clause for nil user in SaveUserPackSequenceItemWorker

### DIFF
--- a/services/QuillLMS/app/workers/save_user_pack_sequence_item_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_item_worker.rb
@@ -8,6 +8,7 @@ class SaveUserPackSequenceItemWorker
   def perform(pack_sequence_item_id, status, user_id)
     return if pack_sequence_item_id.nil? || user_id.nil?
     return unless PackSequenceItem.exists?(id: pack_sequence_item_id)
+    return unless User.exists?(id: user_id)
 
     upsi = UserPackSequenceItem.create_or_find_by!(pack_sequence_item_id: pack_sequence_item_id, user_id: user_id)
     return if upsi.status == status

--- a/services/QuillLMS/spec/workers/save_user_pack_sequence_item_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/save_user_pack_sequence_item_worker_spec.rb
@@ -29,10 +29,19 @@ RSpec.describe SaveUserPackSequenceItemWorker do
     end
   end
 
-  context 'nil pack_sequence_item' do
+  context 'pack_sequence_item does not exist' do
     before { PackSequenceItem.find_by(id: pack_sequence_item_id).destroy }
 
-    it 'should_not_query_user_pack_sequence_item' do
+    it do
+      expect(UserPackSequenceItem).not_to receive(:create_or_find_by!)
+      subject
+    end
+  end
+
+  context 'user does not exist' do
+    before { User.find_by(id: user_id).destroy }
+
+    it do
       expect(UserPackSequenceItem).not_to receive(:create_or_find_by!)
       subject
     end


### PR DESCRIPTION
## WHAT
Fix a[ bug](https://quillorg-5s.sentry.io/issues/3936996968/?environment=production&project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=4) with SaveUserPackSequenceItemWorker 

## WHY
There's a race condition where a user pack sequence item is attempted to be saved but the user might be deleted for some reason simultaneously

## HOW
Add a guard clause that checks that the user does in fact exist.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
