### PR TITLE
Add retry logic for Vertex AI predict call

### DIFF
--- a/services/QuillLMS/engines/evidence/app/services/evidence/vertex_ai/text_classifier.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/vertex_ai/text_classifier.rb
@@ -8,7 +8,7 @@ module Evidence
       PREDICT_API_TIMEOUT = 5.0
 
       PREDICTION_EXCEPTION_CLASSES = [Google::Cloud::InternalError, Google::Cloud::UnknownError]
-      PREDICTION_NUM_RETRIES = 2
+      PREDICTION_NUM_RETRIES = 1
 
       attr_reader :endpoint_external_id, :text
 
@@ -80,7 +80,9 @@ module Evidence
           yield
         rescue *exception_classes => e
           num_retries += 1
-          num_retries <= max_num_retries ? retry : raise(e)
+          retry if num_retries <= max_num_retries
+
+          raise e
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/vertex_ai/text_classifier_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/vertex_ai/text_classifier_spec.rb
@@ -11,34 +11,33 @@ module Evidence
       let(:prediction_client_class) { ::Google::Cloud::AIPlatform::V1::PredictionService::Client }
       let(:prediction_client) { instance_double(prediction_client_class) }
       let(:text) { 'some text' }
+      let(:labels) { ['Label1', 'Label2', 'Label3'] }
+      let(:display_name_values) { labels.map { |label| ::Google::Protobuf::Value.new(string_value: label) } }
+      let(:display_name_list_value) { ::Google::Protobuf::ListValue.new(values: display_name_values) }
+
+      let(:scores) { [0.4, 0.9, 0.8] }
+      let(:confidence_values) { scores.map { |score| Google::Protobuf::Value.new(number_value: score) } }
+      let(:confidence_list_value) { ::Google::Protobuf::ListValue.new(values: confidence_values) }
+
+      let(:top_score_index) { scores.each_with_index.max[1] }
+      let(:label) { labels[top_score_index] }
+      let(:score) { scores[top_score_index] }
+
+      let(:results) do
+        {
+          'confidences' => ::Google::Protobuf::Value.new(list_value: confidence_list_value),
+          'displayNames' => ::Google::Protobuf::Value.new(list_value: display_name_list_value)
+        }
+      end
+
+      let(:prediction) { ::Google::Protobuf::Value.new(struct_value: { fields: results }) }
+      let(:prediction_response) { ::Google::Cloud::AIPlatform::V1::PredictResponse.new(predictions: [prediction]) }
+      let(:endpoint) { described_class.new(endpoint_external_id, '').send(:endpoint) }
+      let(:instances) { [::Google::Protobuf::Value.new(struct_value: { fields: { content: { string_value: text } } })] }
 
       before { allow(prediction_client_class).to receive(:new).and_return(prediction_client) }
 
       context 'successful prediction' do
-        let(:labels) { ['Label1', 'Label2', 'Label3'] }
-        let(:display_name_values) { labels.map { |label| ::Google::Protobuf::Value.new(string_value: label) } }
-        let(:display_name_list_value) { ::Google::Protobuf::ListValue.new(values: display_name_values) }
-
-        let(:scores) { [0.4, 0.9, 0.8] }
-        let(:confidence_values) { scores.map { |score| Google::Protobuf::Value.new(number_value: score) } }
-        let(:confidence_list_value) { ::Google::Protobuf::ListValue.new(values: confidence_values) }
-
-        let(:top_score_index) { scores.each_with_index.max[1] }
-        let(:label) { labels[top_score_index] }
-        let(:score) { scores[top_score_index] }
-
-        let(:results) do
-          {
-            'confidences' => ::Google::Protobuf::Value.new(list_value: confidence_list_value),
-            'displayNames' => ::Google::Protobuf::Value.new(list_value: display_name_list_value)
-          }
-        end
-
-        let(:prediction) { ::Google::Protobuf::Value.new(struct_value: { fields: results }) }
-        let(:prediction_response) { ::Google::Cloud::AIPlatform::V1::PredictResponse.new(predictions: [prediction]) }
-        let(:endpoint) { described_class.new(endpoint_external_id, '').send(:endpoint) }
-        let(:instances) { [::Google::Protobuf::Value.new(struct_value: { fields: { content: { string_value: text } } })] }
-
         before do
           allow(prediction_client)
             .to receive(:predict)
@@ -55,6 +54,34 @@ module Evidence
         before { allow(prediction_client).to receive(:predict).and_raise(error) }
 
         it { expect { subject }.to raise_error(error) }
+
+        described_class::PREDICTION_EXCEPTION_CLASSES.each do |error_class|
+          context "with #{error_class}" do
+            let(:error) { error_class.new }
+
+            before do
+              call_count = 0
+              allow(prediction_client).to receive(:predict) do
+                call_count += 1
+                call_count == 1 ? raise(error): prediction_response
+              end
+            end
+
+            it 'retries once and does not raise error' do
+              expect { subject }.not_to raise_error
+            end
+          end
+        end
+
+        context 'with persistent errors' do
+          let(:error) { Google::Cloud::InternalError.new }
+
+          before { allow(prediction_client).to receive(:predict).and_raise(error) }
+
+          it 'raises the error after retrying' do
+            expect { subject }.to raise_error(error)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## WHAT
Add some retry logic for [Google::Cloud::InternalError](https://quillorg-5s.sentry.io/issues/?environment=production&project=11238&query=is%3Aunresolved+%22Google%3A%3ACloud%3A%3AInternalError%22&referrer=issue-list&statsPeriod=24h) and [Google::Cloud::UnknownError](https://quillorg-5s.sentry.io/issues/4536481195/?environment=production&project=11238&query=is%3Aunresolved+%22Google%3A%3ACloud%3A%3AUnknownError%22&referrer=issue-stream&statsPeriod=7d&stream_index=0)

## WHY
The only info I could find regarding "Error: 2 UNKNOWN: Authentication backend unknown error" pertaining to the `Google::Cloud::UnknownError` was this [issues](https://github.com/firebase/firebase-admin-node/issues/1903#issuecomment-1736342608) thread which suggested that Google's SLA required a retry policy for downtime.

`Google::Cloud::InternalError` isn't very [helpful](https://cloud.google.com/ruby/docs/reference/google-cloud-errors/latest/Google-Cloud-InternalError) either:  "Internal errors. Means some invariants expected by underlying system has been broken. If you see one of these errors, something is very broken."  Some searches [report](https://github.com/googleapis/google-cloud-ruby/issues/7675#issuecomment-789126052) that this might be a service disruption.

## HOW
Add a block `retries_with_exceptions` to retries the prediction API up to two times  (we can even make this one retry if we're worried about latency).



### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
