### PR TITLE
set usage snapshot page live and update guide link

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
@@ -91,7 +91,7 @@ export const AdminSubnav = ({ path }) => {
 
   const dropdownClass = dropdownOpen ? 'open' : '';
 
-  const tabsToShow = window.location.href.includes('usage_snapshot') || window.location.href.includes('data_export') ? tabs : tabsWithoutDataExportReport
+  const tabsToShow = window.location.href.includes('data_export') ? tabs : tabsWithoutDataExportReport
 
   return(
     <React.Fragment>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
@@ -10,7 +10,7 @@ const STANDARDS_REPORTS = 'Standards Reports';
 const USAGE_SNAPSHOT_REPORT = 'Usage Snapshot Report'
 const DATA_EXPORT = 'Data Export'
 
-const tabsWithoutUsageSnapshotAndDataExportReport = {
+const tabsWithoutDataExportReport = {
   [OVERVIEW]: {
     label: OVERVIEW,
     url: '/teachers/premium_hub'
@@ -35,17 +35,17 @@ const tabsWithoutUsageSnapshotAndDataExportReport = {
     label: INTEGRATIONS,
     url: '/teachers/premium_hub/integrations'
   },
-}
-
-const tabs = {
-  ...tabsWithoutUsageSnapshotAndDataExportReport,
-  [DATA_EXPORT]: {
-    label: DATA_EXPORT,
-    url: '/teachers/premium_hub/data_export'
-  },
   [USAGE_SNAPSHOT_REPORT]: {
     label: USAGE_SNAPSHOT_REPORT,
     url: '/teachers/premium_hub/usage_snapshot_report'
+  }
+}
+
+const tabs = {
+  ...tabsWithoutDataExportReport,
+  [DATA_EXPORT]: {
+    label: DATA_EXPORT,
+    url: '/teachers/premium_hub/data_export'
   },
 }
 
@@ -91,7 +91,7 @@ export const AdminSubnav = ({ path }) => {
 
   const dropdownClass = dropdownOpen ? 'open' : '';
 
-  const tabsToShow = window.location.href.includes('usage_snapshot') || window.location.href.includes('data_export') ? tabs : tabsWithoutUsageSnapshotAndDataExportReport
+  const tabsToShow = window.location.href.includes('usage_snapshot') || window.location.href.includes('data_export') ? tabs : tabsWithoutDataExportReport
 
   return(
     <React.Fragment>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -341,7 +341,7 @@ const UsageSnapshotsContainer = ({ adminInfo, accessType, }) => {
         <div className="header">
           <h1>
             <span>Usage Snapshot Report</span>
-            <a href="https://support.quill.org/en/articles/1588988-how-do-i-navigate-the-premium-hub" rel="noopener noreferrer" target="_blank">
+            <a href="https://support.quill.org/en/articles/8358350-how-do-i-use-the-usage-snapshot-report" rel="noopener noreferrer" target="_blank">
               <img alt="" src={`${process.env.CDN_URL}/images/icons/file-document.svg`} />
               <span>Guide</span>
             </a>


### PR DESCRIPTION
## WHAT
Remove restriction around visibility of Usage Snapshot Report tab; update the Guide link.

## WHY
To make this accessible to all users!

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Set-Usage-Snapshot-Report-live-0763bc4b8b7447e79af206ee65bd65f4?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually teted
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES