### PR TITLE
lms/add-srcset-to-team-page

### DIFF
--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -111,7 +111,10 @@ module PagesHelper
           {
             name: 'CJ Colicchio',
             title: 'Social Studies Curriculum Developer',
-            img: 'team-cj-colicchio.webp'
+            img: 'team-cj-colicchio.webp',
+            srcset: {
+              '2x' => 'team-cj-colicchio.webp'
+            }
           },
           {
             name: 'Nattalie Dai',
@@ -156,7 +159,10 @@ module PagesHelper
           {
             name: 'Jamie Monville',
             title: 'Associate Curriculum Product Manager',
-            img: 'team-jamie-monville.webp'
+            img: 'team-jamie-monville.webp',
+            srcset: {
+              '2x' => 'team-jamie-monville.webp'
+            }
           },
           {
             name: 'Katie Moylan',

--- a/services/QuillLMS/app/views/pages/team.html.erb
+++ b/services/QuillLMS/app/views/pages/team.html.erb
@@ -19,7 +19,10 @@
         <div class='team-members'>
           <% team_type[:members].each do |person| %>
             <div class='team-member'>
-              <img class="square-small-img" src=<%= "#{base_image_url}#{person[:img]}" %> alt=<%= "#{person[:name]}"%> />
+              <img class="square-small-img"
+                   src="<%= "#{base_image_url}#{person[:img]}" %>"
+                   srcset="<%= person[:srcset]&.map { |size, src| "#{base_image_url}#{src} #{size}" }&.join(", ") %>"
+                   alt="<%= "#{person[:name]}"%>" />
               <h4> <%= person[:name] %> </h4>
               <h5 class="square-small-img-width"> <%= person[:title] %> </h5>
             </div>


### PR DESCRIPTION
## WHAT
Add support for `srcset` values in Team member images
## WHY
In order to set us up for providing images in multiple resolutions to handle high-res screens
## HOW
Add a new key to the `team_info` records for each team member that can be parsed into a series of `srcset` values.  In the immediate term, this makes image sizing work as expected, and in the longer term this sets us up to actually provide multiple image sizes to support high res screens.

NOTE: This PR is intended to replace #11089 in order to better provide support for future intentions to actually use multiple image sizes across different screen resolutions.

### Screenshots
![](https://user-images.githubusercontent.com/331565/272089030-9f2a7e78-1d66-434f-b31b-a612400cf938.png)
![](https://user-images.githubusercontent.com/331565/272090201-c2a92ffb-5d97-4576-ae27-070b20169018.png)


### Notion Card Links
https://www.notion.so/quill/New-photos-on-Team-Page-are-too-large-on-mobile-view-e48071888a2949579eb94cbb6d0a1b82

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on pure style changes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A