### PR TITLE
add tooltips to activity feed and activity summary

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/scorebook_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/scorebook_page.scss
@@ -63,11 +63,13 @@
 	.icons-wrapper.score-legend {
 		border-bottom: 1px solid $quill-grey-15;
     padding: 48px 0px;
+    .icons {
+      gap: 24px;
+    }
 	}
 
 	.icons-wrapper.icon-legend {
 		.icons {
-      gap: 30px;
 			display: flex;
 			align-items: center;
 			justify-content: space-between;
@@ -76,11 +78,16 @@
 				display: flex;
 				align-items: center;
 				.icons-description-wrapper {
+          max-width: 175px;
 					.title {
             color: $quill-grey-90;
             font-size: 12px;
             font-weight: 700;
             line-height: 14px;
+            &.align-center {
+              display: flex;
+              align-items: center;
+            }
 					}
           .explanation, .description {
             color: $quill-grey-35;
@@ -88,6 +95,9 @@
             font-weight: 400;
             line-height: 16px;
             margin-top: 2px;
+          }
+          img {
+            margin-left: 4px;
           }
 				}
 				.icon-wrapper {
@@ -99,6 +109,9 @@
 
 	.app-legend {
 		margin: 48px 0px;
+    .icons {
+      gap: 30px;
+    }
 		.icon {
       text-align: left;
       min-width: min-content;

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
@@ -354,6 +354,12 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
           />
         </td>
       )
+    } else if (header.containsOwnTooltip) {
+      return (
+        <td key={key}>
+          {sectionText}
+        </td>
+      )
     } else {
       return (
         <td

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
@@ -151,6 +151,7 @@ exports[`ActivityFeed component not on mobile should render when there are activ
           },
           Object {
             "attribute": "scoreTag",
+            "containsOwnTooltip": true,
             "name": "Score",
             "width": "210px",
           },
@@ -172,11 +173,29 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Mar 5th",
             "id": 33,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/76/user/7/activity/810",
-            "scoreTag": <span
-              className="score-tag not-yet-proficient"
-            >
-              Not yet proficient
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag not-yet-proficient"
+                >
+                  Not yet proficient
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
           Object {
@@ -185,11 +204,29 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Mar 5th",
             "id": 32,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/885",
-            "scoreTag": <span
-              className="score-tag proficient"
-            >
-              Proficient
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag proficient"
+                >
+                  Proficient
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
           Object {
@@ -198,11 +235,29 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Mar 5th",
             "id": 29,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/804",
-            "scoreTag": <span
-              className="score-tag proficient"
-            >
-              Proficient
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag proficient"
+                >
+                  Proficient
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
           Object {
@@ -211,11 +266,29 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Mar 5th",
             "id": 28,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/802",
-            "scoreTag": <span
-              className="score-tag nearly-proficient"
-            >
-              Nearly proficient
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag nearly-proficient"
+                >
+                  Nearly proficient
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
           Object {
@@ -224,11 +297,29 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Mar 5th",
             "id": 27,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/75/user/7/activity/808",
-            "scoreTag": <span
-              className="score-tag proficient"
-            >
-              Proficient
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag proficient"
+                >
+                  Proficient
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
           Object {
@@ -237,11 +328,29 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Mar 5th",
             "id": 26,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/801",
-            "scoreTag": <span
-              className="score-tag nearly-proficient"
-            >
-              Nearly proficient
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag nearly-proficient"
+                >
+                  Nearly proficient
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
           Object {
@@ -250,11 +359,29 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Mar 5th",
             "id": 25,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/181",
-            "scoreTag": <span
-              className="score-tag proficient"
-            >
-              Proficient
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag proficient"
+                >
+                  Proficient
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
           Object {
@@ -263,11 +390,30 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Mar 4th",
             "id": 24,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/6/unit/85/user/7/activity/849",
-            "scoreTag": <span
-              className="score-tag completed"
-            >
-              Completed
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag completed"
+                >
+                  Completed
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
           Object {
@@ -276,11 +422,30 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Mar 3rd",
             "id": 23,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/85/user/7/activity/849",
-            "scoreTag": <span
-              className="score-tag completed"
-            >
-              Completed
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag completed"
+                >
+                  Completed
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
           Object {
@@ -289,11 +454,30 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Dec 1st, 2020",
             "id": 3,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/4/user/6/activity/849",
-            "scoreTag": <span
-              className="score-tag completed"
-            >
-              Completed
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag completed"
+                >
+                  Completed
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Tahereh Mafi",
           },
           Object {
@@ -302,11 +486,30 @@ exports[`ActivityFeed component not on mobile should render when there are activ
             "completed": "Dec 1st, 2020",
             "id": 2,
             "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/4/user/7/activity/849",
-            "scoreTag": <span
-              className="score-tag completed"
-            >
-              Completed
-            </span>,
+            "scoreTag": <Tooltip
+              isTabbable={true}
+              tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+              tooltipTriggerStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+              tooltipTriggerText={
+                <span
+                  className="score-tag completed"
+                >
+                  Completed
+                </span>
+              }
+              tooltipTriggerTextClass="data-table-row-section"
+              tooltipTriggerTextStyle={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            />,
             "studentName": "Angie Thomas",
           },
         ]
@@ -413,21 +616,75 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Subject and Object Pronoun Agreement 1
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-33"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag not-yet-proficient"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag not-yet-proficient"
+                    >
+                      Not yet proficient
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Not yet proficient
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag not-yet-proficient"
+                      >
+                        Not yet proficient
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -531,21 +788,75 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 </Tooltip>
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-32"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag proficient"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag proficient"
+                    >
+                      Proficient
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Proficient
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag proficient"
+                      >
+                        Proficient
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -595,21 +906,75 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Capitalize Names of People 1
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-29"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag proficient"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag proficient"
+                    >
+                      Proficient
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Proficient
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag proficient"
+                      >
+                        Proficient
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -659,21 +1024,75 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Capitalize Geographic Names 1
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-28"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag nearly-proficient"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag nearly-proficient"
+                    >
+                      Nearly proficient
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Nearly proficient
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag nearly-proficient"
+                      >
+                        Nearly proficient
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -723,21 +1142,75 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Plural vs. Possessive Nouns 1
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-27"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag proficient"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag proficient"
+                    >
+                      Proficient
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Proficient
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag proficient"
+                      >
+                        Proficient
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -787,21 +1260,75 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Capitalize Holidays and Dates 1
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-26"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag nearly-proficient"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag nearly-proficient"
+                    >
+                      Nearly proficient
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Nearly proficient
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag nearly-proficient"
+                      >
+                        Nearly proficient
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -851,21 +1378,75 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Capitalize Holidays and Geographic Names
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-25"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag proficient"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag proficient"
+                    >
+                      Proficient
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Proficient
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag proficient"
+                      >
+                        Proficient
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -915,21 +1496,76 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Starter Diagnostic
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-24"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag completed"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag completed"
+                    >
+                      Completed
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Completed
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag completed"
+                      >
+                        Completed
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -979,21 +1615,76 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Starter Diagnostic
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-23"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag completed"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag completed"
+                    >
+                      Completed
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Completed
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag completed"
+                      >
+                        Completed
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -1043,21 +1734,76 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Starter Diagnostic
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-3"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag completed"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag completed"
+                    >
+                      Completed
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Completed
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag completed"
+                      >
+                        Completed
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -1107,21 +1853,76 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                 Starter Diagnostic
               </td>
               <td
-                className="data-table-row-section undefined"
                 key="scoreTag-2"
-                style={
-                  Object {
-                    "minWidth": "210px",
-                    "textAlign": "left",
-                    "width": "210px",
-                  }
-                }
               >
-                <span
-                  className="score-tag completed"
+                <Tooltip
+                  isTabbable={true}
+                  tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+                  tooltipTriggerStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
+                  tooltipTriggerText={
+                    <span
+                      className="score-tag completed"
+                    >
+                      Completed
+                    </span>
+                  }
+                  tooltipTriggerTextClass="data-table-row-section"
+                  tooltipTriggerTextStyle={
+                    Object {
+                      "minWidth": "210px",
+                      "width": "210px",
+                    }
+                  }
                 >
-                  Completed
-                </span>
+                  <span
+                    aria-hidden={false}
+                    className="quill-tooltip-trigger "
+                    role="tooltip"
+                    style={
+                      Object {
+                        "minWidth": "210px",
+                        "width": "210px",
+                      }
+                    }
+                  >
+                    <span
+                      className="data-table-row-section"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      style={
+                        Object {
+                          "minWidth": "210px",
+                          "width": "210px",
+                        }
+                      }
+                      tabIndex={0}
+                    >
+                      <span
+                        className="score-tag completed"
+                      >
+                        Completed
+                      </span>
+                    </span>
+                    <span
+                      className="quill-tooltip-wrapper"
+                    >
+                      <span
+                        aria-live="polite"
+                        className="quill-tooltip"
+                      />
+                    </span>
+                  </span>
+                </Tooltip>
               </td>
               <td
                 className="data-table-row-section completed-section"
@@ -1311,11 +2112,29 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Mar 5th",
           "id": 33,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/76/user/7/activity/810",
-          "scoreTag": <span
-            className="score-tag not-yet-proficient"
-          >
-            Not yet proficient
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag not-yet-proficient"
+              >
+                Not yet proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1338,11 +2157,73 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Subject and Object Pronoun Agreement 1
         </div>
         <div>
-          <span
-            className="score-tag not-yet-proficient"
+          <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag not-yet-proficient"
+              >
+                Not yet proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Not yet proficient
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag not-yet-proficient"
+                >
+                  Not yet proficient
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1355,11 +2236,29 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Mar 5th",
           "id": 32,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/885",
-          "scoreTag": <span
-            className="score-tag proficient"
-          >
-            Proficient
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag proficient"
+              >
+                Proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1382,11 +2281,73 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Capitalize Names of People and the Pronoun "I"
         </div>
         <div>
-          <span
-            className="score-tag proficient"
+          <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag proficient"
+              >
+                Proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Proficient
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag proficient"
+                >
+                  Proficient
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1399,11 +2360,29 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Mar 5th",
           "id": 29,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/804",
-          "scoreTag": <span
-            className="score-tag proficient"
-          >
-            Proficient
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag proficient"
+              >
+                Proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1426,11 +2405,73 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Capitalize Names of People 1
         </div>
         <div>
-          <span
-            className="score-tag proficient"
+          <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag proficient"
+              >
+                Proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Proficient
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag proficient"
+                >
+                  Proficient
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1443,11 +2484,29 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Mar 5th",
           "id": 28,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/802",
-          "scoreTag": <span
-            className="score-tag nearly-proficient"
-          >
-            Nearly proficient
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag nearly-proficient"
+              >
+                Nearly proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1470,11 +2529,73 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Capitalize Geographic Names 1
         </div>
         <div>
-          <span
-            className="score-tag nearly-proficient"
+          <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag nearly-proficient"
+              >
+                Nearly proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Nearly proficient
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag nearly-proficient"
+                >
+                  Nearly proficient
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1487,11 +2608,29 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Mar 5th",
           "id": 27,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/75/user/7/activity/808",
-          "scoreTag": <span
-            className="score-tag proficient"
-          >
-            Proficient
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag proficient"
+              >
+                Proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1514,11 +2653,73 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Plural vs. Possessive Nouns 1
         </div>
         <div>
-          <span
-            className="score-tag proficient"
+          <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag proficient"
+              >
+                Proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Proficient
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag proficient"
+                >
+                  Proficient
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1531,11 +2732,29 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Mar 5th",
           "id": 26,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/801",
-          "scoreTag": <span
-            className="score-tag nearly-proficient"
-          >
-            Nearly proficient
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag nearly-proficient"
+              >
+                Nearly proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1558,11 +2777,73 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Capitalize Holidays and Dates 1
         </div>
         <div>
-          <span
-            className="score-tag nearly-proficient"
+          <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag nearly-proficient"
+              >
+                Nearly proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Nearly proficient
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag nearly-proficient"
+                >
+                  Nearly proficient
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1575,11 +2856,29 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Mar 5th",
           "id": 25,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/49/user/7/activity/181",
-          "scoreTag": <span
-            className="score-tag proficient"
-          >
-            Proficient
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag proficient"
+              >
+                Proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1602,11 +2901,73 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Capitalize Holidays and Geographic Names
         </div>
         <div>
-          <span
-            className="score-tag proficient"
+          <Tooltip
+            isTabbable={true}
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag proficient"
+              >
+                Proficient
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Proficient
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag proficient"
+                >
+                  Proficient
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1619,11 +2980,30 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Mar 4th",
           "id": 24,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/6/unit/85/user/7/activity/849",
-          "scoreTag": <span
-            className="score-tag completed"
-          >
-            Completed
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag completed"
+              >
+                Completed
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1646,11 +3026,74 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Starter Diagnostic
         </div>
         <div>
-          <span
-            className="score-tag completed"
+          <Tooltip
+            isTabbable={true}
+            tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag completed"
+              >
+                Completed
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Completed
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag completed"
+                >
+                  Completed
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1663,11 +3106,30 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Mar 3rd",
           "id": 23,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/85/user/7/activity/849",
-          "scoreTag": <span
-            className="score-tag completed"
-          >
-            Completed
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag completed"
+              >
+                Completed
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1690,11 +3152,74 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Starter Diagnostic
         </div>
         <div>
-          <span
-            className="score-tag completed"
+          <Tooltip
+            isTabbable={true}
+            tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag completed"
+              >
+                Completed
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Completed
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag completed"
+                >
+                  Completed
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1707,11 +3232,30 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Dec 1st, 2020",
           "id": 3,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/4/user/6/activity/849",
-          "scoreTag": <span
-            className="score-tag completed"
-          >
-            Completed
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag completed"
+              >
+                Completed
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Tahereh Mafi",
         }
       }
@@ -1734,11 +3278,74 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Starter Diagnostic
         </div>
         <div>
-          <span
-            className="score-tag completed"
+          <Tooltip
+            isTabbable={true}
+            tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag completed"
+              >
+                Completed
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Completed
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag completed"
+                >
+                  Completed
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>
@@ -1751,11 +3358,30 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           "completed": "Dec 1st, 2020",
           "id": 2,
           "link": "/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/1/unit/4/user/7/activity/849",
-          "scoreTag": <span
-            className="score-tag completed"
-          >
-            Completed
-          </span>,
+          "scoreTag": <Tooltip
+            isTabbable={true}
+            tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag completed"
+              >
+                Completed
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+          />,
           "studentName": "Angie Thomas",
         }
       }
@@ -1778,11 +3404,74 @@ exports[`ActivityFeed component on mobile should render when there are activitie
           Starter Diagnostic
         </div>
         <div>
-          <span
-            className="score-tag completed"
+          <Tooltip
+            isTabbable={true}
+            tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+            tooltipTriggerStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
+            tooltipTriggerText={
+              <span
+                className="score-tag completed"
+              >
+                Completed
+              </span>
+            }
+            tooltipTriggerTextClass="data-table-row-section"
+            tooltipTriggerTextStyle={
+              Object {
+                "minWidth": "210px",
+                "width": "210px",
+              }
+            }
           >
-            Completed
-          </span>
+            <span
+              aria-hidden={false}
+              className="quill-tooltip-trigger "
+              role="tooltip"
+              style={
+                Object {
+                  "minWidth": "210px",
+                  "width": "210px",
+                }
+              }
+            >
+              <span
+                className="data-table-row-section"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "minWidth": "210px",
+                    "width": "210px",
+                  }
+                }
+                tabIndex={0}
+              >
+                <span
+                  className="score-tag completed"
+                >
+                  Completed
+                </span>
+              </span>
+              <span
+                className="quill-tooltip-wrapper"
+              >
+                <span
+                  aria-live="polite"
+                  className="quill-tooltip"
+                />
+              </span>
+            </span>
+          </Tooltip>
         </div>
       </a>
     </MobileActivityRow>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/activity_feed.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/activity_feed.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 
-import { DataTable, expandIcon, } from '../../../Shared/index';
+import { DataTable, expandIcon, Tooltip, } from '../../../Shared/index';
+import tooltipCopyForScoreDescriptions from '../modules/tooltipCopyForScoreDescriptions'
 
 const listIllustrationSrc = `${process.env.CDN_URL}/images/pages/dashboard/illustrations-list.svg`
+
+const SCORE_WIDTH = '210px'
 
 const headers = [
   {
@@ -14,9 +17,10 @@ const headers = [
     name: 'Activity',
     attribute: 'activityName',
   }, {
-    width: '210px',
+    width: SCORE_WIDTH,
     name: 'Score',
     attribute: 'scoreTag',
+    containsOwnTooltip: true
   }, {
     width: '84px',
     name: 'Completed',
@@ -57,11 +61,25 @@ const ActivityFeed = ({ onMobile, activityFeed, }) => {
 
   const rows = activityFeed.slice(0, showAll ? ABSOLUTE_MAX : INITIAL_MAX).map(act => {
     const { student_name, activity_name, score, completed, id, unit_id, classroom_id, user_id, activity_id, } = act
+
+    const scoreTagStyle = {
+      minWidth: SCORE_WIDTH,
+      width: SCORE_WIDTH
+    }
+
     return {
       className: "focus-on-light",
       studentName: student_name,
       activityName: activity_name,
-      scoreTag: <span className={`score-tag ${score.toLowerCase().split(' ').join('-')}`}>{score}</span>,
+      scoreTag: (
+        <Tooltip
+          tooltipText={tooltipCopyForScoreDescriptions[score.toLowerCase()]}
+          tooltipTriggerStyle={scoreTagStyle}
+          tooltipTriggerText={<span className={`score-tag ${score.toLowerCase().split(' ').join('-')}`}>{score}</span>}
+          tooltipTriggerTextClass='data-table-row-section'
+          tooltipTriggerTextStyle={scoreTagStyle}
+        />
+      ),
       link: `/teachers/progress_reports/report_from_classroom_and_unit_and_activity_and_user/classroom/${classroom_id}/unit/${unit_id}/user/${user_id}/activity/${activity_id}`,
       completed,
       id,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/tooltipCopyForScoreDescriptions.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/tooltipCopyForScoreDescriptions.ts
@@ -1,0 +1,8 @@
+export default {
+  'frequently demonstrated skill': "The student reaches an optimal response by the final attempt in at least 5 of every 6 questions. This student can produce a strong response either on the first attempt or with feedback.",
+  'sometimes demonstrated skill': 'The student reaches an optimal response by the final attempt in 4 of 6 questions to 2 of 6 questions. This student could benefit from additional Quill practice to strengthen this skill.',
+  'rarely demonstrated skill': 'The student produces an optimal response in fewer than 2 out of 6 questions. This student may need direct teacher support.',
+  'completed': 'Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed.',
+  'in progress': 'The student started this activity but has not yet completed it.',
+  'not started': 'This assigned activity has not yet been started. If the activity has a lock icon, it is not yet available for the student.'
+}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/tooltipCopyForScoreDescriptions.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/tooltipCopyForScoreDescriptions.ts
@@ -4,5 +4,5 @@ export default {
   'rarely demonstrated skill': 'The student produces an optimal response in fewer than 2 out of 6 questions. This student may need direct teacher support.',
   'completed': 'Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed.',
   'in progress': 'The student started this activity but has not yet completed it.',
-  'not started': 'This assigned activity has not yet been started. If the activity has a lock icon, it is not yet available for the student.'
+  'assigned': 'This assigned activity has not yet been started. If the activity has a lock icon, it is not yet available for the student.'
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
@@ -104,6 +104,7 @@ exports[`ScoreLegend component should render 1`] = `
           Assigned
         </span>
       }
+      tooltipText="This assigned activity has not yet been started. If the activity has a lock icon, it is not yet available for the student."
     />
   </div>
 </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/__tests__/__snapshots__/score_legend.test.jsx.snap
@@ -7,144 +7,104 @@ exports[`ScoreLegend component should render 1`] = `
   <div
     className="icons"
   >
-    <div
-      className="icon"
-    >
-      <div
-        className="icon-wrapper icon-green"
-      />
-      <div
-        className="icons-description-wrapper"
-      >
-        <p
-          className="title"
-        >
-          Frequently demonstrated skill
-        </p>
-        <p
-          className="explanation"
-        >
-          100 - 83% of prompts exhibit skill
-        </p>
-      </div>
-    </div>
-    <div
-      className="icon"
-    >
-      <div
-        className="icon-wrapper icon-orange"
-      />
-      <div
-        className="icons-description-wrapper"
-      >
-        <p
-          className="title"
-        >
-          Sometimes demonstrated skill
-        </p>
-        <p
-          className="explanation"
-        >
-          82 - 32% of prompts exhibit skill
-        </p>
-      </div>
-    </div>
-    <div
-      className="icon"
-    >
-      <div
-        className="icon-wrapper icon-red"
-      />
-      <div
-        className="icons-description-wrapper"
-      >
-        <p
-          className="title"
-        >
-          Rarely demonstrated skill
-        </p>
-        <p
-          className="explanation"
-        >
-          31 - 0% of prompts exhibit skill
-        </p>
-      </div>
-    </div>
-    <Tooltip
-      isTabbable={true}
-      tooltipText="This type of activity is not graded."
-      tooltipTriggerText={
+    <Icon
+      explanation="100 - 83% of prompts exhibit skill"
+      icon={
         <div
-          className="icon"
+          className="icon-wrapper icon-green"
+        />
+      }
+      title={
+        <span>
+          Frequently
+          <br />
+          Demonstrated Skill
+        </span>
+      }
+      tooltipText="The student reaches an optimal response by the final attempt in at least 5 of every 6 questions. This student can produce a strong response either on the first attempt or with feedback."
+    />
+    <Icon
+      explanation="82 - 32% of prompts exhibit skill"
+      icon={
+        <div
+          className="icon-wrapper icon-orange"
+        />
+      }
+      title={
+        <span>
+          Sometimes
+          <br />
+          Demonstrated Skill
+        </span>
+      }
+      tooltipText="The student reaches an optimal response by the final attempt in 4 of 6 questions to 2 of 6 questions. This student could benefit from additional Quill practice to strengthen this skill."
+    />
+    <Icon
+      explanation="31 - 0% of prompts exhibit skill"
+      icon={
+        <div
+          className="icon-wrapper icon-red"
+        />
+      }
+      title={
+        <span>
+          Rarely
+          <br />
+          Demonstrated Skill
+        </span>
+      }
+      tooltipText="The student produces an optimal response in fewer than 2 out of 6 questions. This student may need direct teacher support."
+    />
+    <Icon
+      explanation="No score provided"
+      icon={
+        <div
+          className="icon-wrapper icon-blue"
+        />
+      }
+      oneLineTitle={true}
+      title={
+        <span>
+          Completed
+        </span>
+      }
+      tooltipText="Quill Reading for Evidence, Quill Lessons, and Quill Diagnostic activities do not provide a score for students. Instead, a blue square is provided once the activity is completed."
+    />
+    <Icon
+      explanation="Not finished"
+      icon={
+        <div
+          className="icon-wrapper icon-progress"
         >
-          <div
-            className="icon-wrapper icon-blue"
+          <img
+            alt="in progress symbol"
+            className="in-progress-symbol"
+            src="https://assets.quill.org/images/scorebook/blue-circle-sliced.svg"
           />
-          <div
-            className="icons-description-wrapper"
-          >
-            <p
-              className="title"
-            >
-              Completed
-            </p>
-            <p
-              className="explanation"
-            >
-              No score provided
-            </p>
-          </div>
         </div>
       }
+      oneLineTitle={true}
+      title={
+        <span>
+          In Progress
+        </span>
+      }
+      tooltipText="The student started this activity but has not yet completed it."
     />
-    <div
-      className="icon"
-    >
-      <div
-        className="icon-wrapper icon-progress"
-      >
-        <img
-          alt="in progress symbol"
-          className="in-progress-symbol"
-          src="https://assets.quill.org/images/scorebook/blue-circle-sliced.svg"
+    <Icon
+      explanation="Not started"
+      icon={
+        <div
+          className="icon-wrapper icon-unstarted"
         />
-      </div>
-      <div
-        className="icons-description-wrapper"
-      >
-        <p
-          className="title"
-        >
-          In progress
-        </p>
-        <p
-          className="explanation"
-        >
-          Not finished
-        </p>
-      </div>
-    </div>
-    <div
-      className="icon"
-    >
-      <div
-        className="icon-wrapper icon-unstarted"
-      />
-      <div
-        className="icons-description-wrapper"
-      >
-        <p
-          className="title"
-        >
-          Not started
-        </p>
-        <p
-          className="explanation"
-        >
+      }
+      oneLineTitle={true}
+      title={
+        <span>
           Assigned
-        </p>
-      </div>
-    </div>
+        </span>
+      }
+    />
   </div>
 </div>
 `;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/score_legend.jsx
@@ -1,7 +1,26 @@
 import React from 'react';
 
 import { proficiencyCutoffsAsPercentage } from '../../../../modules/proficiency_cutoffs.js';
+import tooltipCopyForScoreDescriptions from '../modules/tooltipCopyForScoreDescriptions'
 import { Tooltip } from '../../../Shared/index';
+
+const Icon = ({ title, tooltipText, explanation, icon, oneLineTitle=false }) => {
+  return (
+    <Tooltip
+      tooltipText={tooltipText}
+      tooltipTriggerText={
+        <div className="icon">
+          {icon}
+          <div className="icons-description-wrapper">
+            <p className={`title ${oneLineTitle ? 'align-center' : ''}`}>{title}<img alt="" src="https://assets.quill.org/images/icons/icons-help.svg" /></p>
+            <p className="explanation">{explanation}</p>
+          </div>
+        </div>
+      }
+    />
+
+  )
+}
 
 export default class ScoreLegend extends React.Component {
   render() {
@@ -9,55 +28,49 @@ export default class ScoreLegend extends React.Component {
     return (
       <div className="icons-wrapper icon-legend score-legend">
         <div className="icons">
-          <div className="icon">
-            <div className="icon-wrapper icon-green" />
-            <div className="icons-description-wrapper">
-              <p className="title">Frequently demonstrated skill</p>
-              <p className="explanation">{`100 - ${cutOff.proficient}% of prompts exhibit skill`}</p>
-            </div>
-          </div>
-          <div className="icon">
-            <div className="icon-wrapper icon-orange" />
-            <div className="icons-description-wrapper">
-              <p className="title">Sometimes demonstrated skill</p>
-              <p className="explanation">{`${cutOff.proficient - 1} - ${cutOff.nearlyProficient}% of prompts exhibit skill`}</p>
-            </div>
-          </div>
-          <div className="icon">
-            <div className="icon-wrapper icon-red" />
-            <div className="icons-description-wrapper">
-              <p className="title">Rarely demonstrated skill</p>
-              <p className="explanation">{`${cutOff.nearlyProficient - 1} - 0% of prompts exhibit skill`}</p>
-            </div>
-          </div>
-          <Tooltip
-            tooltipText='This type of activity is not graded.'
-            tooltipTriggerText={
-              <div className="icon">
-                <div className="icon-wrapper icon-blue" />
-                <div className="icons-description-wrapper">
-                  <p className="title">Completed</p>
-                  <p className="explanation">No score provided</p>
-                </div>
-              </div>
-            }
+          <Icon
+            explanation={`100 - ${cutOff.proficient}% of prompts exhibit skill`}
+            icon={<div className="icon-wrapper icon-green" />}
+            title={<span>Frequently<br />Demonstrated Skill</span>}
+            tooltipText={tooltipCopyForScoreDescriptions['frequently demonstrated skill']}
           />
-          <div className="icon">
-            <div className="icon-wrapper icon-progress">
-              <img alt="in progress symbol" className="in-progress-symbol" src="https://assets.quill.org/images/scorebook/blue-circle-sliced.svg" />
-            </div>
-            <div className="icons-description-wrapper">
-              <p className="title">In progress</p>
-              <p className="explanation">Not finished</p>
-            </div>
-          </div>
-          <div className="icon">
-            <div className="icon-wrapper icon-unstarted" />
-            <div className="icons-description-wrapper">
-              <p className="title">Not started</p>
-              <p className="explanation">Assigned</p>
-            </div>
-          </div>
+          <Icon
+            explanation={`${cutOff.proficient - 1} - ${cutOff.nearlyProficient}% of prompts exhibit skill`}
+            icon={<div className="icon-wrapper icon-orange" />}
+            title={<span>Sometimes<br />Demonstrated Skill</span>}
+            tooltipText={tooltipCopyForScoreDescriptions['sometimes demonstrated skill']}
+          />
+          <Icon
+            explanation={`${cutOff.nearlyProficient - 1} - 0% of prompts exhibit skill`}
+            icon={<div className="icon-wrapper icon-red" />}
+            title={<span>Rarely<br />Demonstrated Skill</span>}
+            tooltipText={tooltipCopyForScoreDescriptions['rarely demonstrated skill']}
+          />
+          <Icon
+            explanation="No score provided"
+            icon={<div className="icon-wrapper icon-blue" />}
+            oneLineTitle={true}
+            title={<span>Completed</span>}
+            tooltipText={tooltipCopyForScoreDescriptions['completed']}
+          />
+          <Icon
+            explanation="Not finished"
+            icon={(
+              <div className="icon-wrapper icon-progress">
+                <img alt="in progress symbol" className="in-progress-symbol" src="https://assets.quill.org/images/scorebook/blue-circle-sliced.svg" />
+              </div>
+            )}
+            oneLineTitle={true}
+            title={<span>In Progress</span>}
+            tooltipText={tooltipCopyForScoreDescriptions['in progress']}
+          />
+          <Icon
+            explanation="Not started"
+            icon={<div className="icon-wrapper icon-unstarted" />}
+            oneLineTitle={true}
+            title={<span>Assigned</span>}
+            tooltipText={tooltipCopyForScoreDescriptions['assigned']}
+          />
         </div>
       </div>
     );


### PR DESCRIPTION
## WHAT
Add tooltips explaining what the score descriptions (ex: 'Frequently demonstrated skill') mean to the Activity Summary and Activity Feed.

## WHY
We want to contextualize these labels for teachers.

## HOW
Add a shared file with the text and use Tooltips in both places to render the data. I needed to modify the `DataTable` to get the tooltip there to display properly.

### Screenshots
<img width="645" alt="Screenshot 2023-09-22 at 7 29 38 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/c2f3ebfa-54d2-4c55-8a0c-d497f7046cb1">
<img width="1058" alt="Screenshot 2023-09-22 at 7 29 25 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/cc00926e-5924-4794-96ca-824de3af38a1">

### Notion Card Links
https://www.notion.so/quill/My-Reports-Activity-Summary-Add-Tooltips-to-Explain-the-New-Scoring-System-Front-end-P1-Task-ed5ffcf54df545d38de6fbb520903f1a?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES