### PR TITLE
Fix clever_authorized? check

### DIFF
--- a/services/QuillLMS/app/models/clever_district_auth_credential.rb
+++ b/services/QuillLMS/app/models/clever_district_auth_credential.rb
@@ -28,6 +28,8 @@ class CleverDistrictAuthCredential < AuthCredential
   PROVIDER = 'clever_district'
 
   def clever_authorized?
-    true
+    return false if expires_at.nil?
+
+    Time.current < expires_at
   end
 end

--- a/services/QuillLMS/app/models/clever_library_auth_credential.rb
+++ b/services/QuillLMS/app/models/clever_library_auth_credential.rb
@@ -28,6 +28,8 @@ class CleverLibraryAuthCredential < AuthCredential
   PROVIDER = 'clever_library'
 
   def clever_authorized?
-    true
+    return false if expires_at.nil?
+
+    Time.current < expires_at
   end
 end

--- a/services/QuillLMS/spec/models/clever_district_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/clever_district_auth_credential_spec.rb
@@ -34,5 +34,17 @@ describe CleverDistrictAuthCredential, type: :model do
 
   it { is_expected.not_to be_canvas_authorized }
   it { is_expected.not_to be_google_authorized }
+
+  context 'expires_at is nil' do
+    subject { create(:clever_library_auth_credential, expires_at: nil) }
+
+    it { is_expected.not_to be_clever_authorized }
+  end
+
+  context 'expires_at is in the past' do
+    subject { create(:clever_library_auth_credential, expires_at: 1.day.ago) }
+
+    it { is_expected.not_to be_clever_authorized }
+  end
 end
 

--- a/services/QuillLMS/spec/models/clever_library_auth_credential_spec.rb
+++ b/services/QuillLMS/spec/models/clever_library_auth_credential_spec.rb
@@ -34,5 +34,16 @@ describe CleverLibraryAuthCredential, type: :model do
 
   it { is_expected.not_to be_canvas_authorized }
   it { is_expected.not_to be_google_authorized }
-end
 
+  context 'expires_at is nil' do
+    subject { create(:clever_library_auth_credential, expires_at: nil) }
+
+    it { is_expected.not_to be_clever_authorized }
+  end
+
+  context 'expires_at is in the past' do
+    subject { create(:clever_library_auth_credential, expires_at: 1.day.ago) }
+
+    it { is_expected.not_to be_clever_authorized }
+  end
+end


### PR DESCRIPTION
## WHAT
Fix a [bug](https://quillorg-5s.sentry.io/issues/4385584391/?environment=production&project=11238&query=is%3Aunresolved+%22Clever%3A%3AApiError%22&referrer=issue-stream&statsPeriod=24h&stream_index=0) involving `Clever::ApiError`

## WHY
This bug was hidden for the most part since we have a somewhat redundant mechanism that when a user signs in with Clever a worker is enqueued to [purge](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/services/clever_integration/auth_credential_saver.rb#L32) an auth_credential in 23.hours.

For the most part this seems to work, although there seem to be some auth_credentials sneaking through the cracks and not getting purged. 

## HOW
Add a check to both auth credential types that checks `expires_at` on the auth credential.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
