### PR TITLE
Fix race condition with save user pack sequence item

### DIFF
--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -84,11 +84,11 @@ class ClassroomUnit < ApplicationRecord
 
   def manage_user_pack_sequence_items
     pack_sequence_items.reload.each do |pack_sequence_item|
-      existing_user_ids = pack_sequence_item.users.pluck(:id)
+      existing_user_ids = pack_sequence_item.reload.users.pluck(:id)
       new_user_ids = assigned_student_ids - existing_user_ids
       deleted_user_ids = existing_user_ids - assigned_student_ids
 
-      new_user_ids.each { |user_id| pack_sequence_item.user_pack_sequence_items.create!(user_id: user_id) }
+      new_user_ids.each { |user_id| pack_sequence_item.user_pack_sequence_items.find_or_create_by!(user_id: user_id) }
 
       pack_sequence_item
         .user_pack_sequence_items

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -194,45 +194,46 @@ describe ClassroomUnit, type: :model, redis: true do
   end
 
   describe 'manage_user_pack_sequence_items' do
-    context 'after_save' do
-      context 'assigned_student_ids has changed' do
-        subject { classroom_unit.reload.update(assigned_student_ids: new_assigned_student_ids, assign_on_join: false) }
+    subject { classroom_unit.reload.update(assigned_student_ids: new_assigned_student_ids, assign_on_join: false) }
 
-        let(:another_student) { create(:student) }
+    let(:another_student) { create(:student) }
 
-        context 'no user_pack_sequence_items exist' do
-          context 'student was removed' do
-            let(:new_assigned_student_ids) { [] }
+    context 'no user_pack_sequence_items exist' do
+      context 'student was removed' do
+        let(:new_assigned_student_ids) { [] }
 
-            it { expect { subject }.not_to change(UserPackSequenceItem, :count) }
-          end
+        it { expect { subject }.not_to change(UserPackSequenceItem, :count) }
+      end
 
-          context 'new student was added' do
-            let(:new_assigned_student_ids) { [student.id, another_student.id]}
+      context 'new student was added' do
+        let(:new_assigned_student_ids) { [student.id, another_student.id]}
 
-            it { expect { subject }.not_to change(UserPackSequenceItem, :count) }
-          end
-        end
+        it { expect { subject }.not_to change(UserPackSequenceItem, :count) }
+      end
+    end
 
-        context 'user_pack_sequence_items exist' do
-          let!(:pack_sequence_item) { create(:pack_sequence_item, classroom_unit: classroom_unit) }
+    context 'user_pack_sequence_items exist' do
+      let!(:pack_sequence_item) { create(:pack_sequence_item, classroom_unit: classroom_unit) }
 
-          before { create(:user_pack_sequence_item, user: student, pack_sequence_item: pack_sequence_item) }
+      before { create(:user_pack_sequence_item, user: student, pack_sequence_item: pack_sequence_item) }
 
-          context 'student was removed' do
-            let(:new_assigned_student_ids) { [] }
+      context 'student was removed' do
+        let(:new_assigned_student_ids) { [] }
 
-            it { expect { subject }.to change(UserPackSequenceItem, :count).from(1).to(0) }
-          end
+        it { expect { subject }.to change(UserPackSequenceItem, :count).from(1).to(0) }
+      end
 
-          context 'new student was added' do
-            let(:new_assigned_student_ids) { [student.id, another_student.id]}
+      context 'new student was added' do
+        let(:new_assigned_student_ids) { [student.id, another_student.id]}
 
-            it { expect { subject }.to change(UserPackSequenceItem, :count).from(1).to(2) }
-          end
+        it { expect { subject }.to change(UserPackSequenceItem, :count).from(1).to(2) }
+
+        context 'but already has a user_pack_sequence_item' do
+          before { create(:user_pack_sequence_item, user: another_student, pack_sequence_item: pack_sequence_item) }
+
+          it { expect { subject }.not_to change(UserPackSequenceItem, :count)}
         end
       end
     end
   end
-
 end


### PR DESCRIPTION
## WHAT
Fix an ActiveRecord::RecordNotUnique [bug](https://quillorg-5s.sentry.io/issues/3863798918/?environment=production&project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=0) involving the saving of UserPackSequenceItem

## WHY
This bug is preventing the remaining pack sequence items in the loop from being created.

## HOW
ClassroomUnit has a callback that manages UserPackSequence items which involves iterating over a loop of pack sequence items and adding new UserPackSequenceItems where needed.  However, these same objects are being manipulated elsewhere so we should adjust the `create!` to `find_or_create_by!` in case new_user_ids is actually stale.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? |  Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
