### PR TITLE
update max widths for admin report ui

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/data-export.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/data-export.scss
@@ -1,5 +1,4 @@
 .data-export-main {
-  padding: 32px 0px 32px 64px !important;
   max-width: calc(100% - 317px) !important;
 
   .data-export-container {
@@ -51,7 +50,6 @@
     }
 
     .preview-section {
-      padding-right: 64px;
 
       .preview-disclaimer-container {
         display: flex;
@@ -72,7 +70,7 @@
       border-radius: 8px;
       overflow-y: clip;
       overflow-x: auto;
-      width: calc(100% - 64px);
+      width: 100%;
 
       .data-table-headers {
         background-color: $quill-grey-1;

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/data-export.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/data-export.scss
@@ -2,11 +2,6 @@
   padding: 32px 0px 32px 64px !important;
   max-width: calc(100% - 317px) !important;
 
-  .header {
-    padding-right: 64px;
-    max-width: 1278px;
-  }
-
   .data-export-container {
     display: flex;
     flex-direction: column;

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/data-export.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/data-export.scss
@@ -21,27 +21,26 @@
 
     .fields-section {
       margin-top: 32px;
-      max-width: 1278px;
-      padding-right: 64px;
+      max-width: $sitewidepagewidth;
 
       .fields-container {
         display: flex;
         flex-wrap: wrap;
-        margin: 16px 0px 32px 0px;
+        margin: 16px 0px 32px;
+        gap: 8px;
 
         .checkbox-container {
           display: flex;
           flex: 1 0 16%;
           max-height: 35px;
           max-width: 165px;
-          min-width: 165px;
+          width: 100%;
           padding: 8px;
           align-items: center;
           gap: 8px;
           border-radius: 8px;
           border: 1px solid $quill-grey-5;
           background: $quill-grey-1;
-          margin: 0px 8px 8px 0px;
 
           label {
             font-weight: 400;

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
@@ -91,16 +91,16 @@
   main {
     padding: 32px 64px;
     border-left: 1px solid $quill-grey-5;
-    max-width: 1329px;
+    max-width: calc($sitewidepagewidth + 129px); // $sitewidepagewidth + 64px padding on both sides + 1 for border
     width: 100%;
     .header {
       display: flex;
       justify-content: space-between;
-      max-width: 1200px;
+      max-width: $sitewidepagewidth;
       width: 100%;
     }
     .sections {
-      max-width: 1200px;
+      max-width: $sitewidepagewidth;
       width: 100%;
     }
     h1 {

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
@@ -90,12 +90,18 @@
   }
   main {
     padding: 32px 64px;
-    width: 100%;
-    max-width: 1343px;
     border-left: 1px solid $quill-grey-5;
+    max-width: 1329px;
+    width: 100%;
     .header {
       display: flex;
       justify-content: space-between;
+      max-width: 1200px;
+      width: 100%;
+    }
+    .sections {
+      max-width: 1200px;
+      width: 100%;
     }
     h1 {
       font-weight: 700;


### PR DESCRIPTION
## WHAT
Update max widths for admin reports.

## WHY
To match the global header width.

## HOW
CSS.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/UI-Updates-Admin-Reports-Usage-Snapshot-Report-Set-Max-Width-of-Tables-to-1200pt-10bf135022284ec68ecf7120cb848c1f?pvs=4

https://www.notion.so/quill/UI-Updates-Admin-Reports-Pages-All-Set-H1-Block-Max-Width-to-1200pt-97798e167c36476e8c50c698a116d829?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Just CSS
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES