### PR TITLE
remove assigned recommendations for quill_staff_demo demo account

### DIFF
--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -2,6 +2,7 @@
 
 module Demo::ReportDemoCreator
   EMAIL = 'hello+demoteacher@quill.org'
+  STAFF_DEMO_EMAIL = "hello+demoteacher+staff@quill.org"
   REPLAYED_ACTIVITY_ID = 434
   REPLAYED_SAMPLE_USER_ID = 312664
 
@@ -293,7 +294,9 @@ module Demo::ReportDemoCreator
 
   def self.create_units(teacher)
     ACTIVITY_PACKS_TEMPLATES.map do |ap|
-      unit_template_id = UnitTemplate.find_by_id(ap[:unit_template_id])&.id # ensures the unit template actually exists in our database
+      # the following line sets the unit template id to nil for the quill_staff_demo account by request of the partnerships team, because they want to be able to assign the starter baseline recommendations
+      # and it ensures the unit template actually exists in our database
+      unit_template_id = teacher.email == STAFF_DEMO_EMAIL ? nil : UnitTemplate.find_by_id(ap[:unit_template_id])&.id
       unit = Unit.find_or_create_by(name: ap[:name], user: teacher, unit_template_id: unit_template_id)
       activity_ids = activity_ids_for_config(ap)
       activity_ids.each { |act_id| UnitActivity.find_or_create_by(activity_id: act_id, unit: unit) }


### PR DESCRIPTION
## WHAT
Make it so activity packs generated for the quill_staff_demo demo account do not have unit template ids, which will prevent them from showing up as previously assigned on the recommendations page.

## WHY
This was a request from the partnerships team.

## HOW
Just add a ternary that checks whether this is the quill_staff_demo account.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Reset-Diagnostic-Recommendations-Report-in-Quill-Demo-Account-756487909b854ef682b6f74f03059b95?d=baa9c5578d93452bafc8bf8423fbe0c3

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES