### PR TITLE
Re-style Empty Progress Reports page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/empty_progress_report.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/empty_progress_report.scss
@@ -1,26 +1,27 @@
 .empty-progress-report {
-  max-width: 500px;
+  max-width: 700px;
   width: 100%;
-  margin: 55px auto 30px;
+  margin: 128px auto 30px;
   text-align: center;
-  h1 {
-    margin: 35px 0px 20px;
-    font-size: 30px;
-    font-weight: 600;
-    color: $quill-black;
+  h2 {
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 26.08px;
+    margin-bottom: 8px;
   }
   p {
-    font-size: 20px;
+    font-weight: 400;
+    font-size: 14px;
     line-height: 1.3;
-    color: $quill-black;
+    color: $quill-grey-50;
   }
   button {
     display: block;
-    margin: 30px auto 25px;
+    margin: 30px auto 18px;
   }
   a {
-    font-size: 16px;
-    color: #00c2a2;
-    border-bottom: 2px solid #00c2a2;
+    font-size: 14px;
+    font-weight: 500;
+    color: $quill-green;
   }
 }

--- a/services/QuillLMS/app/assets/stylesheets/pages/empty_progress_report.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/empty_progress_report.scss
@@ -21,7 +21,7 @@
   }
   a {
     font-size: 14px;
-    font-weight: 500;
+    font-weight: 600;
     color: $quill-green;
   }
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/shared/EmptyProgressReport.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/shared/EmptyProgressReport.jsx
@@ -33,10 +33,9 @@ export default class extends React.Component {
       content = 'In order to access our different reports, you need to create a class and assign activities to your students.'
     } return (
       <div className="empty-progress-report">
-        <img alt="" src='/images/empty_state_illustration.png' />
-        <h1>{title}</h1>
+        <h2>{title}</h2>
         <p>{content}</p>
-        <button className="button-green create-unit featured-button" onClick={onButtonClick}>{buttonText}</button>
+        <button className="quill-button fun primary contained create-unit featured-button" onClick={onButtonClick} type="button">{buttonText}</button>
         <a href="/teacher-center">Teacher Center</a>
       </div>
     );


### PR DESCRIPTION
## WHAT
Updates to the styling on empty progress reports text and buttons/links.

## WHY
We want the whole website to accord with the new design language.

## HOW
Change up the CSS and a little bit of the html to match with the new styling rules.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Updated-UI-Needed-for-My-Reports-Activity-Summary-Page-Empty-State-bbf0f57f02894de0b2330812eb3c66dd?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
