### PR TITLE
Change styling and copy on Diagnostic Reports pages

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_growth_results_summary.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_growth_results_summary.scss
@@ -45,8 +45,6 @@
     }
   }
   .growth-element {
-    margin: 0 auto;
-    margin-top: 10px;
     padding: 8px;
     border-radius: 8px;
     font-size: 12px;
@@ -55,15 +53,23 @@
     img {
       margin-right: 4px;
     }
+    &.in-card.no-growth {
+      margin: 0 auto;
+      margin-top: 10px;
+      width: 80px;
+    }
+    &.in-card:not(.no-growth) {
+      margin: 0 auto;
+      margin-top: 10px;
+      width: 100px;
+    }
     &.no-growth {
       color: $quill-grey-50;
       background-color: $quill-grey-3;
-      width: 80px;
     }
     &:not(.no-growth) {
       color: $quill-green-vibrant;
       background-color: #b8db99;
-      width: 100px;
     }
   }
 

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_growth_results_summary.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_growth_results_summary.scss
@@ -34,12 +34,19 @@
       }
     }
     .card-footer {
-      display: flex;
+      display: block;
+      text-align: center;
+      margin: 0 auto;
       justify-content: space-between;
       align-items: center;
     }
+    .growth-tooltip {
+      margin: 0 auto;
+    }
   }
   .growth-element {
+    margin: 0 auto;
+    margin-top: 10px;
     padding: 8px;
     border-radius: 8px;
     font-size: 12px;
@@ -51,10 +58,12 @@
     &.no-growth {
       color: $quill-grey-50;
       background-color: $quill-grey-3;
+      width: 80px;
     }
     &:not(.no-growth) {
       color: $quill-green-vibrant;
       background-color: #b8db99;
+      width: 100px;
     }
   }
 

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_results_summary.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_results_summary.scss
@@ -27,7 +27,7 @@
   .skill-group-summary-card {
     max-width: 306px;
     width: 100%;
-    height: 252px;
+    height: 282px;
     padding: 16px;
     border-radius: 8px;
     border: solid 1px $quill-grey-5;
@@ -58,6 +58,7 @@
       margin: 0px auto 28px;
     }
     .need-practice-element {
+      font-weight: bold;
       font-size: 12px;
       line-height: 1.33;
       color: $quill-grey-50;

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_results_summary.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_results_summary.scss
@@ -27,7 +27,7 @@
   .skill-group-summary-card {
     max-width: 306px;
     width: 100%;
-    height: 282px;
+    height: 252px;
     padding: 16px;
     border-radius: 8px;
     border: solid 1px $quill-grey-5;
@@ -58,7 +58,6 @@
       margin: 0px auto 28px;
     }
     .need-practice-element {
-      font-weight: bold;
       font-size: 12px;
       line-height: 1.33;
       color: $quill-grey-50;
@@ -72,6 +71,9 @@
     .no-data-yet {
       margin-top: 80px;
     }
+  }
+  .post-diagnostic-summary-card {
+    height: 282px !important;
   }
   .no-data-yet {
     text-align: center;

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -93,10 +93,10 @@ class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean
     const { tooltipVisible, } = this.state
     const tabIndex = isTabbable ? 0 : null;
 
-    const triggerClass = `quill-tooltip-trigger ${tooltipVisible ? 'active' : ''}`
+    const triggerClass = `quill-tooltip-trigger growth-tooltip ${tooltipVisible ? 'active' : ''}`
 
     return (
-      <span
+      <div
         aria-hidden={!isTabbable}
         className={triggerClass}
         ref={node => this.tooltipTrigger = node}
@@ -124,7 +124,7 @@ class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean
             ref={node => this.tooltip = node}
           />
         </span>
-      </span>
+      </div>
     )
   }
 }

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -93,10 +93,10 @@ class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean
     const { tooltipVisible, } = this.state
     const tabIndex = isTabbable ? 0 : null;
 
-    const triggerClass = `quill-tooltip-trigger growth-tooltip ${tooltipVisible ? 'active' : ''}`
+    const triggerClass = `quill-tooltip-trigger ${tooltipVisible ? 'active' : ''}`
 
     return (
-      <div
+      <span
         aria-hidden={!isTabbable}
         className={triggerClass}
         ref={node => this.tooltipTrigger = node}
@@ -124,7 +124,7 @@ class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean
             ref={node => this.tooltip = node}
           />
         </span>
-      </div>
+      </span>
     )
   }
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
@@ -112,13 +112,13 @@ exports[`StudentResultsTable component should render when there is no student da
                 Compound-Complex Sentences
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Compound-Complex Sentences"
                 name="Compound-Complex Sentences"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Compound-Complex Sentences<br/><br/>null</p>"
+                  tooltipText="<p>Compound-Complex Sentences<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -173,13 +173,13 @@ exports[`StudentResultsTable component should render when there is no student da
                 Appositive Phrases
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Appositive Phrases"
                 name="Appositive Phrases"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Appositive Phrases<br/><br/>null</p>"
+                  tooltipText="<p>Appositive Phrases<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -234,13 +234,13 @@ exports[`StudentResultsTable component should render when there is no student da
                 Relative Clauses
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Relative Clauses"
                 name="Relative Clauses"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Relative Clauses<br/><br/>null</p>"
+                  tooltipText="<p>Relative Clauses<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -295,13 +295,13 @@ exports[`StudentResultsTable component should render when there is no student da
                 Participal Phrases
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Participal Phrases"
                 name="Participal Phrases"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Participal Phrases<br/><br/>null</p>"
+                  tooltipText="<p>Participal Phrases<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -356,13 +356,13 @@ exports[`StudentResultsTable component should render when there is no student da
                 Parallel Structure
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Parallel Structure"
                 name="Parallel Structure"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Parallel Structure<br/><br/>null</p>"
+                  tooltipText="<p>Parallel Structure<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -417,13 +417,13 @@ exports[`StudentResultsTable component should render when there is no student da
                 Advanced Combining
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Advanced Combining"
                 name="Advanced Combining"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Advanced Combining<br/><br/>null</p>"
+                  tooltipText="<p>Advanced Combining<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -478,13 +478,13 @@ exports[`StudentResultsTable component should render when there is no student da
                 Subject-Verb Agreement
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Subject-Verb Agreement"
                 name="Subject-Verb Agreement"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Subject-Verb Agreement<br/><br/>null</p>"
+                  tooltipText="<p>Subject-Verb Agreement<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -539,13 +539,13 @@ exports[`StudentResultsTable component should render when there is no student da
                 Nouns, Pronouns, and Verbs
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Nouns, Pronouns, and Verbs"
                 name="Nouns, Pronouns, and Verbs"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Nouns, Pronouns, and Verbs<br/><br/>null</p>"
+                  tooltipText="<p>Nouns, Pronouns, and Verbs<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -1646,13 +1646,13 @@ exports[`StudentResultsTable component should render when there is student data 
                 Capitalization
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Capitalization"
                 name="Capitalization"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Capitalization<br/><br/>null</p>"
+                  tooltipText="<p>Capitalization<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -1727,13 +1727,13 @@ exports[`StudentResultsTable component should render when there is student data 
                 Plural and Possessive Nouns
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Plural and Possessive Nouns"
                 name="Plural and Possessive Nouns"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Plural and Possessive Nouns<br/><br/>null</p>"
+                  tooltipText="<p>Plural and Possessive Nouns<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -1808,13 +1808,13 @@ exports[`StudentResultsTable component should render when there is student data 
                 Adjectives and Adverbs
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Adjectives and Adverbs"
                 name="Adjectives and Adverbs"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Adjectives and Adverbs<br/><br/>null</p>"
+                  tooltipText="<p>Adjectives and Adverbs<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -1889,13 +1889,13 @@ exports[`StudentResultsTable component should render when there is student data 
                 Prepositional Phrases
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Prepositional Phrases"
                 name="Prepositional Phrases"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Prepositional Phrases<br/><br/>null</p>"
+                  tooltipText="<p>Prepositional Phrases<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -1970,13 +1970,13 @@ exports[`StudentResultsTable component should render when there is student data 
                 Compound Subjects, Objects, and Predicates
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Compound Subjects, Objects, and Predicates"
                 name="Compound Subjects, Objects, and Predicates"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Compound Subjects, Objects, and Predicates<br/><br/>null</p>"
+                  tooltipText="<p>Compound Subjects, Objects, and Predicates<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"
@@ -2051,13 +2051,13 @@ exports[`StudentResultsTable component should render when there is student data 
                 Commonly Confused Words
               </span>
               <SkillGroupTooltip
-                description={null}
+                description="null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic."
                 key="Commonly Confused Words"
                 name="Commonly Confused Words"
               >
                 <Tooltip
                   isTabbable={true}
-                  tooltipText="<p>Commonly Confused Words<br/><br/>null</p>"
+                  tooltipText="<p>Commonly Confused Words<br/><br/>null<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \\"improved\\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \\"maintained\\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.</p>"
                   tooltipTriggerText={
                     <img
                       alt="Question mark icon"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummary.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummary.tsx
@@ -26,7 +26,7 @@ import DemoOnboardingTour, { DEMO_ONBOARDING_DIAGNOSTIC_GROWTH_SUMMARY, } from '
 import LoadingSpinner from '../../../shared/loading_indicator.jsx';
 
 function renderGrowthElement(delta: number, text: string) {
-  return delta > 0 ? <div className="growth-element">{triangleUpIcon}<span>{Math.round(delta)}{`% ${text}`}</span></div> : <div className="growth-element no-growth">No growth</div>
+  return delta > 0 ? <div className="growth-element in-card">{triangleUpIcon}<span>{Math.round(delta)}{`% ${text}`}</span></div> : <div className="growth-element in-card no-growth">No growth</div>
 }
 
 const SkillGroupSummaryCard = ({ skillGroupSummary, completedStudentCount }: { skillGroupSummary: SkillGroupSummary, completedStudentCount: number }) => {
@@ -87,7 +87,7 @@ const SkillGroupSummaryCard = ({ skillGroupSummary, completedStudentCount }: { s
   }
 
   return (
-    <section className="skill-group-summary-card">
+    <section className="skill-group-summary-card post-diagnostic-summary-card">
       <div className="card-header">
         <span className="skill-group-name">{name}</span>
         <SkillGroupTooltip description={description} name={name} />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummary.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummary.tsx
@@ -26,7 +26,7 @@ import DemoOnboardingTour, { DEMO_ONBOARDING_DIAGNOSTIC_GROWTH_SUMMARY, } from '
 import LoadingSpinner from '../../../shared/loading_indicator.jsx';
 
 function renderGrowthElement(delta: number, text: string) {
-  return delta > 0 ? <span className="growth-element">{triangleUpIcon}<span>{Math.round(delta)}{`% ${text}`}</span></span> : <span className="growth-element no-growth">No growth</span>
+  return delta > 0 ? <div className="growth-element">{triangleUpIcon}<span>{Math.round(delta)}{`% ${text}`}</span></div> : <div className="growth-element no-growth">No growth</div>
 }
 
 const SkillGroupSummaryCard = ({ skillGroupSummary, completedStudentCount }: { skillGroupSummary: SkillGroupSummary, completedStudentCount: number }) => {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummary.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummary.tsx
@@ -25,8 +25,9 @@ import {
 import DemoOnboardingTour, { DEMO_ONBOARDING_DIAGNOSTIC_GROWTH_SUMMARY, } from '../../../shared/demo_onboarding_tour';
 import LoadingSpinner from '../../../shared/loading_indicator.jsx';
 
-function renderGrowthElement(delta: number, text: string) {
-  return delta > 0 ? <div className="growth-element in-card">{triangleUpIcon}<span>{Math.round(delta)}{`% ${text}`}</span></div> : <div className="growth-element in-card no-growth">No growth</div>
+function renderGrowthElement(delta: number, text: string, inCard?: boolean) {
+  const cardClass = inCard ? 'in-card' : ''
+  return delta > 0 ? <div className={`growth-element ${cardClass}`}>{triangleUpIcon}<span>{Math.round(delta)}{`% ${text}`}</span></div> : <div className="growth-element in-card no-growth">No growth</div>
 }
 
 const SkillGroupSummaryCard = ({ skillGroupSummary, completedStudentCount }: { skillGroupSummary: SkillGroupSummary, completedStudentCount: number }) => {
@@ -42,7 +43,7 @@ const SkillGroupSummaryCard = ({ skillGroupSummary, completedStudentCount }: { s
     const delta = postProficiencyClassPercentage - preProficiencyClassPercentage
 
     let needPracticeElement = <span className="need-practice-element no-practice-needed">No practice needed</span>
-    const growthElement = renderGrowthElement(delta, 'growth')
+    const growthElement = renderGrowthElement(delta, 'growth', true)
 
     if (numberOfStudentsNeedingPracticeInPost) {
       const tooltipText = `<p>${not_yet_proficient_in_post_test_student_names.join('<br>')}</p>`
@@ -140,7 +141,7 @@ export const GrowthResults = ({ activityName, passedStudentResults, passedSkillG
     return(
       <section className="lower-header-section">
         <span className="activity-name">{`${activityDisplayedName}:`}</span>
-        {renderGrowthElement(classwideGrowthDisplayedAverage, 'Class-wide skill growth')}
+        {renderGrowthElement(classwideGrowthDisplayedAverage, 'Class-wide skill growth', false)}
       </section>
     )
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummary.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/growthSummary.tsx
@@ -46,7 +46,7 @@ const SkillGroupSummaryCard = ({ skillGroupSummary, completedStudentCount }: { s
 
     if (numberOfStudentsNeedingPracticeInPost) {
       const tooltipText = `<p>${not_yet_proficient_in_post_test_student_names.join('<br>')}</p>`
-      const tooltipTriggerText = numberOfStudentsNeedingPracticeInPost === 1 ? "1 student needs practice" : `${numberOfStudentsNeedingPracticeInPost} students need practice`
+      const tooltipTriggerText = numberOfStudentsNeedingPracticeInPost === 1 ? "1 student recommended practice" : `${numberOfStudentsNeedingPracticeInPost} students recommended practice`
       needPracticeElement = (<Tooltip
         tooltipText={tooltipText}
         tooltipTriggerText={tooltipTriggerText}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
@@ -27,7 +27,7 @@ import {
   Tooltip,
 } from '../../../../../Shared/index'
 
-const POST_TEST_DESCRIPTION = '\nThe number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \"improved\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \"maintained\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic. \n\n\nThe up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.'
+const POST_TEST_DESCRIPTION = '<br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \"improved\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \"maintained\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.'
 
 interface StudentResultsTableProps {
   skillGroupSummaries: SkillGroupSummary[];

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
@@ -27,7 +27,7 @@ import {
   Tooltip,
 } from '../../../../../Shared/index'
 
-const POST_TEST_DESCRIPTION = '\nThe number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \"improved\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \"maintained\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic. \nThe up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.'
+const POST_TEST_DESCRIPTION = '\nThe number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \"improved\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \"maintained\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic. \n\n\nThe up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.'
 
 interface StudentResultsTableProps {
   skillGroupSummaries: SkillGroupSummary[];

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
@@ -27,6 +27,7 @@ import {
   Tooltip,
 } from '../../../../../Shared/index'
 
+const POST_TEST_DESCRIPTION = '\nThe number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \"improved\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \"maintained\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic. \nThe up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.'
 
 interface StudentResultsTableProps {
   skillGroupSummaries: SkillGroupSummary[];
@@ -241,13 +242,14 @@ const StudentResultsTable = ({ isPreTest, skillGroupSummaries, studentResults, o
 
   const tableHeaders = skillGroupSummaries.map(skillGroupSummary => {
     const { name, description, gained_proficiency_in_post_test_student_names, not_yet_proficient_student_names } = skillGroupSummary
+    const appendedDescription = isPreTest ? description : description + POST_TEST_DESCRIPTION
     const notYetProficientStudentCount = isPreTest && not_yet_proficient_student_names.length
     const proficientStudentCount = isPreTest ? completedStudentCount - notYetProficientStudentCount : gained_proficiency_in_post_test_student_names.length
     return (
       <th className="skill-group-header" key={name}>
         <div className="name-and-tooltip">
           <span className="skill-name">{name}</span>
-          <SkillGroupTooltip description={description} key={name} name={name} />
+          <SkillGroupTooltip description={appendedDescription} key={name} name={name} />
         </div>
         {renderCountData({ completedStudentCount, proficientStudentCount })}
       </th>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
@@ -27,7 +27,7 @@ import {
   Tooltip,
 } from '../../../../../Shared/index'
 
-const POST_TEST_DESCRIPTION = '<br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \"improved\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \"maintained\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.'
+const POST_TEST_DESCRIPTION = '<br/><br/>The number of students who improved or maintained this skill shows you how many students had a positive outcome for this skill area on the post-diagnostic. Students who \"improved\" the skill showed growth by answering more capitalization questions correctly on the post-diagnostic than they did on the pre. Students who \"maintained\" the skill showed proficiency by answering all capitalization questions correctly on both the pre and the post-diagnostic.<br/><br/>The up arrow and number following it focuses just on growth between diagnostics. It shows you how many students improved in the skill from pre to post-diagnostic, not including students who had already shown proficiency in the skill on the pre-diagnostic.'
 
 interface StudentResultsTableProps {
   skillGroupSummaries: SkillGroupSummary[];

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/summary.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/summary.tsx
@@ -33,7 +33,7 @@ const SkillGroupSummaryCard = ({ skillGroupSummary, completedStudentCount }) => 
 
     if (numberOfStudentsNeedingPractice) {
       const tooltipText = `<p>${not_yet_proficient_student_names.join('<br>')}</p>`
-      const tooltipTriggerText = numberOfStudentsNeedingPractice === 1 ? "1 student needs practice" : `${numberOfStudentsNeedingPractice} students need practice`
+      const tooltipTriggerText = numberOfStudentsNeedingPractice === 1 ? "1 student recommended practice" : `${numberOfStudentsNeedingPractice} students recommended practice`
       needPracticeElement = (<Tooltip
         tooltipText={tooltipText}
         tooltipTriggerText={tooltipTriggerText}


### PR DESCRIPTION
## WHAT
-Add extra copy to tooltips for post-diagnostic reports.
-Change copy on reports and modify styling to accommodate more copy in buttons.

## WHY
We want the reports to be more detailed and informative.

## HOW
Change the copy on some of the reports and modify styling, including changing one span element to a div, to accommodate longer copy on some of the buttons in Post-Diagnostic reports.

### Screenshots
<img width="650" alt="Screenshot 2023-10-06 at 5 10 42 PM" src="https://github.com/empirical-org/Empirical-Core/assets/57366100/06249ad8-7a01-4503-b95c-0e10c55773e0">
<img width="479" alt="Screenshot 2023-10-06 at 5 11 44 PM" src="https://github.com/empirical-org/Empirical-Core/assets/57366100/5a27d8d4-219a-44ea-8d86-051cc86f6310">





### Notion Card Links
https://www.notion.so/quill/Class-Summary-Update-Students-Recommended-Practice-Toggle-ade430562eb24ab18f8c634819c6500d?pvs=4
https://www.notion.so/quill/Follow-Up-Project-Update-the-Copy-for-Each-Diagnostic-Skill-Group-to-Explain-What-the-Improvement--7f99633163da4ad18138b0c4965e9f3c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
