### PR TITLE
Handle race condition with saving user pack sequence item

### DIFF
--- a/services/QuillLMS/app/workers/save_user_pack_sequence_item_worker.rb
+++ b/services/QuillLMS/app/workers/save_user_pack_sequence_item_worker.rb
@@ -14,5 +14,9 @@ class SaveUserPackSequenceItemWorker
     return if upsi.status == status
 
     upsi.update!(status: status)
+
+  # While create_or_find_by! runs a race condition with pack sequence item destroyed elsewhere
+  rescue ActiveRecord::InvalidForeignKey
+    retry
   end
 end


### PR DESCRIPTION
## WHAT
Fix a race [condition](https://quillorg-5s.sentry.io/issues/3936996967/?environment=production&project=11238&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=12) with SaveUserPackSequenceItemWorker

## WHY
Multiple user pack sequence items are created whenever a teacher assigns recommendations.  All of these items can quickly be destroyed with a change back from staggered to immediate release.  In the process of doing this a race condition exists where a UserPackSequenceItem.create_or_find_by is called while the PackSequenceItem is being destroyed raising an invalid foreign key.

## HOW
Add a rescue clause for this error and simply retry the job.  If the PackSequenceItem has in fact been destroyed on the retry, it will in fact exit cleanly due to the guard clause PackSequenceItem.exists?

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
