### PR TITLE
lms/classroom-roster-lists-bugfix

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -585,7 +585,7 @@ const ClassroomStudentSection = ({
     const { classroomProvider } = classroom
 
     if (classroomProvider) {
-      const isDisabled = providerConfigLookup[user.provider].title !== classroomProvider
+      const isDisabled = providerConfigLookup[user.provider]?.title !== classroomProvider
       const lastUpdatedDate = moment(classroom.updated_at).format('MMM D, YYYY')
       return (
         <div className="invite-provider-classroom-students">


### PR DESCRIPTION
## WHAT
Use a safe accessor to handle weird edge cases
## WHY
If a user imports a roster through Google or Clever and then later disconnects their account from third-party auth, the current code will error because it tries to access value out of null
## HOW
Use a safe accessor (`?.`) so that in cases where `user.provider` is `null`, and thus we have an undefined value from `providerConfigLookup`, we don't try to access `title` from it for comparison.  Instead we'll get `undefined` which will set the value of `isDisabled` to `false` (since `undefined` won't equal whatever `classroomProvider` is set to).

### Notion Card Links
https://www.notion.so/quill/My-Classes-page-goes-blank-when-attempting-to-open-rosters-ee0707bb13764c62804cd01ed20c555e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  I considered trying to refactor the test for `react-testing` library and adding a case for this, but it seemed like overkill for a safe accessor.
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
