### PR TITLE
fix usage snapshot report filtering issues

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
@@ -40,11 +40,24 @@
       .filter-label {
         display: flex;
         align-items: center;
+        font-size: 16px;
+        line-height: 22px;
+        margin-bottom: 16px;
         img {
           margin-left: 8px;
         }
         .quill-tooltip-wrapper {
           transform: translateX(-25%);
+          max-width: 250px;
+        }
+      }
+      .disabled-classroom-filter {
+        margin-top: 24px;
+        .dropdown__control {
+          width: 100%;
+        }
+        .multi-option-summary-text {
+          color: $quill-grey-50;
         }
       }
     }

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/filters.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/filters.test.tsx
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme';
+import { render, screen, }  from "@testing-library/react";
 import * as React from 'react';
 
 import { timeframes, grades, schools, teachers, classrooms,} from './data'
@@ -43,6 +44,14 @@ describe('Filters component', () => {
 
       expect(component).toMatchSnapshot();
     });
+  })
+
+  describe('when allClassrooms is empty', () => {
+    test('a disabled classrooms dropdown should be rendered', () => {
+      const { asFragment } = render(<Filters {...mockProps} allClassrooms={[]} />);
+      expect(asFragment()).toMatchSnapshot();
+      expect(screen.getByRole('button', { name: /all classrooms selected/i })).toHaveAttribute('disabled')
+    })
   })
 
 });

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
@@ -5,6 +5,8 @@ import useWindowSize from '../../../Shared/hooks/useWindowSize';
 
 const closeIconSrc = `${process.env.CDN_URL}/images/icons/close.svg`
 
+const MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS = 1500
+
 const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassrooms, applyFilters, clearFilters, selectedGrades, setSelectedGrades, hasAdjustedFiltersFromDefault, handleSetSelectedTimeframe, selectedTimeframe, selectedSchools, setSelectedSchools, selectedTeachers, setSelectedTeachers, selectedClassrooms, setSelectedClassrooms, closeMobileFilterMenu, showMobileFilterMenu, hasAdjustedFiltersSinceLastSubmission, customStartDate, customEndDate, }) => {
   const size = useWindowSize();
 
@@ -36,6 +38,43 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
   }
 
   const timeframeHelperText = customStartDate && customEndDate ? `${customStartDate.format('MM/DD/YYYY')} - ${customEndDate.format('MM/DD/YYYY')}` : null
+
+  let classroomsFilter = (
+    <div className="disabled-classroom-filter">
+      <label className="filter-label" htmlFor="classroom-filter">
+        <span>Classroom</span>
+        <Tooltip
+          tooltipText="To filter by classroom, first apply broader filters above."
+          tooltipTriggerText={<img alt={helpIcon.alt} src={helpIcon.src} />}
+        />
+      </label>
+      <DropdownInput
+        disabled={true}
+        id="classroom-filter"
+        isMulti={true}
+        isSearchable={true}
+        label=""
+        options={[allClassrooms[0]]}
+        optionType="classroom"
+        value={[selectedClassrooms[0]]}
+      />
+    </div>
+  )
+
+  if (allClassrooms.length < MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS) {
+    classroomsFilter = (
+      <DropdownInputWithSearchTokens
+        id="classroom-filter"
+        identifier="id"
+        label="Classroom"
+        onChange={setSelectedClassrooms}
+        options={allClassrooms}
+        optionType="classroom"
+        value={selectedClassrooms}
+        valueToDisplay={effectiveSelectedClassrooms()}
+      />
+    )
+  }
 
   return (
     <section className={`filter-container ${showMobileFilterMenu ? 'mobile-open' : 'mobile-hidden'} ${hasAdjustedFiltersFromDefault ? 'space-for-buttons' : ''}`}>
@@ -92,16 +131,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
           value={selectedTeachers}
           valueToDisplay={effectiveSelectedTeachers()}
         />
-        {allClassrooms.length ? <DropdownInputWithSearchTokens
-          id="classroom-filter"
-          identifier="id"
-          label="Classroom"
-          onChange={setSelectedClassrooms}
-          options={allClassrooms}
-          optionType="classroom"
-          value={selectedClassrooms}
-          valueToDisplay={effectiveSelectedClassrooms()}
-        /> : null}
+        {classroomsFilter}
       </div>
       {renderFilterButtons()}
     </section>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
@@ -92,7 +92,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
           value={selectedTeachers}
           valueToDisplay={effectiveSelectedTeachers()}
         />
-        <DropdownInputWithSearchTokens
+        {allClassrooms.length ? <DropdownInputWithSearchTokens
           id="classroom-filter"
           identifier="id"
           label="Classroom"
@@ -101,7 +101,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
           optionType="classroom"
           value={selectedClassrooms}
           valueToDisplay={effectiveSelectedClassrooms()}
-        />
+        /> : null}
       </div>
       {renderFilterButtons()}
     </section>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
@@ -5,8 +5,6 @@ import useWindowSize from '../../../Shared/hooks/useWindowSize';
 
 const closeIconSrc = `${process.env.CDN_URL}/images/icons/close.svg`
 
-const MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS = 1500
-
 const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassrooms, applyFilters, clearFilters, selectedGrades, setSelectedGrades, hasAdjustedFiltersFromDefault, handleSetSelectedTimeframe, selectedTimeframe, selectedSchools, setSelectedSchools, selectedTeachers, setSelectedTeachers, selectedClassrooms, setSelectedClassrooms, closeMobileFilterMenu, showMobileFilterMenu, hasAdjustedFiltersSinceLastSubmission, customStartDate, customEndDate, }) => {
   const size = useWindowSize();
 
@@ -61,7 +59,7 @@ const Filters = ({ allTimeframes, allSchools, allGrades, allTeachers, allClassro
     </div>
   )
 
-  if (allClassrooms.length < MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS) {
+  if (allClassrooms.length) {
     classroomsFilter = (
       <DropdownInputWithSearchTokens
         id="classroom-filter"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -11,7 +11,7 @@ import CustomDateModal from '../components/usage_snapshots/customDateModal'
 import Filters from '../components/usage_snapshots/filters'
 import { CUSTOM } from '../components/usage_snapshots/shared'
 import { Spinner } from '../../Shared/index'
-import { requestGet, } from '../../../modules/request'
+import { requestPost, } from '../../../modules/request'
 import { unorderedArraysAreEqual, } from '../../../modules/unorderedArraysAreEqual'
 
 export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, location }) => {
@@ -130,9 +130,9 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, locat
       grades: selectedGrades?.map(g => g.value)
     }
 
-    const requestUrl = queryString.stringifyUrl({ url: '/snapshots/options', query: searchParams }, { arrayFormat: 'bracket' })
+    const requestUrl = queryString.stringifyUrl({ url: '/snapshots/options', query: searchParams }, { arrayFormat: 'comma' })
 
-    requestGet(requestUrl, (filterData) => {
+    requestPost('/snapshots/options', searchParams, (filterData) => {
       const timeframeOptions = filterData.timeframes.map(tf => ({ ...tf, label: tf.name }))
       const gradeOptions = filterData.grades.map(grade => ({ ...grade, label: grade.name }))
       const schoolOptions = filterData.schools.map(school => ({ ...school, label: school.name, value: school.id }))

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -14,6 +14,8 @@ import { Spinner } from '../../Shared/index'
 import { requestPost, } from '../../../modules/request'
 import { unorderedArraysAreEqual, } from '../../../modules/unorderedArraysAreEqual'
 
+const MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS = 2000
+
 export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, location }) => {
   const [loadingFilters, setLoadingFilters] = React.useState(true)
 
@@ -221,12 +223,15 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, locat
     return <Spinner />
   }
 
+  const selectedClassroomsToPass = selectedClassrooms.length > MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS ? [] : selectedClassrooms
+  const allClassroomsToPass = allClassrooms.length > MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS ? [] : allClassrooms
+
   const filterProps = {
     allTimeframes,
     allSchools,
     allGrades,
     allTeachers,
-    allClassrooms,
+    allClassrooms: allClassroomsToPass,
     applyFilters,
     clearFilters,
     selectedGrades,
@@ -236,7 +241,7 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, locat
     selectedTimeframe,
     selectedSchools,
     setSelectedSchools,
-    selectedClassrooms,
+    selectedClassrooms: selectedClassroomsToPass,
     setSelectedClassrooms,
     selectedTeachers,
     setSelectedTeachers,
@@ -254,8 +259,8 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, locat
     customEndDate,
     pusherChannel,
     searchCount,
-    selectedClassrooms,
-    allClassrooms,
+    selectedClassrooms: selectedClassroomsToPass,
+    allClassrooms: allClassroomsToPass,
     selectedGrades,
     allGrades,
     selectedSchools,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -14,6 +14,8 @@ import { Spinner } from '../../Shared/index'
 import { requestPost, } from '../../../modules/request'
 import { unorderedArraysAreEqual, } from '../../../modules/unorderedArraysAreEqual'
 
+const MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS = 1500
+
 export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, location }) => {
   const [loadingFilters, setLoadingFilters] = React.useState(true)
 
@@ -221,12 +223,14 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, locat
     return <Spinner />
   }
 
+  const allClassroomsToPass = allClassrooms.length > MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS ? [] : allClassrooms
+
   const filterProps = {
     allTimeframes,
     allSchools,
     allGrades,
     allTeachers,
-    allClassrooms,
+    allClassrooms: allClassroomsToPass,
     applyFilters,
     clearFilters,
     selectedGrades,
@@ -255,7 +259,7 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, locat
     pusherChannel,
     searchCount,
     selectedClassrooms,
-    allClassrooms,
+    allClassrooms: allClassroomsToPass,
     selectedGrades,
     allGrades,
     selectedSchools,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -14,8 +14,6 @@ import { Spinner } from '../../Shared/index'
 import { requestPost, } from '../../../modules/request'
 import { unorderedArraysAreEqual, } from '../../../modules/unorderedArraysAreEqual'
 
-const MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS = 2000
-
 export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, location }) => {
   const [loadingFilters, setLoadingFilters] = React.useState(true)
 
@@ -223,15 +221,12 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, locat
     return <Spinner />
   }
 
-  const selectedClassroomsToPass = selectedClassrooms.length > MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS ? [] : selectedClassrooms
-  const allClassroomsToPass = allClassrooms.length > MAXIMUM_CLASSROOM_LENGTH_FOR_FILTERS ? [] : allClassrooms
-
   const filterProps = {
     allTimeframes,
     allSchools,
     allGrades,
     allTeachers,
-    allClassrooms: allClassroomsToPass,
+    allClassrooms,
     applyFilters,
     clearFilters,
     selectedGrades,
@@ -241,7 +236,7 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, locat
     selectedTimeframe,
     selectedSchools,
     setSelectedSchools,
-    selectedClassrooms: selectedClassroomsToPass,
+    selectedClassrooms,
     setSelectedClassrooms,
     selectedTeachers,
     setSelectedTeachers,
@@ -259,8 +254,8 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, locat
     customEndDate,
     pusherChannel,
     searchCount,
-    selectedClassrooms: selectedClassroomsToPass,
-    allClassrooms: allClassroomsToPass,
+    selectedClassrooms,
+    allClassrooms,
     selectedGrades,
     allGrades,
     selectedSchools,

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/checkableDropdownOption.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/checkableDropdownOption.tsx
@@ -28,6 +28,10 @@ export const CheckableDropdownOption = props => {
   const passedProps = {...props}
   passedProps.innerProps.id = data.value
 
+  // improves performance with very large lists, see https://github.com/JedWatson/react-select/issues/3128 for discussion
+  delete passedProps.innerProps.onMouseMove
+  delete passedProps.innerProps.onMouseOver
+
   return (
     <div className="checkable-dropdown-option">
       <components.Option {...passedProps}>

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Select from 'react-select';
+import Select, { createFilter, } from 'react-select';
 
 import { CheckableDropdownOption } from './checkableDropdownOption';
 import { CheckableDropdownValueContainer } from './checkableDropdownValueContainer';
@@ -311,6 +311,7 @@ export class DropdownInput extends React.Component<DropdownInputProps, DropdownI
     const searchable = isSearchable ? 'searchable' : ''
     const checkboxDropdown = isMulti ? 'checkbox-dropdown' : ''
     const sharedClasses = `dropdown-container input-container ${inactiveOrActive} ${hasText} ${notEditable} ${className} ${searchable} ${checkboxDropdown}`
+
     const sharedProps = {
       id,
       cursor,
@@ -329,7 +330,7 @@ export class DropdownInput extends React.Component<DropdownInputProps, DropdownI
       onInputChange: this.handleInputChange,
       tabIndex: isSearchable ? 0 : -1,
       inputValue,
-      filterOption: filterOptions ? this.handleFilterOptions : null
+      filterOption: filterOptions ? this.handleFilterOptions : createFilter({ ignoreAccents: false })
     }
     if (error) {
       if (errorAcknowledged) {

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Select, { createFilter, } from 'react-select';
+import Select from 'react-select';
 
 import { CheckableDropdownOption } from './checkableDropdownOption';
 import { CheckableDropdownValueContainer } from './checkableDropdownValueContainer';
@@ -330,7 +330,7 @@ export class DropdownInput extends React.Component<DropdownInputProps, DropdownI
       onInputChange: this.handleInputChange,
       tabIndex: isSearchable ? 0 : -1,
       inputValue,
-      filterOption: filterOptions ? this.handleFilterOptions : createFilter({ ignoreAccents: false })
+      filterOption: filterOptions ? this.handleFilterOptions : null
     }
     if (error) {
       if (errorAcknowledged) {

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
@@ -303,7 +303,7 @@ export class DropdownInput extends React.Component<DropdownInputProps, DropdownI
 
   renderInput() {
     const { active, errorAcknowledged, menuIsOpen, cursor, inputValue, } = this.state
-    const { className, label, value, placeholder, error, type, id, isSearchable, isMulti, optionType, optionTypeDescriptor, usesCustomOption, filterOptions } = this.props
+    const { className, label, value, placeholder, error, type, id, isSearchable, isMulti, optionType, optionTypeDescriptor, usesCustomOption, filterOptions, disabled, } = this.props
     const passedValue = value || ''
     const hasText = value || isMulti ? 'has-text' : ''
     const inactiveOrActive = active ? 'active' : 'inactive'
@@ -330,7 +330,7 @@ export class DropdownInput extends React.Component<DropdownInputProps, DropdownI
       onInputChange: this.handleInputChange,
       tabIndex: isSearchable ? 0 : -1,
       inputValue,
-      filterOption: filterOptions ? this.handleFilterOptions : null
+      filterOption: filterOptions ? this.handleFilterOptions : null,
     }
     if (error) {
       if (errorAcknowledged) {
@@ -377,6 +377,7 @@ export class DropdownInput extends React.Component<DropdownInputProps, DropdownI
         return (
           <div
             className={sharedClasses}
+            disabled={disabled}
             onClick={this.handleInputInteraction}
             onKeyDown={this.handleKeyDownOnInputContainer}
             onTouchStart={this.handleInputInteraction}

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInputWithSearchTokens.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInputWithSearchTokens.tsx
@@ -28,7 +28,7 @@ const SearchToken = ({ searchItem, onRemoveSearchItem, }: SearchTokenProps) => {
   return (
     <div className="search-token">
       <span>{searchItem.label}</span>
-      <button aria-label={`Remove ${searchItem.label} from filtered list`} className="interactive-wrapper focus-on-light" onClick={handleRemoveSearchItem} type="button"><img alt="" src={removeSearchTokenSrc} /></button>
+      <button aria-label={`Remove ${searchItem.label} from filtered list`} className="interactive-wrapper focus-on-dark" onClick={handleRemoveSearchItem} type="button"><img alt="" src={removeSearchTokenSrc} /></button>
     </div>
   )
 }

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -730,7 +730,7 @@ EmpiricalGrammar::Application.routes.draw do
   resources :snapshots, only: [] do
     collection do
       post :count
-      get :options
+      post :options
       post :top_x
       post :data_export
     end


### PR DESCRIPTION
## WHAT
- Change the /options call from a GET to a POST request so requests with a ton of parameters don't get rejected.
- Make performance improvements to the `DropdownInput` component and disable the `Classroom` component when there are so many options it still lags.

## WHY
To improve UX for users with a ton of data on this page.

## HOW
See "WHAT"

### Screenshots
<img width="244" alt="Screenshot 2023-09-29 at 1 57 11 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/0ec61ca0-6d32-4aba-979b-23f03ebbb4b3">
<img width="246" alt="Screenshot 2023-09-29 at 1 57 16 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/89fd8541-97df-4601-a614-ba84ab886d93">


### Notion Card Links
https://www.notion.so/quill/On-the-new-admin-reports-filter-values-are-not-dynamic-for-users-with-lots-of-data-825bd2eef5304eea8d4aa3ed15fd5df9?pvs=4

https://www.notion.so/quill/Improve-the-front-end-performance-of-the-filters-on-the-new-admin-reports-96015236ab254276b212593a9c44883f?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES