### PR TITLE
add loading spinner and disable button while waiting for response on the cms subscriptions page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/EditOrCreateSubscription.jsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import React from 'react';
 import { SingleDatePicker } from 'react-dates';
-import { DataTable } from '../../Shared/index';
+import { DataTable, ButtonLoadingSpinner, } from '../../Shared/index';
 import ItemDropdown from '../components/general_components/dropdown_selectors/item_dropdown.jsx';
 
 import { requestPost, requestPut, } from '../../../modules/request/index';
@@ -23,6 +23,7 @@ export default class EditOrCreateSubscription extends React.Component {
       subscription: defaultSubscription,
       firstFocused: false,
       secondFocused: false,
+      submitting: false,
       schools
     }
   }
@@ -176,23 +177,30 @@ export default class EditOrCreateSubscription extends React.Component {
 
   handleSubmit = () => {
     const { view, } = this.props
+    const { submitting, } = this.state
+
+    if (submitting) { return }
+
     const submitVars = this.submitVars()
     const that = this
 
-    submitVars.requestMethod(
-      submitVars.urlString,
-      submitVars.data,
-      (body) => {
-        alert('Subscription was saved');
-        if (view === 'new') {
-          // redirect back to the school or district details page
-          window.location = window.location.href.replace('new_subscription', '')
+    this.setState({ submitting: true, }, () => {
+      submitVars.requestMethod(
+        submitVars.urlString,
+        submitVars.data,
+        (body) => {
+          alert('Subscription was saved');
+          if (view === 'new') {
+            // redirect back to the school or district details page
+            window.location = window.location.href.replace('new_subscription', '')
+          }
+        },
+        (body) => {
+          this.setState({ submitting: false, })
+          alert('There was an error. Please try again and contact a dev if you continue to get this warning.')
         }
-      },
-      (body) => {
-        alert('There was an error. Please try again and contact a dev if you continue to get this warning.')
-      }
-    )
+      )
+    })
   }
 
   isInvoice = () => {
@@ -380,8 +388,20 @@ export default class EditOrCreateSubscription extends React.Component {
   }
 
   submitButton = () => {
+    const { submitting, } = this.state
     const { subscriberType, view } = this.props
     const submitAction = subscriberType === 'User' ? this.handleSubmit : this.submitConfirmation
+
+    if (submitting) {
+      return (
+        <div>
+          <button className="q-button cta-button bg-quillgreen text-white" disabled={true} type="submit">
+            <span>{view === 'new' ? 'New' : 'Update'} Subscription</span>
+            <ButtonLoadingSpinner />
+          </button>
+        </div>
+      )
+    }
 
     return (
       <div>


### PR DESCRIPTION
## WHAT
Add loading spinner and disable button while waiting for request to complete when subscriptions are created via the CMS.

## WHY
Some of these requests are long-running, and we want to indicate to the user that something has happened, as well as prevent them from creating duplicate subscriptions by clicking multiple times.

## HOW
Just add a key to state that tracks if the request has been submitted and prevents further submission if it's true.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Multiple-School-Premium-subscriptions-being-added-for-a-school-4047858acf8d4ce39865806b4066d5e9?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES