### PR TITLE
Lms/send pusher in sidekiq job

### DIFF
--- a/services/QuillLMS/app/workers/canvas_integration/import_teacher_classrooms_students_worker.rb
+++ b/services/QuillLMS/app/workers/canvas_integration/import_teacher_classrooms_students_worker.rb
@@ -13,9 +13,9 @@ module CanvasIntegration
 
       if teacher.canvas_authorized?
         TeacherClassroomsStudentsImporter.run(teacher, selected_classroom_ids)
-        PusherTrigger.run(teacher_id, PUSHER_EVENT, "Canvas classroom students imported for #{teacher_id}.")
+        SendPusherMessageWorker.perform_async(teacher_id, PUSHER_EVENT, "Canvas classroom students imported for #{teacher_id}.")
       else
-        PusherTrigger.run(teacher_id, PUSHER_FAILED_EVENT, "Reauthorization needed for user #{teacher_id}.")
+        SendPusherMessageWorker.perform_async(teacher_id, PUSHER_FAILED_EVENT, "Reauthorization needed for user #{teacher_id}.")
       end
     rescue => e
       ErrorNotifier.report(e)

--- a/services/QuillLMS/app/workers/clever_integration/import_teacher_classrooms_students_worker.rb
+++ b/services/QuillLMS/app/workers/clever_integration/import_teacher_classrooms_students_worker.rb
@@ -13,9 +13,9 @@ module CleverIntegration
 
       if teacher.clever_authorized?
         TeacherClassroomsStudentsImporter.run(teacher, selected_classroom_ids)
-        PusherTrigger.run(teacher_id, PUSHER_EVENT, "Clever classroom students imported for #{teacher_id}.")
+        SendPusherMessageWorker.perform_async(teacher_id, PUSHER_EVENT, "Clever classroom students imported for #{teacher_id}.")
       else
-        PusherTrigger.run(teacher_id, PUSHER_FAILED_EVENT, "Reauthorization needed for user #{teacher_id}.")
+        SendPusherMessageWorker.perform_async(teacher_id, PUSHER_FAILED_EVENT, "Reauthorization needed for user #{teacher_id}.")
       end
     rescue => e
       ErrorNotifier.report(e)

--- a/services/QuillLMS/app/workers/google_integration/import_teacher_classrooms_students_worker.rb
+++ b/services/QuillLMS/app/workers/google_integration/import_teacher_classrooms_students_worker.rb
@@ -13,9 +13,9 @@ module GoogleIntegration
 
       if teacher.google_authorized?
         TeacherClassroomsStudentsImporter.run(teacher, selected_classroom_ids)
-        PusherTrigger.run(teacher_id, PUSHER_EVENT, "Google classroom students imported for #{teacher_id}.")
+        SendPusherMessageWorker.perform_async(teacher_id, PUSHER_EVENT, "Google classroom students imported for #{teacher_id}.")
       else
-        PusherTrigger.run(teacher_id, PUSHER_FAILED_EVENT, "Reauthorization needed for user #{teacher_id}.")
+        SendPusherMessageWorker.perform_async(teacher_id, PUSHER_FAILED_EVENT, "Reauthorization needed for user #{teacher_id}.")
       end
     rescue => e
       ErrorNotifier.report(e)

--- a/services/QuillLMS/app/workers/send_pusher_message_worker.rb
+++ b/services/QuillLMS/app/workers/send_pusher_message_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SendPusherMessageWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
+  def perform(user_id, pusher_event, payload = nil)
+    return unless user_id and pusher_event
+
+    PusherTrigger.run(user_id, pusher_event, payload)
+  end
+end

--- a/services/QuillLMS/app/workers/send_pusher_message_worker.rb
+++ b/services/QuillLMS/app/workers/send_pusher_message_worker.rb
@@ -5,7 +5,7 @@ class SendPusherMessageWorker
   sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
 
   def perform(user_id, pusher_event, payload = nil)
-    return unless user_id and pusher_event
+    return unless user_id && pusher_event
 
     PusherTrigger.run(user_id, pusher_event, payload)
   end

--- a/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
@@ -14,7 +14,7 @@ module Snapshots
       payload = generate_payload(query, timeframe, school_ids, filters)
       Rails.cache.write(cache_key, payload.to_a, expires_in: cache_expiry)
 
-      PusherTrigger.run(user_id, PUSHER_EVENT,
+      SendPusherMessageWorker.perform_async(user_id, PUSHER_EVENT,
         {
           query: query,
           timeframe: timeframe['name'],

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -35,7 +35,7 @@ module Snapshots
 
       Rails.cache.write(cache_key, payload, expires_in: cache_expiry)
 
-      PusherTrigger.run(user_id, PUSHER_EVENT,
+      SendPusherMessageWorker.perform_async(user_id, PUSHER_EVENT,
         {
           query: query,
           timeframe: timeframe['name'],

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -23,7 +23,7 @@ module Snapshots
 
       Rails.cache.write(cache_key, payload.to_a, expires_in: cache_expiry)
 
-      PusherTrigger.run(user_id, PUSHER_EVENT,
+      SendPusherMessageWorker.perform_async(user_id, PUSHER_EVENT,
         {
           query: query,
           timeframe: timeframe['name'],

--- a/services/QuillLMS/spec/workers/send_pusher_message_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/send_pusher_message_worker_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SendPusherMessageWorker do
+  subject { described_class.new }
+
+  describe '#perform' do
+    let(:user_id) { 1 }
+    let(:event_name) { "PusherTestEvent" }
+    let(:payload) { "test payload" }
+    let(:perform) { subject.perform(user_id, event_name, payload) }
+
+    it do
+      expect(PusherTrigger).to receive(:run).with(user_id, event_name, payload)
+      perform
+    end
+
+    context 'no valid user_id' do
+      let(:user_id) { nil }
+
+      it do
+        expect(PusherTrigger).not_to receive(:run)
+        perform
+      end
+    end
+
+    context 'no valid event_name' do
+      let(:event_name) { nil }
+
+      it do
+        expect(PusherTrigger).not_to receive(:run)
+        perform
+      end
+    end
+
+    context 'no specified payload' do
+      let(:perform) { subject.perform(user_id, event_name) }
+
+      it do
+        expect(PusherTrigger).to receive(:run).with(user_id, event_name, nil)
+        perform
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
@@ -64,14 +64,14 @@ module Snapshots
       it 'should execute a query for the timeframe' do
         expect(query_double).to receive(:run).with(expected_query_args)
         expect(Rails.cache).to receive(:write)
-        expect(PusherTrigger).to receive(:run)
+        expect(SendPusherMessageWorker).to receive(:perform_async)
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters)
       end
 
       context 'serialization/deserialization' do
         it 'should deserialize timeframes back into DateTimes' do
-          allow(PusherTrigger).to receive(:run)
+          allow(SendPusherMessageWorker).to receive(:perform_async)
           Sidekiq::Testing.inline! do
             expect(query_double).to receive(:run).with(expected_query_args)
 
@@ -84,7 +84,7 @@ module Snapshots
         it 'should execute a query for the timeframe' do
           expect(query_double).to receive(:run).with(expected_query_args)
           expect(Rails.cache).to receive(:write)
-          expect(PusherTrigger).to receive(:run)
+          expect(SendPusherMessageWorker).to receive(:perform_async)
 
           subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys)
         end
@@ -98,14 +98,14 @@ module Snapshots
 
         expect(query_double).to receive(:run).and_return(payload)
         expect(Rails.cache).to receive(:write).with(cache_key, payload, expires_in: cache_ttl)
-        expect(PusherTrigger).to receive(:run)
+        expect(SendPusherMessageWorker).to receive(:perform_async)
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters)
       end
 
       it 'should send a Pusher notification' do
         expect(Rails.cache).to receive(:write)
-        expect(PusherTrigger).to receive(:run).with(user_id, described_class::PUSHER_EVENT, {
+        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::PUSHER_EVENT, {
           query: query,
           timeframe: timeframe_name,
           school_ids: school_ids

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
@@ -64,14 +64,14 @@ module Snapshots
       it 'should execute a query for the timeframe' do
         expect(query_double).to receive(:run).with(expected_query_args)
         expect(Rails.cache).to receive(:write)
-        expect(PusherTrigger).to receive(:run)
+        expect(SendPusherMessageWorker).to receive(:perform_async)
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters)
       end
 
       context 'serialization/deserialization' do
-        it 'should desieralize timeframes back into DateTimes' do
-          allow(PusherTrigger).to receive(:run)
+        it 'should deserialize timeframes back into DateTimes' do
+          allow(SendPusherMessageWorker).to receive(:perform_async)
           Sidekiq::Testing.inline! do
             expect(query_double).to receive(:run).with(expected_query_args)
 
@@ -84,7 +84,7 @@ module Snapshots
         it 'should execute a query for the timeframe' do
           expect(query_double).to receive(:run).with(expected_query_args)
           expect(Rails.cache).to receive(:write)
-          expect(PusherTrigger).to receive(:run)
+          expect(SendPusherMessageWorker).to receive(:perform_async)
 
           subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys)
         end
@@ -98,14 +98,14 @@ module Snapshots
 
         expect(query_double).to receive(:run).and_return(payload)
         expect(Rails.cache).to receive(:write).with(cache_key, payload, expires_in: cache_ttl)
-        expect(PusherTrigger).to receive(:run)
+        expect(SendPusherMessageWorker).to receive(:perform_async)
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters)
       end
 
       it 'should send a Pusher notification' do
         expect(Rails.cache).to receive(:write)
-        expect(PusherTrigger).to receive(:run).with(user_id, described_class::PUSHER_EVENT, {
+        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::PUSHER_EVENT, {
           query: query,
           timeframe: timeframe_name,
           school_ids: school_ids


### PR DESCRIPTION
## WHAT
Use a separate Sidekiq job to send Pusher notifications for other Sidekiq jobs
## WHY
Currently, if an error happens when sending a Pusher notification in a Sidekiq job, the error will trigger a retry of the entire job, even if it's expensive.  In cases where everything in the job worked except for the Pusher call, we don't want to retry the entire job.  By separating the Pusher message into its own worker we isolate errors and retry logic.
## HOW
- Create a new Sidekiq worker to send Pusher messages
- Update all existing Sidekiq workers that call `PusherTrigger.run` to enqueue an instance of the new `SendPusherMessageWorker` Sidekiq worker

### Notion Card Links
https://www.notion.so/quill/Do-Admin-Snapshot-Pusher-notification-sends-in-a-separate-Sidekiq-job-53d255a94ce0438caec44e4f0e14c8ea?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
