### PR TITLE
add shogun to spellcheck, relax bad words list to allow kirishitan

### DIFF
--- a/services/QuillLMS/engines/evidence/config/initializers/bad_words.json
+++ b/services/QuillLMS/engines/evidence/config/initializers/bad_words.json
@@ -3,7 +3,7 @@
     "*damn",
     "*dyke",
     "*fuck*",
-    "*shit*",
+    "*shit",
     "@$$",
     "Ass Monkey",
     "Assface",

--- a/services/QuillLMS/engines/evidence/lib/evidence/spelling_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/spelling_check.rb
@@ -26,6 +26,8 @@ module Evidence
       'then',
       'sanchez',
       'sánchez',
+      "shoguns'",
+      "shogun's",
       'kanaka',
       'kānaka',
       'worldwatch',
@@ -89,7 +91,7 @@ module Evidence
     private def bing_response
       @response ||= HTTParty.get(BING_API_URL.to_s,
         headers: {
-          "Ocp-Apim-Subscription-Key": ENV['OCP-APIM-SUBSCRIPTION-KEY']
+          "Ocp-Apim-Subscription-Key": ENV['BING_SPELL_KEY']
         },
         query: {
           text: @entry,


### PR DESCRIPTION
## WHAT / HOW
- Add permutations of the word 'shogun' to exceptions list, as bing was tripping on them
- relax the "*shit*" bad words entry, to allow Kirishitan. Note: we could add infrastructure to handle prompt-wise bad word exceptions, but this would add complexity to our system and we should first discuss if the juice is worth the squeeze.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Add-words-to-spelling-exceptions-profanity-exceptions-and-opinion-algorithm-91c436efe2614cc6a2416a8b7fe4cc3b

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manual - config only
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
