### PR TITLE
update color hexes for quill-dark-gold-50 and quill-gold-50

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/variables.scss
+++ b/services/QuillLMS/app/assets/stylesheets/variables.scss
@@ -84,14 +84,14 @@ $quill-maroon-5: #FCEAE1;
 $quill-maroon-1: #FDF5F0;
 
 $quill-gold: #DF9E3D;
-$quill-gold-50: #F8A823;
+$quill-gold-50: #ECB55A;
 $quill-gold-20: #FFD999;
 $quill-gold-10: #FCE3BD;
 $quill-gold-5: #FFEFD6;
 $quill-gold-1: #FFF9EF;
 
 $quill-gold-dark: #9F6405;
-$quill-gold-dark-50: #C97C00;
+$quill-gold-dark-50: #C38D33;
 $quill-gold-dark-20: #E3BB7A;
 $quill-gold-dark-10: #E4D0B0;
 $quill-gold-dark-5: #F6E9D5;


### PR DESCRIPTION
## WHAT
Update color hexes.

## WHY
Jack requested this change.

## HOW
Just update them in the global variable file (so easy!)

### Screenshots
<img width="750" alt="Screenshot 2023-10-11 at 10 34 49 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/1f56e34b-d940-4fea-a543-ab7b990e094e">


### Notion Card Links
https://www.notion.so/quill/Update-Quill-Color-Palette-Quill-Gold-50-Quill-Gold-Dark-50-556a23db80684ad3b583d4d205921135

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES