### PR TITLE
Fix race condition with manage_user_pack_sequence_items

### DIFF
--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -88,7 +88,11 @@ class ClassroomUnit < ApplicationRecord
       new_user_ids = assigned_student_ids - existing_user_ids
       deleted_user_ids = existing_user_ids - assigned_student_ids
 
-      new_user_ids.each { |user_id| pack_sequence_item.user_pack_sequence_items.find_or_create_by!(user_id: user_id) }
+      new_user_ids.each do |user_id|
+        UserPackSequenceItem.find_or_create_by!(pack_sequence_item_id: pack_sequence_item.id, user_id: user_id)
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
 
       pack_sequence_item
         .user_pack_sequence_items

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -234,6 +234,21 @@ describe ClassroomUnit, type: :model, redis: true do
           it { expect { subject }.not_to change(UserPackSequenceItem, :count)}
         end
       end
+
+      context 'race condition exists with user_pack_sequence_item creation' do
+        let(:new_assigned_student_ids) { [student.id, another_student.id]}
+
+        before do
+          allow(UserPackSequenceItem)
+            .to receive(:find_or_create_by!)
+            .with(pack_sequence_item_id: pack_sequence_item.id, user_id: another_student.id)
+            .and_raise(ActiveRecord::RecordNotUnique)
+            .once
+            .and_call_original
+        end
+
+        it { expect { subject }.to change(UserPackSequenceItem, :count).from(1).to(2) }
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix a race [condition](https://quillorg-5s.sentry.io/issues/4421162514/?environment=production&project=11238&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=6) with user_pack_sequence_items

## WHY
The user pack sequence item is created in some other process.

## HOW
Add a rescue retry clause 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
