### PR TITLE
fix frontend bug to show rename activity pack errors and update error message

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -35,7 +35,6 @@ class Teachers::UnitsController < ApplicationController
     render json: response.to_json
   end
 
-  # rubocop:disable Lint/DuplicateBranch
   def update
     unit_template_names = UnitTemplate.pluck(:name).map(&:downcase)
     if unit_params[:name] && unit_params[:name] === ''
@@ -48,7 +47,6 @@ class Teachers::UnitsController < ApplicationController
       render json: {errors: { name: "Each activity pack needs a unique name. You're already using that name for another activity pack. Please choose a different name."} }, status: 422
     end
   end
-  # rubocop:enable Lint/DuplicateBranch
 
   def update_classroom_unit_assigned_students
     activities_data = UnitActivity.where(unit_id: params[:id]).order(:order_number).pluck(:activity_id).map { |id| { id: id } }

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -41,7 +41,7 @@ class Teachers::UnitsController < ApplicationController
     if unit_params[:name] && unit_params[:name] === ''
       render json: {errors: { name: 'Unit must have a name'} }, status: 422
     elsif unit_template_names.include?(unit_params[:name].downcase)
-      render json: {errors: { name: "Each activity pack needs a unique name. You're already using that name for another activity pack. Please choose a different name."} }, status: 422
+      render json: {errors: { name: "Existing activity packs cannot be updated to share a name with featured activity packs. Please choose a different name."} }, status: 422
     elsif Unit.find(params[:id])&.update(unit_params)
       render json: {}
     else

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/rename_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/rename_modal.tsx
@@ -20,7 +20,7 @@ const RenameModal = ({ onSuccess, closeModal, unitId, unitName, }) => {
       name,
       () => onSuccess('Activity pack renamed'),
       (response) => {
-        setErrors(response.body.errors)
+        setErrors(response.errors)
         setTimesSubmitted(timesSubmitted + 1)
       }
     )


### PR DESCRIPTION
## WHAT
Fix bug where a rename update for activity packs was erroring, but the error wasn't being displayed to users. Also update the copy of that error since it wasn't totally accurate to the problem.

## WHY
We want users to know why something they're trying to do isn't working.

## HOW
Update the frontend to look for errors in the right place (on `response` rather than `response.body`), and update the error copy.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Rename-feature-on-the-My-Activities-page-not-functioning-as-expected-635881a6299a447fbbfaff13ae4126f5?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES