### PR TITLE
fix missed lesson indicator alignment

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/scorebook_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/scorebook_page.scss
@@ -145,7 +145,10 @@
   }
 
 	.missed-indicator {
-		height: 38px;
+    height: 38px;
+    position: absolute;
+    left: 0px;
+    top: 1px;
 	}
 
 	.attempt-count {


### PR DESCRIPTION
## WHAT
Fix bug with aligning the missed lesson indicator (the big x).

## WHY
So this displays correctly.

## HOW
Just adjust the CSS.

### Screenshots
<img width="1370" alt="Screenshot 2023-09-27 at 11 25 58 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/cff2d0a0-2840-4b9e-bd74-e145b659610e">


### Notion Card Links
https://www.notion.so/quill/Layout-issue-Quill-Lesson-squares-on-Activity-Summary-report-d0d743d71a7948f7b0df78afa3bba7fe

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - pure CSS change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES