### PR TITLE
Log calls to teacher fix recalculate staggered release locks

### DIFF
--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -257,6 +257,7 @@ class TeacherFixController < ApplicationController
     return render json: { error: 'Teacher not found' }, status: 404 if teacher.nil?
 
     teacher.classrooms_i_teach.each(&:save_user_pack_sequence_items)
+    log_recalculate_staggered_release_locks
 
     render json: {}, status: 200
   end
@@ -290,5 +291,17 @@ class TeacherFixController < ApplicationController
 
   private def teacher
     @teacher ||= User.find_by_username_or_email(params['teacher_identifier'])
+  end
+
+  private def log_recalculate_staggered_release_locks
+    ChangeLog.create!(
+      action: ChangeLog::USER_ACTIONS[:recalculate_staggered_release_locks],
+      changed_attribute: nil,
+      changed_record: teacher,
+      explanation: caller_locations[0].to_s,
+      new_value: nil,
+      previous_value: nil,
+      user_id: current_user.id
+    )
   end
 end

--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -100,7 +100,8 @@ class ChangeLog < ApplicationRecord
     sign_in: 'Impersonated User',
     show: 'Visited User Admin Page',
     edit: 'Visited User Edit Page',
-    update: 'Edited User'
+    update: 'Edited User',
+    recalculate_staggered_release_locks: 'Recalculated Staggered Release Locks'
   }
 
   GENERIC_USER_ACTIONS = [

--- a/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_fix_controller_spec.rb
@@ -598,6 +598,8 @@ describe TeacherFixController do
           subject
           expect(response.code).to eq '200'
         end
+
+        it { expect { subject }.to change(ChangeLog, :count).by(1) }
       end
 
       context 'that has no students' do


### PR DESCRIPTION
## WHAT
Log calls to `TeacherFixController#recalculate_staggered_release_locks`

## WHY
We'd like to have a clear number of how often this is happening so that we can determine if more interim solutions are required.

## HOW
Add a ChangeLog creation after the locks are recalculated.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Track-Usage-of-the-Recalculate-Staggered-Release-Locks-Teacher-Fix-f4c6052282464c548a1c3bd07d712fe2?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
