### PR TITLE
Global tertiary navigation fix

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
@@ -472,7 +472,6 @@
       a {
         display: flex;
         align-items: center;
-        height: 28px !important;
         &.active {
           color: $quill-maroon !important;
         }

--- a/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
@@ -75,7 +75,8 @@
 
       li {
         float: left;
-        padding: 4px;
+        padding-left: 4px;
+        padding-right: 4px;
         &:first-of-type {
           padding-left: 0px;
         }
@@ -83,7 +84,9 @@
           border-radius: 6px;
           color: $quill-white;
           font-size: 13px;
-          height: 35px;
+          display: flex;
+          align-items: center;
+          height: 28px;
           padding: 5px 12px;
 
           &.active {
@@ -213,12 +216,6 @@
   ul {
     display: flex;
     align-items: center;
-    li {
-      padding: 0px 5px !important;
-      a {
-        height: 28px !important;
-      }
-    }
   }
 
   a {

--- a/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
@@ -60,7 +60,7 @@
 .tab-subnavigation-wrapper {
   &.desktop {
     background: $quill-green;
-    min-height: 48px;
+    min-height: 44px;
     padding: 8px 0;
 
     &.about-subtabs {


### PR DESCRIPTION
## WHAT
fix padding for global tertiary navigation

## WHY
we want it to be uniform across tabs

## HOW
just tweak CSS

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Global-Navigation-UI-Issue-Tertiary-Level-Tab-on-Home-My-Classes-and-My-Activities-has-inconsi-6b94a67b58714bb3bca0581dfcd12a62

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | no-- small CSS change
Have you deployed to Staging? | (yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
