### PR TITLE
Synthetic Data - Update OpenAI model and use it for Labeled Data

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/labeledDataUploadForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/syntheticData/labeledDataUploadForm.tsx
@@ -73,7 +73,7 @@ const LabeledDataUploadForm = ({ history, match }) => {
         setErrorOrSuccessMessage(errors.first.message);
       } else {
         setErrors([]);
-        setFilenames([]);
+        setPromptFiles({...blankPromptFiles});
         setErrorOrSuccessMessage('Synthetic Data started! You will receive an email with the csv files');
       }
       toggleSubmissionModal();

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
@@ -9,12 +9,13 @@ module Evidence
       ENDPOINT = '/completions'
 
       MAX_TOKENS = 24
-      # A-D, (A)Least -> (D)Most Complex/Expensive
+
       MODELS = {
         ada: 'text-ada-001',
         babbage: 'text-babbage-001',
         curie: 'text-curie-001',
-        davinci: 'text-davinci-002'
+        davinci: 'text-davinci-002',
+        turbo35_instruct: 'gpt-3.5-turbo-instruct'
       }
 
       STOP_TOKENS = [". ", "; ", "? ", "! "] # max of 4 stop tokens
@@ -22,7 +23,7 @@ module Evidence
 
       attr_accessor :prompt, :temperature, :count, :model_key, :options
 
-      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :curie, options: {})
+      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :turbo35_instruct, options: {})
         @prompt = prompt
         @temperature = temperature
         @count = count

--- a/services/QuillLMS/engines/evidence/lib/evidence/synthetic/labeled_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/synthetic/labeled_data_generator.rb
@@ -21,7 +21,7 @@ module Evidence
         spelling_passage_specific: Synthetic::Generators::SpellingPassageSpecific
       }
 
-      DEFAULT_GENERATORS = GENERATORS.slice(:translation, :spelling, :spelling_passage_specific)
+      DEFAULT_GENERATORS = GENERATORS.slice(:paraphrase, :spelling, :spelling_passage_specific)
 
       TEST_GENERATOR_KEYS = [:spelling_passage_specific]
 

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/labeled_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/labeled_data_generator_spec.rb
@@ -246,7 +246,7 @@ describe Evidence::Synthetic::LabeledDataGenerator do
       stub_const("Evidence::Synthetic::ManualTypes::MIN_TEST_PER_LABEL", 0)
       stub_const("Evidence::Synthetic::ManualTypes::MIN_TRAIN_PER_LABEL", 0)
 
-      allow(Evidence::Synthetic::Generators::Translation).to receive(:run).with([text1, text2], {:languages=>[:es], passage: passage.text}).and_return(translation_response)
+      allow(Evidence::Synthetic::Generators::Paraphrase).to receive(:run).with([text1, text2], {:languages=>[:es], passage: passage.text}).and_return(translation_response)
       allow(Evidence::Synthetic::Generators::Spelling).to receive(:run).with([text1, text2], {:languages=>[:es], passage: passage.text}).and_return(spelling_response)
     end
 


### PR DESCRIPTION
## WHAT
A few small changes to the synthetic data flow:
1. Update to use a newer OpenAI model `GPT3.5-turbo-instruct`
2. Use OpenAI rather than Google Translate for Labeled Synthetic data
3. Fix a small JS bug that makes it appear the files aren't processed.
## WHY
We want to use the newer AI models for better synthetic data. 

Also, the long-term plan was to deprecate the Google Translate flow (it seems the google upgrade may have broken this code anyway, so instead of fixing it, just moving to OpenAI). The newer models seem to perform well in my initial 
## HOW
Small config changes mostly.

Note, there will be a future PR to remove the Google Translate code entirely (leaving it to get this out quicker).
### Screenshots


### Notion Card Links
https://www.notion.so/quill/ea241f31a84c4b79ad56e83e99f7ee93?v=469e2a0c2d8c41539bbe1c8690c4afd7&p=fe5bbc21ec8d49e48e113771739bbc44&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'
Have you deployed to Staging? | Yes, and verified.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
