### PR TITLE
allow logged-out users to access /teachers/view_demo; fix regeneration

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -10,7 +10,7 @@ class Teachers::ClassroomManagerController < ApplicationController
 
   around_action :force_writer_db_role, only: [:assign, :dashboard, :lesson_planner]
 
-  before_action :teacher_or_public_activity_packs, except: [:unset_preview_as_student, :unset_view_demo]
+  before_action :teacher_or_public_activity_packs, except: [:unset_preview_as_student, :unset_view_demo, :view_demo]
   # WARNING: these filter methods check against classroom_id, not id.
   before_action :authorize_owner!, except: [:scores, :scorebook, :lesson_planner, :preview_as_student, :unset_preview_as_student, :view_demo, :unset_view_demo, :activity_feed]
   before_action :authorize_teacher!, only: [:scores, :scorebook, :lesson_planner]

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -46,6 +46,10 @@ module Teacher
     Classroom.find_by_sql(base_sql_for_teacher_classrooms)
   end
 
+  def unscoped_classrooms_i_teach
+    Classroom.find_by_sql(base_sql_for_teacher_classrooms(only_visible_classrooms: false))
+  end
+
   def classrooms_i_own
     Classroom.find_by_sql("#{base_sql_for_teacher_classrooms} AND ct.role = 'owner'")
   end

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -129,6 +129,7 @@ module Demo::ReportDemoCreator
     },
     {
       name: 'Reading for Evidence Pack',
+      unit_template_id: nil,
       activity_sessions: [
         {
           2371 => KEN_ID,

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -292,7 +292,8 @@ module Demo::ReportDemoCreator
 
   def self.create_units(teacher)
     ACTIVITY_PACKS_TEMPLATES.map do |ap|
-      unit = Unit.find_or_create_by(name: ap[:name], user: teacher, unit_template_id: ap[:unit_template_id])
+      unit_template_id = UnitTemplate.find_by_id(ap[:unit_template_id])&.id # ensures the unit template actually exists in our database
+      unit = Unit.find_or_create_by(name: ap[:name], user: teacher, unit_template_id: unit_template_id)
       activity_ids = activity_ids_for_config(ap)
       activity_ids.each { |act_id| UnitActivity.find_or_create_by(activity_id: act_id, unit: unit) }
 

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Demo::ReportDemoCreator do
   context 'ACTIVITY_PACKS_TEMPLATES config' do
-    let(:expected_keys) {[:activity_sessions, :name]}
+    let(:expected_keys) {[:activity_sessions, :name, :unit_template_id]}
 
     subject { described_class::ACTIVITY_PACKS_TEMPLATES }
 


### PR DESCRIPTION
## WHAT
Fix various issues with the `/teachers/view_demo` path, including:

- account regeneration did not work properly if original Quill Classroom had been archived
- logged-out users couldn't access /teachers/view_demo
- assigned recommendations weren't showing up on the recommendations page of the diagnostic reports

## WHY
We want the demo account to be as useful as possible for teachers.

## HOW
- Add a new function to check for an unscoped version of `classrooms_i_teach` so that if the Quill Classroom has been archived, it can still get wiped correctly and then the one can be generated
- Add activity pack ids to the assigned recommendations packs so the logic on the recommendations page can identify them as assigned
- Remove the logged in user constraint from the `view_demo` path 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - manually tested
Have you deployed to Staging? | Tested with staging data locally
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A