### PR TITLE
lms/make-view-as-student-scrollable

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -1294,7 +1294,8 @@
       }
     }
     .data-table {
-      height: calc(100% - 58px);
+      /* 90vh is the max-height of the modal, and 282px is the sum of the content in the non-'middle-section' parts of the modal */
+      height: calc(90vh - 282px);
     }
     .data-table-row:last-of-type {
       border-bottom: 1px solid $quill-grey-5 !important;


### PR DESCRIPTION
## WHAT
Update the dynamic `height` style calculation for the table
## WHY
The old heigh calculation looks like it wasn't working at all.  Maybe you can't use % designations inside of a vh designation (we use 90vh for the modal max-height)?  I'm not sure, and couldn't find any easily-accessible documentation on that particular interaction.  Anyway, this update seems to resolve the problem.
## HOW
Replace the old `calc` value used for `height` of the data-table element.  It appears the the old calculation was probably out of date anyway (subtracting `58px` was probably not enough for the current design), but using `100%` as the base value of the calculation didn't seem to actually do anything at all, no matter what was subtracted from it.  Using `90vh` (the max-height defined for the modal) as a basis for subtraction seems to work, though.

Note that there are a number of additional possible approaches to resolving this issue, but the presence of an existing style `height` rule with a `calc` value implies that this is the approach we intended at some point, so maintaining continuity with old intentions seemed reasonable to me.

### Notion Card Links
https://www.notion.so/quill/Teacher-is-not-able-to-scroll-through-the-students-in-the-View-as-student-form-d5799eac4e8f4099aa4234ec4beb8f2a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests for style
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
