### PR TITLE
Remove premium promo sub-banner from last Spring

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/premium_banners/premium_banner_builder.jsx
@@ -85,23 +85,6 @@ export default class PremiumBannerBuilder extends React.Component {
               {this.stateSpecificComponents()}
             </div>
           </div>
-          <div className='row school-premium-banner'>
-            <div className='container'>
-              <span>
-                <div className='row'>
-                  <div className='col-md-9 col-xs-12 pull-left'>
-                    <h4>Representing a School or District?</h4>
-                    <span>Starting April 1st, when you purchase School or District Premium, you&apos;ll receive Quill Premium for free for the remainder of the school year!</span>
-                  </div>
-                  <div className='col-md-3 col-xs-12 pull-right'>
-                    <div className='premium-button-box text-center'>
-                      <a href='/premium/request-school-quote'><button className='btn-orange' type='button'>Get in touch!</button></a>
-                    </div>
-                  </div>
-                </div>
-              </span>
-            </div>
-          </div>
         </div>
       );
     }


### PR DESCRIPTION
## WHAT
Remove a premium promo banner from last spring.
## WHY
This banner should have been removed previously since the promo doesn't make sense in the new school year.
## HOW
Delete the static html for the sub banner
### Screenshots
### Before
---
<img width="1493" alt="Screenshot 2023-10-12 at 4 16 04 PM" src="https://github.com/empirical-org/Empirical-Core/assets/1304933/0a71d1c8-4924-4648-a8ca-42828c9f601f">

### After
---
<img width="1582" alt="Screenshot 2023-10-12 at 4 14 28 PM" src="https://github.com/empirical-org/Empirical-Core/assets/1304933/9f0cf025-7e57-4596-8e28-34c070072124">


### Notion Card Links
https://www.notion.so/quill/Remove-the-Representing-a-School-or-District-banner-on-the-premium-page-91b6e9b1e39d4f66a16962a2bb93c3a7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, tiny change.
Have you deployed to Staging? | Tested locally, very tiny, static html change
Self-Review: Have you done an initial self-review of the code below on Github? | Yup
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes.
