### PR TITLE
lms/fix-team-image-size

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/team.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/team.scss
@@ -18,6 +18,7 @@
     flex-wrap: wrap;
   }
   .team-member {
+    max-width: 219px;
     margin-right: 24px;
     margin-bottom: 40px;
   }


### PR DESCRIPTION
## WHAT
Add a max-width to team-member divs
## WHY
We were relying on image size of 219x219px to set the size of these elements, but we're considering using 2x images for better display on hi-res displays where normal images can look fuzzy.  In order to support that, we'll need the CSS of the page itself to control the size of these divs.
## HOW
Just add a `max-width` rule to the `team-member` to explicitly control the width of team member divs instead of just relying on the defined size of the images.

NOTE: there's a more robust version of this approach using [Responsive Image approaches](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images), but I think we should try to resolve the immediate issue quickly and leave ourselves time to have a longer discussion about what our broader goals are and which approach would serve them best.

### Screenshots
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/9f2a7e78-1d66-434f-b31b-a612400cf938)
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/c2a92ffb-5d97-4576-ae27-070b20169018)

### Notion Card Links
https://www.notion.so/quill/New-photos-on-Team-Page-are-too-large-on-mobile-view-e48071888a2949579eb94cbb6d0a1b82

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on pure style changes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
