### PR TITLE
Reorder activity packs bug fix

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/containers/UnitTemplates/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/UnitTemplates/index.tsx
@@ -6,7 +6,7 @@ import UnitTemplateRow from './unitTemplateRow'
 import { flagOptions } from '../../../../constants/flagOptions'
 import { requestGet, } from '../../../../modules/request/index'
 import LoadingSpinner from '../../../Connect/components/shared/loading_indicator.jsx'
-import { SortableList, Tooltip } from '../../../Shared/index'
+import { SortableList, Tooltip, PRODUCTION_FLAG, } from '../../../Shared/index'
 import getAuthToken from '../../components/modules/get_auth_token'
 import { ALL_DIAGNOSTICS, ALL_FLAGS, NOT_ARCHIVED_FLAG, orderedUnitTemplates, sortUnitTemplates } from '../../helpers/unitTemplates'
 


### PR DESCRIPTION
## WHAT
fix bug for reordering activity packs

## WHY
we want activity packs to be sortable from the CMS

## HOW
just re-add a missing import that was previously removed 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Can-t-reorder-packs-in-activity-pack-editor-22175f62ecab4760a9119af7d7401d30

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
