### PR TITLE
Require Concepts and show No-Concept Questions first on Connect/Grammar admin

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
@@ -16,9 +16,21 @@ export default class extends React.Component {
     cuesLabel: this.props.question.cuesLabel ? this.props.question.cuesLabel : '',
     optimalResponseText: '',
     showDefaultInstructions: false,
+    showConceptNullError: false,
   };
 
+  showConceptNullError() {
+    this.setState({showConceptNullError: true})
+  }
+
   submit = () => {
+    const { concept } = this.state
+
+    if (!concept) {
+      this.showConceptNullError()
+      return
+    }
+
     const questionObj = {
       conceptUID: this.props.question.conceptUID,
       cuesLabel: this.props.question.cuesLabel,
@@ -76,14 +88,18 @@ export default class extends React.Component {
   };
 
   renderConceptSelector = () => {
+    const { showConceptNullError } = this.state
+    const labelClass = showConceptNullError ? 'red-label' : ''
+
     return (
       <div>
-        <label className="label">Concept</label>
+        <label className={`label ${labelClass}`}>Concept</label>
         <div>
           <ConceptSelector
             currentConceptUID={this.state.concept}
             handleSelectorChange={this.handleSelectorChange}
           />
+           {showConceptNullError && <p className={labelClass}>Add a concept to save this question</p>}
         </div>
       </div>
     )

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
@@ -28,7 +28,7 @@ export default class extends React.Component {
     }
 
     const questionObj = {
-      conceptID: this.state.concept,
+      conceptID: concept,
       cuesLabel: this.props.question.cuesLabel,
       focusPoints: this.props.question.focusPoints,
       incorrectSequences: this.props.question.incorrectSequences,

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
@@ -19,20 +19,16 @@ export default class extends React.Component {
     showConceptNullError: false,
   };
 
-  showConceptNullError() {
-    this.setState({showConceptNullError: true})
-  }
-
   submit = () => {
     const { concept } = this.state
 
     if (!concept) {
-      this.showConceptNullError()
+      this.setState({showConceptNullError: true})
       return
     }
 
     const questionObj = {
-      conceptUID: this.props.question.conceptUID,
+      conceptID: this.state.concept,
       cuesLabel: this.props.question.cuesLabel,
       focusPoints: this.props.question.focusPoints,
       incorrectSequences: this.props.question.incorrectSequences,

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
@@ -95,7 +95,7 @@ export default class extends React.Component {
             currentConceptUID={this.state.concept}
             handleSelectorChange={this.handleSelectorChange}
           />
-           {showConceptNullError && <p className={labelClass}>Add a concept to save this question</p>}
+          {showConceptNullError && <p className={labelClass}>Add a concept to save this question</p>}
         </div>
       </div>
     )

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
@@ -60,27 +60,23 @@ export class QuestionListByConcept extends React.Component<any, any> {
   }
 
   renderQuestionsWithoutValidKey = () => {
-    if(!this.props.displayNoConceptQuestions) {
-      return (<div />)
-    } else {
-      const concepts = hashToCollection(this.props.concepts.data['0']);
-      const questions = hashToCollection(this.props.questions.data);
-      const questionsToRender = _.reject(questions, (question) => {
-        return !!_.find(concepts, {uid: question.conceptID})
-      })
-      const label = (<p className="menu-label">
-      No valid concept
-      </p>)
-      return this.renderConceptWithQuestions(questionsToRender, label);
-    }
+    const concepts = hashToCollection(this.props.concepts.data['0']);
+    const questions = hashToCollection(this.props.questions);
+    const questionsToRender = _.reject(questions, (question) => {
+      return !!_.find(concepts, {uid: question.conceptID})
+    })
+    const label = (<p className="menu-label">
+    No valid concept
+    </p>)
+    return this.renderConceptWithQuestions(questionsToRender, label);
   }
 
   render() {
     return (
       <aside className="menu">
         <div className="admin-container">
-          {this.mapConceptsToList()}
           {this.renderQuestionsWithoutValidKey()}
+          {this.mapConceptsToList()}
         </div>
       </aside>
     );

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
@@ -65,9 +65,7 @@ export class QuestionListByConcept extends React.Component<any, any> {
     const questionsToRender = _.reject(questions, (question) => {
       return !!_.find(concepts, {uid: question.conceptID})
     })
-    const label = (<p className="menu-label">
-    No valid concept
-    </p>)
+    const label = (<p className="menu-label">No valid concept</p>)
     return this.renderConceptWithQuestions(questionsToRender, label);
   }
 

--- a/services/QuillLMS/client/app/bundles/Connect/styles/style.scss
+++ b/services/QuillLMS/client/app/bundles/Connect/styles/style.scss
@@ -510,6 +510,10 @@ textarea.submission {
   }
 }
 
+.red-label {
+  color: red;
+}
+
 .lesson-sidebar-section {
   display: flex;
   flex-direction: row;

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
@@ -84,9 +84,7 @@ export default class QuestionListByConcept extends React.Component<QuestionListB
     const questionsToRender = _.reject(questions, (question) => {
       return !!_.find(concepts, {uid: question.conceptID})
     })
-    const label = (<p className="menu-label">
-    No valid concept
-    </p>)
+    const label = (<p className="menu-label">No valid concept</p>)
     return this.renderConceptWithQuestions(questionsToRender, label, 0);
   }
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
@@ -10,7 +10,6 @@ interface QuestionListByConceptProps {
   concepts: ConceptReducerState;
   showOnlyArchived: boolean;
   basePath: string;
-  displayNoConceptQuestions: boolean;
   questions: QuestionsReducerState;
 }
 
@@ -79,9 +78,22 @@ export default class QuestionListByConcept extends React.Component<QuestionListB
     })
   }
 
+  renderQuestionsWithoutValidKey = () => {
+    const concepts = hashToCollection(this.props.concepts.data['0']);
+    const questions = hashToCollection(this.props.questions);
+    const questionsToRender = _.reject(questions, (question) => {
+      return !!_.find(concepts, {uid: question.conceptID})
+    })
+    const label = (<p className="menu-label">
+    No valid concept
+    </p>)
+    return this.renderConceptWithQuestions(questionsToRender, label, 0);
+  }
+
   render() {
     return (
       <aside className="menu">
+        {this.renderQuestionsWithoutValidKey()}
         {this.mapConceptsToList()}
       </aside>
     );


### PR DESCRIPTION
## WHAT
1. Prevent admin from creating new questions unless the question is associated with a concept.
2. Show questions with no concept first in the list when accessing "Questions List" on Connect and Grammar.

## WHY
Admin are trying to clean up questions with no concepts attached.

## HOW
Modify the New Question form to prevent submission and show a message if there is no concept.
Render questions with no concept before questions with a concept on questions list (and remove the catch that was preventing this list from being generated).

### Screenshots
![Screenshot 2023-09-12 at 4 29 05 AM](https://github.com/empirical-org/Empirical-Core/assets/57366100/e2a85e0d-8768-4176-b842-6a241e850feb)
![Screenshot 2023-09-12 at 4 31 08 AM](https://github.com/empirical-org/Empirical-Core/assets/57366100/70a8858b-9644-419c-8dbe-0a91df2b4f75)


### Notion Card Links
![internal tools](https://www.notion.so/quill/Internal-tool-updates-to-ensure-that-questions-have-concepts-4f1aeae7db384d4eb411b269003f3875?pvs=4)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
