### PR TITLE
assignment copy change for coteachers

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -264,7 +264,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             diagnostic={
               Object {
                 "activityId": 1664,
-                "lockedText": "This is locked because you haven't assigned the Starter Baseline Diagnostic yet. Assign it to unlock the Starter Growth Diagnostic.",
+                "lockedText": "This is locked because you haven't assigned the Starter Baseline Diagnostic yet. Assign it to unlock the Starter Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
                 "name": "Starter Growth Diagnostic (Post)",
                 "unitTemplateId": 217,
                 "what": "The Starter Growth Diagnostic has different questions but covers the same skills as the Starter Baseline Diagnostic.",
@@ -499,14 +499,14 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             diagnostic={
               Object {
                 "activityId": 1669,
-                "lockedText": "This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic.",
+                "lockedText": "This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
                 "name": "Intermediate Growth Diagnostic (Post)",
                 "unitTemplateId": 237,
                 "what": "The Intermediate Growth Diagnostic has different questions but covers the same skills as the Intermediate Baseline Diagnostic.",
                 "when": "Your students have completed the Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
               }
             }
-            lockedText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
+            lockedText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
             showNewTag={true}
           >
             <AssignmentCard
@@ -525,7 +525,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
               buttonLink="/activity_sessions/anonymous?activity_id=1669"
               buttonText="Preview"
               header="Intermediate Growth Diagnostic (Post)"
-              lockedText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
+              lockedText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
               selectCard={[Function]}
               showNewTag={true}
             >
@@ -571,7 +571,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                     </a>
                     <Tooltip
                       isTabbable={true}
-                      tooltipText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
+                      tooltipText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
                       tooltipTriggerText={
                         <button
                           className="quill-button small disabled contained"
@@ -780,14 +780,14 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             diagnostic={
               Object {
                 "activityId": 1680,
-                "lockedText": "This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic.",
+                "lockedText": "This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
                 "name": "Advanced Growth Diagnostic (Post)",
                 "unitTemplateId": 409,
                 "what": "The Advanced Growth Diagnostic has different questions but covers the same skills as the Advanced Baseline Diagnostic.",
                 "when": "Your students have completed the Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
               }
             }
-            lockedText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
+            lockedText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
             showNewTag={true}
           >
             <AssignmentCard
@@ -806,7 +806,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
               buttonLink="/activity_sessions/anonymous?activity_id=1680"
               buttonText="Preview"
               header="Advanced Growth Diagnostic (Post)"
-              lockedText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
+              lockedText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
               selectCard={[Function]}
               showNewTag={true}
             >
@@ -852,7 +852,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                     </a>
                     <Tooltip
                       isTabbable={true}
-                      tooltipText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
+                      tooltipText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
                       tooltipTriggerText={
                         <button
                           className="quill-button small disabled contained"
@@ -1061,7 +1061,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             diagnostic={
               Object {
                 "activityId": 1774,
-                "lockedText": "This is locked because you haven't assigned the ELL Starter Baseline Diagnostic yet. Assign it to unlock the ELL Starter Growth Diagnostic.",
+                "lockedText": "This is locked because you haven't assigned the ELL Starter Baseline Diagnostic yet. Assign it to unlock the ELL Starter Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
                 "name": "ELL Starter Growth Diagnostic (Post)",
                 "unitTemplateId": 411,
                 "what": "The ELL Starter Growth Diagnostic has different questions but covers the same skills as the ELL Starter Baseline Diagnostic.",
@@ -1294,7 +1294,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             diagnostic={
               Object {
                 "activityId": 1814,
-                "lockedText": "This is locked because you haven't assigned the ELL Intermediate Baseline Diagnostic yet. Assign it to unlock the ELL Intermediate Growth Diagnostic.",
+                "lockedText": "This is locked because you haven't assigned the ELL Intermediate Baseline Diagnostic yet. Assign it to unlock the ELL Intermediate Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
                 "name": "ELL Intermediate Growth Diagnostic (Post)",
                 "unitTemplateId": 444,
                 "what": "The ELL Intermediate Growth Diagnostic has different questions but covers the same skills as the ELL Intermediate Baseline Diagnostic.",
@@ -1527,7 +1527,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             diagnostic={
               Object {
                 "activityId": 1818,
-                "lockedText": "This is locked because you haven't assigned the ELL Advanced Baseline Diagnostic yet. Assign it to unlock the ELL Advanced Growth Diagnostic.",
+                "lockedText": "This is locked because you haven't assigned the ELL Advanced Baseline Diagnostic yet. Assign it to unlock the ELL Advanced Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
                 "name": "ELL Advanced Growth Diagnostic (Post)",
                 "unitTemplateId": 445,
                 "what": "The ELL Advanced Growth Diagnostic has different questions but covers the same skills as the ELL Advanced Baseline Diagnostic.",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
@@ -46,7 +46,7 @@ export const starterPostTest = {
   unitTemplateId: STARTER_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
   what: 'The Starter Growth Diagnostic has different questions but covers the same skills as the Starter Baseline Diagnostic.',
   when: "Your students have completed the Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-  lockedText: "This is locked because you haven't assigned the Starter Baseline Diagnostic yet. Assign it to unlock the Starter Growth Diagnostic."
+  lockedText: "This is locked because you haven't assigned the Starter Baseline Diagnostic yet. Assign it to unlock the Starter Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
 }
 
 export const intermediatePreTest = {
@@ -63,7 +63,7 @@ export const intermediatePostTest = {
   unitTemplateId: INTERMEDIATE_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
   what: 'The Intermediate Growth Diagnostic has different questions but covers the same skills as the Intermediate Baseline Diagnostic.',
   when: "Your students have completed the Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-  lockedText: "This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic."
+  lockedText: "This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
 }
 
 export const advancedPreTest = {
@@ -80,7 +80,7 @@ export const advancedPostTest = {
   unitTemplateId: ADVANCED_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
   what: 'The Advanced Growth Diagnostic has different questions but covers the same skills as the Advanced Baseline Diagnostic.',
   when: "Your students have completed the Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-  lockedText: "This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic."
+  lockedText: "This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
 }
 
 export const ellStarterPreTest = {
@@ -97,7 +97,7 @@ export const ellStarterPostTest = {
   unitTemplateId: ELL_STARTER_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
   what: 'The ELL Starter Growth Diagnostic has different questions but covers the same skills as the ELL Starter Baseline Diagnostic.',
   when: "Your students have completed the ELL Starter Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-  lockedText: "This is locked because you haven't assigned the ELL Starter Baseline Diagnostic yet. Assign it to unlock the ELL Starter Growth Diagnostic."
+  lockedText: "This is locked because you haven't assigned the ELL Starter Baseline Diagnostic yet. Assign it to unlock the ELL Starter Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
 }
 
 export const ellIntermediatePreTest = {
@@ -114,7 +114,7 @@ export const ellIntermediatePostTest = {
   unitTemplateId: ELL_INTERMEDIATE_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
   what: 'The ELL Intermediate Growth Diagnostic has different questions but covers the same skills as the ELL Intermediate Baseline Diagnostic.',
   when: "Your students have completed the ELL Intermediate Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-  lockedText: "This is locked because you haven't assigned the ELL Intermediate Baseline Diagnostic yet. Assign it to unlock the ELL Intermediate Growth Diagnostic."
+  lockedText: "This is locked because you haven't assigned the ELL Intermediate Baseline Diagnostic yet. Assign it to unlock the ELL Intermediate Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
 }
 
 export const ellAdvancedPreTest = {
@@ -131,7 +131,7 @@ export const ellAdvancedPostTest = {
   unitTemplateId: ELL_ADVANCED_DIAGNOSTIC_POST_UNIT_TEMPLATE_ID,
   what: 'The ELL Advanced Growth Diagnostic has different questions but covers the same skills as the ELL Advanced Baseline Diagnostic.',
   when: "Your students have completed the ELL Advanced Baseline Diagnostic, you've assigned the recommended practice, and now you're ready to measure their growth.",
-  lockedText: "This is locked because you haven't assigned the ELL Advanced Baseline Diagnostic yet. Assign it to unlock the ELL Advanced Growth Diagnostic."
+  lockedText: "This is locked because you haven't assigned the ELL Advanced Baseline Diagnostic yet. Assign it to unlock the ELL Advanced Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
 }
 
 export const apWritingSkills = {
@@ -168,12 +168,12 @@ export const springboardWritingSkills = {
 
 
 export const postTestClassAssignmentLockedMessages = {
-  1664: "You can't assign the Starter Growth Diagnostic to this class until you've assigned them the Starter Baseline Diagnostic.",
-  1669: "You can't assign the Intermediate Growth Diagnostic to this class until you've assigned them the Intermediate Baseline Diagnostic.",
-  1680: "You can't assign the Advanced Growth Diagnostic to this class until you've assigned them the Advanced Baseline Diagnostic.",
-  1774: "You can't assign the ELL Starter Growth Diagnostic to this class until you've assigned them the ELL Starter Baseline Diagnostic.",
-  1814: "You can't assign the ELL Intermediate Growth Diagnostic to this class until you've assigned them the ELL Intermediate Baseline Diagnostic.",
-  1818: "You can't assign the ELL Advanced Growth Diagnostic to this class until you've assigned them the ELL Advanced Baseline Diagnostic."
+  1664: "You can't assign the Starter Growth Diagnostic to this class until you've assigned them the Starter Baseline Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
+  1669: "You can't assign the Intermediate Growth Diagnostic to this class until you've assigned them the Intermediate Baseline Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
+  1680: "You can't assign the Advanced Growth Diagnostic to this class until you've assigned them the Advanced Baseline Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
+  1774: "You can't assign the ELL Starter Growth Diagnostic to this class until you've assigned them the ELL Starter Baseline Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
+  1814: "You can't assign the ELL Intermediate Growth Diagnostic to this class until you've assigned them the ELL Intermediate Baseline Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics.",
+  1818: "You can't assign the ELL Advanced Growth Diagnostic to this class until you've assigned them the ELL Advanced Baseline Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
 }
 
 export const postTestWarningModalPreNameCorrespondence = {


### PR DESCRIPTION
## WHAT
Update the locked message when assigning post tests to tell co-teachers to ask the classroom owner to assign it.

## WHY
This was causing confusion for co-teachers.

## HOW
Just copy updates.

### Screenshots
<img width="311" alt="Screenshot 2023-09-22 at 9 58 21 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/0cd62dbc-a7e8-4453-a7f4-45fd16ca89a8">
<img width="527" alt="Screenshot 2023-09-22 at 9 56 19 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/813b26e8-439c-4d91-ab34-afe9484e8b41">


### Notion Card Links
https://www.notion.so/quill/Allow-co-teachers-to-assign-a-Growth-Diagnostic-6f084d7e95334756b45f870d5109bf66?d=fa71cb8746d34939b952e665ffb9bbc2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES