### PR TITLE
Loosen sentence length requirement on Connect/Diagnostic

### DIFF
--- a/lambdas/rematching/package.json
+++ b/lambdas/rematching/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "pg": "^7.7.1",
-    "quill-marking-logic": "0.15.10",
+    "quill-marking-logic": "0.15.11",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "sequelize": "^4.44.3",

--- a/packages/quill-marking-logic/package.json
+++ b/packages/quill-marking-logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "description": "Shared Quill logic for grading and contextualizing student writing.",
   "main": "./dist/lib",
   "module": "./dist/lib",

--- a/packages/quill-marking-logic/src/libs/matchers/min_length_match.spec.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/min_length_match.spec.ts
@@ -1,5 +1,7 @@
 import { assert } from 'chai';
+
 import {minLengthMatch, minLengthChecker} from './min_length_match'
+
 import {Response} from '../../interfaces'
 import {feedbackStrings} from '../constants/feedback_strings'
 import {conceptResultTemplate} from '../helpers/concept_result_template'
@@ -7,7 +9,7 @@ import {getTopOptimalResponse} from '../sharedResponseFunctions'
 
 describe('The minLengthMatch function', () => {
 
-  it('should return true if the response string is at least two words shorter than any of the optimal responses', () => {
+  it('should return true if the response string is at least four words shorter than any of the optimal responses', () => {
     const responseString = "My dog napped";
     const savedResponses: Array<Response> = [
       {
@@ -30,7 +32,7 @@ describe('The minLengthMatch function', () => {
     assert.ok(minLengthMatch(responseString, savedResponses));
   });
 
-  it('Should take a response string and return undefined if it is shorter than the shortest optimal response by one word or less', () => {
+  it('Should take a response string and return undefined if it is shorter than the shortest optimal response by three words or less', () => {
     const responseString = "My dog took a nap.";
     const savedResponses: Array<Response> = [
       {
@@ -57,7 +59,7 @@ describe('The minLengthMatch function', () => {
 
 describe('The minLengthChecker', () => {
 
-  const responseString = "My dog napped";
+  const responseString = "My dog";
   const savedResponses: Array<Response> = [
     {
       id: 1,
@@ -77,7 +79,7 @@ describe('The minLengthChecker', () => {
     }
   ]
 
-  it('Should return a partial response if response string is at least two words shorter than any of them', () => {
+  it('Should return a partial response if response string is at least four words shorter than any of them', () => {
     const shortestOptimalResponse = savedResponses.sort(r => r.text.length)[0]
     const partialResponse =  {
       feedback: feedbackStrings.minLengthError,

--- a/packages/quill-marking-logic/src/libs/matchers/min_length_match.spec.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/min_length_match.spec.ts
@@ -9,8 +9,8 @@ import {getTopOptimalResponse} from '../sharedResponseFunctions'
 
 describe('The minLengthMatch function', () => {
 
-  it('should return true if the response string is at least four words shorter than any of the optimal responses', () => {
-    const responseString = "My dog napped";
+  it('should return true if the response string four words or more shorter than any of the optimal responses', () => {
+    const responseString = "My dog.";
     const savedResponses: Array<Response> = [
       {
         id: 1,
@@ -30,6 +30,29 @@ describe('The minLengthMatch function', () => {
       }
     ]
     assert.ok(minLengthMatch(responseString, savedResponses));
+  });
+
+  it('should return false if the response string is only shorter than the optimal response by two words', () => {
+    const responseString = "My sleepy dog took.";
+    const savedResponses: Array<Response> = [
+      {
+        id: 1,
+        text: "My sleepy dog took a nap.",
+        feedback: "Good job, that's a sentence!",
+        optimal: true,
+        count: 1,
+        question_uid: 'question 1'
+      },
+      {
+        id: 2,
+        text: "My happy dog took a long nap.",
+        feedback: "Good job, that's a sentence!",
+        optimal: true,
+        count: 1,
+        question_uid: 'question 2'
+      }
+    ]
+    assert.notOk(minLengthMatch(responseString, savedResponses));
   });
 
   it('Should take a response string and return undefined if it is shorter than the shortest optimal response by three words or less', () => {
@@ -93,6 +116,11 @@ describe('The minLengthChecker', () => {
     assert.equal(minLengthChecker(responseString, savedResponses).author, partialResponse.author);
     assert.equal(minLengthChecker(responseString, savedResponses).parent_id, partialResponse.parent_id);
     assert.equal(minLengthChecker(responseString, savedResponses).concept_results.length, partialResponse.concept_results.length);
+  });
+
+  it('Should not return a partial response if response string is only two words shorter than the optimal response', () => {
+    const responseString = 'My happy dog took a'
+    assert.equal(minLengthChecker(responseString, savedResponses), null);
   });
 
   it('Should not return any concept results if it is asked to', () => {

--- a/packages/quill-marking-logic/src/libs/matchers/min_length_match.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/min_length_match.ts
@@ -1,5 +1,6 @@
 import * as _ from 'underscore'
 import {stringNormalize} from 'quill-string-normalizer'
+
 import {getOptimalResponses} from '../sharedResponseFunctions'
 import {Response, PartialResponse} from '../../interfaces'
 import {feedbackStrings} from '../constants/feedback_strings'

--- a/packages/quill-marking-logic/src/libs/matchers/min_length_match.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/min_length_match.ts
@@ -9,7 +9,7 @@ import {conceptResultTemplate} from '../helpers/concept_result_template'
 export function minLengthMatch(responseString:string, responses:Array<Response>):Boolean {
   const optimalResponses = getOptimalResponses(responses);
   const lengthsOfResponses = optimalResponses.map(resp => stringNormalize(resp.text).split(' ').length);
-  const minLength = _.min(lengthsOfResponses) - 1;
+  const minLength = _.min(lengthsOfResponses) - 3;
   return responseString.split(' ').length < minLength
 }
 

--- a/services/QuillLMS/client/package.json
+++ b/services/QuillLMS/client/package.json
@@ -84,7 +84,7 @@
     "pusher-js": "^5.0.1",
     "qs": "^6.11.1",
     "query-string": "^6.13.6",
-    "quill-marking-logic": "^0.15.10",
+    "quill-marking-logic": "^0.15.11",
     "quill-string-normalizer": "0.0.9",
     "raven-js": "^3.17.0",
     "react": "^18.2.0",

--- a/services/QuillLMS/package-lock.json
+++ b/services/QuillLMS/package-lock.json
@@ -881,9 +881,9 @@
       }
     },
     "quill-marking-logic": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.15.10.tgz",
-      "integrity": "sha512-0ap+AUaYH7ep6pt9/X35a204tgNTFq93GZGSay4G43KgEX02+tK2uGUqmo4YuPSI9cUvmCzxLO7P/NPjnF69jQ==",
+      "version": "0.15.11",
+      "resolved": "https://registry.npmjs.org/quill-marking-logic/-/quill-marking-logic-0.15.11.tgz",
+      "integrity": "sha512-auYKHD8bIq1UnykepRuavJLxvg6docz0C7aGxs35U86QdXKNzntM7GtCgtfOeOvTu4gNMc4z3zuPF2Y2QmjHbQ==",
       "requires": {
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "foreman": "^3.0.1",
     "lazysizes": "^5.2.0-beta1",
-    "quill-marking-logic": "0.15.10",
+    "quill-marking-logic": "0.15.11",
     "react-csv": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## WHAT
Shorten the minimum sentence length from 2 words shorter than the optimal response, to 4 words shorter than the optimal response.

## WHY
Right now our requirement for sentence minimum length is a bit too strict. It requires sentences to be at most two words shorter than the optimal response, which is too strict.

## HOW
Change the logic in the marking logic to allow for up to 3 words shorter than the optimal response.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
