### PR TITLE
handle stripe subscription with no card

### DIFF
--- a/services/QuillLMS/app/models/stripe_integration/subscription.rb
+++ b/services/QuillLMS/app/models/stripe_integration/subscription.rb
@@ -53,7 +53,7 @@ module StripeIntegration
 
     private def stripe_payment_method
       Stripe::PaymentMethod.retrieve(stripe_payment_method_id)&.card
-    rescue Stripe::InvalidRequestError
+    rescue Stripe::InvalidRequestError, NoMethodError
       nil
     end
 


### PR DESCRIPTION
## WHAT
Handle stripe subscriptions where the user paid with a bank account directly instead of a card.

## WHY
We don't want this page to error when the user paid with a bank account.

## HOW
Update the `stripe_payment_method` function to just return `nil` when `&.card` is not a function.

Note: the UI for this page will show "Credit card ending in null" etc, instead of properly addressing it as a bank account. Since that would require a much more substantial rewrite, and this is currently only affecting one teacher, I think that's an acceptable tradeoff for now, but will flag it to support in case the issue becomes more widespread and we want to take it on as a product task.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/500-error-on-teacher-s-My-Subscriptions-page-95016a01881e4f8a82faef4e758a29dd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A