### PR TITLE
Fix various bugs

### DIFF
--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -91,7 +91,7 @@ class ClassroomUnit < ApplicationRecord
       new_user_ids.each do |user_id|
         UserPackSequenceItem.find_or_create_by!(pack_sequence_item_id: pack_sequence_item.id, user_id: user_id)
       rescue ActiveRecord::RecordNotUnique
-        retry
+        next
       end
 
       pack_sequence_item

--- a/services/QuillLMS/app/services/clever_integration/district_client.rb
+++ b/services/QuillLMS/app/services/clever_integration/district_client.rb
@@ -18,17 +18,21 @@ module CleverIntegration
     end
 
     def teacher_classrooms(teacher_clever_id)
-      data_api
-        .get_sections_for_teacher(teacher_clever_id)
-        .data
-        .map { |classroom_data| DistrictClassroomDataAdapter.run(classroom_data) }
+      handle_client_errors do
+        data_api
+          .get_sections_for_teacher(teacher_clever_id)
+          .data
+          .map { |classroom_data| DistrictClassroomDataAdapter.run(classroom_data) }
+      end
     end
 
     def classroom_students(classroom_clever_id)
-      data_api
-        .get_students_for_section(classroom_clever_id)
-        .data
-        .map { |student_data| DistrictStudentDataAdapter.run(student_data) }
+      handle_client_errors do
+        data_api
+          .get_students_for_section(classroom_clever_id)
+          .data
+          .map { |student_data| DistrictStudentDataAdapter.run(student_data) }
+      end
     end
 
     private def data_api
@@ -39,6 +43,12 @@ module CleverIntegration
         api_instance.api_client.config = config
         api_instance
       end
+    end
+
+    private def handle_client_errors
+      yield
+    rescue ::Clever::ApiError => e
+      e.code == 404 ? [] : ErrorNotifier.report(e)
     end
   end
 end

--- a/services/QuillLMS/app/services/clever_integration/library_client.rb
+++ b/services/QuillLMS/app/services/clever_integration/library_client.rb
@@ -37,7 +37,7 @@ module CleverIntegration
       case response.code
       when 200
         response.parsed_response['data']
-      when 401
+      when 401, 404
         error_data
       else
         ErrorNotifier.report(HttpError.new("HTTP #{response.code}"))

--- a/services/QuillLMS/app/workers/reset_lesson_cache_worker.rb
+++ b/services/QuillLMS/app/workers/reset_lesson_cache_worker.rb
@@ -12,7 +12,7 @@ class ResetLessonCacheWorker
     $redis.del("user_id:#{user_id}_lessons_array")
     user = User.find_by(id: user_id)
 
-    return ErrorNotifier.report(UserNotFoundError, user_id: user_id) if user.nil?
+    return ErrorNotifier.report(UserNotFoundError.new, user_id: user_id) if user.nil?
 
     user.set_lessons_cache
   end

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -244,10 +244,9 @@ describe ClassroomUnit, type: :model, redis: true do
             .with(pack_sequence_item_id: pack_sequence_item.id, user_id: another_student.id)
             .and_raise(ActiveRecord::RecordNotUnique)
             .once
-            .and_call_original
         end
 
-        it { expect { subject }.to change(UserPackSequenceItem, :count).from(1).to(2) }
+        it { expect { subject }.not_to change(UserPackSequenceItem, :count) }
       end
     end
   end

--- a/services/QuillLMS/spec/services/clever_integration/district_client_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/district_client_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe CleverIntegration::DistrictClient do
 
   let(:district_client) { described_class.new(district_token) }
 
+  let(:error400) { ::Clever::ApiError.new(code: 400) }
+  let(:error404) { ::Clever::ApiError.new(code: 404) }
+
   before do
     expect(Clever::DataApi).to receive(:new).and_return(data_api)
     expect(data_api).to receive(:api_client).and_return(api_client)
@@ -23,12 +26,29 @@ RSpec.describe CleverIntegration::DistrictClient do
   context '#teacher_classrooms' do
     subject { district_client.teacher_classrooms(teacher_clever_id) }
 
-    let(:classrooms_attrs) { [classroom1_attrs, classroom2_attrs]}
-    let(:data) { classrooms_data }
+    context 'when client returns data' do
+      let(:classrooms_attrs) { [classroom1_attrs, classroom2_attrs]}
+      let(:data) { classrooms_data }
 
-    before { expect(data_api).to receive(:get_sections_for_teacher).with(teacher_clever_id).and_return(data) }
+      before { expect(data_api).to receive(:get_sections_for_teacher).with(teacher_clever_id).and_return(data) }
 
-    it { is_expected.to eq classrooms_attrs }
+      it { is_expected.to eq classrooms_attrs }
+    end
+
+    context 'when a client error with status code 404 occurs' do
+      before { allow(data_api).to receive(:get_sections_for_teacher).and_raise(error404) }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when a client error with a different status code occurs' do
+      before { allow(data_api).to receive(:get_sections_for_teacher).and_raise(error400) }
+
+      it do
+        expect(ErrorNotifier).to receive(:report).with(error400)
+        subject
+      end
+    end
   end
 
   context '#classroom_students' do
@@ -36,22 +56,43 @@ RSpec.describe CleverIntegration::DistrictClient do
 
     let(:students_attrs) { [student1_attrs, student2_attrs] }
 
-    before { expect(data_api).to receive(:get_students_for_section).with(classroom_external_id).and_return(data) }
+    context 'when client returns data' do
+      before { expect(data_api).to receive(:get_students_for_section).with(classroom_external_id).and_return(data) }
 
-    context 'classroom 1' do
-      let(:data) { classroom1_students_data }
-      let(:classroom_external_id) { classroom1_attrs[:classroom_external_id] }
-      let(:students_attrs) { [student1_attrs, student2_attrs] }
+      context 'classroom 1' do
+        let(:data) { classroom1_students_data }
+        let(:classroom_external_id) { classroom1_attrs[:classroom_external_id] }
+        let(:students_attrs) { [student1_attrs, student2_attrs] }
 
-      it { is_expected.to eq students_attrs}
+        it { is_expected.to eq students_attrs}
+      end
+
+      context 'classroom 2' do
+        let(:data) { classroom2_students_data }
+        let(:classroom_external_id) { classroom2_attrs[:classroom_external_id] }
+        let(:students_attrs) { [student3_attrs] }
+
+        it { is_expected.to eq students_attrs}
+      end
     end
 
-    context 'classroom 2' do
-      let(:data) { classroom2_students_data }
-      let(:classroom_external_id) { classroom2_attrs[:classroom_external_id] }
-      let(:students_attrs) { [student3_attrs] }
+    context 'when a client error with status code 404 occurs' do
+      let(:classroom_external_id) { classroom1_attrs[:classroom_external_id] }
 
-      it { is_expected.to eq students_attrs}
+      before { allow(data_api).to receive(:get_students_for_section).and_raise(error404) }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when a client error with a different status code occurs' do
+      let(:classroom_external_id) { classroom1_attrs[:classroom_external_id] }
+
+      before { allow(data_api).to receive(:get_students_for_section).and_raise(error400) }
+
+      it do
+        expect(ErrorNotifier).to receive(:report).with(error400)
+        subject
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/library_client_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/library_client_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
+      it { is_not_expected_to_report_error }
+    end
+
+    context 'resource not found' do
+      let(:code) { 404 }
+      let(:parsed_response) { {'error' => 'Resource not found' } }
+      let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
+
+      it { is_expected.to eq [] }
+      it { is_not_expected_to_report_error }
     end
 
     context 'unknown error' do
@@ -50,11 +60,7 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
-
-      it do
-        expect(ErrorNotifier).to receive(:report).with(an_instance_of(described_class::HttpError))
-        subject
-      end
+      it { is_expected_to_report_error }
     end
   end
 
@@ -69,6 +75,7 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:classrooms_attrs) { [classroom1_attrs, classroom2_attrs]}
 
       it { is_expected.to eq classrooms_attrs }
+      it { is_not_expected_to_report_error }
     end
 
     context 'unauthorized token' do
@@ -77,6 +84,15 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
+      it { is_not_expected_to_report_error }
+    end
+
+    context 'resource not found' do
+      let(:code) { 404 }
+      let(:parsed_response) { {'error' => 'Resource not found' } }
+
+      it { is_expected.to eq [] }
+      it { is_not_expected_to_report_error }
     end
 
     context 'unknown error' do
@@ -84,11 +100,17 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:parsed_response) { {'error' => 'Unknown error' } }
 
       it { is_expected.to eq [] }
-
-      it do
-        expect(ErrorNotifier).to receive(:report).with(an_instance_of(described_class::HttpError))
-        subject
-      end
+      it { is_expected_to_report_error }
     end
+  end
+
+  def is_not_expected_to_report_error
+    expect(ErrorNotifier).not_to receive(:report)
+    subject
+  end
+
+  def is_expected_to_report_error
+    expect(ErrorNotifier).to receive(:report).with(an_instance_of(described_class::HttpError))
+    subject
   end
 end

--- a/services/QuillLMS/spec/services/clever_integration/library_client_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/library_client_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
-      it { is_not_expected_to_report_error }
+      it { not_expected_to_report_error? }
     end
 
     context 'resource not found' do
@@ -51,7 +51,7 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
-      it { is_not_expected_to_report_error }
+      it { not_expected_to_report_error? }
     end
 
     context 'unknown error' do
@@ -60,7 +60,7 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
-      it { is_expected_to_report_error }
+      it { expected_to_report_error? }
     end
   end
 
@@ -75,7 +75,7 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:classrooms_attrs) { [classroom1_attrs, classroom2_attrs]}
 
       it { is_expected.to eq classrooms_attrs }
-      it { is_not_expected_to_report_error }
+      it { not_expected_to_report_error? }
     end
 
     context 'unauthorized token' do
@@ -84,7 +84,7 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
-      it { is_not_expected_to_report_error }
+      it { not_expected_to_report_error? }
     end
 
     context 'resource not found' do
@@ -92,7 +92,7 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:parsed_response) { {'error' => 'Resource not found' } }
 
       it { is_expected.to eq [] }
-      it { is_not_expected_to_report_error }
+      it { not_expected_to_report_error? }
     end
 
     context 'unknown error' do
@@ -100,16 +100,16 @@ RSpec.describe CleverIntegration::LibraryClient do
       let(:parsed_response) { {'error' => 'Unknown error' } }
 
       it { is_expected.to eq [] }
-      it { is_expected_to_report_error }
+      it { expected_to_report_error? }
     end
   end
 
-  def is_not_expected_to_report_error
+  def not_expected_to_report_error?
     expect(ErrorNotifier).not_to receive(:report)
     subject
   end
 
-  def is_expected_to_report_error
+  def expected_to_report_error?
     expect(ErrorNotifier).to receive(:report).with(an_instance_of(described_class::HttpError))
     subject
   end


### PR DESCRIPTION
## WHAT
1. Fix a [bug](https://quillorg-5s.sentry.io/issues/4385584391/?environment=production&project=11238&query=is%3Aunresolved+clever&referrer=issue-stream&statsPeriod=24h&stream_index=4) with the handling of Clever::ApiError
2. Fix a [bug](https://quillorg-5s.sentry.io/issues/4442201366/?project=11238&referrer=github-pr-bot) with a previous fix
3. Fix a [bug](https://quillorg-5s.sentry.io/issues/4442240660/?environment=production&project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=5) with handling 404 errors in clever imports
4. Fix a [bug](https://quillorg-5s.sentry.io/issues/4440251869/?environment=production&project=11238&query=is%3Aunresolved+UserNotFoundError&referrer=issue-stream&statsPeriod=24h&stream_index=0) involving an argument error.

## WHY
1. Clever district users sometimes will get `Clever::ApiError` thrown when attempting to pull classroom roster information.
2. `retry` is not actually what we want here.
3. For whatever reason, a resource might not be found
4. Wrong argument type was passed to ErrorNotifier
 
## HOW
1. Currently, this error is not handled so any downstream calls on TeacherClassroomsCache will fail.  Instead, catch the error and return an empty array to help with downstream processing.
2. Change `retry` to `next` as we don't actually need to attempt a create again
3. Add `404` to the case statement.
4. Append `.new` on the Error class.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
