### PR TITLE
Fix Canvas Import bug with course pagination

### DIFF
--- a/services/QuillLMS/spec/services/canvas_integration/rest_client_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/rest_client_spec.rb
@@ -15,9 +15,8 @@ describe CanvasIntegration::RestClient do
     subject { rest_client.teacher_classrooms }
 
     let(:courses_path) { described_class::COURSES_PATH }
-    let(:courses_response) { double(HTTParty::Response, body: courses_data.to_json) }
 
-    before { allow(canvas_api).to receive(:api_get_request).with(courses_path).and_return(courses_response) }
+    before { allow(canvas_api).to receive(:api_get_all_request).with(courses_path).and_return(courses_data) }
 
     context 'no classrooms' do
       let(:courses_data) { [] }
@@ -32,10 +31,11 @@ describe CanvasIntegration::RestClient do
       let(:course_id) { course_data['id'] }
       let(:course_name) { course_data['name'] }
 
-      let(:section_data) { create(:canvas_section_payload, id: course_id, name: course_name) }
+      let(:section_data) { create(:canvas_section_payload, id: course_id, name: course_name, students: students) }
+      let(:num_students) { 2 }
+      let(:students) { create_list(:canvas_student_payload, num_students) }
       let(:sections_data) { [section_data] }
       let(:sections_path) { "#{courses_path}/#{course_id}/sections?include[]=students" }
-      let(:sections_response) { double(HTTParty::Response, body: sections_data.to_json) }
 
       let(:already_imported) { false }
       let(:classroom_external_id) { CanvasClassroom.build_classroom_external_id(canvas_instance.id, course_id) }
@@ -45,13 +45,13 @@ describe CanvasIntegration::RestClient do
           alreadyImported: already_imported,
           classroom_external_id: classroom_external_id,
           name: course_name,
-          studentCount: 0
+          studentCount: num_students
         }
       end
 
       let(:classrooms) { [classroom] }
 
-      before { allow(canvas_api).to receive(:api_get_request).with(sections_path).and_return(sections_response) }
+      before { allow(canvas_api).to receive(:api_get_all_request).with(sections_path).and_return(sections_data) }
 
       it { is_expected.to eq classrooms }
 


### PR DESCRIPTION
## WHAT
Fix a bug with the importing of Canvas rosters.

## WHY
If teachers have more than 10 courses, Canvas returns results in page formats.  The current implementation only gives the ability to import the first page.

## HOW
Utilize the `api_get_all_requests` method that will go through all of the courses.

I've also added a 2 year window to constrain the number of courses that are potentially importable.  Otherwise, the number might get into the hundreds for some teachers.

Finally, in testing this, I noticed that requesting some courses results in a timeout gateway error.  I've added a rescue clause to handle that case:
```
    rescue LMS::Canvas::InvalidAPIRequestException => e
```

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
