### PR TITLE
fix issue where recommended activity packs are staying closed

### DIFF
--- a/services/QuillLMS/app/services/units/assignment_helpers.rb
+++ b/services/QuillLMS/app/services/units/assignment_helpers.rb
@@ -29,7 +29,8 @@ module Units::AssignmentHelpers
 
     if units.present?
       unit = Units::AssignmentHelpers.find_unit_from_units(units)
-      unit.update(visible: true, open: true) if unit && !unit.visible
+      unit.update(visible: true) if unit && !unit.visible
+      unit.update(open: true) if unit && !unit.open
     end
 
     classroom_data = {


### PR DESCRIPTION
## WHAT
Fix problem where teachers assign recommended packs one school year, then close them, and then when they reassign them again the following year they stay closed.

## WHY
This is confusing UX.

## HOW
Just update the helper so that if a pack is closed when it is reassigned, it gets opened (we were already doing this if the pack was archived).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/If-classes-to-which-closed-activity-packs-were-assigned-are-archived-are-the-closed-activity-packs--89dd9171d4a04abc9f89660c98193ac6?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES