### PR TITLE
surface better errors for staff school creation

### DIFF
--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -92,7 +92,7 @@ class Cms::SchoolsController < Cms::CmsController
   def create
     new_school = School.new(edit_or_add_school_params)
 
-    if new_school.safer_save
+    if new_school.save_with_error_handling
       redirect_to cms_school_path(new_school.id)
     else
       redirect_to new_cms_school_path, flash: { error: new_school.errors.full_messages }

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -91,10 +91,11 @@ class Cms::SchoolsController < Cms::CmsController
 
   def create
     new_school = School.new(edit_or_add_school_params)
-    if new_school.save
+
+    if new_school.safer_save
       redirect_to cms_school_path(new_school.id)
     else
-      redirect_to new_cms_school_path, flash: { error: new_school.errors }
+      redirect_to new_cms_school_path, flash: { error: new_school.errors.full_messages }
     end
   end
 

--- a/services/QuillLMS/app/models/application_record.rb
+++ b/services/QuillLMS/app/models/application_record.rb
@@ -6,15 +6,26 @@ class ApplicationRecord < ActiveRecord::Base
   connects_to database: { writing: :primary, reading: :replica }
 
   # Rescues previously unhandled exceptions, like ActiveRecord::RecordNotUnique
-  def safer_save
+  def save_with_error_handling
     save
   rescue ActiveRecord::RecordNotUnique => e
-    /Key \((\w+)\)/ =~ e.message
+    handle_not_unique_error(e)
+  rescue StandardError => e
+    handle_standard_error(e)
+  end
+
+  def handle_not_unique_error(exception)
+    /Key \((\w+)\)/ =~ exception.message
     attribute_sym = Regexp.last_match(1) ? Regexp.last_match(1).to_sym : :base
     errors.add(attribute_sym, 'not unique')
-    false
-  rescue StandardError => e
-    errors.add(:base, :invalid, message: e)
+    ErrorNotifier.report(exception)
     false
   end
+
+  def handle_standard_error(exception)
+    errors.add(:base, :invalid, message: exception)
+    ErrorNotifier.report(exception)
+    false
+  end
+
 end

--- a/services/QuillLMS/app/models/application_record.rb
+++ b/services/QuillLMS/app/models/application_record.rb
@@ -4,4 +4,17 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   connects_to database: { writing: :primary, reading: :replica }
+
+  # Rescues previously unhandled exceptions, like ActiveRecord::RecordNotUnique
+  def safer_save
+    save
+  rescue ActiveRecord::RecordNotUnique => e
+    /Key \((\w+)\)/ =~ e.message
+    attribute_sym = Regexp.last_match(1) ? Regexp.last_match(1).to_sym : :base
+    errors.add(attribute_sym, 'not unique')
+    false
+  rescue StandardError => e
+    errors.add(:base, :invalid, message: e)
+    false
+  end
 end

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -158,6 +158,21 @@ describe Cms::SchoolsController do
       expect(School.last.free_lunches).to eq 2
       expect(response).to redirect_to cms_school_path(School.last.id)
     end
+
+    it 'should not raise exception when creating a school with duplicate nces_id' do
+      expect do
+        2.times do
+          post :create, params: { school: {
+              name: "test",
+              city: "test city",
+              state: "test state",
+              zipcode: "11000",
+              free_lunches: 2,
+              nces_id: "1"
+          } }
+        end
+      end.to_not raise_error
+    end
   end
 
   describe '#edit_subscription' do

--- a/services/QuillLMS/spec/models/application_record_spec.rb
+++ b/services/QuillLMS/spec/models/application_record_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe(ApplicationRecord, :type => :model) do
-  describe '#safer_save' do
+  describe '#save_with_error_handling' do
     context 'no exception' do
       let!(:a_school) { build(:school) }
 
-      it { expect(a_school.safer_save).to be true }
+      it { expect(a_school.save_with_error_handling).to be true }
 
       it 'should append no model errors' do
-        a_school.safer_save
+        a_school.save_with_error_handling
         expect(a_school.errors).to be_empty
       end
     end
@@ -21,18 +21,18 @@ RSpec.describe(ApplicationRecord, :type => :model) do
 
       it 'should rescue the exception' do
         expect do
-          school_with_duplicate_nces_id.safer_save
+          school_with_duplicate_nces_id.save_with_error_handling
         end.to_not raise_error
       end
 
       it 'should append the correct error to model.errors' do
-        school_with_duplicate_nces_id.safer_save
+        school_with_duplicate_nces_id.save_with_error_handling
         error = school_with_duplicate_nces_id.errors.first
         expect(error).to be_present
         expect(error.attribute).to eq :nces_id
       end
 
-      it { expect(school_with_duplicate_nces_id.safer_save).to be false }
+      it { expect(school_with_duplicate_nces_id.save_with_error_handling).to be false }
     end
   end
 end

--- a/services/QuillLMS/spec/models/application_record_spec.rb
+++ b/services/QuillLMS/spec/models/application_record_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe(ApplicationRecord, :type => :model) do
+  describe '#safer_save' do
+    context 'no exception' do
+      let!(:a_school) { build(:school) }
+
+      it { expect(a_school.safer_save).to be true }
+
+      it 'should append no model errors' do
+        a_school.safer_save
+        expect(a_school.errors).to be_empty
+      end
+    end
+
+    context 'ActiveRecord::RecordNotUnique exception' do
+      let!(:a_school) { create(:school, nces_id: '123') }
+      let!(:school_with_duplicate_nces_id) { build(:school, nces_id: '123') }
+
+      it 'should rescue the exception' do
+        expect do
+          school_with_duplicate_nces_id.safer_save
+        end.to_not raise_error
+      end
+
+      it 'should append the correct error to model.errors' do
+        school_with_duplicate_nces_id.safer_save
+        error = school_with_duplicate_nces_id.errors.first
+        expect(error).to be_present
+        expect(error.attribute).to eq :nces_id
+      end
+
+      it { expect(school_with_duplicate_nces_id.safer_save).to be false }
+    end
+  end
+end


### PR DESCRIPTION
## WHAT / HOW
Rescues exceptions during ActiveRecord validation that are not handled by ActiveRecord. Typically, these will be Postgres errors. Example: when an index constraint is violated. 

## WHY
So instead of this:
<img width="1170" alt="Screenshot 2023-09-14 at 2 09 30 PM" src="https://github.com/empirical-org/Empirical-Core/assets/90669/c14c853b-acbb-496b-9b5a-9782d496e267">

Users get an actionable error message, and are redirected back the the create form:

<img width="1626" alt="Screenshot 2023-09-14 at 7 16 49 PM" src="https://github.com/empirical-org/Empirical-Core/assets/90669/8ceb7207-1526-4e30-82d3-956d70bafd4b">

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Unable-to-create-New-Schools-in-CMS-006dc7f847cf4787baf3221e972e12d8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
