### PR TITLE
Lms/admin snapshot front end retry

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -52,6 +52,10 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     getData()
   }, [searchCount])
 
+  React.useEffect(() => {
+    console.log(`retryTimeout set to ${retryTimeout}`)
+  }, [retryTimeout])
+
   function resetToDefault() {
     setCount(passedCount || null)
     setChangeDirection(passedChangeDirection || null)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -49,7 +49,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     resetToDefault()
 
     setRetryTimeout(setTimeout(getData, 20000))
-    getData()
+    getData(retryTimeout)
   }, [searchCount])
 
   React.useEffect(() => {
@@ -62,7 +62,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     setChange(passedChange || 0)
   }
 
-  function getData() {
+  function getData(retryTimeout) {
     const searchParams = {
       query: queryKey,
       timeframe: selectedTimeframe,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -74,7 +74,6 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     }
 
     requestPost(`/snapshots/count`, searchParams, (body) => {
-      console.log(`making API call for ${queryKey}`)
       if (!body.hasOwnProperty('results')) {
         setLoading(true)
       } else {
@@ -101,7 +100,6 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
           setChangeDirection(NONE)
         }
         if (retryTimeout) {
-          console.log(`clearing timeout for ${queryKey}`)
           clearTimeout(retryTimeout)
         }
         setLoading(false)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -49,10 +49,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     resetToDefault()
 
     getData()
-    setRetryTimeout(setTimeout(() => {
-      console.log('timeout-based retry')
-      getData
-    }, 1000))
+    setRetryTimeout(setTimeout(getData, 500))
   }, [searchCount])
 
   function resetToDefault() {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -49,7 +49,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     resetToDefault()
 
     getData()
-    setRetryTimeout(setTimeout(getData, 2000))
+    setRetryTimeout(setTimeout(getData, 20000))
   }, [searchCount])
 
   function resetToDefault() {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -74,7 +74,9 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
       grades: selectedGrades
     }
 
+    console.log(retryTimeout)
     requestPost(`/snapshots/count`, searchParams, (body) => {
+      console.log(retryTimeout)
       if (!body.hasOwnProperty('results')) {
         setLoading(true)
       } else {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -37,6 +37,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
   const [change, setChange] = React.useState(passedChange || 0)
   const [changeDirection, setChangeDirection] = React.useState(passedChangeDirection || null)
   const [loading, setLoading] = React.useState(false)
+  const [retryTimeout, setRetryTimeout] = React.useState(null)
 
   React.useEffect(() => {
     initializePusher()
@@ -48,6 +49,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     resetToDefault()
 
     getData()
+    setRetryTimeout(setTimeout(getData, 1000))
   }, [searchCount])
 
   function resetToDefault() {
@@ -94,6 +96,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
         } else {
           setChangeDirection(NONE)
         }
+        if (retryTimeout) clearTimeout(retryTimeout)
         setLoading(false)
       }
     })

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -96,7 +96,11 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
         } else {
           setChangeDirection(NONE)
         }
-        if (retryTimeout) clearTimeout(retryTimeout)
+        if (retryTimeout) {
+          console.log(retryTimeout)
+          console.log('clearing retryTimeout')
+          clearTimeout(retryTimeout)
+        }
         setLoading(false)
       }
     })

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -74,6 +74,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     }
 
     requestPost(`/snapshots/count`, searchParams, (body) => {
+      console.log(`making API call for ${queryKey}`)
       if (!body.hasOwnProperty('results')) {
         setLoading(true)
       } else {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -49,7 +49,10 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     resetToDefault()
 
     getData()
-    setRetryTimeout(setTimeout(getData, 1000))
+    setRetryTimeout(setTimeout(() => {
+      console.log('timeout-based retry')
+      getData
+    }, 1000))
   }, [searchCount])
 
   function resetToDefault() {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -48,8 +48,8 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
 
     resetToDefault()
 
-    getData()
     setRetryTimeout(setTimeout(getData, 20000))
+    getData()
   }, [searchCount])
 
   function resetToDefault() {
@@ -97,11 +97,11 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
           setChangeDirection(NONE)
         }
         if (retryTimeout) {
-          console.log(retryTimeout)
-          console.log('clearing retryTimeout')
+          console.log(`clearing retryTimeout for ${queryKey}`)
           clearTimeout(retryTimeout)
         }
         setLoading(false)
+        console.log(`loaded data for ${queryKey}`)
       }
     })
   }

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -96,6 +96,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
         } else {
           setChangeDirection(NONE)
         }
+        console.log(retryTimeout)
         if (retryTimeout) {
           console.log(`clearing retryTimeout for ${queryKey}`)
           clearTimeout(retryTimeout)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -74,7 +74,6 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     }
 
     requestPost(`/snapshots/count`, searchParams, (body) => {
-      console.log(retryTimeout)
       if (!body.hasOwnProperty('results')) {
         setLoading(true)
       } else {
@@ -100,13 +99,10 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
         } else {
           setChangeDirection(NONE)
         }
-        console.log(retryTimeout)
         if (retryTimeout) {
-          console.log(`clearing retryTimeout for ${queryKey}`)
           clearTimeout(retryTimeout)
         }
         setLoading(false)
-        console.log(`loaded data for ${queryKey}`)
       }
     })
   }

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -49,11 +49,10 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     resetToDefault()
 
     setRetryTimeout(setTimeout(getData, 20000))
-    getData(retryTimeout)
   }, [searchCount])
 
   React.useEffect(() => {
-    console.log(`retryTimeout set to ${retryTimeout}`)
+    if (retryTimeout) getData()
   }, [retryTimeout])
 
   function resetToDefault() {
@@ -62,7 +61,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     setChange(passedChange || 0)
   }
 
-  function getData(retryTimeout) {
+  function getData() {
     const searchParams = {
       query: queryKey,
       timeframe: selectedTimeframe,
@@ -74,7 +73,6 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
       grades: selectedGrades
     }
 
-    console.log(retryTimeout)
     requestPost(`/snapshots/count`, searchParams, (body) => {
       console.log(retryTimeout)
       if (!body.hasOwnProperty('results')) {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -100,6 +100,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
           setChangeDirection(NONE)
         }
         if (retryTimeout) {
+          console.log(`clearing timeout for ${queryKey}`)
           clearTimeout(retryTimeout)
         }
         setLoading(false)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -49,7 +49,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     resetToDefault()
 
     getData()
-    setRetryTimeout(setTimeout(getData, 500))
+    setRetryTimeout(setTimeout(getData, 2000))
   }, [searchCount])
 
   function resetToDefault() {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -71,6 +71,7 @@ const DataTable = ({ headers, data, numberOfRows, }) => {
 const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, passedData, pusherChannel, }: SnapshotRankingProps) => {
   const [data, setData] = React.useState(null)
   const [loading, setLoading] = React.useState(false)
+  const [retryTimeout, setRetryTimeout] = React.useState(null)
   const [showModal, setShowModal] = React.useState(false)
 
   React.useEffect(() => {
@@ -80,8 +81,12 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
   React.useEffect(() => {
     resetToDefault()
 
-    getData()
+    setRetryTimeout(setTimeout(getData, 20000))
   }, [searchCount])
+
+  React.useEffect(() => {
+    if (retryTimeout) getData()
+  }, [retryTimeout])
 
   function resetToDefault() {
     setData(passedData || null)
@@ -107,6 +112,9 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
         // We consider `null` to be a lack of data, so if the result is `[]` we need to explicitly `setData(null)`
         const data = results.length > 0 ? results : null
         setData(data)
+        if (retryTimeout) {
+          clearTimeout(retryTimeout)
+        }
         setLoading(false)
       }
     })


### PR DESCRIPTION
## WHAT
Add a bit of logic to retry Admin Snapshot data calls on the front-end if it takes more than 20 seconds for Pusher to trigger a data reload
## WHY
It looks like some amount of the time Pusher isn't properly triggering data reloads.  Even in these cases, it looks like the backend jobs are completing and the data is making it into cache, it's just not being reloaded so it appears as if the data never loads.  By using `setTimeout` we provide a fallback mechanism to load that data out of cache in these cases.
## HOW
- Add a new value to component to state to store a timeout ID
- Use a React effect to set a timeout on component initialization to `getData` 20 seconds after component initialization
- When processing data from API calls, if there is data, clear the `timeout` interval so that we don't trigger unnecessary API calls

### Notion Card Links
https://www.notion.so/quill/Add-a-front-end-retry-after-20s-for-Admin-Snapshot-queries-605032ace8d84a5fbc6fa6d592603277?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on this behavior
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
