### PR TITLE
Fix assign students regression

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/assign_students.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/assign_students.test.jsx.snap
@@ -35,12 +35,25 @@ exports[`Assign students component should render 1`] = `
           type="button"
         >
           <img
-            alt="Canvas Icon"
+            alt="Clever Icon"
             className="import-from-provider-button-icon"
-            src="undefined/images/icons/canvas.svg"
+            src="undefined/images/icons/clever.svg"
           />
           Import from 
-          Canvas
+          Clever
+        </button>
+        <button
+          className="interactive-wrapper import-from-provider-button"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt="Google Classroom Icon"
+            className="import-from-provider-button-icon"
+            src="undefined/images/icons/google-classroom.svg"
+          />
+          Import from 
+          Google Classroom
         </button>
         <button
           className="quill-button medium secondary outlined create-a-class-button"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/assign_students.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/assign_students.tsx
@@ -252,7 +252,7 @@ const AssignStudents = ({
 
   const renderImportFromProviderButton = (theProvider: string) => {
     if (provider && provider != theProvider) { return null }
-    if (!provider && theProvider !== canvasProvider) { return null }
+    if (!provider && theProvider === canvasProvider) { return null }
 
     const theProviderTitle = providerConfigLookup[theProvider].title
 

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/__tests__/__snapshots__/unitActivityDates.tsx.snap
@@ -6,7 +6,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
   defaultText="No date selected"
   handleClickCopyToAll={[Function]}
   icon={null}
-  initialValue={"2022-11-10T06:00:00.000Z"}
+  initialValue={"2022-11-10T05:00:00.000Z"}
   rowIndex={0}
 >
   <div
@@ -21,7 +21,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
         closeOnSelect={false}
         closeOnTab={true}
         dateFormat="MMM D"
-        initialValue={"2022-11-10T06:00:00.000Z"}
+        initialValue={"2022-11-10T05:00:00.000Z"}
         initialViewDate={2022-11-10T09:00:00.000Z}
         input={true}
         inputProps={Object {}}
@@ -85,7 +85,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       "onFocus": [Function],
                       "onKeyDown": [Function],
                       "type": "text",
-                      "value": "Nov 10 6:00 am",
+                      "value": "Nov 10 5:00 am",
                     }
                   }
                 >
@@ -102,7 +102,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                       onKeyDown={[Function]}
                       placeholder="No date selected"
                       type="text"
-                      value="Nov 10 6:00 am"
+                      value="Nov 10 5:00 am"
                     />
                     <img
                       alt="dropdown indicator"
@@ -120,7 +120,7 @@ exports[`DatePickerContainer component renders when there is an initial value 1`
                   moment={[Function]}
                   navigate={[Function]}
                   renderDay={[Function]}
-                  selectedDate={"2022-11-10T06:00:00.000Z"}
+                  selectedDate={"2022-11-10T05:00:00.000Z"}
                   showView={[Function]}
                   timeFormat="h:mm a"
                   updateDate={[Function]}


### PR DESCRIPTION
## WHAT
Fix a regression with AssignStudents flow and "Import from Canvas" button.  This was fixed in the active_classrooms.tsx [file](https://github.com/empirical-org/Empirical-Core/commit/39c5b672b7e83a9288c860e4f9a02216c9d9099b#diff-9d09a9ca9a79e256baddf7dcfcf581cc6961982c39c6cbddc25b741f8d21f9fcR412) a month ago, but I forgot about this component too.

## WHY
The "import from Canvas Button" is shown when it should be hidden.

## HOW
Fix conditional logic in assign_students.tsx

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
