### PR TITLE
remove is_demo clause from question scoring eligibility

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -380,7 +380,7 @@ class Teachers::UnitsController < ApplicationController
 
   private def fetch_diagnostic_units_cache
     current_user.all_classrooms_cache(key: 'teachers.classrooms.diagnostic_units') do
-      DiagnosticsOrganizedByClassroomFetcher.run(current_user, session[:demo_id].present?)
+      DiagnosticsOrganizedByClassroomFetcher.run(current_user)
     end
   end
 end

--- a/services/QuillLMS/app/services/diagnostics_organized_by_classroom_fetcher.rb
+++ b/services/QuillLMS/app/services/diagnostics_organized_by_classroom_fetcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DiagnosticsOrganizedByClassroomFetcher < ApplicationService
-  attr_reader :user, :is_demo
+  attr_reader :user
 
   ACTIVITY_IDS_TO_NAMES = {
     Activity::STARTER_DIAGNOSTIC_ACTIVITY_ID => 'Starter Diagnostic',
@@ -14,9 +14,8 @@ class DiagnosticsOrganizedByClassroomFetcher < ApplicationService
 
   QUESTION_SCORING_ELIGIBILITY_CUTOFF_DATE = DateTime.new(2023, 7, 19, 0, 0, 0)
 
-  def initialize(user, is_demo)
+  def initialize(user)
     @user = user
-    @is_demo = is_demo
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
@@ -96,7 +95,7 @@ class DiagnosticsOrganizedByClassroomFetcher < ApplicationService
     record = records[0]
     return if !record
 
-    record['eligible_for_question_scoring'] = !is_demo && (activity_sessions.empty? || activity_sessions.last.completed_at  > QUESTION_SCORING_ELIGIBILITY_CUTOFF_DATE)
+    record['eligible_for_question_scoring'] = activity_sessions.empty? || activity_sessions.last.completed_at  > QUESTION_SCORING_ELIGIBILITY_CUTOFF_DATE
     record['completed_count'] = activity_sessions.size
     record['assigned_count'] = assigned_student_ids.size
     record.except('unit_id', 'unit_name', 'classroom_unit_id', 'assigned_student_ids')

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -162,7 +162,7 @@ describe Teachers::UnitsController, type: :controller do
     end
 
     it 'should successfully render both fresh data and cached data' do
-      expect(DiagnosticsOrganizedByClassroomFetcher).to receive(:run).once.with(teacher, false).and_call_original
+      expect(DiagnosticsOrganizedByClassroomFetcher).to receive(:run).once.with(teacher).and_call_original
 
       2.times do
         get :diagnostic_units

--- a/services/QuillLMS/spec/services/diagnostics_organized_by_classroom_fetcher_spec.rb
+++ b/services/QuillLMS/spec/services/diagnostics_organized_by_classroom_fetcher_spec.rb
@@ -16,61 +16,49 @@ RSpec.describe DiagnosticsOrganizedByClassroomFetcher do
   let!(:date_before_question_switchover) { DateTime.new(2023, 7, 18, 0, 0, 0) }
   let!(:date_after_question_switchover) { DateTime.new(2023, 7, 20, 0, 0, 0) }
 
-  subject { described_class.new(user, is_demo) }
+  subject { described_class.new(user) }
 
-  context "user is demo" do
-    let(:is_demo) { true }
+  describe 'record_with_aggregated_activity_sessions' do
 
-    describe 'record_with_aggregated_activity_sessions' do
+    context 'there are no completed activity sessions' do
+      it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(true) }
+    end
+
+    context 'all activity sessions were completed after the question scoring switchover date' do
+      let!(:activity_session) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit1, completed_at: date_after_question_switchover)}
+
+      it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(true) }
+    end
+
+    context 'all activity sessions were completed before the question scoring switchover date' do
+      let!(:activity_session) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit1, completed_at: date_before_question_switchover)}
+
       it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(false) }
     end
-  end
 
-  context "user is not demo" do
-    let(:is_demo) { false }
+    context 'every student who completed an activity session for the given activity and classroom before the switchover also completed one after' do
+      let!(:unit2) { create(:unit, user: user) }
+      let!(:unit_activity2) { create(:unit_activity, unit: unit2, activity: activity )}
+      let!(:classroom_unit2) { create(:classroom_unit, unit: unit2, classroom: classroom, assigned_student_ids: [student1.id]) }
+      let!(:activity_session1) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit1, completed_at: date_after_question_switchover)}
+      let!(:activity_session2) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit2, completed_at: date_before_question_switchover)}
 
-    describe 'record_with_aggregated_activity_sessions' do
-
-      context 'there are no completed activity sessions' do
-        it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(true) }
-      end
-
-      context 'all activity sessions were completed after the question scoring switchover date' do
-        let!(:activity_session) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit1, completed_at: date_after_question_switchover)}
-
-        it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(true) }
-      end
-
-      context 'all activity sessions were completed before the question scoring switchover date' do
-        let!(:activity_session) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit1, completed_at: date_before_question_switchover)}
-
-        it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(false) }
-      end
-
-      context 'every student who completed an activity session for the given activity and classroom before the switchover also completed one after' do
-        let!(:unit2) { create(:unit, user: user) }
-        let!(:unit_activity2) { create(:unit_activity, unit: unit2, activity: activity )}
-        let!(:classroom_unit2) { create(:classroom_unit, unit: unit2, classroom: classroom, assigned_student_ids: [student1.id]) }
-        let!(:activity_session1) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit1, completed_at: date_after_question_switchover)}
-        let!(:activity_session2) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit2, completed_at: date_before_question_switchover)}
-
-        it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(true) }
-      end
-
-      context 'not every student who completed an activity session for the given activity and classroom before the switchover also completed one after' do
-        let!(:student2) { create(:student) }
-        let!(:classroom_student2) { create(:students_classrooms, classroom: classroom, student: student2) }
-        let!(:unit2) { create(:unit, user: user) }
-        let!(:unit_activity2) { create(:unit_activity, unit: unit2, activity: activity )}
-        let!(:classroom_unit2) { create(:classroom_unit, unit: unit2, classroom: classroom, assigned_student_ids: [student1.id, student2.id]) }
-        let!(:activity_session1) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit1, completed_at: date_after_question_switchover)}
-        let!(:activity_session2) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit2, completed_at: date_before_question_switchover)}
-        let!(:activity_session3) { create(:activity_session, user: student2, activity: activity, classroom_unit: classroom_unit2, completed_at: date_before_question_switchover)}
-
-        it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(false) }
-      end
-
+      it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(true) }
     end
+
+    context 'not every student who completed an activity session for the given activity and classroom before the switchover also completed one after' do
+      let!(:student2) { create(:student) }
+      let!(:classroom_student2) { create(:students_classrooms, classroom: classroom, student: student2) }
+      let!(:unit2) { create(:unit, user: user) }
+      let!(:unit_activity2) { create(:unit_activity, unit: unit2, activity: activity )}
+      let!(:classroom_unit2) { create(:classroom_unit, unit: unit2, classroom: classroom, assigned_student_ids: [student1.id, student2.id]) }
+      let!(:activity_session1) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit1, completed_at: date_after_question_switchover)}
+      let!(:activity_session2) { create(:activity_session, user: student1, activity: activity, classroom_unit: classroom_unit2, completed_at: date_before_question_switchover)}
+      let!(:activity_session3) { create(:activity_session, user: student2, activity: activity, classroom_unit: classroom_unit2, completed_at: date_before_question_switchover)}
+
+      it { expect(subject.record_with_aggregated_activity_sessions(activity.id, classroom.id)['eligible_for_question_scoring']).to eq(false) }
+    end
+
   end
 
 end


### PR DESCRIPTION
## WHAT
Remove `is_demo` clause from question scoring eligibility conditional, so that teachers can see all diagnostic pages fully populated in the demo account.

## WHY
So that the data renders for the demo account now that the data we need is in place.

## HOW
Just remove all reference to `is_demo` in this file.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Remove-is_demo-clause-from-eligible_for_question_scoring-conditional-4c400ba62b14445799750660d77c9f6d?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES