### PR TITLE
update the font we use to display responses for internal tools

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
@@ -507,7 +507,7 @@ export default class Response extends React.Component<ResponseProps, ResponseSta
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><span style={{ whiteSpace: 'pre-wrap' }}>{response.text}</span> {author}</p>
+                <p><pre>{response.text}</pre> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.jsx
@@ -415,7 +415,7 @@ export default class extends React.Component {
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><span style={{ whiteSpace: 'pre-wrap' }}>{response.text}</span> {author}</p>
+                <p><pre>{response.text}</pre> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
@@ -414,7 +414,7 @@ export default class extends React.Component<ResponseProps, ResponseState> {
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><span style={{ whiteSpace: 'pre-wrap' }}>{response.text}</span> {author}</p>
+                <p><pre>{response.text}</pre> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Shared/styles/internal_tool.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/internal_tool.scss
@@ -1,0 +1,8 @@
+.content .media-content {
+  pre {
+    padding: 0px;
+    display: inline;
+    background-color: inherit;
+    white-space: pre-wrap;
+  }
+}

--- a/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
@@ -25,6 +25,7 @@
 @import './video_players.scss';
 @import './notification_bar.scss';
 @import './dropdown_input_with_search_tokens.scss';
+@import './internal_tool';
 @import "~react-select-search/style.css";
 
 #main-content {


### PR DESCRIPTION
## WHAT
Update the font we use to display responses for the internal tools.

## WHY
The font we used wasn't differentiating between two apostrophes (`''`) and one set of quotation marks (`"`), making it appear that responses were incorrectly being given the Punctuation Rule when in fact that was correct.

## HOW
Just change the HTML tag to `pre` and use some CSS.

### Screenshots
<img width="914" alt="Screenshot 2023-10-11 at 10 26 39 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/855e3a74-d2e8-4179-9644-e5b852d584c9">


### Notion Card Links
https://www.notion.so/quill/Issues-with-quotation-marks-in-Quill-Grammar-5472e8d80e954e6a8866b522469e4cab?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - visual only
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES