### PR TITLE
Disable import provider students if teacher is not synced

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -2,7 +2,8 @@ import * as moment from 'moment'
 import * as React from 'react'
 import { useState } from 'react'
 
-import { canvasProvider, cleverProvider, googleProvider } from './providerHelpers'
+import { canvasProvider, cleverProvider, classroomProviders, googleProvider, providerConfigLookup } from './providerHelpers'
+
 import EditStudentAccountModal from './edit_student_account_modal'
 import MergeStudentAccountsModal from './merge_student_accounts_modal'
 import MoveStudentsModal from './move_students_modal'
@@ -59,7 +60,7 @@ function activeHeaders(hasClassroomProvider: boolean) {
     rowSectionClassName: 'show-overflow'
   }
 
-  const actions =  {
+  const actions = {
     name: 'Actions',
     attribute: 'actions',
     isActions: true
@@ -105,11 +106,11 @@ enum modalNames {
 }
 
 interface ClassroomStudentSectionProps {
-  user: any;
   classroom: any;
   classrooms: Array<any>;
   isOwnedByCurrentUser: boolean;
   provider?: string;
+  user: any;
   onSuccess: (event) => void;
   inviteStudents?: (event) => void;
   importProviderClassroomStudents?: (event) => void;
@@ -123,10 +124,11 @@ const ClassroomStudentSection = ({
   inviteStudents,
   isOwnedByCurrentUser,
   onSuccess,
+  user,
   viewAsStudent,
 }: ClassroomStudentSectionProps) => {
-  const [selectedStudentIds, setSelectedStudentIds] = useState<Array<string|number>>([])
-  const [studentIdsForModal, setStudentIdsForModal] = useState<Array<string|number>>([])
+  const [selectedStudentIds, setSelectedStudentIds] = useState<Array<string | number>>([])
+  const [studentIdsForModal, setStudentIdsForModal] = useState<Array<string | number>>([])
   const [showModal, setShowModal] = useState<modalNames>()
 
   const allStudentsAreProvider = (provider: string) => {
@@ -210,11 +212,11 @@ const ClassroomStudentSection = ({
     if (user_external_id) {
       return synced ? [viewAsStudent] : [viewAsStudent, moveClass, removeFromClass]
     } else if (classrooms.length > 1 && isOwnedByCurrentUser) {
-      return [ editAccount, resetPassword, viewAsStudent, mergeAccounts, moveClass, removeFromClass ]
+      return [editAccount, resetPassword, viewAsStudent, mergeAccounts, moveClass, removeFromClass]
     } else if (isOwnedByCurrentUser) {
-      return [ editAccount, resetPassword, viewAsStudent, mergeAccounts, removeFromClass ]
+      return [editAccount, resetPassword, viewAsStudent, mergeAccounts, removeFromClass]
     } else {
-      return [ editAccount, resetPassword, viewAsStudent, removeFromClass ]
+      return [editAccount, resetPassword, viewAsStudent, removeFromClass]
     }
   }
 
@@ -243,7 +245,7 @@ const ClassroomStudentSection = ({
     viewAsStudent(null)
   }
 
-  const onClickViewAsIndividualStudent = (id: string|number) => {
+  const onClickViewAsIndividualStudent = (id: string | number) => {
     viewAsStudent(id)
   }
 
@@ -251,31 +253,31 @@ const ClassroomStudentSection = ({
     action.value()
   }
 
-  const editStudentAccount = (id=null) => {
+  const editStudentAccount = (id = null) => {
     // we will only show the edit student account dropdown option when only one student is selected
     setShowModal(modalNames.editStudentAccountModal)
     setStudentIdsForModal([id || selectedStudentIds[0]])
   }
 
-  const resetStudentPassword = (id=null) => {
+  const resetStudentPassword = (id = null) => {
     // we will only show the reset password account dropdown option when only one student is selected
     setShowModal(modalNames.resetStudentPasswordModal)
     setStudentIdsForModal([id || selectedStudentIds[0]])
   }
 
-  const mergeStudentAccounts = (id=null) => {
+  const mergeStudentAccounts = (id = null) => {
     // we will only show the merge student accounts account dropdown option when one or two students are selected
     setShowModal(modalNames.mergeStudentAccountsModal)
     setStudentIdsForModal(id ? [id] : selectedStudentIds)
   }
 
-  const moveClass = (id=null) => {
+  const moveClass = (id = null) => {
     // we will show the move class dropdown option when any number of students are selected
     setShowModal(modalNames.moveStudentsModal)
     setStudentIdsForModal(id ? [id] : selectedStudentIds)
   }
 
-  const removeStudentFromClass = (id=null) => {
+  const removeStudentFromClass = (id = null) => {
     // we will show the remove student from class dropdown option when any number of students are selected
     const studentIds = id ? [id] : selectedStudentIds
     setShowModal(modalNames.removeStudentsModal)
@@ -372,28 +374,28 @@ const ClassroomStudentSection = ({
     } = dropdownActions()
 
     if (anySelectedProviderStudents) {
-      return [ viewAsStudent, removeFromClass ]
+      return [viewAsStudent, removeFromClass]
     } else if (classrooms.length > 1 && isOwnedByCurrentUser) {
       if (selectedStudentIds.length === 1) {
-        return [ editAccount, resetPassword, viewAsStudent, mergeAccounts, moveClass, removeFromClass ]
+        return [editAccount, resetPassword, viewAsStudent, mergeAccounts, moveClass, removeFromClass]
       } else if (selectedStudentIds.length === 2) {
-        return [ viewAsStudent, mergeAccounts, moveClass, removeFromClass ]
+        return [viewAsStudent, mergeAccounts, moveClass, removeFromClass]
       } else {
-        return [ viewAsStudent, moveClass, removeFromClass ]
+        return [viewAsStudent, moveClass, removeFromClass]
       }
     } else if (isOwnedByCurrentUser) {
       if (selectedStudentIds.length === 1) {
-        return [ editAccount, resetPassword, viewAsStudent, mergeAccounts, removeFromClass ]
+        return [editAccount, resetPassword, viewAsStudent, mergeAccounts, removeFromClass]
       } else if (selectedStudentIds.length === 2) {
-        return [ viewAsStudent, mergeAccounts, removeFromClass ]
+        return [viewAsStudent, mergeAccounts, removeFromClass]
       } else {
-        return [ viewAsStudent, removeFromClass ]
+        return [viewAsStudent, removeFromClass]
       }
     } else {
       if (selectedStudentIds.length === 1) {
-        return [ editAccount, resetPassword, viewAsStudent, removeFromClass ]
+        return [editAccount, resetPassword, viewAsStudent, removeFromClass]
       } else {
-        return [ viewAsStudent, removeFromClass ]
+        return [viewAsStudent, removeFromClass]
       }
     }
   }
@@ -426,13 +428,19 @@ const ClassroomStudentSection = ({
 
       if (allStudentsAreGoogle) {
         header = <h4>This class is managed through <u>Google</u></h4>
-        copy = "Your students’ account information is linked to your Google Classroom account. Go to your Google Classroom account to edit your students."
+        copy = user.classroom_provider === googleProvider
+          ? "Your students’ account information is linked to your Google Classroom account. Go to your Google Classroom account to edit your students."
+          : "Your students’ account information is on Google Classroom. To enable auto-syncing, you'll need to link your account to Google."
       } else if (allStudentsAreClever) {
         header = <h4>This class is managed through <u>Clever</u></h4>
-        copy = "Your students’ account information is auto-synced from your Clever account. You can modify your Quill class rosters from your Clever account."
+        copy = user.classroom_provider === cleverProvider
+          ? "Your students’ account information is auto-synced from your Clever account. You can modify your Quill class rosters from your Clever account."
+          : "Your students’ account information is on Clever.  To enable auto-syncing, you'll need to link your account to Clever."
       } else if (allStudentsAreCanvas) {
         header = <h4>This class is managed through <u>Canvas</u></h4>
-        copy = "Your students’ account information is auto-synced from your Canvas Instance. Go to your Canvas Instance to edit your students."
+        copy = user.classroom_provider === canvasProvider
+          ? "Your students’ account information is auto-synced from your Canvas Instance. Go to your Canvas Instance to edit your students."
+          : "Your students’ account information is on Canvas. To enable auto-syncing, you'll need to link your account to Canvas."
       }
       return (
         <div className="provider-note-of-explanation">
@@ -577,10 +585,16 @@ const ClassroomStudentSection = ({
     const { classroomProvider } = classroom
 
     if (classroomProvider) {
+      const isDisabled = providerConfigLookup[user.provider].title !== classroomProvider
       const lastUpdatedDate = moment(classroom.updated_at).format('MMM D, YYYY')
       return (
         <div className="invite-provider-classroom-students">
-          <button className="quill-button primary outlined small" onClick={importProviderClassroomStudents} type="button">
+          <button
+            className={`quill-button primary outlined small ${isDisabled ? 'disabled' : ''}`}
+            disabled={isDisabled}
+            onClick={importProviderClassroomStudents}
+            type="button"
+          >
             Import {classroomProvider} students
           </button>
           <span>Last imported {lastUpdatedDate}</span>
@@ -615,11 +629,12 @@ const ClassroomStudentSection = ({
       )
     } else if (classroom.visible) {
       let copy = 'Click on the "Invite students" button to get started with your writing instruction!'
-      if (classroom.google_classroom_id) {
-        copy = 'Click on the "Import Google Classroom students" button to get started with your writing instruction!'
-      } else if (classroom.clever_id) {
-        copy = 'Add students to your class in Clever and they will automatically appear here.'
+      const { classroom_provider } = classroom
+
+      if (classroomProviders.includes(classroom_provider)) {
+        copy = `Add students to your class in ${classroom_provider} and they will automatically appear here.`
       }
+
       return (
         <div className="students-section">
           <div className="students-section-header">

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/providerHelpers.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/providerHelpers.ts
@@ -1,6 +1,10 @@
 export const canvasProvider = 'Canvas'
 export const cleverProvider = 'Clever'
 export const googleProvider = 'Google'
+export const canvasClassroomProvider = 'Canvas'
+export const cleverClassroomProvider = 'Clever'
+export const googleClassroomProvider = 'Google Classroom'
+export const classroomProviders = [canvasClassroomProvider, cleverClassroomProvider, googleClassroomProvider]
 
 const importClassroomsEventName = (provider: string) => `${provider.toLowerCase()}-classroom-students-imported`
 const importClassroomsPath = (provider: string) => `/${provider.toLowerCase()}_integration/teachers/import_classrooms`
@@ -18,7 +22,7 @@ export const providerConfigLookup = {
     isCanvas: true,
     retrieveClassroomsEventName: retrieveClassroomsEventName(canvasProvider),
     retrieveClassroomsPath: retrieveClassroomsPath(canvasProvider),
-    title: 'Canvas',
+    title: canvasClassroomProvider,
   },
   [cleverProvider]: {
     importClassroomsEventName: importClassroomsEventName(cleverProvider),
@@ -28,7 +32,7 @@ export const providerConfigLookup = {
     isClever: true,
     retrieveClassroomsEventName: retrieveClassroomsEventName(cleverProvider),
     retrieveClassroomsPath: retrieveClassroomsPath(cleverProvider),
-    title: 'Clever',
+    title: cleverClassroomProvider,
   },
   [googleProvider]: {
     importClassroomsEventName: importClassroomsEventName(googleProvider),
@@ -38,7 +42,7 @@ export const providerConfigLookup = {
     isGoogle: true,
     retrieveClassroomsPath: retrieveClassroomsPath(googleProvider),
     retrieveClassroomsEventName: retrieveClassroomsEventName(googleProvider),
-    title: 'Google Classroom',
+    title: googleClassroomProvider,
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
@@ -6,7 +6,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
   defaultText="No date selected"
   handleClickCopyToAll={[Function]}
   icon={null}
-  initialValue={"2022-11-10T03:00:00.000Z"}
+  initialValue={"2022-11-10T05:00:00.000Z"}
   rowIndex={0}
 >
   <div
@@ -21,7 +21,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
         closeOnSelect={false}
         closeOnTab={true}
         dateFormat="MMM D"
-        initialValue={"2022-11-10T03:00:00.000Z"}
+        initialValue={"2022-11-10T05:00:00.000Z"}
         initialViewDate={2022-11-10T09:00:00.000Z}
         input={true}
         inputProps={Object {}}
@@ -85,7 +85,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       "onFocus": [Function],
                       "onKeyDown": [Function],
                       "type": "text",
-                      "value": "Nov 10 3:00 am",
+                      "value": "Nov 10 5:00 am",
                     }
                   }
                 >
@@ -102,7 +102,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       onKeyDown={[Function]}
                       placeholder="No date selected"
                       type="text"
-                      value="Nov 10 3:00 am"
+                      value="Nov 10 5:00 am"
                     />
                     <img
                       alt="dropdown indicator"
@@ -120,7 +120,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                   moment={[Function]}
                   navigate={[Function]}
                   renderDay={[Function]}
-                  selectedDate={"2022-11-10T03:00:00.000Z"}
+                  selectedDate={"2022-11-10T05:00:00.000Z"}
                   showView={[Function]}
                   timeFormat="h:mm a"
                   updateDate={[Function]}


### PR DESCRIPTION
## WHAT
Fix a [bug](https://quillorg-5s.sentry.io/issues/4439569622/?environment=production&project=11238&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=12) that involves teachers attempting to import classroom students

## WHY
Our UI offers a button in the Classroom view for "Import [provider] students"  when all students in the classroom are [provider] associated accounts.  However, the ability to actually import from that classroom depends on if the teacher is also synced to that same [provider].  

For example, if a teacher has a Clever classroom but is currently linked to a Google account, they should not be able to auto-sync from that classroom until they link their account to Clever.

## HOW
Disable the import button and add explanatory copy if the user has different account linked than the classroom provider they are attempting to import. 

### Screenshots
![Screenshot 2023-08-31 at 9 52 02 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/0a1d74da-e44a-4cd3-8e19-22a0fe2a2f38)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
