### PR TITLE
lms/change-admin-snapshot-worker-priority

### DIFF
--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -4,6 +4,8 @@ module Snapshots
   class CacheSnapshotCountWorker
     include Sidekiq::Worker
 
+    sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
     PUSHER_EVENT = 'admin-snapshot-count-cached'
 
     QUERIES = {

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -4,6 +4,8 @@ module Snapshots
   class CacheSnapshotTopXWorker
     include Sidekiq::Worker
 
+    sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
     PUSHER_EVENT = 'admin-snapshot-top-x-cached'
 
     QUERIES = {


### PR DESCRIPTION
## WHAT
Assign Snapshot workers to the CRITICAL_EXTERNAL queue
## WHY
So that report generation doesn't get stuck behind all other CRITICAL and CRITICAL_EXTERNAL jobs during times of high traffic.  (We really should have done this originally given the use case of "users are actively waiting for the response of this worker", but it slipped through without being done.)
## HOW
Just specify the Sidekiq queue that these workers should be in rather than letting them fall into DEFAULT.

### Notion Card Links
https://www.notion.so/quill/Improve-the-Admin-Usage-Snapshot-Report-metric-load-times-8d08aa3720a249488b3aec47eee3c703

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests cover what queue workers are assigned to
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
