### PR TITLE
Bust lms cache in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - bundle-cache-lms-v2-{{ checksum "services/QuillLMS/Gemfile.lock" }}
-            - bundle-cache-lms-v2
+            - bundle-cache-lms-v3-{{ checksum "services/QuillLMS/Gemfile.lock" }}
+            - bundle-cache-lms-v3
       - run:
           name: Bundle Install if cache isn't present.
           command: |
@@ -36,7 +36,7 @@ jobs:
             bundle config --local gems.contribsys.com ${BUNDLE_GEMS__CONTRIBSYS__COM}
             bundle check || bundle install --path vendor/bundle
       - save_cache:
-          key: bundle-cache-lms-v2-{{ checksum "services/QuillLMS/Gemfile.lock" }}
+          key: bundle-cache-lms-v3-{{ checksum "services/QuillLMS/Gemfile.lock" }}
           paths:
             - services/QuillLMS/vendor/bundle
       - run:
@@ -104,8 +104,8 @@ jobs:
             - services/QuillLMS/client/node_modules
       - restore_cache:
           keys:
-            - bundle-cache-lms-v2-{{ checksum "services/QuillLMS/Gemfile.lock" }}
-            - bundle-cache-lms-v2
+            - bundle-cache-lms-v3-{{ checksum "services/QuillLMS/Gemfile.lock" }}
+            - bundle-cache-lms-v3
       - run:
           name: Bundle Install if cache isn't present.
           command: |
@@ -114,7 +114,7 @@ jobs:
             bundle config --local gems.contribsys.com ${BUNDLE_GEMS__CONTRIBSYS__COM}
             bundle check || bundle install --path vendor/bundle
       - save_cache:
-          key: bundle-cache-lms-v2-{{ checksum "services/QuillLMS/Gemfile.lock" }}
+          key: bundle-cache-lms-v3-{{ checksum "services/QuillLMS/Gemfile.lock" }}
           paths:
             - services/QuillLMS/vendor/bundle
       - run:
@@ -170,8 +170,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - bundle-cache-lms-v2-{{ checksum "services/QuillLMS/Gemfile.lock" }}
-            - bundle-cache-lms-v2
+            - bundle-cache-lms-v3-{{ checksum "services/QuillLMS/Gemfile.lock" }}
+            - bundle-cache-lms-v3
       - run:
           name: Bundle Install if cache isn't present.
           command: |
@@ -181,7 +181,7 @@ jobs:
             bundle config --local gems.contribsys.com ${BUNDLE_GEMS__CONTRIBSYS__COM}
             bundle check || bundle install --path vendor/bundle
       - save_cache:
-          key: bundle-cache-lms-v2-{{ checksum "services/QuillLMS/Gemfile.lock" }}
+          key: bundle-cache-lms-v3-{{ checksum "services/QuillLMS/Gemfile.lock" }}
           paths:
             - services/QuillLMS/vendor/bundle
       - run:
@@ -329,8 +329,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - bundle-cache-evidence-v2-{{ checksum "services/QuillLMS/engines/evidence/Gemfile.lock" }}
-            - bundle-cache-evidence-v2
+            - bundle-cache-evidence-v3-{{ checksum "services/QuillLMS/engines/evidence/Gemfile.lock" }}
+            - bundle-cache-evidence-v3
       - run:
           name: Bundle Install if cache isn't present.
           command: |
@@ -339,7 +339,7 @@ jobs:
             bundle config --local gems.contribsys.com ${BUNDLE_GEMS__CONTRIBSYS__COM}
             bundle check || bundle install --path vendor/bundle
       - save_cache:
-          key: bundle-cache-evidence-v2-{{ checksum "services/QuillLMS/engines/evidence/Gemfile.lock" }}
+          key: bundle-cache-evidence-v3-{{ checksum "services/QuillLMS/engines/evidence/Gemfile.lock" }}
           paths:
             - services/QuillLMS/engines/evidence/vendor/bundle
       - run:


### PR DESCRIPTION
## WHAT
Circleci is current failing to [build](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/24192/workflows/e0b88ea8-8792-4758-848f-423d8bd73051/jobs/285088?invite=true#step-107-13_131):
![Screenshot 2023-08-30 at 10 06 58 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/650e2df1-c739-4d6e-80c3-410cb3a84b6b)

## WHY
Not sure why it is failing but there is some discussion [here](https://github.com/ffi/ffi/issues/881)

## HOW
This [post](https://github.com/orgs/community/discussions/24949) suggests busting the cache.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Config change.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
