### PR TITLE
Add Vertex AI backfill rake task

### DIFF
--- a/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
+++ b/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+namespace :vertex_ai  do
+  desc 'Populate prompt endpoint and model IDs'
+  task populate_prompt_endpoint_and_model_ids: :environment do
+    pipe_data = $stdin.read unless $stdin.tty?
+
+    rows_data = []
+
+    endpoint_client = ::Google::Cloud::AIPlatform::V1::EndpointService::Client.new
+    parent = "projects/#{ENV.fetch('VERTEX_AI_PROJECT_ID')}/locations/#{ENV.fetch('VERTEX_AI_LOCATION')}"
+
+    CSV.parse(pipe_data, headers: true) do |row|
+      row_data = row.to_h
+      conjunction = row_data['Conjunction'].downcase
+      evidence_activity_id = row_data['Activity ID']
+      name = "automl_#{row['AutoML Dataset']}"
+      link = row_data['CMS Link'] = "https://www.quill.org/cms/evidence#/activities/#{evidence_activity_id}}/semantic-labels/#{conjunction}"
+      row_data['CMS Link title'] = row_data.delete('Link to CMS')
+      row_data['Prompt ID'] = Evidence::Prompt.find_by(activity_id: evidence_activity_id, conjunction: conjunction).id
+      model_id = row['Vertex Model ID']
+      model_name = "projects/#{ENV.fetch('VERTEX_AI_PROJECT_ID')}/locations/#{ENV.fetch('VERTEX_AI_LOCATION')}/models/#{model_id}"
+      endpoint = endpoint_client.list_endpoints(parent: parent).find { |e| e.display_name.start_with?(name) }
+      row_data['Endpoint ID'] = endpoint&.name&.split('/')&.last
+      model = endpoint&.deployed_models&.find { |m| endpoint.display_name == m.display_name && m.display_name.start_with?(name) }
+      row_data['Model ID'] = model&.model&.split('/')&.last
+      row_data['Name'] = endpoint&.display_name
+
+      rows_data << row_data
+    end
+
+    CSV.open("vertex_output.csv", "wb") do |csv|
+      csv << rows_data.first.keys
+
+      rows_data.each do |row|
+        csv << row.values
+      end
+    end
+  end
+
+  task backfill_evidence_automl_models: :environment do
+    pipe_data = $stdin.read unless $stdin.tty?
+
+    CSV.parse(pipe_data, headers: true) do |row|
+      next if row['Model ID'].blank? || row['Endpoint ID'].blank? || row['Prompt ID'].blank? || row['Model ID'].blank? || row['Name'].blank?
+
+      Evidence::AutomlModel.create!(
+        endpoint_external_id: row['Endpoint ID'],
+        model_external_id: row['Model ID'],
+        name: row['Name'],
+        notes: 'Initial Vertex Model',
+        prompt_id: row['Prompt ID'],
+        state: 'inactive'
+      )
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
+++ b/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :vertex_ai  do
-  desc 'Populate prompt endpoint and model IDs'
+  desc 'Populate prompt endpoint and model IDs (note these need to be run locally as files are not available on the server))'
   task populate_prompt_endpoint_and_model_ids: :environment do
     pipe_data = $stdin.read unless $stdin.tty?
 
@@ -38,11 +38,12 @@ namespace :vertex_ai  do
     end
   end
 
+  desc 'Backfill evidence_automl_models (note these need to be run locally as files are not available on the server))'
   task backfill_evidence_automl_models: :environment do
     pipe_data = $stdin.read unless $stdin.tty?
 
     CSV.parse(pipe_data, headers: true) do |row|
-      next if row['Model ID'].blank? || row['Endpoint ID'].blank? || row['Prompt ID'].blank? || row['Model ID'].blank? || row['Name'].blank? || row['Labels'].blank?
+      next if row['Model ID'].blank? || row['Endpoint ID'].blank? || row['Prompt ID'].blank? || row['Name'].blank? || row['Labels'].blank?
 
       model_id = ActiveRecord::Base.connection.quote(row['Model ID'])
       endpoint_id = ActiveRecord::Base.connection.quote(row['Endpoint ID'])


### PR DESCRIPTION
## WHAT
Add a rake task to populate pre-existing `Evidence::AutomlModel` records

## WHY
There is a UI to add new Evidence::AutomlModel but this rake task will add existing ones to our database

## HOW
There are two rake tasks.
`populate_prompt_endpoint_and_model_ids`:  This will populate a csv with the correct values for `endpoint_external_id`, `model_external_id`,`prompt_id`. and `labels`.  Curriculum requested this updated file which is why there are two rake tasks.

With the values from the previous rake task, run`backfill_evidence_automl_models` to create the new records.
Raw sql is used since the Evidence::AutomlModel does not point to the newer table yet (that change happens downstream in `bs-vertex-backfill`)

Logistics:
The `populate_prompt_endpoint_and_model_ids` task has to be run first on a downstream branch `bs-vertex-ai` so that it has access to the vertex ai platform and the params builder.  Once the values are populated into vertex_backfill.csv, `backfill_evidence_automl_models` can be run on this branch `bs-vertex-backfill`. 

I've also added a deploy script [here](https://www.notion.so/quill/Implement-Vertex-AI-in-Evidence-with-parity-for-AutoML-features-cc6f6f4562a544b489bd2eff7ec0f686?pvs=4#4823dc30da824bafa4c137f8e2e1f669)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
