### PR TITLE
remove n+1 load issue in rules analysis query

### DIFF
--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -70,14 +70,16 @@ class RuleFeedbackHistory
     }
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.format_sql_results(relations)
     relations.map do |r|
+      first_feedback, second_feedback = r.feedbacks.sort_by(&:order)
       {
           rule_uid: r.rules_uid,
           api_name: r.rule_type,
           rule_order: r.rule_suborder,
-          first_feedback: r.feedbacks.order(:order).first&.text || '',
-          second_feedback: r.feedbacks.order(:order).second&.text || '',
+          first_feedback: first_feedback&.text || '',
+          second_feedback: second_feedback&.text || '',
           rule_note: r.rule_note,
           rule_name: r.rule_name,
           avg_confidence: r.avg_confidence ? (r.avg_confidence * 100).round : nil,
@@ -90,4 +92,5 @@ class RuleFeedbackHistory
 
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end


### PR DESCRIPTION
## WHAT
Removes n+1 loading issue in the Rules Analysis query

## WHY
Query is slowed by unnecessary DB calls

## HOW
Avoid the use of Arel method (order) that forces n+1 query. Use Ruby Std Lib sort instead.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Slow-load-times-for-Rules-Analysis-page-140330cfe5cc4e0989cdb30173688e38

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Existing specs already cover the change.
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
