### PR TITLE
update fill in the blanks concept results file to use shared function

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/fillInTheBlanks.js
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/conceptResults/fillInTheBlanks.js
@@ -1,39 +1,18 @@
+import { getConceptResultsForAttempt } from './sharedConceptResultsFunctions';
+
 import { hashToCollection, } from '../../../Shared/index';
 import { formattedCues } from '../formattedCues';
 
 export function getConceptResultsForFillInTheBlanks(question) {
-  const prompt = question.prompt.replace(/(<([^>]+)>)/ig, '').replace(/&nbsp;/ig, '');
-  let answer = question.attempts[0].submitted;
-  let conceptResults = [];
-  const responseObject = question.attempts[0].response;
-  if (responseObject) {
-    const conceptResultObject = responseObject.conceptResults || responseObject.concept_results
-    conceptResults = hashToCollection(conceptResultObject) || [];
-    answer = responseObject.text;
-  } else {
-    conceptResults = [];
-  }
-  if (conceptResults.length === 0) {
-    conceptResults = [{
-      conceptUID: question.conceptID,
-      correct: false,
-    }];
-  }
-  let directions = question.instructions || 'Fill in the blanks.';
+  const nestedConceptResults = question.attempts.map((attempt, index) => getConceptResultsForFillInTheBlanksAttempt(question, index));
+  return [].concat.apply([], nestedConceptResults); // Flatten nested Array
+}
+
+export function getConceptResultsForFillInTheBlanksAttempt(question, attemptIndex) {
+  let directions = question.instructions || 'Fill in the blanks.'
+
   if (question.cues && question.cues[0] !== '') {
     directions += ` ${formattedCues(question.cues)}`;
   }
-  return conceptResults.map((conceptResult, i) => ({
-    concept_uid: conceptResult.conceptUID,
-    question_type: 'fill-in-the-blanks',
-    metadata: {
-      correct: conceptResult.correct ? 1 : 0,
-      directions,
-      prompt,
-      answer,
-      attemptNumber: i + 1,
-      question_uid: question.key,
-      question_concept_uid: question.conceptID
-    },
-  }));
+  return getConceptResultsForAttempt(question, attemptIndex, 'fill-in-the-blanks', directions);
 }


### PR DESCRIPTION
## WHAT
Update fill in the blanks concept results file in Connect to use the shared concept results function.

## WHY
The existing file was written to only ever pass concept results from a question's first attempt. It doesn't look like it ever worked differently, but this is definitely not the behavior we want.

## HOW
Just pass data through to the shared functions and manually test both the normal and the turk flows to make sure things still work as expected.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fill-in-the-Blank-scoring-issue-9b74222d486c437e8e04fcec893f2411

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES