### PR TITLE
hide percentage change if change is zero

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
@@ -70,10 +70,7 @@ exports[`SnapshotCount component size medium should match snapshot 1`] = `
     <div
       className="change"
     >
-      <span>
-        0
-        %
-      </span>
+      <span />
     </div>
   </section>
 </SnapshotCount>
@@ -158,8 +155,7 @@ exports[`SnapshotCount component size medium when there is data with a negative 
         src="undefined/images/pages/administrator/usage_snapshot_report/arrow_down_icon.svg"
       />
       <span>
-        50
-        %
+        50%
       </span>
     </div>
   </section>
@@ -245,8 +241,7 @@ exports[`SnapshotCount component size medium when there is data with a positive 
         src="undefined/images/pages/administrator/usage_snapshot_report/arrow_up_icon.svg"
       />
       <span>
-        50
-        %
+        50%
       </span>
     </div>
   </section>
@@ -323,10 +318,7 @@ exports[`SnapshotCount component size medium when there is no data  should match
     <div
       className="change"
     >
-      <span>
-        0
-        %
-      </span>
+      <span />
     </div>
   </section>
 </SnapshotCount>
@@ -402,10 +394,7 @@ exports[`SnapshotCount component size small when it is coming soon should match 
     <div
       className="change"
     >
-      <span>
-        0
-        %
-      </span>
+      <span />
     </div>
   </section>
 </SnapshotCount>
@@ -490,8 +479,7 @@ exports[`SnapshotCount component size small when there is data with a negative t
         src="undefined/images/pages/administrator/usage_snapshot_report/arrow_down_icon.svg"
       />
       <span>
-        50
-        %
+        50%
       </span>
     </div>
   </section>
@@ -577,8 +565,7 @@ exports[`SnapshotCount component size small when there is data with a positive t
         src="undefined/images/pages/administrator/usage_snapshot_report/arrow_up_icon.svg"
       />
       <span>
-        50
-        %
+        50%
       </span>
     </div>
   </section>
@@ -655,10 +642,7 @@ exports[`SnapshotCount component size small when there is no data  should match 
     <div
       className="change"
     >
-      <span>
-        0
-        %
-      </span>
+      <span />
     </div>
   </section>
 </SnapshotCount>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotSection.test.tsx.snap
@@ -188,10 +188,7 @@ exports[`SnapshotSection component when the section is Classrooms should match s
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -263,10 +260,7 @@ exports[`SnapshotSection component when the section is Classrooms should match s
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -339,10 +333,7 @@ exports[`SnapshotSection component when the section is Classrooms should match s
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -414,10 +405,7 @@ exports[`SnapshotSection component when the section is Classrooms should match s
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -726,10 +714,7 @@ exports[`SnapshotSection component when the section is Highlights should match s
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -802,10 +787,7 @@ exports[`SnapshotSection component when the section is Highlights should match s
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -1080,10 +1062,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -1156,10 +1135,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -1232,10 +1208,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -1308,10 +1281,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -1656,10 +1626,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -1732,10 +1699,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -1808,10 +1772,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -1884,10 +1845,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -1959,10 +1917,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -2680,10 +2635,7 @@ exports[`SnapshotSection component when the section is Users should match snapsh
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -2756,10 +2708,7 @@ exports[`SnapshotSection component when the section is Users should match snapsh
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -2832,10 +2781,7 @@ exports[`SnapshotSection component when the section is Users should match snapsh
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>
@@ -2908,10 +2854,7 @@ exports[`SnapshotSection component when the section is Users should match snapsh
               <div
                 className="change"
               >
-                <span>
-                  0
-                  %
-                </span>
+                <span />
               </div>
             </section>
           </SnapshotCount>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -135,7 +135,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
       </div>
       <div className="change">
         {icon}
-        <span>{change}%</span>
+        <span>{change === 0 ? null : `${change}%`}</span>
       </div>
     </section>
   )


### PR DESCRIPTION
## WHAT
Hide percentage change on Admin Usage Snapshot if the change rate is zero.

## WHY
To avoid showing unhelpful information.

## HOW
Just add a ternary.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/On-the-Usage-Snapshot-Report-hide-the-percent-change-value-if-it-is-0-5798b85b7c404d73b145e612af53a1a6?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES