### PR TITLE
Handle 401 errors with Clever Library access

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -9,7 +9,6 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 3.0
   Exclude:
     - "QuillLMS/engines/evidence/spec/dummy/**/*"
     - "QuillLMS/engines/evidence/lib/generators/**/*"

--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -9,6 +9,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
+  TargetRubyVersion: 3.0
   Exclude:
     - "QuillLMS/engines/evidence/spec/dummy/**/*"
     - "QuillLMS/engines/evidence/lib/generators/**/*"

--- a/services/QuillLMS/app/services/clever_integration/library_client.rb
+++ b/services/QuillLMS/app/services/clever_integration/library_client.rb
@@ -5,30 +5,44 @@ module CleverIntegration
     include HTTParty
     base_uri 'https://api.clever.com/v2.0'
 
+    class HttpError < StandardError; end
+
     def initialize(bearer_token)
       @options = { headers: { "Authorization": "Bearer #{bearer_token}" } }
     end
 
     def get_district(district_id:)
-      get_path("/districts/#{district_id}")
+      get_path("/districts/#{district_id}", nil)
     end
 
     def get_teacher(teacher_id:)
-      get_path("/teachers/#{teacher_id}")
+      get_path("/teachers/#{teacher_id}", nil)
     end
 
     def classroom_students(section_id)
-      get_path("/sections/#{section_id}/students")
+      get_path("/sections/#{section_id}/students", [])
         .map { |student_data| LibraryStudentDataAdapter.run(student_data) }
     end
 
     def teacher_classrooms(teacher_clever_id)
-      get_path("/teachers/#{teacher_clever_id}/sections")
+      get_path("/teachers/#{teacher_clever_id}/sections", [])
         .map { |classroom_data| LibraryClassroomDataAdapter.run(classroom_data) }
     end
 
-    private def get_path(path)
-      self.class.get(path, @options).parsed_response["data"]
+    private def get_path(path, error_data)
+      handle_response(self.class.get(path, @options), error_data)
+    end
+
+    private def handle_response(response, error_data)
+      case response.code
+      when 200
+        response.parsed_response['data']
+      when 401
+        error_data
+      else
+        ErrorNotifier.report(HttpError.new("HTTP #{response.code}"))
+        error_data
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/library_client_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/library_client_spec.rb
@@ -9,17 +9,18 @@ RSpec.describe CleverIntegration::LibraryClient do
   let(:teacher) { create(:teacher, clever_id: teacher_clever_id) }
   let(:bearer_token) { 'not-a-real-bearer-token' }
   let(:options) { { headers: { "Authorization": "Bearer #{bearer_token}" } } }
+  let(:http_response) { double(:http_response, code: code, parsed_response: parsed_response) }
 
   before { expect(described_class).to receive(:get).with(path, options).and_return(http_response) }
 
-  context '#classroom_students' do
+  describe '#classroom_students' do
     subject { client.classroom_students(classroom_external_id) }
 
-    let(:http_response) { double(:http_response, parsed_response: classroom_students_data) }
     let(:path) { "/sections/#{classroom_external_id}/students" }
 
     context 'classroom 1' do
-      let(:classroom_students_data) { classroom1_students_data }
+      let(:code) { 200 }
+      let(:parsed_response) { classroom1_students_data }
       let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
       let(:students_attrs) { [student1_attrs, student2_attrs] }
 
@@ -27,21 +28,67 @@ RSpec.describe CleverIntegration::LibraryClient do
     end
 
     context 'classroom 2' do
-      let(:classroom_students_data) { classroom2_students_data }
+      let(:code) { 200 }
+      let(:parsed_response) { classroom2_students_data }
       let(:classroom_external_id)  { classroom2_attrs[:classroom_external_id] }
       let(:students_attrs) { [student3_attrs] }
 
       it { is_expected.to eq students_attrs}
     end
+
+    context 'unauthorized token' do
+      let(:code) { 401 }
+      let(:parsed_response) { {'error' => 'Unrecognized token string' } }
+      let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
+
+      it { is_expected.to eq [] }
+    end
+
+    context 'unknown error' do
+      let(:code) { 500 }
+      let(:parsed_response) { {'error' => 'Unknown error' } }
+      let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
+
+      it { is_expected.to eq [] }
+
+      it do
+        expect(ErrorNotifier).to receive(:report).with(an_instance_of(described_class::HttpError))
+        subject
+      end
+    end
   end
 
-  context '#teacher_classrooms' do
+  describe '#teacher_classrooms' do
     subject { client.teacher_classrooms(teacher.clever_id) }
 
-    let(:http_response) { double(:http_response, parsed_response: classrooms_data) }
     let(:path) { "/teachers/#{teacher.clever_id}/sections" }
-    let(:classrooms_attrs) { [classroom1_attrs, classroom2_attrs]}
 
-    it { is_expected.to eq classrooms_attrs }
+    context 'successful response' do
+      let(:code) { 200 }
+      let(:parsed_response) { classrooms_data }
+      let(:classrooms_attrs) { [classroom1_attrs, classroom2_attrs]}
+
+      it { is_expected.to eq classrooms_attrs }
+    end
+
+    context 'unauthorized token' do
+      let(:code) { 401 }
+      let(:parsed_response) { {'error' => 'Unrecognized token string' } }
+      let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
+
+      it { is_expected.to eq [] }
+    end
+
+    context 'unknown error' do
+      let(:code) { 500 }
+      let(:parsed_response) { {'error' => 'Unknown error' } }
+
+      it { is_expected.to eq [] }
+
+      it do
+        expect(ErrorNotifier).to receive(:report).with(an_instance_of(described_class::HttpError))
+        subject
+      end
+    end
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/teacher_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/teacher_updater_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CleverIntegration::TeacherUpdater do
   context 'teacher is already linked with clever' do
     let(:provider_trait) { :signed_up_with_clever }
     let(:user_external_id) { teacher.clever_id }
-    let(:name) { Faker::Name.custom_name }
+    let(:name) { 'Another Teacher' }
     let(:email) { Faker::Internet.email }
 
     it { expect { subject }.to change(teacher, :name).to(name) }


### PR DESCRIPTION
## WHAT
Fix a [bug](https://quillorg-5s.sentry.io/issues/4435014759/?environment=production&project=11238&query=is%3Aunresolved+clever&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=1) with Clever Library Unauthorized access

## WHY
Some Clever Library users will have a valid auth_credential, but for whatever reason, when attempting to pull rostering information, that particular auth_credential returns a `401`. 

## HOW
Add a check for status code before parsing the data in the payload.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
