### PR TITLE
lms/add-critical-external-sidekiq-to-local-dev

### DIFF
--- a/services/QuillLMS/Procfile.static
+++ b/services/QuillLMS/Procfile.static
@@ -1,7 +1,7 @@
 # Run Rails without hot reloading (static assets).
 rails: rails s -b 0.0.0.0
 
-worker: bundle exec sidekiq -v -q default -q critical
+worker: bundle exec sidekiq -v -q default -q critical -q critical_external
 reportworker: bundle exec sidekiq -v -q low
 
 # Build client assets, watching for changes.


### PR DESCRIPTION
## WHAT
Add critical_external queue to the local Sidekiq server
## WHY
So jobs of that class get processed locally
## HOW
Just add the name of the queue

### Notion Card Links
https://www.notion.so/quill/Add-critical_external-queue-to-Procfile-static-Sidekiq-worker-4da7fdea49eb4cffb40d43494b24f4c2?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, no behavior change in the code
Have you deployed to Staging? | No, local development only
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
