### PR TITLE
Fix my activities table display issue

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/my_activities.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/my_activities.scss
@@ -52,10 +52,6 @@
         padding-top: 20px;
       }
     }
-    .data-table {
-      overflow-x: auto !important;
-      max-width: 80vw;
-    }
     .activity-pack-top-section {
       padding: 32px;
       border-bottom: 1px solid $quill-grey-5;
@@ -223,6 +219,55 @@
     }
   }
 
+  @media (max-width: 1200px) {
+    .activity-pack {
+      .data-table {
+        .data-table-headers {
+          .tool-and-name-section-header {
+            width: 500px !important;
+            min-width: 500px !important;
+          }
+        }
+        .data-table-row {
+          .tool-and-name-section {
+            width: 500px !important;
+            min-width: 500px !important;
+            .activity-name-link {
+              width: 450px;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @media (max-width: 1070px) {
+    .activity-pack {
+      .data-table {
+        .data-table-headers {
+          .tool-and-name-section-header {
+            width: 400px !important;
+            min-width: 400px !important;
+          }
+        }
+        .data-table-body {
+          .list-item {
+            width: auto !important;
+            .data-table-row {
+              .tool-and-name-section {
+                width: 400px !important;
+                min-width: 400px !important;
+                .activity-name-link {
+                  width: 350px;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   @media (min-width: 992px) {
     .small-screen {
       display: none;
@@ -241,10 +286,28 @@
         display: none;
       }
       .data-table {
-        overflow: hidden;
-        .due-date-picker, .publish-date-picker, .publish-date-header-container, .due-date-header-container, .reorder-header, .reorder-section {
-          display: none;
-        }
+        .data-table-headers {
+            .tool-and-name-section-header {
+              width: 350px !important;
+              min-width: 350px !important;
+            }
+          }
+
+          .data-table-body {
+            .list-item {
+              width: auto !important;
+
+              .data-table-row {
+                .tool-and-name-section {
+                  width: 350px !important;
+                  min-width: 350px !important;
+                  .activity-name-link {
+                    width: 300px;
+                  }
+                }
+              }
+            }
+          }
       }
     }
     .quill-modal {
@@ -252,7 +315,123 @@
     }
   }
 
-  @media (max-width: 500px) {
+  @media (max-width: 920px) {
+    .activity-pack {
+      .data-table {
+        .data-table-headers {
+          .tool-and-name-section-header {
+            width: 300px !important;
+            min-width: 300px !important;
+          }
+        }
+
+        .data-table-body {
+          .list-item {
+            width: auto !important;
+
+            .data-table-row {
+              .tool-and-name-section {
+                width: 300px !important;
+                min-width: 300px !important;
+                .activity-name-link {
+                  width: 250px;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @media (max-width: 870px) {
+    .activity-pack {
+      .data-table {
+        .data-table-headers {
+          .tool-and-name-section-header {
+            width: 250px !important;
+            min-width: 250px !important;
+          }
+        }
+
+        .data-table-body {
+          .list-item {
+            width: auto !important;
+
+            .data-table-row {
+              .tool-and-name-section {
+                width: 250px !important;
+                min-width: 250px !important;
+                .activity-name-link {
+                  width: 200px;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @media (max-width: 820px) {
+    .activity-pack {
+      .data-table {
+        .data-table-headers {
+          .tool-and-name-section-header {
+            width: 200px !important;
+            min-width: 200px !important;
+          }
+        }
+
+        .data-table-body {
+          .list-item {
+            width: auto !important;
+
+            .data-table-row {
+              .tool-and-name-section {
+                width: 200px !important;
+                min-width: 200px !important;
+                .activity-name-link {
+                  width: 150px;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @media (max-width: 770px) {
+    .activity-pack {
+      .data-table {
+        .data-table-headers {
+          .tool-and-name-section-header {
+            width: 150px !important;
+            min-width: 150px !important;
+          }
+        }
+
+        .data-table-body {
+          .list-item {
+            width: auto !important;
+
+            .data-table-row {
+              .tool-and-name-section {
+                width: 150px !important;
+                min-width: 150px !important;
+                .activity-name-link {
+                  width: 100px;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @media (max-width: 720px) {
     .my-activities-header {
       padding-left: 16px;
       padding-right: 16px;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=438"
               tabIndex={-1}
             >
@@ -131,6 +132,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=441"
               tabIndex={-1}
             >
@@ -198,6 +200,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=775"
               tabIndex={-1}
             >
@@ -265,6 +268,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=844"
               tabIndex={-1}
             >
@@ -332,6 +336,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=846"
               tabIndex={-1}
             >
@@ -622,6 +627,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=438"
                   tabIndex={-1}
                 >
@@ -689,6 +695,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=441"
                   tabIndex={-1}
                 >
@@ -756,6 +763,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=775"
                   tabIndex={-1}
                 >
@@ -823,6 +831,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=844"
                   tabIndex={-1}
                 >
@@ -890,6 +899,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=846"
                   tabIndex={-1}
                 >
@@ -941,6 +951,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
           Array [
             Object {
               "attribute": "toolAndNameSection",
+              "headerClassName": "tool-and-name-section-header",
               "name": <span
                 className="tool-and-name-header"
               >
@@ -1063,6 +1074,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=438"
                   tabIndex={-1}
                 >
@@ -1130,6 +1142,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=441"
                   tabIndex={-1}
                 >
@@ -1197,6 +1210,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=775"
                   tabIndex={-1}
                 >
@@ -1264,6 +1278,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=844"
                   tabIndex={-1}
                 >
@@ -1331,6 +1346,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=846"
                   tabIndex={-1}
                 >
@@ -1356,7 +1372,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
               Order
             </th>
             <th
-              className="data-table-header undefined"
+              className="data-table-header tool-and-name-section-header"
               scope="col"
               style={
                 Object {
@@ -1549,6 +1565,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=438"
                             tabIndex={-1}
                           >
@@ -1669,6 +1686,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=441"
                             tabIndex={-1}
                           >
@@ -1789,6 +1807,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=775"
                             tabIndex={-1}
                           >
@@ -1909,6 +1928,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=844"
                             tabIndex={-1}
                           >
@@ -2029,6 +2049,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=846"
                             tabIndex={-1}
                           >
@@ -2164,6 +2185,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=438"
                               tabIndex={-1}
                             >
@@ -2284,6 +2306,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=441"
                               tabIndex={-1}
                             >
@@ -2404,6 +2427,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=775"
                               tabIndex={-1}
                             >
@@ -2524,6 +2548,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=844"
                               tabIndex={-1}
                             >
@@ -2644,6 +2669,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=846"
                               tabIndex={-1}
                             >
@@ -2801,6 +2827,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=438"
                                 tabIndex={-1}
                               >
@@ -2921,6 +2948,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=441"
                                 tabIndex={-1}
                               >
@@ -3041,6 +3069,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=775"
                                 tabIndex={-1}
                               >
@@ -3161,6 +3190,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=844"
                                 tabIndex={-1}
                               >
@@ -3281,6 +3311,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=846"
                                 tabIndex={-1}
                               >
@@ -3412,6 +3443,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=438"
                                   tabIndex={-1}
                                 >
@@ -3536,6 +3568,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                     />
                                   </span>
                                   <a
+                                    className="activity-name-link"
                                     href="/activity_sessions/anonymous?activity_id=438"
                                     tabIndex={-1}
                                   >
@@ -3676,6 +3709,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=438"
                                   tabIndex={-1}
                                 >
@@ -5193,6 +5227,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=441"
                                   tabIndex={-1}
                                 >
@@ -5317,6 +5352,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                     />
                                   </span>
                                   <a
+                                    className="activity-name-link"
                                     href="/activity_sessions/anonymous?activity_id=441"
                                     tabIndex={-1}
                                   >
@@ -5457,6 +5493,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=441"
                                   tabIndex={-1}
                                 >
@@ -6940,6 +6977,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=775"
                                   tabIndex={-1}
                                 >
@@ -7064,6 +7102,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                     />
                                   </span>
                                   <a
+                                    className="activity-name-link"
                                     href="/activity_sessions/anonymous?activity_id=775"
                                     tabIndex={-1}
                                   >
@@ -7204,6 +7243,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=775"
                                   tabIndex={-1}
                                 >
@@ -8687,6 +8727,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=844"
                                   tabIndex={-1}
                                 >
@@ -8811,6 +8852,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                     />
                                   </span>
                                   <a
+                                    className="activity-name-link"
                                     href="/activity_sessions/anonymous?activity_id=844"
                                     tabIndex={-1}
                                   >
@@ -8951,6 +8993,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=844"
                                   tabIndex={-1}
                                 >
@@ -10434,6 +10477,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=846"
                                   tabIndex={-1}
                                 >
@@ -10558,6 +10602,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                     />
                                   </span>
                                   <a
+                                    className="activity-name-link"
                                     href="/activity_sessions/anonymous?activity_id=846"
                                     tabIndex={-1}
                                   >
@@ -10698,6 +10743,7 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                                   />
                                 </span>
                                 <a
+                                  className="activity-name-link"
                                   href="/activity_sessions/anonymous?activity_id=846"
                                   tabIndex={-1}
                                 >
@@ -12206,6 +12252,7 @@ exports[`ActivityPack component renders if the current user did not create the u
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=41"
               tabIndex={-1}
             >
@@ -12254,6 +12301,7 @@ exports[`ActivityPack component renders if the current user did not create the u
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=215"
               tabIndex={-1}
             >
@@ -12302,6 +12350,7 @@ exports[`ActivityPack component renders if the current user did not create the u
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=289"
               tabIndex={-1}
             >
@@ -12350,6 +12399,7 @@ exports[`ActivityPack component renders if the current user did not create the u
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=295"
               tabIndex={-1}
             >
@@ -12398,6 +12448,7 @@ exports[`ActivityPack component renders if the current user did not create the u
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=386"
               tabIndex={-1}
             >
@@ -12446,6 +12497,7 @@ exports[`ActivityPack component renders if the current user did not create the u
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=418"
               tabIndex={-1}
             >
@@ -12494,6 +12546,7 @@ exports[`ActivityPack component renders if the current user did not create the u
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=434"
               tabIndex={-1}
             >
@@ -12542,6 +12595,7 @@ exports[`ActivityPack component renders if the current user did not create the u
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=437"
               tabIndex={-1}
             >
@@ -12590,6 +12644,7 @@ exports[`ActivityPack component renders if the current user did not create the u
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=849"
               tabIndex={-1}
             >
@@ -12719,6 +12774,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=41"
                   tabIndex={-1}
                 >
@@ -12767,6 +12823,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=215"
                   tabIndex={-1}
                 >
@@ -12815,6 +12872,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=289"
                   tabIndex={-1}
                 >
@@ -12863,6 +12921,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=295"
                   tabIndex={-1}
                 >
@@ -12911,6 +12970,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=386"
                   tabIndex={-1}
                 >
@@ -12959,6 +13019,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=418"
                   tabIndex={-1}
                 >
@@ -13007,6 +13068,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=434"
                   tabIndex={-1}
                 >
@@ -13055,6 +13117,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=437"
                   tabIndex={-1}
                 >
@@ -13103,6 +13166,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=849"
                   tabIndex={-1}
                 >
@@ -13144,6 +13208,7 @@ exports[`ActivityPack component renders if the current user did not create the u
           Array [
             Object {
               "attribute": "toolAndNameSection",
+              "headerClassName": "tool-and-name-section-header",
               "name": <span
                 className="tool-and-name-header"
               >
@@ -13247,6 +13312,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=41"
                   tabIndex={-1}
                 >
@@ -13295,6 +13361,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=215"
                   tabIndex={-1}
                 >
@@ -13343,6 +13410,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=289"
                   tabIndex={-1}
                 >
@@ -13391,6 +13459,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=295"
                   tabIndex={-1}
                 >
@@ -13439,6 +13508,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=386"
                   tabIndex={-1}
                 >
@@ -13487,6 +13557,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=418"
                   tabIndex={-1}
                 >
@@ -13535,6 +13606,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=434"
                   tabIndex={-1}
                 >
@@ -13583,6 +13655,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=437"
                   tabIndex={-1}
                 >
@@ -13631,6 +13704,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                   />
                 </span>
                 <a
+                  className="activity-name-link"
                   href="/activity_sessions/anonymous?activity_id=849"
                   tabIndex={-1}
                 >
@@ -13650,7 +13724,7 @@ exports[`ActivityPack component renders if the current user did not create the u
             className="data-table-headers"
           >
             <th
-              className="data-table-header undefined"
+              className="data-table-header tool-and-name-section-header"
               scope="col"
               style={
                 Object {
@@ -13831,6 +13905,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                     />
                   </span>
                   <a
+                    className="activity-name-link"
                     href="/activity_sessions/anonymous?activity_id=41"
                     tabIndex={-1}
                   >
@@ -13917,6 +13992,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                     />
                   </span>
                   <a
+                    className="activity-name-link"
                     href="/activity_sessions/anonymous?activity_id=215"
                     tabIndex={-1}
                   >
@@ -14003,6 +14079,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                     />
                   </span>
                   <a
+                    className="activity-name-link"
                     href="/activity_sessions/anonymous?activity_id=289"
                     tabIndex={-1}
                   >
@@ -14089,6 +14166,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                     />
                   </span>
                   <a
+                    className="activity-name-link"
                     href="/activity_sessions/anonymous?activity_id=295"
                     tabIndex={-1}
                   >
@@ -14175,6 +14253,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                     />
                   </span>
                   <a
+                    className="activity-name-link"
                     href="/activity_sessions/anonymous?activity_id=386"
                     tabIndex={-1}
                   >
@@ -14261,6 +14340,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                     />
                   </span>
                   <a
+                    className="activity-name-link"
                     href="/activity_sessions/anonymous?activity_id=418"
                     tabIndex={-1}
                   >
@@ -14347,6 +14427,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                     />
                   </span>
                   <a
+                    className="activity-name-link"
                     href="/activity_sessions/anonymous?activity_id=434"
                     tabIndex={-1}
                   >
@@ -14433,6 +14514,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                     />
                   </span>
                   <a
+                    className="activity-name-link"
                     href="/activity_sessions/anonymous?activity_id=437"
                     tabIndex={-1}
                   >
@@ -14519,6 +14601,7 @@ exports[`ActivityPack component renders if the current user did not create the u
                     />
                   </span>
                   <a
+                    className="activity-name-link"
                     href="/activity_sessions/anonymous?activity_id=849"
                     tabIndex={-1}
                   >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=438"
               tabIndex={-1}
             >
@@ -131,6 +132,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=441"
               tabIndex={-1}
             >
@@ -198,6 +200,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=775"
               tabIndex={-1}
             >
@@ -265,6 +268,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=844"
               tabIndex={-1}
             >
@@ -332,6 +336,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=846"
               tabIndex={-1}
             >
@@ -381,6 +386,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
       Array [
         Object {
           "attribute": "toolAndNameSection",
+          "headerClassName": "tool-and-name-section-header",
           "name": <span
             className="tool-and-name-header"
           >
@@ -503,6 +509,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=438"
               tabIndex={-1}
             >
@@ -570,6 +577,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=441"
               tabIndex={-1}
             >
@@ -637,6 +645,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=775"
               tabIndex={-1}
             >
@@ -704,6 +713,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=844"
               tabIndex={-1}
             >
@@ -771,6 +781,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=846"
               tabIndex={-1}
             >
@@ -796,7 +807,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
           Order
         </th>
         <th
-          className="data-table-header undefined"
+          className="data-table-header tool-and-name-section-header"
           scope="col"
           style={
             Object {
@@ -989,6 +1000,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                         />
                       </span>
                       <a
+                        className="activity-name-link"
                         href="/activity_sessions/anonymous?activity_id=438"
                         tabIndex={-1}
                       >
@@ -1109,6 +1121,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                         />
                       </span>
                       <a
+                        className="activity-name-link"
                         href="/activity_sessions/anonymous?activity_id=441"
                         tabIndex={-1}
                       >
@@ -1229,6 +1242,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                         />
                       </span>
                       <a
+                        className="activity-name-link"
                         href="/activity_sessions/anonymous?activity_id=775"
                         tabIndex={-1}
                       >
@@ -1349,6 +1363,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                         />
                       </span>
                       <a
+                        className="activity-name-link"
                         href="/activity_sessions/anonymous?activity_id=844"
                         tabIndex={-1}
                       >
@@ -1469,6 +1484,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                         />
                       </span>
                       <a
+                        className="activity-name-link"
                         href="/activity_sessions/anonymous?activity_id=846"
                         tabIndex={-1}
                       >
@@ -1604,6 +1620,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                           />
                         </span>
                         <a
+                          className="activity-name-link"
                           href="/activity_sessions/anonymous?activity_id=438"
                           tabIndex={-1}
                         >
@@ -1724,6 +1741,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                           />
                         </span>
                         <a
+                          className="activity-name-link"
                           href="/activity_sessions/anonymous?activity_id=441"
                           tabIndex={-1}
                         >
@@ -1844,6 +1862,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                           />
                         </span>
                         <a
+                          className="activity-name-link"
                           href="/activity_sessions/anonymous?activity_id=775"
                           tabIndex={-1}
                         >
@@ -1964,6 +1983,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                           />
                         </span>
                         <a
+                          className="activity-name-link"
                           href="/activity_sessions/anonymous?activity_id=844"
                           tabIndex={-1}
                         >
@@ -2084,6 +2104,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                           />
                         </span>
                         <a
+                          className="activity-name-link"
                           href="/activity_sessions/anonymous?activity_id=846"
                           tabIndex={-1}
                         >
@@ -2241,6 +2262,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=438"
                             tabIndex={-1}
                           >
@@ -2361,6 +2383,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=441"
                             tabIndex={-1}
                           >
@@ -2481,6 +2504,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=775"
                             tabIndex={-1}
                           >
@@ -2601,6 +2625,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=844"
                             tabIndex={-1}
                           >
@@ -2721,6 +2746,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                             />
                           </span>
                           <a
+                            className="activity-name-link"
                             href="/activity_sessions/anonymous?activity_id=846"
                             tabIndex={-1}
                           >
@@ -2852,6 +2878,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=438"
                               tabIndex={-1}
                             >
@@ -2976,6 +3003,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=438"
                                 tabIndex={-1}
                               >
@@ -3116,6 +3144,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=438"
                               tabIndex={-1}
                             >
@@ -4633,6 +4662,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=441"
                               tabIndex={-1}
                             >
@@ -4757,6 +4787,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=441"
                                 tabIndex={-1}
                               >
@@ -4897,6 +4928,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=441"
                               tabIndex={-1}
                             >
@@ -6380,6 +6412,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=775"
                               tabIndex={-1}
                             >
@@ -6504,6 +6537,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=775"
                                 tabIndex={-1}
                               >
@@ -6644,6 +6678,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=775"
                               tabIndex={-1}
                             >
@@ -8127,6 +8162,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=844"
                               tabIndex={-1}
                             >
@@ -8251,6 +8287,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=844"
                                 tabIndex={-1}
                               >
@@ -8391,6 +8428,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=844"
                               tabIndex={-1}
                             >
@@ -9874,6 +9912,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=846"
                               tabIndex={-1}
                             >
@@ -9998,6 +10037,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                                 />
                               </span>
                               <a
+                                className="activity-name-link"
                                 href="/activity_sessions/anonymous?activity_id=846"
                                 tabIndex={-1}
                               >
@@ -10138,6 +10178,7 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                               />
                             </span>
                             <a
+                              className="activity-name-link"
                               href="/activity_sessions/anonymous?activity_id=846"
                               tabIndex={-1}
                             >
@@ -11638,6 +11679,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=41"
               tabIndex={-1}
             >
@@ -11686,6 +11728,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=215"
               tabIndex={-1}
             >
@@ -11734,6 +11777,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=289"
               tabIndex={-1}
             >
@@ -11782,6 +11826,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=295"
               tabIndex={-1}
             >
@@ -11830,6 +11875,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=386"
               tabIndex={-1}
             >
@@ -11878,6 +11924,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=418"
               tabIndex={-1}
             >
@@ -11926,6 +11973,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=434"
               tabIndex={-1}
             >
@@ -11974,6 +12022,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=437"
               tabIndex={-1}
             >
@@ -12022,6 +12071,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=849"
               tabIndex={-1}
             >
@@ -12061,6 +12111,7 @@ exports[`ActivityTable component renders if the current user did not create the 
       Array [
         Object {
           "attribute": "toolAndNameSection",
+          "headerClassName": "tool-and-name-section-header",
           "name": <span
             className="tool-and-name-header"
           >
@@ -12164,6 +12215,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=41"
               tabIndex={-1}
             >
@@ -12212,6 +12264,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=215"
               tabIndex={-1}
             >
@@ -12260,6 +12313,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=289"
               tabIndex={-1}
             >
@@ -12308,6 +12362,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=295"
               tabIndex={-1}
             >
@@ -12356,6 +12411,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=386"
               tabIndex={-1}
             >
@@ -12404,6 +12460,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=418"
               tabIndex={-1}
             >
@@ -12452,6 +12509,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=434"
               tabIndex={-1}
             >
@@ -12500,6 +12558,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=437"
               tabIndex={-1}
             >
@@ -12548,6 +12607,7 @@ exports[`ActivityTable component renders if the current user did not create the 
               />
             </span>
             <a
+              className="activity-name-link"
               href="/activity_sessions/anonymous?activity_id=849"
               tabIndex={-1}
             >
@@ -12567,7 +12627,7 @@ exports[`ActivityTable component renders if the current user did not create the 
         className="data-table-headers"
       >
         <th
-          className="data-table-header undefined"
+          className="data-table-header tool-and-name-section-header"
           scope="col"
           style={
             Object {
@@ -12748,6 +12808,7 @@ exports[`ActivityTable component renders if the current user did not create the 
                 />
               </span>
               <a
+                className="activity-name-link"
                 href="/activity_sessions/anonymous?activity_id=41"
                 tabIndex={-1}
               >
@@ -12834,6 +12895,7 @@ exports[`ActivityTable component renders if the current user did not create the 
                 />
               </span>
               <a
+                className="activity-name-link"
                 href="/activity_sessions/anonymous?activity_id=215"
                 tabIndex={-1}
               >
@@ -12920,6 +12982,7 @@ exports[`ActivityTable component renders if the current user did not create the 
                 />
               </span>
               <a
+                className="activity-name-link"
                 href="/activity_sessions/anonymous?activity_id=289"
                 tabIndex={-1}
               >
@@ -13006,6 +13069,7 @@ exports[`ActivityTable component renders if the current user did not create the 
                 />
               </span>
               <a
+                className="activity-name-link"
                 href="/activity_sessions/anonymous?activity_id=295"
                 tabIndex={-1}
               >
@@ -13092,6 +13156,7 @@ exports[`ActivityTable component renders if the current user did not create the 
                 />
               </span>
               <a
+                className="activity-name-link"
                 href="/activity_sessions/anonymous?activity_id=386"
                 tabIndex={-1}
               >
@@ -13178,6 +13243,7 @@ exports[`ActivityTable component renders if the current user did not create the 
                 />
               </span>
               <a
+                className="activity-name-link"
                 href="/activity_sessions/anonymous?activity_id=418"
                 tabIndex={-1}
               >
@@ -13264,6 +13330,7 @@ exports[`ActivityTable component renders if the current user did not create the 
                 />
               </span>
               <a
+                className="activity-name-link"
                 href="/activity_sessions/anonymous?activity_id=434"
                 tabIndex={-1}
               >
@@ -13350,6 +13417,7 @@ exports[`ActivityTable component renders if the current user did not create the 
                 />
               </span>
               <a
+                className="activity-name-link"
                 href="/activity_sessions/anonymous?activity_id=437"
                 tabIndex={-1}
               >
@@ -13436,6 +13504,7 @@ exports[`ActivityTable component renders if the current user did not create the 
                 />
               </span>
               <a
+                className="activity-name-link"
                 href="/activity_sessions/anonymous?activity_id=849"
                 tabIndex={-1}
               >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/activity_table.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/activity_table.tsx
@@ -34,6 +34,7 @@ const tableHeaders = (isOwner) => ([
     name: <span className="tool-and-name-header"><span>Tool</span><span>Activity</span></span>,
     attribute: 'toolAndNameSection',
     width: isOwner ? '624px' : '764px',
+    headerClassName: 'tool-and-name-section-header',
     rowSectionClassName: 'tool-and-name-section'
   },
   {
@@ -170,7 +171,7 @@ const ActivityTable = ({ data, onSuccess, isOwner, handleActivityClicked, handle
     const activity = classroomActivityArray.find(act => act.activityId === activityId)
     if (!activity){ return }
     const toolIcon = getIconForActivityClassification(activity.activityClassificationId)
-    const previewLink = <a href={`/activity_sessions/anonymous?activity_id=${activity.activityId}`} tabIndex={-1}>{activity.name}</a>
+    const previewLink = <a className="activity-name-link" href={`/activity_sessions/anonymous?activity_id=${activity.activityId}`} tabIndex={-1}>{activity.name}</a>
     activity.toolAndNameSection = (<a className="interactive-wrapper focus-on-light" href={`/activity_sessions/anonymous?activity_id=${activity.activityId}`} id={`tool-and-name-section-${activity.uaId}`}>
       <span className="tool-icon-wrapper">{toolIcon}</span>
       {previewLink}

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
@@ -6,7 +6,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
   defaultText="No date selected"
   handleClickCopyToAll={[Function]}
   icon={null}
-  initialValue={"2022-11-10T06:00:00.000Z"}
+  initialValue={"2022-11-10T05:00:00.000Z"}
   rowIndex={0}
 >
   <div
@@ -21,7 +21,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
         closeOnSelect={false}
         closeOnTab={true}
         dateFormat="MMM D"
-        initialValue={"2022-11-10T06:00:00.000Z"}
+        initialValue={"2022-11-10T05:00:00.000Z"}
         initialViewDate={2022-11-10T09:00:00.000Z}
         input={true}
         inputProps={Object {}}
@@ -85,7 +85,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       "onFocus": [Function],
                       "onKeyDown": [Function],
                       "type": "text",
-                      "value": "Nov 10 6:00 am",
+                      "value": "Nov 10 5:00 am",
                     }
                   }
                 >
@@ -102,7 +102,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       onKeyDown={[Function]}
                       placeholder="No date selected"
                       type="text"
-                      value="Nov 10 6:00 am"
+                      value="Nov 10 5:00 am"
                     />
                     <img
                       alt="dropdown indicator"
@@ -120,7 +120,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                   moment={[Function]}
                   navigate={[Function]}
                   renderDay={[Function]}
-                  selectedDate={"2022-11-10T06:00:00.000Z"}
+                  selectedDate={"2022-11-10T05:00:00.000Z"}
                   showView={[Function]}
                   timeFormat="h:mm a"
                   updateDate={[Function]}


### PR DESCRIPTION
## WHAT
fix display issue with my activities table where the calendar widget was being cutoff due to scroll issues

## WHY
we want this to display correctly at different window sizes

## HOW
add several media queries to manually update the activity name link section width to handle window resize (there was a separate issue I discovered when removing the overflow and width attributes where the header row was breaking out past the parent container due to the fixed widths exceeding the total width of the page-- this accounts for that issue as well) 

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1209" alt="Screen Shot 2023-09-07 at 4 37 25 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/36039137-454a-4d24-9adc-d7685641eeb9">
<img width="993" alt="Screen Shot 2023-09-07 at 4 37 37 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/650a6763-9f7d-4c95-80a2-d8eacba4fd02">
<img width="726" alt="Screen Shot 2023-09-07 at 4 38 28 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/e9af3c98-9dbe-46f3-b3d7-7ee56fc4a33e">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/When-a-teacher-sets-a-publish-date-or-due-date-the-calendar-can-get-cut-off-e9401b619910447eb93e91f45baff3fa

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
