### PR TITLE
Lms/admin snapshots filters teachers without classrooms

### DIFF
--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -74,8 +74,8 @@ class SnapshotsController < ApplicationController
 
     teachers = User.distinct
       .joins(:schools_users)
-      .joins(:classrooms_teachers)
-      .joins("INNER JOIN classrooms ON classrooms_teachers.classroom_id = classrooms.id") # manual join to avoid the default scope on Classroom
+      .left_outer_joins(:classrooms_teachers)
+      .joins("LEFT OUTER JOIN classrooms ON classrooms_teachers.classroom_id = classrooms.id") # manual join to avoid the default scope on Classroom
       .where(schools_users: {school_id: filtered_schools.pluck(:id)})
 
     return teachers.where(classrooms: {grade: grades}) if grades.present?

--- a/services/QuillLMS/app/lib/snapshots/timeframes.rb
+++ b/services/QuillLMS/app/lib/snapshots/timeframes.rb
@@ -58,10 +58,10 @@ module Snapshots
       }, {
         value: 'custom',
         name: 'Custom',
-        previous_start: proc { |_, custom_start, custom_end| DateTime.parse(custom_start) - (DateTime.parse(custom_end) - DateTime.parse(custom_start)) },
-        previous_end: proc { |_, custom_start| DateTime.parse(custom_start) },
-        current_start: proc { |_, custom_start| DateTime.parse(custom_start) },
-        current_end: proc { |_, _, custom_end| DateTime.parse(custom_end) }
+        previous_start: proc { |_, custom_start, custom_end| (DateTime.parse(custom_start) - (DateTime.parse(custom_end) - DateTime.parse(custom_start))).beginning_of_day },
+        previous_end: proc { |_, custom_start| DateTime.parse(custom_start).end_of_day },
+        current_start: proc { |_, custom_start| DateTime.parse(custom_start).beginning_of_day },
+        current_end: proc { |_, _, custom_end| DateTime.parse(custom_end).end_of_day }
       }
     ]
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash'
 import * as Pusher from 'pusher-js';
 
 import { FULL, restrictedPage, } from '../shared';
+import { selectionsEqual, } from '../components/usage_snapshots/shared'
 import CustomDateModal from '../components/usage_snapshots/customDateModal'
 import SnapshotSection from '../components/usage_snapshots/snapshotSection'
 import Filters from '../components/usage_snapshots/filters'
@@ -239,7 +240,12 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
   function handleClickDownloadReport() { window.print() }
 
   function mapItemsIfNotAll(selectedItems, allItems, mapKey = 'id') {
-    if (unorderedArraysAreEqual(selectedItems, allItems)) return null
+    // selectedItems may, by design, be a superset of allItems, but if everything in allItems is in selectedItems, we want to treat it as "everything" being selected
+    const allItemsSelected = allItems.every((i) => {
+      return _.some(selectedItems, i)
+    })
+
+    if (allItemsSelected || selectionsEqual(selectedItems, allItems)) return null
 
     return selectedItems.map(i => i[mapKey])
   }

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -241,8 +241,8 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
 
   function mapItemsIfNotAll(selectedItems, allItems, mapKey = 'id') {
     // selectedItems may, by design, be a superset of allItems, but if everything in allItems is in selectedItems, we want to treat it as "everything" being selected
-    const allItemsSelected = allItems.every((i) => {
-      return _.some(selectedItems, i)
+    const allItemsSelected = allItems.every((item) => {
+      return _.some(selectedItems, item)
     })
 
     if (allItemsSelected || selectionsEqual(selectedItems, allItems)) return null

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -343,6 +343,7 @@ describe SnapshotsController, type: :controller do
 
     context 'teachers with no classrooms' do
       subject { get :options }
+
       let(:json_response) { JSON.parse(response.body) }
 
       before do

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -341,6 +341,20 @@ describe SnapshotsController, type: :controller do
       expect(json_response['teachers']).to eq([{"id" => teacher.id, "name" => teacher.name}])
     end
 
+    context 'teachers with no classrooms' do
+      subject { get :options }
+      let(:json_response) { JSON.parse(response.body) }
+
+      before do
+        classrooms_teacher.destroy
+      end
+
+      it do
+        subject
+        expect(json_response['teachers']).to eq([{"id" => teacher.id, "name" => teacher.name}])
+      end
+    end
+
     it 'should return a list of all classrooms and their ids tied to the current_user' do
       get :options
 

--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -63,10 +63,10 @@ module Snapshots
 
         it do
           expect(described_class.calculate_timeframes('custom', custom_start: custom_start.to_s, custom_end: custom_end.to_s)).to eq([
-            custom_start - (custom_end - custom_start),
-            custom_start,
-            custom_start,
-            custom_end
+            (custom_start - (custom_end - custom_start)).beginning_of_day,
+            custom_start.end_of_day,
+            custom_start.beginning_of_day,
+            custom_end.end_of_day
           ])
         end
       end


### PR DESCRIPTION
## WHAT
- Update admin filter generation logic to include Teachers that do not have classrooms (as long as they're associated with a relevant school)
- Update the logic for applying filters to API calls so that it better understands when "all" items from a filter are selected because we want to submit `null` as the value for that category filter in those cases instead of having a huge array of redundant IDs
- Update `custom` timeframe calculation so that it has the same start and end of day as other time-frames
## WHY
- We want to count and include teachers in our stats even if they don't have classrooms
- Simplifying the "all selected" logic makes our API calls and caching less complex, and also ensures that we don't mistakenly exclude items in cases where the logic that populates the filters is off but the user doesn't care to apply filters of that class
- We want someone who puts in a custom timeframe to get the same results as a matching pre-defined timeframe
## HOW
- Use `LEFT OUTER JOINS` for `classroom` relationships when generating teacher filters so that if the teacher has no classroom they still end up in the results
- Add an extra condition when deciding whether or not to send `null` as a filter value so that if `selected` items is a superset of `all` items (containing at least every member of `all`), we count that as all-selected even if `selected` has additional items in it.
- Just add `beginning_of_day` and `end_of_day` to custom timeframe calculation lambdas

### Notion Card Links
https://www.notion.so/quill/Admin-Usage-Snapshot-Report-QA-Week-of-July-17-767225ae4fd74382bfed44861d36f589?d=1c41c3ee821141fcacc2c8054d38b703#2fa451e21bca4905bac0a92959ac9097

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
