### PR TITLE
Bug fix/ standardize hover states for tertiary navigation

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
@@ -472,8 +472,20 @@
       a {
         display: flex;
         align-items: center;
+        .small-diamond-icon {
+          background-image: url("https://assets.quill.org/images/icons/white-diamond.svg");
+        }
         &.active {
           color: $quill-maroon !important;
+          .small-diamond-icon {
+            background-image: url("https://assets.quill.org/images/icons/red-diamond.svg");
+          }
+          &:hover {
+            color: $quill-white !important;
+            .small-diamond-icon {
+              background-image: url("https://assets.quill.org/images/icons/white-diamond.svg");
+            }
+          }
         }
 
         &.premium {

--- a/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
@@ -92,6 +92,13 @@
           &.active {
             background: $quill-white;
             color: $quill-green;
+            text-decoration: none;
+          }
+
+          &:hover {
+            background-color: rgba(255, 255, 255, 0.5);
+            text-decoration: none;
+            color: $quill-white;
           }
 
           .fa-external-link {
@@ -234,6 +241,7 @@
       }
       &:hover {
         color: $quill-white;
+        background-color: rgba(255, 255, 255, 0.5);
         .small-diamond-icon {
           background-image: url("https://assets.quill.org/images/icons/white-diamond.svg");
         }
@@ -242,13 +250,7 @@
     .small-diamond-icon {
       background-image: url("https://assets.quill.org/images/icons/white-diamond.svg");
     }
-
   }
-  a:hover {
-    text-decoration: none;
-    background-color: rgba(255, 255, 255, 0.5);
-  }
-
   li a img {
     margin-top: -3px;
   }

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AdminSubnav it should render 1`] = `
+<DocumentFragment>
+  <div
+    class="tab-subnavigation-wrapper mobile class-subnav premium-hub-subnav red"
+  >
+    <div
+      class="dropdown-container"
+    >
+      <div
+        class=""
+      >
+        <button
+          class="interactive-wrapper"
+          id="mobile-subnav-dropdown"
+          type="button"
+        >
+          <p />
+          <i
+            class="fa fa-thin fa-angle-down"
+          />
+        </button>
+        <ul
+          class="dropdown-menu"
+        >
+          <li>
+            <a
+              class=" "
+              href="/teachers/premium_hub"
+            >
+              Overview
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=" "
+              href="/teachers/premium_hub/school_subscriptions"
+            >
+              School Subscriptions
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=" premium"
+              href="/teachers/premium_hub/district_activity_scores"
+            >
+              Activity Scores
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=" premium"
+              href="/teachers/premium_hub/district_concept_reports"
+            >
+              Concept Reports
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=" premium"
+              href="/teachers/premium_hub/district_standards_reports"
+            >
+              Standards Reports
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=" premium"
+              href="/teachers/premium_hub/integrations"
+            >
+              Integrations
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=" premium"
+              href="/teachers/premium_hub/usage_snapshot_report"
+            >
+              Usage Snapshot Report
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="tab-subnavigation-wrapper desktop class-subnav premium-hub-subnav"
+  >
+    <div
+      class="container"
+    >
+      <ul>
+        <li>
+          <a
+            class=" "
+            href="/teachers/premium_hub"
+          >
+            Overview
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li>
+          <a
+            class=" "
+            href="/teachers/premium_hub/school_subscriptions"
+          >
+            School Subscriptions
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li>
+          <a
+            class=" premium"
+            href="/teachers/premium_hub/district_activity_scores"
+          >
+            Activity Scores
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li>
+          <a
+            class=" premium"
+            href="/teachers/premium_hub/district_concept_reports"
+          >
+            Concept Reports
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li>
+          <a
+            class=" premium"
+            href="/teachers/premium_hub/district_standards_reports"
+          >
+            Standards Reports
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li>
+          <a
+            class=" premium"
+            href="/teachers/premium_hub/integrations"
+          >
+            Integrations
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li>
+          <a
+            class=" premium"
+            href="/teachers/premium_hub/usage_snapshot_report"
+          >
+            Usage Snapshot Report
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/subnav_tabs.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/subnav_tabs.test.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { MemoryRouter } from 'react-router';
+import { render } from "@testing-library/react";
+
+import { AdminSubnav } from '../subnav_tabs'
+
+const mockPath = {
+  path: {
+    pathname: ''
+  }
+}
+describe('AdminSubnav', () => {
+  test('it should render', () => {
+    const { asFragment } = render(<MemoryRouter><AdminSubnav path={mockPath} /></MemoryRouter>);
+    expect(asFragment()).toMatchSnapshot();
+  })
+})

--- a/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
@@ -27,7 +27,7 @@ function getIcon(tabLabel: string) {
   const isReportingTab = premiumHubReportingTabs.includes(tabLabel)
 
   if (isReportingTab) {
-    return <div className="small-diamond-icon"></div>
+    return <div className="small-diamond-icon" />
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { MAX_VIEW_WIDTH_FOR_MOBILE_NAVBAR } from '../utils/constants';
-import { redDiamondIcon, whiteDiamondIcon } from '../images';
 
 const premiumHubReportingTabs = [
   'Activity Scores',
@@ -24,11 +23,11 @@ interface renderNavListProps {
   listClass?: string
 }
 
-function getIcon(isActive: boolean, tabLabel: string) {
+function getIcon(tabLabel: string) {
   const isReportingTab = premiumHubReportingTabs.includes(tabLabel)
 
-  if ((isActive && isReportingTab) || isReportingTab) {
-    return <div className="small-diamond-icon red"></div>
+  if (isReportingTab) {
+    return <div className="small-diamond-icon"></div>
   }
 }
 
@@ -52,7 +51,7 @@ function renderListItem({ tabs, handleLinkClick, tabLabel, activeTab, i }) {
     <li key={i}>
       <Link className={linkClass} onClick={handleLinkClick} to={tabs[tabLabel].url}>
         {tabLabel}
-        {getIcon(!!activeClass, tabLabel)}
+        {getIcon(tabLabel)}
       </Link>
     </li>
   )

--- a/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
@@ -27,10 +27,8 @@ interface renderNavListProps {
 function getIcon(isActive: boolean, tabLabel: string) {
   const isReportingTab = premiumHubReportingTabs.includes(tabLabel)
 
-  if (isActive && isReportingTab) {
-    return <img alt={redDiamondIcon.alt} src={redDiamondIcon.src} />
-  } else if (isReportingTab) {
-    return <img alt={whiteDiamondIcon.alt} src={whiteDiamondIcon.src} />
+  if ((isActive && isReportingTab) || isReportingTab) {
+    return <div className="small-diamond-icon red"></div>
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/my_activities_tabs.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/my_activities_tabs.test.tsx.snap
@@ -1,0 +1,110 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MyActivitiesTabs it should render 1`] = `
+<DocumentFragment>
+  <div
+    class="unit-tabs tab-subnavigation-wrapper mobile"
+  >
+    <div
+      class="dropdown-container"
+    >
+      <div
+        class=""
+      >
+        <button
+          class="interactive-wrapper"
+          id="mobile-subnav-dropdown"
+          type="button"
+        >
+          <p>
+            My Open Activity Packs
+          </p>
+          <i
+            class="fa fa-thin fa-angle-down"
+          />
+        </button>
+        <ul
+          class="dropdown-menu"
+        >
+          <li>
+            <a
+              class="active "
+              href="/teachers/classrooms/activity_planner"
+            >
+              My Open Activity Packs
+            </a>
+            <div
+              class="checkmark-icon active"
+            />
+          </li>
+          <li>
+            <a
+              class=" "
+              href="/teachers/classrooms/activity_planner/closed"
+            >
+              My Closed Activity Packs
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=" "
+              href="/teachers/classrooms/activity_planner/lessons"
+            >
+              Launch Lessons
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="unit-tabs tab-subnavigation-wrapper desktop"
+  >
+    <div
+      class="container"
+    >
+      <ul>
+        <li>
+          <a
+            class="active "
+            href="/teachers/classrooms/activity_planner"
+          >
+            My Open Activity Packs
+          </a>
+          <div
+            class="checkmark-icon active"
+          />
+        </li>
+        <li>
+          <a
+            class=" "
+            href="/teachers/classrooms/activity_planner/closed"
+          >
+            My Closed Activity Packs
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li>
+          <a
+            class=" "
+            href="/teachers/classrooms/activity_planner/lessons"
+          >
+            Launch Lessons
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/my_activities_tabs.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/my_activities_tabs.test.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { MemoryRouter } from 'react-router';
+import { render } from "@testing-library/react";
+
+import { MyActivitiesTabs } from '../my_activities_tabs'
+
+describe('MyActivitiesTabs', () => {
+  test('it should render', () => {
+    const { asFragment } = render(<MemoryRouter><MyActivitiesTabs /></MemoryRouter>);
+    expect(asFragment()).toMatchSnapshot();
+  })
+})

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/my_activities_tabs.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/my_activities_tabs.jsx
@@ -20,7 +20,7 @@ const tabs = {
   }
 }
 
-const MyActivitiesTabs = () => {
+export const MyActivitiesTabs = () => {
   const [dropdownOpen, setDropdownOpen] = React.useState(false);
 
   let openActivityPacksClassName, closedActivityPacksClassName, lessonsClassName, activeTab

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/my_activities_tabs.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/my_activities_tabs.jsx
@@ -40,8 +40,6 @@ const MyActivitiesTabs = () => {
     setDropdownOpen(!dropdownOpen)
   }
 
-  const activeStates = [openActivityPacksClassName, closedActivityPacksClassName, lessonsClassName];
-
   return(
     <React.Fragment>
       <div className="unit-tabs tab-subnavigation-wrapper mobile">

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/my_activities_tabs.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/my_activities_tabs.jsx
@@ -51,13 +51,13 @@ const MyActivitiesTabs = () => {
               <p>{activeTab}</p>
               <i className="fa fa-thin fa-angle-down" />
             </button>
-            {renderNavList({ tabs, activeStates, handleLinkClick: handleDropdownClick, listClass: 'dropdown-menu' })}
+            {renderNavList({ tabs, handleLinkClick: handleDropdownClick, activeTab, listClass: 'dropdown-menu' })}
           </div>
         </div >
       </div >
       <div className='unit-tabs tab-subnavigation-wrapper desktop'>
         <div className="container">
-          {renderNavList({ tabs, activeStates, handleLinkClick: handleDropdownClick })}
+          {renderNavList({ tabs, handleLinkClick: handleDropdownClick, activeTab })}
         </div>
       </div>
     </React.Fragment>


### PR DESCRIPTION
## WHAT
standardize hover states for tertiary navigation

## WHY
we want these to be consistent across all tertiary navigation items

## HOW
tweak CSS and navigation render helper method

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="566" alt="Screen Shot 2023-10-03 at 9 55 52 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/69dc31e1-c08b-483a-8ed0-134388c7b9a0">
<img width="657" alt="Screen Shot 2023-10-03 at 9 56 08 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/a1a99979-fd74-464d-ac67-afcb1b383550">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Hover-state-on-Tertiary-Level-Navigation-is-Inconsistent-Across-the-Site-d8b80e05504a471ba3c42a30a503508b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
