### PR TITLE
Add rake task for updating missing labels

### DIFF
--- a/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
+++ b/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
@@ -102,6 +102,8 @@ namespace :vertex_ai  do
       Evidence::AutomlModel
         .where(id: new_model.id)
         .update_all(labels: old_labels)
+
+      new_model.activate
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
+++ b/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
@@ -93,17 +93,30 @@ namespace :vertex_ai  do
       SQL
     ).to_a
 
+    ids = []
+
     old_models.each do |old_model|
       old_labels = old_model['labels'].tr('{}', '').split(',')
       new_model = Evidence::AutomlModel.find_by(state: 'active', prompt_id: old_model['prompt_id'])
       next if new_model.nil?
 
+      p [new_model.id, new_model.labels.count, new_model.state]
       # bypass attr_readonly on labels
       Evidence::AutomlModel
         .where(id: new_model.id)
         .update_all(labels: old_labels)
 
-      new_model.activate
+      ids << new_model.id
+
+      p [new_model.id, new_model.labels.count, new_model.state]
+    end
+
+    ids.each do |id|
+      automl_model = Evidence::AutomlModel.find(id)
+      p [automl_model.id, automl_model.state]
+      automl_model.activate
+      automl_model.reload
+      p [automl_model.id, automl_model.state]
     end
   end
 end


### PR DESCRIPTION
## WHAT
Add some missing labels to some `Evidence::AutomlModel` records.

## WHY
The newer VertexAI platform [calls](https://github.com/empirical-org/Empirical-Core/pull/11077/files#diff-c21102ad7b2c166705578e0e8a39a45e0f2cbe4e9947188a210f9800b8cd9789R43) to list_model_evaluation doesn't seem to give more than 10 labels unlike the previous Automl platform [calls](https://github.com/empirical-org/Empirical-Core/pull/11077/files#diff-70439603968f8c630250eb1ac42b66c2103f93439e33c71d664b83536a7f4e4aL155).

However, some models have more than 10 labels so we need to fill those in.

## HOW
Go back through the older table `comprehension.automl_models` and link the prompt_id with the newer table `evidence.automl_models`.  Find those older models with more than 10 labels and assign them to the corresponding `Evidence::AutomlModel` record. 

Notes for confirming the correct update are [here](https://www.notion.so/quill/Vertex-AI-missing-labels-c18fa42cda7a45d2a6f092b8edcd2218?pvs=4)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Vertex-AI-missing-labels-c18fa42cda7a45d2a6f092b8edcd2218?pvs=4


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Data update.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
