### PR TITLE
fix footer width issue

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/footer.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/footer.scss
@@ -152,7 +152,8 @@
       margin: 0 0 8px;
     }
     .partner-links {
-      width: 860px;
+      max-width: 860px;
+      width: 100%;
       display: flex;
       align-items: center;
       justify-content: space-between;

--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -1088,6 +1088,7 @@
   text-align: left;
   overflow: hidden;
   max-height: 100vh;
+  height: auto !important;
   .create-a-class-modal-content {
     max-height: 100vh;
     height: 100%;

--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -1132,7 +1132,8 @@
     }
 
     .create-a-class-form {
-      width: 512px;
+      max-width: 512px;
+      width: 100%;
       .input-container {
         margin-bottom: 12px;
         &.grade {

--- a/services/QuillLMS/client/app/bundles/Shared/styles/input.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/input.scss
@@ -53,7 +53,7 @@
   }
 
   input, input:focus {
-    height: 20px;
+    height: 24px;
     padding-left: 0px;
   }
 


### PR DESCRIPTION
## WHAT
Fix issue where the footer's set width was too wide for mobile browsers.

## WHY
This causes the screen to get squished at smaller page views.

## HOW
Change the width to a max-width and set the width to 100% instead. Note: this is generally a good strategy for responsive design. I'm going to try to do a better job in code reviews of making sure we aren't setting hard widths in CSS that are wider than the smallest mobile browsers, because that will always result in poor UI.

### Screenshots
<img width="1453" alt="Screenshot 2023-10-02 at 4 12 27 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/b22a91a7-fe34-4638-92df-8156c5efbc7d">
<img width="245" alt="Screenshot 2023-10-02 at 4 18 57 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/68705d10-87db-4500-b532-5c0c6e8f7d6c">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - CSS only
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES