### PR TITLE
fix diagnostic report display issue by stricter filtering by class roster

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -83,6 +83,7 @@ module DiagnosticReports
   private def assigned_student_ids_filtered_by_classroom_roster(classroom_units)
     classroom_id = classroom_units.first&.classroom_id
     return [] unless classroom_id
+
     assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
     rostered_student_ids = Classroom.find(classroom_id).students.pluck(:id)
     assigned_student_ids.intersection(rostered_student_ids)

--- a/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
+++ b/services/QuillLMS/app/controllers/concerns/diagnostic_reports.rb
@@ -57,7 +57,6 @@ module DiagnosticReports
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id=nil, hashify_activity_sessions: false)
     if unit_id
       classroom_unit = ClassroomUnit.find_by(unit_id: unit_id, classroom_id: classroom_id)
@@ -67,7 +66,7 @@ module DiagnosticReports
         .where(classroom_unit: classroom_unit, is_final_score: true, user_id: classroom_unit.assigned_student_ids, activity_id: activity_id)
     else
       classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})
-      assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
+      assigned_student_ids = assigned_student_ids_filtered_by_classroom_roster(classroom_id, classroom_units)
       @assigned_students = User.where(id: assigned_student_ids).sort_by { |u| u.last_name }
       @activity_sessions = ActivitySession
         .includes(:concept_results, activity: {diagnostic_question_skills: :question})
@@ -80,7 +79,12 @@ module DiagnosticReports
 
     @activity_sessions = @activity_sessions.to_h { |session| [session.user_id, session] }
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
+
+  private def assigned_student_ids_filtered_by_classroom_roster(classroom_id, classroom_units)
+    assigned_student_ids = classroom_units.map { |cu| cu.assigned_student_ids }.flatten.uniq
+    rostered_student_ids = Classroom.find(classroom_id).students.pluck(:id)
+    assigned_student_ids.intersection(rostered_student_ids)
+  end
 
   private def set_pre_test_activity_sessions_and_assigned_students(activity_id, classroom_id, hashify_activity_sessions: false)
     classroom_units = ClassroomUnit.where(classroom_id: classroom_id).joins(:unit, :unit_activities).where(unit: {unit_activities: {activity_id: activity_id}})

--- a/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/diagnostic_reports_spec.rb
@@ -147,6 +147,13 @@ describe DiagnosticReports do
         expect(@activity_sessions).to include(activity_session3)
       end
 
+      it 'should not include an activity session that is not associated with the current classroom' do
+        [students_classroom1, students_classroom3].each(&:delete)
+        set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(unit_activity1.activity_id, classroom.id, nil)
+        expect(@assigned_students).to eq [student2]
+        expect(@activity_sessions.map(&:user_id).uniq).to eq [student2.id]
+      end
+
     end
   end
 


### PR DESCRIPTION
fix diagnostic report display issue by stricter filtering by class roster

## WHAT / HOW
For diagnostic reports, check assigned_student_ids against the students rostered in the given classroom 

## WHY
If Classroom Units exist from recycling classes, or other teacher fixes, students who have transferred out of class A may still appear in class A's diagnostic report, causing confusion. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Students-appearing-in-Practice-recommendations-report-for-a-class-in-which-they-are-no-longer-roster-66b201d11b6240babbf971585212bd4d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
