### PR TITLE
fix bug with resetting custom dates for data export and usage snapshots

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/DataExportContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/DataExportContainer.tsx
@@ -180,6 +180,8 @@ const DataExportContainer = ({ adminInfo, accessType, }) => {
     setSelectedTeachers(originalAllTeachers)
     setSelectedClassrooms(originalAllClassrooms)
     setSelectedTimeframe(defaultTimeframe(allTimeframes))
+    setCustomStartDate(null)
+    setCustomEndDate(null)
 
     // what follows is basically duplicating the logic in applyFilters, but avoids a race condition where the "lastSubmitted" values get set before the new selected values are set
     setSearchCount(searchCount + 1)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -197,6 +197,8 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
     setSelectedTeachers(originalAllTeachers)
     setSelectedClassrooms(originalAllClassrooms)
     setSelectedTimeframe(defaultTimeframe(allTimeframes))
+    setCustomStartDate(null)
+    setCustomEndDate(null)
 
     // what follows is basically duplicating the logic in applyFilters, but avoids a race condition where the "lastSubmitted" values get set before the new selected values are set
     setSearchCount(searchCount + 1)


### PR DESCRIPTION
## WHAT
Fix bug where clearing filters didn't reset custom dates in the data export and usage snapshot reports. 

## WHY
We want this to work as expected.

## HOW
Just update the equivalent function in both places to wipe the `customStartDate` and `customEndDate`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Clear-filters-on-the-new-admin-reports-is-not-working-correctly-for-custom-timeframes-3b04cbabbe3e44baa00c37baaf2cc8e8?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES