### PR TITLE
Add hint to vertex-ai-form

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/modelForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/modelForm.tsx
@@ -89,7 +89,7 @@ const ModelForm = ({ location, history, match }) => {
       <DropdownInput
         handleChange={handleSetName}
         isSearchable={true}
-        label="Name"
+        label="Name (note: if you're not finding a particular name, ensure that endpoint and model name are identical including leading/trailing whitespace)"
         options={nameOptions}
         value={nameOptions.find(opt => opt.value === name)}
       />
@@ -102,7 +102,7 @@ const ModelForm = ({ location, history, match }) => {
       />
       <button className="quill-button fun primary contained" id="add-model-button" onClick={submitModel} type="submit">Submit</button>
       {errors['Model Submission Error'] && <p className="error-message">{errors['Model Submission Error']}</p>}
-    </div>
+    </div >
   );
 }
 


### PR DESCRIPTION
## WHAT
Add some language to dropdown selector for Vertex AI model creation

## WHY
When creating endpoints in the Vertex AI UI, if a leading/trailing whitespace is added to the name, the Google Cloud UI does not display it so when comparing Endpoint and Model names it's difficult to reconcile why they are different.  For example, 
![Screenshot 2023-10-12 at 2 57 53 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/d4a569b4-b40c-4470-bf34-fb5b562a11b5))

But in the UI, the whitespace is invisible:
![Screenshot 2023-10-12 at 2 58 25 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/32e5db1a-d437-448e-8b19-12057e1bfeac)

## HOW
Initially, I thought about using `.strip` on the input coming in from Google AI, but since our dropdown only lists model-endpoint pairs that are exactly the same, we can validate the names upstream immediately.  In the old automl platform there was only `model` to worry about but now we have model and endpoint to contend with.  This copy prevents gotchas downstream where we have to remember `.strip` anytime we're using `.display_name` on models or endpoints.

Curriculum has updated their endpoint creation documentation to include a note about leading/trailing whitespace with names.  

This hint is just another place where users will be reminded to update the gold standard name on Vertex AI.

### Screenshots
![Screenshot 2023-10-12 at 2 50 48 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/634c3522-1238-4e50-8ea5-a3e501480bf8)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Minor copy change.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
