### PR TITLE
Remove support email and phone numbers from footer

### DIFF
--- a/docs/_layouts/layout.html
+++ b/docs/_layouts/layout.html
@@ -189,7 +189,6 @@
         <div class="privacy">
           <a href="/tos">Terms</a>
           <a href="/privacy">Privacy</a>
-          <a>hello@quill.org</a>
         </div>
         <div class="social">
           <a target="_blank" href="http://twitter.com/Quill_org"><i class="fa fa-twitter" aria-hidden="true"></i></a>

--- a/services/QuillLMS/app/views/application/footer/_base.html.erb
+++ b/services/QuillLMS/app/views/application/footer/_base.html.erb
@@ -3,6 +3,4 @@
   <p>Quill is 501(c)(3) nonprofit organization</p>
   <a href="/tos">Terms</a>
   <a href="/privacy">Privacy</a>
-  <a>hello@quill.org</a>
-  <a href="tel:510-671-0222">510-671-0222</a>
 </div>


### PR DESCRIPTION
## WHAT
Remove email and phone numbers for support from website footers.

## WHY
We want users to get this info from our Contact Us page from now on.

## HOW
Remove this content from html pages.

### Screenshots
![Screenshot 2023-09-05 at 2 41 30 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/49c419da-9777-4578-89cb-068f3a8bc7c2)


### Notion Card Links

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
