### PR TITLE
remove canvas link from assignment workflow

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/assign_students.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/assign_students.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react';
 
-import ClassroomCard from './classroom_card'
-import CreateAClassInlineForm from './create_a_class_inline_form'
+import ClassroomCard from './classroom_card';
+import CreateAClassInlineForm from './create_a_class_inline_form';
 
-import { canvasProvider, cleverProvider, googleProvider, providerConfigLookup } from '../../../classrooms/providerHelpers'
-import { requestGet } from '../../../../../../modules/request/index'
-import { Snackbar, defaultSnackbarTimeout } from '../../../../../Shared/index'
-import useSnackbarMonitor from '../../../../../Shared/hooks/useSnackbarMonitor'
-import pusherInitializer from '../../../../../../modules/pusherInitializer'
-import ImportProviderClassroomsModal from '../../../classrooms/import_provider_classrooms_modal'
-import LinkProviderAccountModal from '../../../classrooms/link_provider_account_modal'
-import NoClassroomsToImportModal from '../../../classrooms/no_classrooms_to_import_modal'
-import ReauthorizeProviderModal from '../../../classrooms/reauthorize_provider_modal'
-import ButtonLoadingIndicator from '../../../shared/button_loading_indicator'
+import pusherInitializer from '../../../../../../modules/pusherInitializer';
+import { requestGet } from '../../../../../../modules/request/index';
+import useSnackbarMonitor from '../../../../../Shared/hooks/useSnackbarMonitor';
+import { Snackbar, defaultSnackbarTimeout } from '../../../../../Shared/index';
+import ImportProviderClassroomsModal from '../../../classrooms/import_provider_classrooms_modal';
+import LinkProviderAccountModal from '../../../classrooms/link_provider_account_modal';
+import NoClassroomsToImportModal from '../../../classrooms/no_classrooms_to_import_modal';
+import { canvasProvider, cleverProvider, googleProvider, providerConfigLookup } from '../../../classrooms/providerHelpers';
+import ReauthorizeProviderModal from '../../../classrooms/reauthorize_provider_modal';
+import ButtonLoadingIndicator from '../../../shared/button_loading_indicator';
 
 const canvasIconSrc = `${process.env.CDN_URL}/images/icons/canvas.svg`
 const cleverIconSrc = `${process.env.CDN_URL}/images/icons/clever.svg`
@@ -223,7 +223,6 @@ const AssignStudents = ({
             <span className="assignment-section-name">Choose classes or students</span>
           </div>
           <div className="import-or-create-classroom-buttons">
-            {renderImportFromProviderButton(canvasProvider)}
             {renderImportFromProviderButton(cleverProvider)}
             {renderImportFromProviderButton(googleProvider)}
             <button


### PR DESCRIPTION
## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Import-from-Canvas-option-displayed-in-the-assignment-workflow-doesn-t-work-949a755835824b289bed458c9702ea21

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
