### PR TITLE
lms/remove-source-classroom-unit-id

### DIFF
--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -4,15 +4,14 @@
 #
 # Table name: classroom_units
 #
-#  id                       :integer          not null, primary key
-#  assign_on_join           :boolean          default(FALSE)
-#  assigned_student_ids     :integer          default([]), is an Array
-#  visible                  :boolean          default(TRUE)
-#  created_at               :datetime
-#  updated_at               :datetime
-#  classroom_id             :integer          not null
-#  source_classroom_unit_id :integer
-#  unit_id                  :integer          not null
+#  id                   :integer          not null, primary key
+#  assign_on_join       :boolean          default(FALSE)
+#  assigned_student_ids :integer          default([]), is an Array
+#  visible              :boolean          default(TRUE)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  classroom_id         :integer          not null
+#  unit_id              :integer          not null
 #
 # Indexes
 #

--- a/services/QuillLMS/db/migrate/20230929135017_remove_source_from_classroom_unit.rb
+++ b/services/QuillLMS/db/migrate/20230929135017_remove_source_from_classroom_unit.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSourceFromClassroomUnit < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :classroom_units, :source_classroom_unit_id, :integer
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -1349,8 +1349,7 @@ CREATE TABLE public.classroom_units (
     assigned_student_ids integer[] DEFAULT '{}'::integer[],
     assign_on_join boolean DEFAULT false,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    source_classroom_unit_id integer
+    updated_at timestamp without time zone
 );
 
 
@@ -10497,6 +10496,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230731184420'),
 ('20230801140455'),
 ('20230801140522'),
-('20230912150456');
+('20230912150456'),
+('20230929135017');
 
 

--- a/services/QuillLMS/spec/factories/classroom_units.rb
+++ b/services/QuillLMS/spec/factories/classroom_units.rb
@@ -4,15 +4,14 @@
 #
 # Table name: classroom_units
 #
-#  id                       :integer          not null, primary key
-#  assign_on_join           :boolean          default(FALSE)
-#  assigned_student_ids     :integer          default([]), is an Array
-#  visible                  :boolean          default(TRUE)
-#  created_at               :datetime
-#  updated_at               :datetime
-#  classroom_id             :integer          not null
-#  source_classroom_unit_id :integer
-#  unit_id                  :integer          not null
+#  id                   :integer          not null, primary key
+#  assign_on_join       :boolean          default(FALSE)
+#  assigned_student_ids :integer          default([]), is an Array
+#  visible              :boolean          default(TRUE)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  classroom_id         :integer          not null
+#  unit_id              :integer          not null
 #
 # Indexes
 #

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -4,15 +4,14 @@
 #
 # Table name: classroom_units
 #
-#  id                       :integer          not null, primary key
-#  assign_on_join           :boolean          default(FALSE)
-#  assigned_student_ids     :integer          default([]), is an Array
-#  visible                  :boolean          default(TRUE)
-#  created_at               :datetime
-#  updated_at               :datetime
-#  classroom_id             :integer          not null
-#  source_classroom_unit_id :integer
-#  unit_id                  :integer          not null
+#  id                   :integer          not null, primary key
+#  assign_on_join       :boolean          default(FALSE)
+#  assigned_student_ids :integer          default([]), is an Array
+#  visible              :boolean          default(TRUE)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  classroom_id         :integer          not null
+#  unit_id              :integer          not null
 #
 # Indexes
 #


### PR DESCRIPTION
## WHAT
Remove a column that we never ended up using
## WHY
We added this column when we thought it would be necessary for Admin Diagnostic reporting, but realized that it wouldn't we should clean it up.  (A query to the production database confirms that this column is `null` for all rows.)
## HOW
Add a migration to remove the column since it's not in use.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, we never implemented code to use this
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
