### PR TITLE
Set rubocop enforcement to Ruby 3

### DIFF
--- a/services/.rubocop.yml
+++ b/services/.rubocop.yml
@@ -9,6 +9,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
+  TargetRubyVersion: 3.0
   Exclude:
     - "QuillLMS/engines/evidence/spec/dummy/**/*"
     - "QuillLMS/engines/evidence/lib/generators/**/*"

--- a/services/QuillCMS/lib/modules/incorrect_sequence_calculator.rb
+++ b/services/QuillCMS/lib/modules/incorrect_sequence_calculator.rb
@@ -53,7 +53,7 @@ class ActiveRecord::Relation
       last_id = last_item.is_a?(Array) ? last_item[id_index] : last_item
 
       # Remove :id column if not in *columns
-      items.map! { |row| row[1..-1] } if remove_id_from_results
+      items.map! { |row| row[1..] } if remove_id_from_results
 
       yield items
 

--- a/services/QuillCMS/spec/rails_helper.rb
+++ b/services/QuillCMS/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: engines/evidence
   specs:
-    evidence (0.0.8)
+    evidence (0.0.9)
       google-cloud-automl (~> 1.3.0)
       google-cloud-automl-v1 (~> 0.7.0)
       google-cloud-translate (~> 3.4.1)
@@ -329,10 +329,10 @@ GEM
       googleapis-common-protos (>= 1.3.10, < 2.a)
       googleapis-common-protos-types (>= 1.0.5, < 2.a)
       googleauth (>= 0.16.2, < 2.a)
-    google-cloud-translate-v3 (0.7.3)
+    google-cloud-translate-v3 (0.8.0)
       gapic-common (>= 0.19.1, < 2.a)
       google-cloud-errors (~> 1.0)
-    google-protobuf (3.23.4)
+    google-protobuf (3.24.2)
     googleapis-common-protos (1.4.0)
       google-protobuf (~> 3.14)
       googleapis-common-protos-types (~> 1.2)
@@ -350,7 +350,7 @@ GEM
       railties
       sprockets-rails
     graphql (1.11.7)
-    grpc (1.56.2)
+    grpc (1.57.0)
       google-protobuf (~> 3.23)
       googleapis-common-protos-types (~> 1.0)
     hashdiff (1.0.1)

--- a/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
@@ -109,7 +109,7 @@ class Api::V1::ClassroomUnitsController < Api::ApiController
 
     teacher_ids = classroom_unit.try(&:classroom).try(&:teacher_ids)
     if teacher_ids
-      teacher_ids_h = teacher_ids.collect { |item| [item, true] }.to_h
+      teacher_ids_h = teacher_ids.to_h { |item| [item, true] }
     end
     render json: {teacher_ids: teacher_ids_h || {}}
   end

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::Base
   before_action :set_default_cache_security_headers
 
   def show_errors
-    status = env['PATH_INFO'][1..-1]
+    status = env['PATH_INFO'][1..]
     render_error(status)
   end
 

--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -79,7 +79,7 @@ module DiagnosticReports
 
     return unless hashify_activity_sessions
 
-    @activity_sessions = @activity_sessions.map { |session| [session.user_id, session] }.to_h
+    @activity_sessions = @activity_sessions.to_h { |session| [session.user_id, session] }
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
@@ -95,7 +95,7 @@ module DiagnosticReports
 
     return unless hashify_activity_sessions
 
-    @pre_test_activity_sessions = @pre_test_activity_sessions.map { |session| [session.user_id, session] }.to_h
+    @pre_test_activity_sessions = @pre_test_activity_sessions.to_h { |session| [session.user_id, session] }
   end
 
   private def set_post_test_activity_sessions_and_assigned_students(activity_id, classroom_id, hashify_activity_sessions: false)
@@ -110,7 +110,7 @@ module DiagnosticReports
 
     return unless hashify_activity_sessions
 
-    @post_test_activity_sessions = @post_test_activity_sessions.map { |session| [session.user_id, session] }.to_h
+    @post_test_activity_sessions = @post_test_activity_sessions.to_h { |session| [session.user_id, session] }
   end
 
   private def summarize_student_proficiency_for_skill_per_activity(present_skill_number, correct_skill_number)

--- a/services/QuillLMS/app/helpers/segmentio_helper.rb
+++ b/services/QuillLMS/app/helpers/segmentio_helper.rb
@@ -29,7 +29,7 @@ module SegmentioHelper
   def format_analytics_properties(request, properties)
     common_properties = { path: request.fullpath,
                           referrer: request.referrer, }
-    custom_properties = properties.map{ |k,v| ["custom_#{k}", v] }.to_h
+    custom_properties = properties.to_h{ |k,v| ["custom_#{k}", v] }
     custom_properties.merge(common_properties)
   end
 end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -141,8 +141,7 @@ class ActivitySession < ApplicationRecord
   # returns {user_id: average}
   def self.average_scores_by_student(user_ids)
     averages_for_user_ids(user_ids)
-      .map { |as| [as['user_id'], (as['avg'].to_f * 100).to_i] }
-      .to_h
+      .to_h { |as| [as['user_id'], (as['avg'].to_f * 100).to_i] }
   end
 
   def timespent

--- a/services/QuillLMS/app/models/canvas_account.rb
+++ b/services/QuillLMS/app/models/canvas_account.rb
@@ -24,7 +24,7 @@
 class CanvasAccount < ApplicationRecord
   class InvalidUserExternalIdFormatError < StandardError; end
 
-  VALID_USER_EXTERNAL_ID_FORMAT = /\A\d+:[a-fA-F0-9]+\z/.freeze
+  VALID_USER_EXTERNAL_ID_FORMAT = /\A\d+:[a-fA-F0-9]+\z/
 
   belongs_to :canvas_instance
   belongs_to :user

--- a/services/QuillLMS/app/models/canvas_classroom.rb
+++ b/services/QuillLMS/app/models/canvas_classroom.rb
@@ -25,7 +25,7 @@
 class CanvasClassroom < ProviderClassroom
   class InvalidClassroomExternalIdFormatError < StandardError; end
 
-  VALID_CLASSROOM_EXTERNAL_ID_FORMAT = /\A\d+:\d+\z/.freeze
+  VALID_CLASSROOM_EXTERNAL_ID_FORMAT = /\A\d+:\d+\z/
 
   belongs_to :canvas_instance
   belongs_to :classroom

--- a/services/QuillLMS/app/models/user_activity_classification.rb
+++ b/services/QuillLMS/app/models/user_activity_classification.rb
@@ -43,8 +43,7 @@ class UserActivityClassification < ApplicationRecord
   # returns {user_id: total}
   def self.completed_activities_by_student(user_ids)
     completed_activities_for_user_ids(user_ids)
-    .map{|r| [r['user_id'], r['total'].to_i]}
-    .to_h
+    .to_h{|r| [r['user_id'], r['total'].to_i]}
   end
 
   def self.count_for(user, activity_classification)

--- a/services/QuillLMS/app/services/application_service.rb
+++ b/services/QuillLMS/app/services/application_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationService
-  def self.run(*args, **options, &block)
-    new(*args, **options, &block).run
+  def self.run(...)
+    new(...).run
   end
 end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -121,7 +121,7 @@ module Evidence
 
     # params [:id]
     def topic_optimal_info
-      prompt_concept_uids = @activity.prompts.map do |prompt|
+      prompt_concept_uids = @activity.prompts.to_h do |prompt|
         automl_rules = prompt.rules.filter { |rule| rule.rule_type == Evidence::Rule::TYPE_AUTOML && rule.optimal }
         # Our expectation is that all AutoML rules for a given prompt have
         # the same concept_uid, so this should always extract the correct
@@ -129,7 +129,7 @@ module Evidence
         automl_concept_uid = automl_rules.map(&:concept_uid).uniq.first
 
         [prompt.id, automl_concept_uid]
-      end.to_h
+      end
 
       # This is hard-coded because I couldn't figure out a clean way to
       # generate it dynamically.  This is basically the items in

--- a/services/QuillLMS/engines/evidence/app/models/evidence/application_service.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/application_service.rb
@@ -2,8 +2,8 @@
 
 module Evidence
   class ApplicationService
-    def self.run(*args, **options, &block)
-      new(*args, **options, &block).run
+    def self.run(...)
+      new(...).run
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/evidence.gemspec
+++ b/services/QuillLMS/engines/evidence/evidence.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Evidence app as a rails engine'
   s.description = 'API endpoints used by Evidence to be mounted in the main app'
   s.license     = 'MIT'
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 3.0'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/version.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/version.rb
@@ -3,6 +3,6 @@
 module Evidence
   # Zeitwerk requires a class Version to be consistent with version.rb filename.
   class Version
-    VERSION = "0.0.8"
+    VERSION = "0.0.9"
   end
 end

--- a/services/QuillLMS/lib/tasks/report_demo.rake
+++ b/services/QuillLMS/lib/tasks/report_demo.rake
@@ -24,8 +24,7 @@ namespace :report_demo do
             student
               .activity_sessions
               .where(activity_id: unit.activities.pluck(:id))
-              .map { |activity_session| [activity_session.activity_id, student.id] }
-              .to_h
+              .to_h { |activity_session| [activity_session.activity_id, student.id] }
         end
       end
     end

--- a/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
@@ -284,7 +284,7 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
   end
 
   describe '#classroom_teacher_and_coteacher_ids' do
-    let(:teacher_ids) { classroom.teacher_ids.collect {|i| [i, true]}.to_h }
+    let(:teacher_ids) { classroom.teacher_ids.to_h {|i| [i, true]} }
 
     before { session[:user_id] = teacher.id }
 

--- a/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
@@ -145,9 +145,9 @@ describe GrowthResultsSummary do
       ]
       @skill_groups = [pre_test_skill_group_activity.skill_group]
       @pre_test_assigned_students = [student1, student2]
-      @pre_test_activity_sessions = [pre_test_activity_session].map { |session| [session.user_id, session] }.to_h
+      @pre_test_activity_sessions = [pre_test_activity_session].to_h { |session| [session.user_id, session] }
       @post_test_assigned_students = [student1, student2]
-      @post_test_activity_sessions = [post_test_activity_session].map { |session| [session.user_id, session] }.to_h
+      @post_test_activity_sessions = [post_test_activity_session].to_h { |session| [session.user_id, session] }
       expect(student_results).to eq(
         [
           {
@@ -245,7 +245,7 @@ describe GrowthResultsSummary do
       @pre_test_assigned_students = [student2]
       @pre_test_activity_sessions = []
       @post_test_assigned_students = [student2]
-      @post_test_activity_sessions = [post_test_activity_session_with_no_pre_test].map { |session| [session.user_id, session] }.to_h
+      @post_test_activity_sessions = [post_test_activity_session_with_no_pre_test].to_h { |session| [session.user_id, session] }
       expect(student_results).to eq(
         [
           {

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -127,7 +127,7 @@ describe ResultsSummary do
       ]
       @skill_groups = [skill_group_activity.skill_group]
       @assigned_students = [student1, student2]
-      @activity_sessions = [activity_session1].map { |session| [session.user_id, session] }.to_h
+      @activity_sessions = [activity_session1].to_h { |session| [session.user_id, session] }
 
       expect(student_results).to eq(
         [

--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -684,8 +684,8 @@ RSpec.describe FeedbackHistory, type: :model do
       end
 
       it 'should take the query from #session_data_for_csv and return a shaped payload with records qualifying for scoring' do
-        histories_for_scoring = @histories[2..-1]
-        prompts_for_scoring = @prompts[2..-1]
+        histories_for_scoring = @histories[2..]
+        prompts_for_scoring = @prompts[2..]
 
         responses = FeedbackHistory.session_data_for_csv(responses_for_scoring: true).map(&:serialize_csv_data)
 

--- a/services/QuillLMS/spec/rails_helper.rb
+++ b/services/QuillLMS/spec/rails_helper.rb
@@ -13,7 +13,7 @@ require 'factory_bot_rails'
 require 'spec_helper'
 
 # This should eager load the TeacherNotification sub-classes which is necessary in our testing environment because we use the TeacherNotification.subclasses call for validation, and without eager loading that value starts as an empty array
-Dir[File.join(__dir__, '..', 'app', 'models', 'teacher_notifications', '*.rb')].sort.each { |file| require file }
+Dir[File.join(__dir__, '..', 'app', 'models', 'teacher_notifications', '*.rb')].each { |file| require file }
 
 # Use a fake Sidekiq since we don't maintain redis for testing
 Sidekiq::Testing.fake!
@@ -41,10 +41,10 @@ RSpec::Matchers.define_negated_matcher :not_change, :change
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].sort.each {|f| require f}
+Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
 # shared contexts and groups to behave like
-Dir[Rails.root.join("spec/shared/**/*.rb")].sort.each {|f| require f}
+Dir[Rails.root.join("spec/shared/**/*.rb")].each {|f| require f}
 
 # ensure the db is properly migrated
 ActiveRecord::Migration.maintain_test_schema!

--- a/services/QuillLMS/spec/services/google_integration/rest_client_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/rest_client_spec.rb
@@ -64,7 +64,7 @@ module GoogleIntegration
       end
 
       context 'when user owns a course' do
-        let(:filtered_courses_data) { courses_data[1..-1] }
+        let(:filtered_courses_data) { courses_data[1..] }
 
         before { courses_data.first.owner_id = user.user_external_id }
 

--- a/services/QuillLMS/spec/support/helpers/mock_data_helper.rb
+++ b/services/QuillLMS/spec/support/helpers/mock_data_helper.rb
@@ -10,6 +10,6 @@ module MockDataHelper
     # If there is no folder for holding our mock data, create it.
     FileUtils.mkdir_p 'client/__mockdata__'
     condition = "_#{condition.downcase.gsub(/[^0-9a-z_]/, '_')}" if condition
-    File.write("client/__mockdata__/#{response.request.fullpath.gsub('/', '_')[1..-1]}#{condition}.json", response.body)
+    File.write("client/__mockdata__/#{response.request.fullpath.gsub('/', '_')[1..]}#{condition}.json", response.body)
   end
 end

--- a/services/QuillLMS/spec/support/helpers/sanitization_helper.rb
+++ b/services/QuillLMS/spec/support/helpers/sanitization_helper.rb
@@ -7,11 +7,11 @@ module SanitizationHelper
   # trusted in most circumstances. But, it's sufficient for most of our cases.
   def sanitize_hash_array_for_comparison_with_sql(array_of_hashes)
     array_of_hashes.map do |hash|
-      hash.map do |key, value|
+      hash.to_h do |key, value|
         # Convert Times to have the right level of fidelity, and strip trailing zeroes
         value = value.strftime('%Y-%m-%d %T.%6N').gsub(/0*$/, '') if value.is_a? Time
         [key.to_s, value]
-      end.to_h
+      end
     end
   end
 
@@ -21,11 +21,11 @@ module SanitizationHelper
   # to and amended as necessary.
   def sanitize_hash_array_for_comparison_with_redis(array_of_hashes)
     array_of_hashes.map do |hash|
-      hash.map do |key, value|
+      hash.to_h do |key, value|
         # Convert numeric values to strings
         value = value.to_s if value.is_a? Numeric
         [key.to_s, value]
-      end.to_h
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Update enforcement of Rubocop settings to Ruby 3

## WHY
We're on Ruby 3 now so it doesn't make sense to enforce Ruby 2.5

## HOW
Update .rubocop.yml `TargetRubyVersion`

Fix four types of violations
1.  Replace `(*args, **options, &block)` parameter lists with the [argument forwarding](https://blog.saeloun.com/2019/12/04/ruby-2-7-adds-new-operator-for-arguments-forwarding/) operator `(...)`  
2. replace `.collect { }.to_h` and `.map { }.to_h` to just `.to_h { }`
3. replace `[n..-1]` with `[n..]`
4. Remove redundant `.freeze`


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
