### PR TITLE
update styling of my reports page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/bootstrap.scss
+++ b/services/QuillLMS/app/assets/stylesheets/bootstrap.scss
@@ -273,7 +273,7 @@ body {
   font-size: 14px;
   line-height: 1.42857143;
   color: $quill-black;
-  background-color: #f7f5f5;
+  background-color: $quill-grey-1;
 }
 input,
 button,
@@ -319,7 +319,7 @@ img {
 .img-thumbnail {
   padding: 4px;
   line-height: 1.42857143;
-  background-color: #f7f5f5;
+  background-color: $quill-grey-1;
   border: 1px solid #dddddd;
   border-radius: 4px;
   -webkit-transition: all 0.2s ease-in-out;
@@ -1465,7 +1465,7 @@ th {
   border-top: 2px solid #dddddd;
 }
 .table .table {
-  background-color: #f7f5f5;
+  background-color: $quill-grey-1;
 }
 .table-condensed > thead > tr > th,
 .table-condensed > tbody > tr > th,
@@ -3047,7 +3047,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   .nav-tabs.nav-justified > .active > a,
   .nav-tabs.nav-justified > .active > a:hover,
   .nav-tabs.nav-justified > .active > a:focus {
-    border-bottom-color: #f7f5f5;
+    border-bottom-color: $quill-grey-1;
   }
 }
 .nav-pills > li {
@@ -3115,7 +3115,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   .nav-tabs-justified > .active > a,
   .nav-tabs-justified > .active > a:hover,
   .nav-tabs-justified > .active > a:focus {
-    border-bottom-color: #f7f5f5;
+    border-bottom-color: $quill-grey-1;
   }
 }
 .tab-content > .tab-pane {
@@ -3450,7 +3450,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   }
 }
 .navbar-default {
-  background-color: #f7f5f5;
+  background-color: $quill-grey-1;
   border-color: transparent;
 }
 .navbar-default .navbar-brand {
@@ -3682,7 +3682,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   line-height: 1.42857143;
   text-decoration: none;
   color: $quill-black;
-  background-color: #f7f5f5;
+  background-color: $quill-grey-1;
   border: 1px solid #cecece;
   border-top: none;
   border-top-left-radius: 0;
@@ -3776,7 +3776,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pager li > span {
   display: inline-block;
   padding: 5px 14px;
-  background-color: #f7f5f5;
+  background-color: $quill-grey-1;
   border: 1px solid #dddddd;
   border-radius: 15px;
 }
@@ -3798,7 +3798,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pager .disabled > a:focus,
 .pager .disabled > span {
   color: #777777;
-  background-color: #f7f5f5;
+  background-color: $quill-grey-1;
   cursor: not-allowed;
 }
 .label {
@@ -3950,7 +3950,7 @@ a.list-group-item.active > .badge,
   padding: 4px;
   margin-bottom: 20px;
   line-height: 1.42857143;
-  background-color: #f7f5f5;
+  background-color: $quill-grey-1;
   border: 1px solid #dddddd;
   border-radius: 4px;
   -webkit-transition: all 0.2s ease-in-out;

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
@@ -809,9 +809,6 @@ $lightgray: #cecece;
       margin-left: 6px;
     }
   }
-  h3 + div {
-    padding-top: 10px;
-  }
 
   @media screen and (max-width: 768px) {
     .header {

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
@@ -770,17 +770,12 @@ $lightgray: #cecece;
 
 /* for progress report landing page*/
 .progress-reports-landing-page {
-  margin: auto;
-  max-width: 1025px;
   a {
     text-decoration: none;
   }
-  .generic-mini {
-    margin: 20px;
-  }
   .header {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     margin: 0px 20px;
     align-items: center;
     text-align: left;
@@ -793,14 +788,25 @@ $lightgray: #cecece;
     }
   }
   .premium {
-    margin-top: 5px;
-    color: #eda41b;
+    border-radius: 4px;
+    border: 1px solid $quill-gold-dark-20;
+    background: $quill-gold-10;
+    width: min-content;
+    margin: auto;
+    white-space: nowrap;
+    color: $quill-gold-dark-50;
     font-size: 12px;
-    font-weight: 600;
+    font-style: normal;
+    font-weight: 700;
     text-transform: uppercase;
-    /* want shorter images if we have the premium row of type*/
-    & + div {
-      height: 120px;
+    padding: 2px 8px;
+    display: flex;
+    align-items: center;
+    margin-top: 7px;
+    img {
+      width: 14px;
+      height: 11px;
+      margin-left: 6px;
     }
   }
   h3 + div {

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_student_responses_index.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_student_responses_index.scss
@@ -9,7 +9,7 @@
     margin-top: 24px;
     .data-table-headers {
       height: 32px;
-      background-color: #F8F8F8;
+      background-color: $quill-grey-1;
       min-height: 68px;
       padding: 0px 8px;
       th {

--- a/services/QuillLMS/app/assets/stylesheets/shared/activity_tables/generic-mini.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/activity_tables/generic-mini.scss
@@ -1,11 +1,11 @@
 .generic-mini-container {
-    max-width: 100%;
-    text-align: center;
-    h1 {
-        font-size: 24px;
-        font-weight: 600;
-        margin: 30 0 15 0px;
-    }
+  max-width: 100%;
+  text-align: center;
+  h1 {
+    font-size: 24px;
+    font-weight: 700;
+    margin: 64px 0px;
+  }
 }
 .generic-minis {
     max-width: 100%;
@@ -22,36 +22,48 @@
     }
 }
 .generic-mini {
-    color: #333333;
-    font-size: 12px;
-    min-width: 300px;
-    width: 300px;
-    height: 270px;
-    background: $quill-white;
-    border: solid 1px #cecece;
-    padding: 10px;
-    margin-bottom: 40px;
-    cursor: pointer;
-    h3 {
-        font-size: 20px;
-        font-weight: 600;
-        line-height: 1.25;
-        margin-top: 7px;
+  font-size: 12px;
+  width: 100%;
+  max-width: 379px;
+  min-height: 301px;
+  background: #FFF;
+  border: solid 1px #cecece;
+  padding: 10px;
+  margin-bottom: 32px;
+  cursor: pointer;
+  display: flex;
+  padding: 24px 16px 32px 16px;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 16px;
+  border: 1px solid $quill-grey-15;
+  background: $quill-white;
+  box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.10);
+
+  h3 {
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 25px;
+  }
+  .img-wrapper {
+    height: 135px;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    img {
+      padding-top: 20px;
     }
-    .img-wrapper {
-        height: 135px;
-        display: flex;
-        justify-content: center;
-        align-items: flex-start;
-        img {
-            padding-top: 20px;
-        }
-    }
-    &:hover {
-        outline: solid 2.5px #00c2a2;
-    }
-    p { font-size: 14px;
-        line-height: 1.57;
-        margin-bottom: 10px;
-    }
+  }
+  &:hover {
+    border: 1px solid $quill-green;
+    outline: 1px solid $quill-green;
+  }
+  p {
+    color: $quill-grey-50;
+    text-align: center;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 22px;
+  }
 }

--- a/services/QuillLMS/app/assets/stylesheets/shared/activity_tables/generic-mini.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/activity_tables/generic-mini.scss
@@ -27,12 +27,9 @@
   width: 100%;
   max-width: 378px;
   min-height: 270px;
-  background: #FFF;
-  border: solid 1px #cecece;
-  padding: 10px;
   cursor: pointer;
   display: flex;
-  padding: 24px 16px 32px 16px;
+  padding: 24px 16px 32px;
   flex-direction: column;
   align-items: center;
   border-radius: 16px;

--- a/services/QuillLMS/app/assets/stylesheets/shared/activity_tables/generic-mini.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/activity_tables/generic-mini.scss
@@ -43,10 +43,10 @@
     line-height: 25px;
   }
   .img-wrapper {
-    height: 135px;
     display: flex;
     justify-content: center;
     align-items: flex-start;
+    min-height: 117px;
     img {
       padding-top: 20px;
     }

--- a/services/QuillLMS/app/assets/stylesheets/shared/activity_tables/generic-mini.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/activity_tables/generic-mini.scss
@@ -17,6 +17,7 @@
     justify-content: space-around;
     flex-wrap: wrap;
     margin: auto;
+    gap: 32px;
     a {
       color: black;
     }
@@ -24,12 +25,11 @@
 .generic-mini {
   font-size: 12px;
   width: 100%;
-  max-width: 379px;
-  min-height: 301px;
+  max-width: 378px;
+  min-height: 270px;
   background: #FFF;
   border: solid 1px #cecece;
   padding: 10px;
-  margin-bottom: 32px;
   cursor: pointer;
   display: flex;
   padding: 24px 16px 32px 16px;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/landing_page.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/landing_page.test.jsx.snap
@@ -1,0 +1,262 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LandingPage component matches the snapshot 1`] = `
+<LandingPage>
+  <div
+    className="progress-reports-landing-page"
+  >
+    <DemoOnboardingTour
+      pageKey="demo-onboarding-student-reports-landing-page"
+    >
+      <span />
+    </DemoOnboardingTour>
+    <div
+      className="generic-mini-container"
+    >
+      <div
+        className="header"
+      >
+        <h1>
+          Choose which type of report you’d like to see:
+        </h1>
+      </div>
+      <div
+        className="generic-minis"
+      >
+        <div
+          className="generic-mini"
+          key="Activity Summary"
+        >
+          <a
+            href="/teachers/classrooms/scorebook"
+          >
+            <h3>
+              Activity Summary
+            </h3>
+            <div
+              className="img-wrapper"
+            >
+              <img
+                alt=""
+                src="undefined/images/shared/visual_overview.svg"
+              />
+            </div>
+            <p
+              style={
+                Object {
+                  "padding": "0px 2px",
+                }
+              }
+            >
+              Quickly see which activities your students have completed and the skills that were demonstrated.
+            </p>
+          </a>
+        </div>
+        <div
+          className="generic-mini"
+          key="Activity Analysis"
+        >
+          <a
+            href="/teachers/progress_reports/diagnostic_reports#/activity_packs"
+          >
+            <h3>
+              Activity Analysis
+            </h3>
+            <div
+              className="img-wrapper"
+            >
+              <img
+                alt=""
+                src="undefined/images/shared/activity_analysis.svg"
+              />
+            </div>
+            <p
+              style={Object {}}
+            >
+              See how students responded to each question and get a clear analysis of the skills they demonstrated.
+            </p>
+          </a>
+        </div>
+        <div
+          className="generic-mini"
+          id="diagnostic-reports-card"
+          key="Diagnostics"
+        >
+          <a
+            href="/teachers/progress_reports/diagnostic_reports/#/diagnostics"
+          >
+            <h3>
+              Diagnostics
+            </h3>
+            <div
+              className="img-wrapper"
+            >
+              <img
+                alt=""
+                src="undefined/images/shared/diagnostic.svg"
+              />
+            </div>
+            <p
+              style={Object {}}
+            >
+              View diagnostic results and get a personalized learning plan with recommended activities.
+            </p>
+          </a>
+        </div>
+        <div
+          className="generic-mini"
+          key="Activity Scores"
+        >
+          <a
+            href="/teachers/progress_reports/activities_scores_by_classroom"
+          >
+            <h3>
+              Activity Scores
+            </h3>
+            <h4
+              className="premium"
+            >
+              <span>
+                Premium
+              </span>
+              <img
+                alt=""
+                src="undefined/images/icons/yellow-diamond.svg"
+              />
+            </h4>
+            <div
+              className="img-wrapper"
+            >
+              <img
+                alt=""
+                src="undefined/images/illustrations/activity-scores-illustration.svg"
+              />
+            </div>
+            <p
+              style={
+                Object {
+                  "padding": "0px 7px",
+                }
+              }
+            >
+              View and download each student’s overall score and their individual scores per activity as a PDF or CSV.
+            </p>
+          </a>
+        </div>
+        <div
+          className="generic-mini"
+          key="Concepts"
+        >
+          <a
+            href="/teachers/progress_reports/concepts/students"
+          >
+            <h3>
+              Concepts
+            </h3>
+            <h4
+              className="premium"
+            >
+              <span>
+                Premium
+              </span>
+              <img
+                alt=""
+                src="undefined/images/icons/yellow-diamond.svg"
+              />
+            </h4>
+            <div
+              className="img-wrapper"
+            >
+              <img
+                alt=""
+                src="undefined/images/shared/concepts.svg"
+              />
+            </div>
+            <p
+              style={Object {}}
+            >
+              View an overall summary of how each of your students is performing across all writing and grammar concepts.
+            </p>
+          </a>
+        </div>
+        <div
+          className="generic-mini"
+          key="Standards"
+        >
+          <a
+            href="/teachers/progress_reports/standards/classrooms"
+          >
+            <h3>
+              Standards
+            </h3>
+            <h4
+              className="premium"
+            >
+              <span>
+                Premium
+              </span>
+              <img
+                alt=""
+                src="undefined/images/icons/yellow-diamond.svg"
+              />
+            </h4>
+            <div
+              className="img-wrapper"
+            >
+              <img
+                alt=""
+                src="undefined/images/shared/common_core.svg"
+              />
+            </div>
+            <p
+              style={Object {}}
+            >
+              View this report to see how your students are performing on specific National standards.
+            </p>
+          </a>
+        </div>
+        <div
+          className="generic-mini"
+          key="Data Export"
+        >
+          <a
+            href="/teachers/progress_reports/activity_sessions"
+          >
+            <h3>
+              Data Export
+            </h3>
+            <h4
+              className="premium"
+            >
+              <span>
+                Premium
+              </span>
+              <img
+                alt=""
+                src="undefined/images/icons/yellow-diamond.svg"
+              />
+            </h4>
+            <div
+              className="img-wrapper"
+            >
+              <img
+                alt=""
+                src="undefined/images/shared/list_overview.svg"
+              />
+            </div>
+            <p
+              style={
+                Object {
+                  "marginTop": "-17px",
+                }
+              }
+            >
+              You can export the data as a CSV file by filtering for the classrooms, activity packs, or students you would like to export and then pressing “Download Report.”
+            </p>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</LandingPage>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/landing_page.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/landing_page.test.jsx.snap
@@ -25,13 +25,13 @@ exports[`LandingPage component matches the snapshot 1`] = `
       >
         <div
           className="generic-mini"
-          key="Activity Summary"
+          key="Activity Summary Report"
         >
           <a
             href="/teachers/classrooms/scorebook"
           >
             <h3>
-              Activity Summary
+              Activity Summary Report
             </h3>
             <div
               className="img-wrapper"
@@ -54,13 +54,13 @@ exports[`LandingPage component matches the snapshot 1`] = `
         </div>
         <div
           className="generic-mini"
-          key="Activity Analysis"
+          key="Activity Analysis Report"
         >
           <a
             href="/teachers/progress_reports/diagnostic_reports#/activity_packs"
           >
             <h3>
-              Activity Analysis
+              Activity Analysis Report
             </h3>
             <div
               className="img-wrapper"
@@ -80,13 +80,13 @@ exports[`LandingPage component matches the snapshot 1`] = `
         <div
           className="generic-mini"
           id="diagnostic-reports-card"
-          key="Diagnostics"
+          key="Diagnostics Report"
         >
           <a
             href="/teachers/progress_reports/diagnostic_reports/#/diagnostics"
           >
             <h3>
-              Diagnostics
+              Diagnostics Report
             </h3>
             <div
               className="img-wrapper"
@@ -105,13 +105,13 @@ exports[`LandingPage component matches the snapshot 1`] = `
         </div>
         <div
           className="generic-mini"
-          key="Activity Scores"
+          key="Activity Scores Report"
         >
           <a
             href="/teachers/progress_reports/activities_scores_by_classroom"
           >
             <h3>
-              Activity Scores
+              Activity Scores Report
             </h3>
             <h4
               className="premium"
@@ -145,13 +145,13 @@ exports[`LandingPage component matches the snapshot 1`] = `
         </div>
         <div
           className="generic-mini"
-          key="Concepts"
+          key="Concepts Report"
         >
           <a
             href="/teachers/progress_reports/concepts/students"
           >
             <h3>
-              Concepts
+              Concepts Report
             </h3>
             <h4
               className="premium"
@@ -181,13 +181,13 @@ exports[`LandingPage component matches the snapshot 1`] = `
         </div>
         <div
           className="generic-mini"
-          key="Standards"
+          key="Standards Report"
         >
           <a
             href="/teachers/progress_reports/standards/classrooms"
           >
             <h3>
-              Standards
+              Standards Report
             </h3>
             <h4
               className="premium"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/landing_page.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/landing_page.test.jsx.snap
@@ -175,7 +175,7 @@ exports[`LandingPage component matches the snapshot 1`] = `
             <p
               style={Object {}}
             >
-              View an overall summary of how each of your students is performing across all writing and grammar concepts.
+              View an overall summary of how your students are performing across all writing and grammar concepts.
             </p>
           </a>
         </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/landing_page.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/landing_page.test.jsx.snap
@@ -42,11 +42,7 @@ exports[`LandingPage component matches the snapshot 1`] = `
               />
             </div>
             <p
-              style={
-                Object {
-                  "padding": "0px 2px",
-                }
-              }
+              style={Object {}}
             >
               Quickly see which activities your students have completed and the skills that were demonstrated.
             </p>
@@ -133,11 +129,7 @@ exports[`LandingPage component matches the snapshot 1`] = `
               />
             </div>
             <p
-              style={
-                Object {
-                  "padding": "0px 7px",
-                }
-              }
+              style={Object {}}
             >
               View and download each student’s overall score and their individual scores per activity as a PDF or CSV.
             </p>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/landing_page.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/landing_page.test.jsx
@@ -1,0 +1,14 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import LandingPage from '../landing_page.jsx';
+
+describe('LandingPage component', () => {
+  const wrapper = mount(
+    <LandingPage   />
+  );
+
+  it('matches the snapshot', () => {
+    expect(wrapper).toMatchSnapshot()
+  });
+})

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { PROGRESS_REPORTS_SELECTED_CLASSROOM_ID, } from './progress_report_constants';
 
-import { DropdownInput, } from '../../../Shared/index';
 import DemoOnboardingTour, { DEMO_ONBOARDING_STUDENT_REPORTS_LANDING_PAGE, } from '../shared/demo_onboarding_tour';
 
 const ALL = 'ALL'
@@ -14,7 +13,7 @@ const miniList = () => {
       title: 'Activity Summary',
       href: '/teachers/classrooms/scorebook',
       img: `${process.env.CDN_URL}/images/shared/visual_overview.svg`,
-      bodyText: 'Quickly see which activities your students have completed with color coded icons that show level of proficiency.',
+      bodyText: 'Quickly see which activities your students have completed and the skills that were demonstrated.',
       pStyle: { padding: '0px 2px', },
       flag: null,
     }, {
@@ -28,14 +27,14 @@ const miniList = () => {
       href: '/teachers/progress_reports/diagnostic_reports/#/diagnostics',
       id: 'diagnostic-reports-card',
       img: `${process.env.CDN_URL}/images/shared/diagnostic.svg`,
-      bodyText: 'View the results of the diagnostics, and get a personalized learning plan with recommended activities.',
+      bodyText: 'View diagnostic results and get a personalized learning plan with recommended activities.',
       flag: null,
     }, {
       title: 'Activity Scores',
       premium: true,
       href: '/teachers/progress_reports/activities_scores_by_classroom',
       img: `${process.env.CDN_URL}/images/illustrations/activity-scores-illustration.svg`,
-      bodyText: 'View and download the overall score and the individual scores on each activity in an activity pack as a CSV.',
+      bodyText: 'View and download each student’s overall score and their individual scores per activity as a PDF or CSV.',
       flag: null,
       pStyle: { padding: '0px 7px', },
     }, {
@@ -43,21 +42,21 @@ const miniList = () => {
       premium: true,
       href: '/teachers/progress_reports/concepts/students',
       img: `${process.env.CDN_URL}/images/shared/concepts.svg`,
-      bodyText: 'View an overall summary of how each of your students is performing on all of the  writing and grammar concepts.',
+      bodyText: 'View an overall summary of how each of your students is performing across all writing and grammar concepts.',
       flag: null,
     }, {
       title: 'Standards',
       premium: true,
       href: '/teachers/progress_reports/standards/classrooms',
       img: `${process.env.CDN_URL}/images/shared/common_core.svg`,
-      bodyText: 'Following the Common Core? Check this view to see how your students are performing on specific standards.',
+      bodyText: 'View this report to see how your students are performing on specific National standards.',
       flag: null,
     }, {
       title: 'Data Export',
       premium: true,
       href: '/teachers/progress_reports/activity_sessions',
       img: `${process.env.CDN_URL}/images/shared/list_overview.svg`,
-      bodyText: 'You can export the data as a CSV file by filtering for the classrooms, activity packs, or students you would like to export and then pressing "Download Report."',
+      bodyText: 'You can export the data as a CSV file by filtering for the classrooms, activity packs, or students you would like to export and then pressing “Download Report.”',
       flag: null,
       pStyle: { marginTop: '-17px', },
     }
@@ -65,7 +64,7 @@ const miniList = () => {
 }
 
 const miniBuilder = (mini) => {
-  const premium = mini.premium ? <h4 className="premium">Premium<i aria-hidden="true" className="fas fa-star" /></h4> : null;
+  const premium = mini.premium ? <h4 className="premium"><span>Premium</span><img alt="" src={`${process.env.CDN_URL}/images/icons/yellow-diamond.svg`} /></h4> : null;
   return (
     <div className="generic-mini" id={mini.id} key={mini.title}>
       <a href={mini.href}>
@@ -82,16 +81,6 @@ const miniBuilder = (mini) => {
 
 
 const LandingPage = ({ classrooms, flag, }) => {
-  const selectedClassroom = classrooms && classrooms.find(c => Number(c.id) === Number(window.localStorage.getItem(PROGRESS_REPORTS_SELECTED_CLASSROOM_ID)))
-  const [selectedClassroomId, setSelectedClassroomId] = React.useState(selectedClassroom && selectedClassroom.id || ALL)
-
-  function onClassesDropdownChange(e) {
-    window.localStorage.setItem(PROGRESS_REPORTS_SELECTED_CLASSROOM_ID, e.value)
-    setSelectedClassroomId(e.value)
-  }
-
-  const dropdownOptions = [ALL_OPTION].concat(classrooms ? classrooms.map(c => ({ value: c.id, label: c.name, })) : [])
-
   const minis = () => {
     const minisArr = [];
     miniList().forEach((mini) => {
@@ -115,12 +104,6 @@ const LandingPage = ({ classrooms, flag, }) => {
       <div className="generic-mini-container">
         <div className="header">
           <h1>Choose which type of report you’d like to see:</h1>
-          <DropdownInput
-            handleChange={onClassesDropdownChange}
-            isSearchable={false}
-            options={dropdownOptions}
-            value={dropdownOptions.find(opt => opt.value === selectedClassroomId)}
-          />
         </div>
         <div className="generic-minis">{minis()}</div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
@@ -11,7 +11,6 @@ const miniList = () => {
       href: '/teachers/classrooms/scorebook',
       img: `${process.env.CDN_URL}/images/shared/visual_overview.svg`,
       bodyText: 'Quickly see which activities your students have completed and the skills that were demonstrated.',
-      pStyle: { padding: '0px 2px', },
       flag: null,
     }, {
       title: 'Activity Analysis Report',
@@ -33,7 +32,6 @@ const miniList = () => {
       img: `${process.env.CDN_URL}/images/illustrations/activity-scores-illustration.svg`,
       bodyText: 'View and download each student’s overall score and their individual scores per activity as a PDF or CSV.',
       flag: null,
-      pStyle: { padding: '0px 7px', },
     }, {
       title: 'Concepts Report',
       premium: true,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
@@ -39,7 +39,7 @@ const miniList = () => {
       premium: true,
       href: '/teachers/progress_reports/concepts/students',
       img: `${process.env.CDN_URL}/images/shared/concepts.svg`,
-      bodyText: 'View an overall summary of how each of your students is performing across all writing and grammar concepts.',
+      bodyText: 'View an overall summary of how your students are performing across all writing and grammar concepts.',
       flag: null,
     }, {
       title: 'Standards Report',

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
@@ -4,9 +4,6 @@ import { PROGRESS_REPORTS_SELECTED_CLASSROOM_ID, } from './progress_report_const
 
 import DemoOnboardingTour, { DEMO_ONBOARDING_STUDENT_REPORTS_LANDING_PAGE, } from '../shared/demo_onboarding_tour';
 
-const ALL = 'ALL'
-const ALL_OPTION = { label: 'All classrooms', value: ALL }
-
 const miniList = () => {
   return [
     {
@@ -80,7 +77,7 @@ const miniBuilder = (mini) => {
 };
 
 
-const LandingPage = ({ classrooms, flag, }) => {
+const LandingPage = ({ flag, }) => {
   const minis = () => {
     const minisArr = [];
     miniList().forEach((mini) => {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/landing_page.jsx
@@ -7,27 +7,27 @@ import DemoOnboardingTour, { DEMO_ONBOARDING_STUDENT_REPORTS_LANDING_PAGE, } fro
 const miniList = () => {
   return [
     {
-      title: 'Activity Summary',
+      title: 'Activity Summary Report',
       href: '/teachers/classrooms/scorebook',
       img: `${process.env.CDN_URL}/images/shared/visual_overview.svg`,
       bodyText: 'Quickly see which activities your students have completed and the skills that were demonstrated.',
       pStyle: { padding: '0px 2px', },
       flag: null,
     }, {
-      title: 'Activity Analysis',
+      title: 'Activity Analysis Report',
       href: '/teachers/progress_reports/diagnostic_reports#/activity_packs',
       img: `${process.env.CDN_URL}/images/shared/activity_analysis.svg`,
       bodyText: 'See how students responded to each question and get a clear analysis of the skills they demonstrated.',
       flag: null,
     }, {
-      title: 'Diagnostics',
+      title: 'Diagnostics Report',
       href: '/teachers/progress_reports/diagnostic_reports/#/diagnostics',
       id: 'diagnostic-reports-card',
       img: `${process.env.CDN_URL}/images/shared/diagnostic.svg`,
       bodyText: 'View diagnostic results and get a personalized learning plan with recommended activities.',
       flag: null,
     }, {
-      title: 'Activity Scores',
+      title: 'Activity Scores Report',
       premium: true,
       href: '/teachers/progress_reports/activities_scores_by_classroom',
       img: `${process.env.CDN_URL}/images/illustrations/activity-scores-illustration.svg`,
@@ -35,14 +35,14 @@ const miniList = () => {
       flag: null,
       pStyle: { padding: '0px 7px', },
     }, {
-      title: 'Concepts',
+      title: 'Concepts Report',
       premium: true,
       href: '/teachers/progress_reports/concepts/students',
       img: `${process.env.CDN_URL}/images/shared/concepts.svg`,
       bodyText: 'View an overall summary of how each of your students is performing across all writing and grammar concepts.',
       flag: null,
     }, {
-      title: 'Standards',
+      title: 'Standards Report',
       premium: true,
       href: '/teachers/progress_reports/standards/classrooms',
       img: `${process.env.CDN_URL}/images/shared/common_core.svg`,


### PR DESCRIPTION
## WHAT
Update styling of My Reports page.

## WHY
To modernize and be consistent with the site's visual language.

## HOW
React and CSS

### Screenshots
<img width="663" alt="Screenshot 2023-08-30 at 1 06 51 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/39f92640-9750-43a9-b21d-9654209ae94a">

### Notion Card Links
https://www.notion.so/quill/Design-Updates-My-Reports-Home-i-e-Choose-Type-Reports-Page-e64ee1b09e814586b20f03e32c0bcc45?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES