### PR TITLE
Add some guard clauses to a couple worker classes

### DIFF
--- a/services/QuillLMS/app/queries/impact_metrics/active_teachers_all_time_query.rb
+++ b/services/QuillLMS/app/queries/impact_metrics/active_teachers_all_time_query.rb
@@ -4,10 +4,6 @@ module ImpactMetrics
   class ActiveTeachersAllTimeQuery < ::QuillBigQuery::Query
     ACTIVITY_SESSION_MINIMUM = 9
 
-    def initialize(options)
-      super(**options)
-    end
-
     def run
       run_query
     end

--- a/services/QuillLMS/app/workers/expire_password_token_worker.rb
+++ b/services/QuillLMS/app/workers/expire_password_token_worker.rb
@@ -3,8 +3,14 @@
 class ExpirePasswordTokenWorker
   include Sidekiq::Worker
 
-  def perform(id)
-    User.find(id)&.update!(token: nil)
-  end
+  class UserNotFoundError < StandardError; end
 
+  def perform(user_id)
+    return if user_id.nil?
+
+    user = User.find_by(id: user_id)
+    return ErrorNotifier.report(UserNotFoundError, user_id: user_id) if user.nil?
+
+    user.update!(token: nil)
+  end
 end

--- a/services/QuillLMS/app/workers/reset_lesson_cache_worker.rb
+++ b/services/QuillLMS/app/workers/reset_lesson_cache_worker.rb
@@ -4,9 +4,16 @@ class ResetLessonCacheWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
-  def perform(id)
-    $redis.del("user_id:#{id}_lessons_array")
-    @user = User.find(id)
-    @user.set_lessons_cache
+  class UserNotFoundError < StandardError; end
+
+  def perform(user_id)
+    return if user_id.nil?
+
+    $redis.del("user_id:#{user_id}_lessons_array")
+    user = User.find_by(id: user_id)
+
+    return ErrorNotifier.report(UserNotFoundError, user_id: user_id) if user.nil?
+
+    user.set_lessons_cache
   end
 end

--- a/services/QuillLMS/app/workers/set_impact_metrics_worker.rb
+++ b/services/QuillLMS/app/workers/set_impact_metrics_worker.rb
@@ -7,17 +7,13 @@ class SetImpactMetricsWorker
   SENTENCES_PER_ACTIVITY_SESSION = 10
 
   def perform
-    set_impact_metrics
-  end
-
-  def set_impact_metrics
     finished_activity_sessions_count = ImpactMetrics::ActivitiesAllTimeQuery.run[0]["count"]
     active_students_count = ImpactMetrics::ActiveStudentsAllTimeQuery.run[0]["count"]
 
     teachers = ImpactMetrics::ActiveTeachersAllTimeQuery.run
     teacher_ids = teachers.to_a.map {|teacher| teacher["id"]}
 
-    schools = ImpactMetrics::SchoolsContainingCertainTeachersQuery.run(teacher_ids)
+    schools = ImpactMetrics::SchoolsContainingCertainTeachersQuery.run(teacher_ids: teacher_ids)
     low_income_schools = schools.select { |school| (school["free_lunches"] || 0) > FREE_LUNCH_MINIMUM}
 
     number_of_sentences = self.class.round_to_ten_thousands(finished_activity_sessions_count) * SENTENCES_PER_ACTIVITY_SESSION

--- a/services/QuillLMS/spec/workers/expire_password_token_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/expire_password_token_worker_spec.rb
@@ -2,17 +2,31 @@
 
 require 'rails_helper'
 
-describe ExpirePasswordTokenWorker do
-  subject { described_class.new }
+RSpec.describe ExpirePasswordTokenWorker do
+  subject { described_class.new.perform(user_id) }
 
-  describe '#perform' do
-    let!(:user) { create(:user) }
+  let(:user_id) { nil }
 
-    it 'should set user token to nil' do
-      user.refresh_token!
-      subject.perform(user.id)
-      expect(user.reload.token).to eq nil
+  context 'when user_id is nil' do
+    it { expect { subject }.not_to raise_error }
+  end
+
+  context 'when user is not present' do
+    let(:user_id) { 1 }
+
+    it do
+      expect(ErrorNotifier).to receive(:report).with(described_class::UserNotFoundError, user_id: user_id)
+      subject
     end
+  end
+
+  context 'when user is present' do
+    let(:user) { create(:user) }
+    let(:user_id) { user.id }
+
+    before { user.refresh_token! }
+
+    it { expect { subject }.to change { user.reload.token }.to(nil) }
   end
 end
 

--- a/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
@@ -32,7 +32,7 @@ describe SetImpactMetricsWorker do
       allow(ImpactMetrics::ActivitiesAllTimeQuery).to receive(:run).and_return(activity_sessions_payload)
       allow(ImpactMetrics::ActiveStudentsAllTimeQuery).to receive(:run).and_return(active_students_payload)
       allow(ImpactMetrics::ActiveTeachersAllTimeQuery).to receive(:run).and_return(teachers_payload)
-      allow(ImpactMetrics::SchoolsContainingCertainTeachersQuery).to receive(:run).with(teachers.pluck(:id)).and_return(schools_payload)
+      allow(ImpactMetrics::SchoolsContainingCertainTeachersQuery).to receive(:run).with(teacher_ids: teachers.pluck(:id)).and_return(schools_payload)
     end
 
     it 'should set the NUMBER_OF_SENTENCES redis value' do


### PR DESCRIPTION
## WHAT
1.  Add some guard clauses to ExpirePasswordTokenWorker
2. Add some guard clauses to ResetLessonCacheWorker
3. Fix method call in SetImpactMetricsWorker

## WHY
They are all showing up in the retry queue

## HOW
1. Add early returns for nil user_id and nil user
2. Add early returns for nil user_id and nil user
3. Add teacher_ids named parameter

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A