### PR TITLE
Lms/split snapshot count timeframes

### DIFF
--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -160,7 +160,7 @@ class SnapshotsController < ApplicationController
         teacher_ids: snapshot_params[:teacher_ids],
         classroom_ids: snapshot_params[:classroom_ids]
       },
-      previous_timeframe: snapshot_params[:previous_timeframe])
+      snapshot_params[:previous_timeframe])
 
     { message: 'Generating snapshot' }
   end

--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -148,6 +148,8 @@ class SnapshotsController < ApplicationController
       timeframe_end = previous_end
     end
 
+    return { count: nil } unless timeframe_start && timeframe_end
+
     cache_key = cache_key_for_timeframe(snapshot_params[:timeframe], timeframe_start, timeframe_end)
     response = Rails.cache.read(cache_key)
 

--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -36,7 +36,7 @@ class SnapshotsController < ApplicationController
   end
 
   def previous_count
-    render json: retrieve_cache_or_enqueue_worker(WORKERS_FOR_ACTIONS[action_name], true)
+    render json: retrieve_cache_or_enqueue_worker(WORKERS_FOR_ACTIONS[action_name], previous_timeframe: true)
   end
 
   def top_x
@@ -137,7 +137,7 @@ class SnapshotsController < ApplicationController
     return render json: { error: 'user is not authorized for all specified schools' }, status: 403
   end
 
-  private def retrieve_cache_or_enqueue_worker(worker, previous_timeframe = false)
+  private def retrieve_cache_or_enqueue_worker(worker, previous_timeframe: false)
 
     previous_start, previous_end, timeframe_start, timeframe_end = Snapshots::Timeframes.calculate_timeframes(snapshot_params[:timeframe],
       custom_start: snapshot_params[:timeframe_custom_start],

--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -134,14 +134,10 @@ class SnapshotsController < ApplicationController
 
   private def retrieve_cache_or_enqueue_worker(worker)
 
-    previous_start, previous_end, timeframe_start, timeframe_end = Snapshots::Timeframes.calculate_timeframes(snapshot_params[:timeframe],
+    timeframe_start, timeframe_end = Snapshots::Timeframes.calculate_timeframes(snapshot_params[:timeframe],
       custom_start: snapshot_params[:timeframe_custom_start],
-      custom_end: snapshot_params[:timeframe_custom_end])
-
-    if snapshot_params[:previous_timeframe]
-      timeframe_start = previous_start
-      timeframe_end = previous_end
-    end
+      custom_end: snapshot_params[:timeframe_custom_end],
+      previous_timeframe: snapshot_params[:previous_timeframe])
 
     return { count: nil } unless timeframe_start && timeframe_end
 

--- a/services/QuillLMS/app/lib/snapshots/timeframes.rb
+++ b/services/QuillLMS/app/lib/snapshots/timeframes.rb
@@ -69,13 +69,19 @@ module Snapshots
       TIMEFRAMES.find { |timeframe| timeframe[:value] == timeframe_value }
     end
 
-    def self.calculate_timeframes(timeframe_value, custom_start: nil, custom_end: nil)
+    def self.calculate_timeframes(timeframe_value, custom_start: nil, custom_end: nil, previous_timeframe: false)
       timeframe = find_timeframe(timeframe_value)
 
       end_of_yesterday = DateTime.current.end_of_day - 1.day
 
-      [:previous_start, :previous_end, :current_start, :current_end].map do |value|
-        timeframe[value].call(end_of_yesterday, custom_start, custom_end)
+      if previous_timeframe
+        [:previous_start, :previous_end].map do |value|
+          timeframe[value].call(end_of_yesterday, custom_start, custom_end)
+        end
+      else
+        [:current_start, :current_end].map do |value|
+          timeframe[value].call(end_of_yesterday, custom_start, custom_end)
+        end
       end
     end
 

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -63,10 +63,8 @@ module Snapshots
     end
 
     private def generate_payload(query, timeframe, school_ids, filters)
-      previous_timeframe_start = parse_datetime_string(timeframe['previous_start'])
-      previous_timeframe_end = parse_datetime_string(timeframe['previous_end'])
-      current_timeframe_start = parse_datetime_string(timeframe['current_start'])
-      timeframe_end = parse_datetime_string(timeframe['current_end'])
+      timeframe_start = parse_datetime_string(timeframe['timeframe_start'])
+      timeframe_end = parse_datetime_string(timeframe['timeframe_end'])
       filters_symbolized = filters.symbolize_keys
 
       long_process_notifier = LongProcessNotifier.new(
@@ -74,7 +72,7 @@ module Snapshots
         TOO_SLOW_THRESHOLD,
         {
           query:,
-          timeframe_start: current_timeframe_start,
+          timeframe_start:,
           timeframe_end:,
           school_ids:
         }.merge(filters_symbolized)
@@ -82,21 +80,10 @@ module Snapshots
 
       long_process_notifier.run do
         current_snapshot = QUERIES[query].run(**{
-          timeframe_start: current_timeframe_start,
+          timeframe_start:,
           timeframe_end:,
           school_ids:
         }.merge(filters_symbolized))
-
-        if previous_timeframe_start
-          previous_snapshot = QUERIES[query].run(**{
-            timeframe_start: previous_timeframe_start,
-            timeframe_end: previous_timeframe_end,
-            school_ids:
-          }.merge(filters_symbolized))
-        else
-          previous_snapshot = nil
-        end
-        { current: current_snapshot&.fetch(:count, nil), previous: previous_snapshot&.fetch(:count, nil) }
       end
     end
 

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_previous_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_previous_count_worker.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Snapshots
+  class CacheSnapshotPreviousCountWorker < CacheSnapshotCountWorker
+    PUSHER_EVENT = 'admin-snapshot-previous-count-cached'
+  end
+end

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_previous_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_previous_count_worker.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Snapshots
-  class CacheSnapshotPreviousCountWorker < CacheSnapshotCountWorker
-    PUSHER_EVENT = 'admin-snapshot-previous-count-cached'
-  end
-end

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -25,7 +25,8 @@ module Snapshots
       'most-completed-activities' => Snapshots::MostCompletedActivitiesQuery
     }
 
-    def perform(cache_key, query, user_id, timeframe, school_ids, filters)
+    # previous_timeframe param here is not used, but is included to enforce parity with the CacheSnapshotCountWorker signature
+    def perform(cache_key, query, user_id, timeframe, school_ids, filters, previous_timeframe)
       payload = generate_payload(query, timeframe, school_ids, filters)
 
       Rails.cache.write(cache_key, payload.to_a, expires_in: cache_expiry)

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -51,8 +51,8 @@ module Snapshots
     end
 
     private def generate_payload(query, timeframe, school_ids, filters)
-      timeframe_start = DateTime.parse(timeframe['current_start'])
-      timeframe_end = DateTime.parse(timeframe['current_end'])
+      timeframe_start = DateTime.parse(timeframe['timeframe_start'])
+      timeframe_end = DateTime.parse(timeframe['timeframe_end'])
       filters_symbolized = filters.symbolize_keys
 
       long_process_notifier = LongProcessNotifier.new(

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`SnapshotCount component size medium when there is data with a negative 
   passedChange={50}
   passedChangeDirection="negative"
   passedCount={1000}
+  passedPrevious={2000}
   queryKey="sentences-written"
   searchCount={1}
   selectedClassroomIds={
@@ -171,7 +172,8 @@ exports[`SnapshotCount component size medium when there is data with a positive 
   label="Sentences written"
   passedChange={50}
   passedChangeDirection="positive"
-  passedCount={1000}
+  passedCount={1500}
+  passedPrevious={1000}
   queryKey="sentences-written"
   searchCount={1}
   selectedClassroomIds={
@@ -224,7 +226,7 @@ exports[`SnapshotCount component size medium when there is data with a positive 
       <span
         className="count"
       >
-        1,000
+        1,500
       </span>
       <span
         className="snapshot-label"
@@ -410,6 +412,7 @@ exports[`SnapshotCount component size small when there is data with a negative t
   passedChange={50}
   passedChangeDirection="negative"
   passedCount={1000}
+  passedPrevious={2000}
   queryKey="sentences-written"
   searchCount={1}
   selectedClassroomIds={
@@ -495,7 +498,8 @@ exports[`SnapshotCount component size small when there is data with a positive t
   label="Sentences written"
   passedChange={50}
   passedChangeDirection="positive"
-  passedCount={1000}
+  passedCount={1500}
+  passedPrevious={1000}
   queryKey="sentences-written"
   searchCount={1}
   selectedClassroomIds={
@@ -548,7 +552,7 @@ exports[`SnapshotCount component size small when there is data with a positive t
       <span
         className="count"
       >
-        1,000
+        1,500
       </span>
       <span
         className="snapshot-label"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/snapshotCount.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/snapshotCount.test.tsx
@@ -33,13 +33,15 @@ describe('SnapshotCount component', () => {
   }
 
   const positiveTrendData = {
-    passedCount: 1000,
+    passedCount: 1500,
+    passedPrevious: 1000,
     passedChange: 50,
     passedChangeDirection: POSITIVE
   }
 
   const negativeTrendData = {
     passedCount: 1000,
+    passedPrevious: 2000,
     passedChange: 50,
     passedChangeDirection: NEGATIVE
   }

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -64,7 +64,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
   }, [previousRetryTimeout])
 
   React.useEffect(() => {
-    if (!previous || count === 'N/A') {
+    if (!previous || count === 'N/A' || count === null) {
       setChangeDirection(NONE)
       return
     }

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -33,10 +33,10 @@ interface SnapshotCountProps {
 const PUSHER_CURRENT_EVENT_KEY = 'admin-snapshot-count-cached'
 const PUSHER_PREVIOUS_EVENT_KEY = 'admin-snapshot-previous-count-cached'
 
-const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, passedCount, passedChange, passedChangeDirection, singularLabel, pusherChannel, }: SnapshotCountProps) => {
+const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, passedCount, passedPrevious, passedChange, passedChangeDirection, singularLabel, pusherChannel, }: SnapshotCountProps) => {
   const [count, setCount] = React.useState(passedCount || null)
-  const [previous, setPrevious] = React.useState(null)
-  const [change, setChange] = React.useState(passedChange || 0)
+  const [previous, setPrevious] = React.useState(passedPrevious)
+  const [change, setChange] = React.useState(passedChange)
   const [changeDirection, setChangeDirection] = React.useState(passedChangeDirection || null)
   const [loading, setLoading] = React.useState(false)
   const [currentRetryTimeout, setCurrentRetryTimeout] = React.useState(null)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -119,7 +119,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
   }
 
   function getPreviousData() {
-    requestPost(`/snapshots/previous_count`, getSearchParams(), (body) => {
+    requestPost(`/snapshots/count?previous_timeframe=true`, getSearchParams(), (body) => {
       if (!body.hasOwnProperty('results')) return
 
       clearTimeout(previousRetryTimeout)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -160,7 +160,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     });
   };
 
-  const className = `snapshot-item snapshot-count ${size} ${changeDirection || ''}`
+  const className = `snapshot-item snapshot-count ${size} ${(changeDirection !== NONE) ? changeDirection : ''}`
 
   let icon
 

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -730,6 +730,7 @@ EmpiricalGrammar::Application.routes.draw do
     collection do
       post :count
       post :options
+      post :previous_count
       post :top_x
       post :data_export
     end

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -23,6 +23,13 @@ describe SnapshotsController, type: :controller do
         [:top_x, 'most-active-schools']
       ]
     }
+    let(:previous_start) { now - 1.day }
+    let(:previous_end) { current_start }
+    let(:current_start) { now }
+    let(:current_end) { now + 1.day }
+    let(:previous_timeframe) { [previous_start, previous_end] }
+    let(:current_timeframe) { [current_start, current_end] }
+    let(:timeframes) { current_timeframe }
 
     before do
       allow(DateTime).to receive(:current).and_return(now)
@@ -33,11 +40,6 @@ describe SnapshotsController, type: :controller do
       let(:grades) { ['Kindergarten', '1'] }
       let(:teacher_ids) { ['4', '5'] }
       let(:classroom_ids) { ['7', '8'] }
-      let(:previous_start) { now - 1.day }
-      let(:previous_end) { current_start }
-      let(:current_start) { now }
-      let(:current_end) { now + 1.day }
-      let(:timeframes) { [previous_start, previous_end, current_start, current_end] }
 
       before do
         allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
@@ -152,23 +154,23 @@ describe SnapshotsController, type: :controller do
       end
 
       context 'param variation' do
-        let(:previous_timeframe) { 'PREVIOUS_TIMEFRAME' }
+        let(:previous_start) { 'PREVIOUS_TIMEFRAME' }
         let(:previous_end) { 'PREVIOUS_END' }
-        let(:current_timeframe) { 'CURRENT_TIMEFRAME' }
-        let(:timeframe_end) { 'TIMEFRAME_END' }
+        let(:current_start) { 'CURRENT_TIMEFRAME' }
+        let(:current_end) { 'TIMEFRAME_END' }
 
         it 'should trigger a job to cache data if the cache is empty for counts' do
           query_name = 'active-classrooms'
 
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return([previous_timeframe, previous_end, current_timeframe, timeframe_end])
+          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
           expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
           expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(cache_key,
             query_name,
             user.id,
             {
               name: timeframe_name,
-              timeframe_start: current_timeframe,
-              timeframe_end: timeframe_end
+              timeframe_start: current_start,
+              timeframe_end: current_end
             },
             school_ids,
             {
@@ -188,14 +190,14 @@ describe SnapshotsController, type: :controller do
         it 'should trigger a job to cache data if the cache is empty for previous_counts' do
           query_name = 'active-classrooms'
 
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return([previous_timeframe, previous_end, current_timeframe, timeframe_end])
+          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(previous_timeframe)
           expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
           expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(cache_key,
             query_name,
             user.id,
             {
               name: timeframe_name,
-              timeframe_start: previous_timeframe,
+              timeframe_start: previous_start,
               timeframe_end: previous_end
             },
             school_ids,
@@ -232,15 +234,15 @@ describe SnapshotsController, type: :controller do
         it 'should trigger a job to cache data if the cache is empty for top_x' do
           query_name = 'most-active-schools'
 
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return([previous_timeframe, previous_end, current_timeframe, timeframe_end])
+          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
           expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
           expect(Snapshots::CacheSnapshotTopXWorker).to receive(:perform_async).with(cache_key,
             query_name,
             user.id,
             {
               name: timeframe_name,
-              timeframe_start: current_timeframe,
-              timeframe_end: timeframe_end
+              timeframe_start: current_start,
+              timeframe_end: current_end
             },
             school_ids,
             {
@@ -260,15 +262,15 @@ describe SnapshotsController, type: :controller do
         it 'should trigger a job to cache data if the cache is empty for data_export' do
           query_name = 'data-export'
 
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return([previous_timeframe, previous_end, current_timeframe, timeframe_end])
+          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
           expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
           expect(Snapshots::CachePremiumReportsWorker).to receive(:perform_async).with(cache_key,
             query_name,
             user.id,
             {
               name: timeframe_name,
-              timeframe_start: current_timeframe,
-              timeframe_end: timeframe_end
+              timeframe_start: current_start,
+              timeframe_end: current_end
             },
             school_ids,
             {
@@ -291,15 +293,15 @@ describe SnapshotsController, type: :controller do
           teacher_ids = ['3', '4']
           classroom_ids = ['5', '6', '7']
 
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return([previous_timeframe, previous_end, current_timeframe, timeframe_end])
+          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
           expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
           expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(cache_key,
             query_name,
             user.id,
             {
               name: timeframe_name,
-              timeframe_start: current_timeframe,
-              timeframe_end: timeframe_end
+              timeframe_start: current_start,
+              timeframe_end: current_end
             },
             school_ids,
             {

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -167,10 +167,8 @@ describe SnapshotsController, type: :controller do
             user.id,
             {
               name: timeframe_name,
-              previous_start: previous_timeframe,
-              previous_end: previous_end,
-              current_start: current_timeframe,
-              current_end: timeframe_end
+              timeframe_start: current_timeframe,
+              timeframe_end: timeframe_end
             },
             school_ids,
             {
@@ -180,6 +178,33 @@ describe SnapshotsController, type: :controller do
             })
 
           get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
+
+          json_response = JSON.parse(response.body)
+
+          expect(json_response).to eq("message" => "Generating snapshot")
+        end
+
+        it 'should trigger a job to cache data if the cache is empty for previous_counts' do
+          query_name = 'active-classrooms'
+
+          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return([previous_timeframe, previous_end, current_timeframe, timeframe_end])
+          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+          expect(Snapshots::CacheSnapshotPreviousCountWorker).to receive(:perform_async).with(cache_key,
+            query_name,
+            user.id,
+            {
+              name: timeframe_name,
+              timeframe_start: previous_timeframe,
+              timeframe_end: previous_end
+            },
+            school_ids,
+            {
+              grades: nil,
+              teacher_ids: nil,
+              classroom_ids: nil
+            })
+
+          get :previous_count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
 
           json_response = JSON.parse(response.body)
 
@@ -196,10 +221,8 @@ describe SnapshotsController, type: :controller do
             user.id,
             {
               name: timeframe_name,
-              previous_start: previous_timeframe,
-              previous_end: previous_end,
-              current_start: current_timeframe,
-              current_end: timeframe_end
+              timeframe_start: current_timeframe,
+              timeframe_end: timeframe_end
             },
             school_ids,
             {
@@ -225,10 +248,8 @@ describe SnapshotsController, type: :controller do
             user.id,
             {
               name: timeframe_name,
-              previous_start: previous_timeframe,
-              previous_end: previous_end,
-              current_start: current_timeframe,
-              current_end: timeframe_end
+              timeframe_start: current_timeframe,
+              timeframe_end: timeframe_end
             },
             school_ids,
             {
@@ -257,10 +278,8 @@ describe SnapshotsController, type: :controller do
             user.id,
             {
               name: timeframe_name,
-              previous_start: previous_timeframe,
-              previous_end: previous_end,
-              current_start: current_timeframe,
-              current_end: timeframe_end
+              timeframe_start: current_timeframe,
+              timeframe_end: timeframe_end
             },
             school_ids,
             {
@@ -285,10 +304,8 @@ describe SnapshotsController, type: :controller do
             user.id,
             {
               name: timeframe_name,
-              previous_start: current_start - timeframe_length,
-              previous_end: current_start,
-              current_start: current_start,
-              current_end: current_end
+              timeframe_start: current_start,
+              timeframe_end: current_end
             },
             school_ids,
             {

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -211,6 +211,22 @@ describe SnapshotsController, type: :controller do
           expect(json_response).to eq("message" => "Generating snapshot")
         end
 
+        context 'all-time timeframe' do
+          let(:query_name) { 'active-classrooms' }
+          let(:timeframe_name) { 'all-time' }
+
+          it 'previous_count should return nil without having to check cache' do
+            expect(Rails.cache).not_to receive(:read)
+            expect(Snapshots::CacheSnapshotPreviousCountWorker).not_to receive(:perform_async)
+
+            get :previous_count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
+
+            json_response = JSON.parse(response.body)
+
+            expect(json_response).to eq("count" => nil)
+          end
+        end
+
         it 'should trigger a job to cache data if the cache is empty for top_x' do
           query_name = 'most-active-schools'
 

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -178,7 +178,7 @@ describe SnapshotsController, type: :controller do
               teacher_ids: nil,
               classroom_ids: nil
             },
-            previous_timeframe: nil)
+            nil)
 
           get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
 
@@ -206,7 +206,7 @@ describe SnapshotsController, type: :controller do
               teacher_ids: nil,
               classroom_ids: nil
             },
-            previous_timeframe: "true")
+            "true")
 
           get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids, previous_timeframe: true }
 
@@ -250,7 +250,7 @@ describe SnapshotsController, type: :controller do
               teacher_ids: nil,
               classroom_ids: nil
             },
-            previous_timeframe: nil)
+            nil)
 
           get :top_x, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
 
@@ -278,7 +278,7 @@ describe SnapshotsController, type: :controller do
               teacher_ids: nil,
               classroom_ids: nil
             },
-            previous_timeframe: nil)
+            nil)
 
           get :data_export, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
 
@@ -309,7 +309,7 @@ describe SnapshotsController, type: :controller do
               teacher_ids: teacher_ids,
               classroom_ids: classroom_ids
             },
-            previous_timeframe: nil)
+            nil)
 
           get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids, grades: grades, teacher_ids: teacher_ids, classroom_ids: classroom_ids }
         end
@@ -336,7 +336,7 @@ describe SnapshotsController, type: :controller do
               teacher_ids: nil,
               classroom_ids: nil
             },
-            previous_timeframe: nil)
+            nil)
 
           get :count, params: { query: query_name, timeframe: timeframe_name, timeframe_custom_start: current_start.to_s, timeframe_custom_end: current_end.to_s, school_ids: school_ids }
         end

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -175,7 +175,8 @@ describe SnapshotsController, type: :controller do
               grades: nil,
               teacher_ids: nil,
               classroom_ids: nil
-            })
+            },
+            previous_timeframe: nil)
 
           get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
 
@@ -189,7 +190,7 @@ describe SnapshotsController, type: :controller do
 
           allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return([previous_timeframe, previous_end, current_timeframe, timeframe_end])
           expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-          expect(Snapshots::CacheSnapshotPreviousCountWorker).to receive(:perform_async).with(cache_key,
+          expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(cache_key,
             query_name,
             user.id,
             {
@@ -202,9 +203,10 @@ describe SnapshotsController, type: :controller do
               grades: nil,
               teacher_ids: nil,
               classroom_ids: nil
-            })
+            },
+            previous_timeframe: "true")
 
-          get :previous_count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
+          get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids, previous_timeframe: true }
 
           json_response = JSON.parse(response.body)
 
@@ -217,9 +219,9 @@ describe SnapshotsController, type: :controller do
 
           it 'previous_count should return nil without having to check cache' do
             expect(Rails.cache).not_to receive(:read)
-            expect(Snapshots::CacheSnapshotPreviousCountWorker).not_to receive(:perform_async)
+            expect(Snapshots::CacheSnapshotCountWorker).not_to receive(:perform_async)
 
-            get :previous_count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
+            get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids, previous_timeframe: true }
 
             json_response = JSON.parse(response.body)
 
@@ -245,7 +247,8 @@ describe SnapshotsController, type: :controller do
               grades: nil,
               teacher_ids: nil,
               classroom_ids: nil
-            })
+            },
+            previous_timeframe: nil)
 
           get :top_x, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
 
@@ -272,7 +275,8 @@ describe SnapshotsController, type: :controller do
               grades: nil,
               teacher_ids: nil,
               classroom_ids: nil
-            })
+            },
+            previous_timeframe: nil)
 
           get :data_export, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
 
@@ -302,7 +306,8 @@ describe SnapshotsController, type: :controller do
               grades: grades,
               teacher_ids: teacher_ids,
               classroom_ids: classroom_ids
-            })
+            },
+            previous_timeframe: nil)
 
           get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids, grades: grades, teacher_ids: teacher_ids, classroom_ids: classroom_ids }
         end
@@ -328,7 +333,8 @@ describe SnapshotsController, type: :controller do
               grades: nil,
               teacher_ids: nil,
               classroom_ids: nil
-            })
+            },
+            previous_timeframe: nil)
 
           get :count, params: { query: query_name, timeframe: timeframe_name, timeframe_custom_start: current_start.to_s, timeframe_custom_end: current_end.to_s, school_ids: school_ids }
         end

--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -28,10 +28,15 @@ module Snapshots
 
       it do
         expect(described_class.calculate_timeframes('last-30-days')).to eq([
-          end_of_yesterday - 60.days,
-          end_of_yesterday - 30.days,
           end_of_yesterday - 30.days,
           end_of_yesterday
+        ])
+      end
+
+      it do
+        expect(described_class.calculate_timeframes('last-30-days', previous_timeframe: true)).to eq([
+          end_of_yesterday - 60.days,
+          end_of_yesterday - 30.days
         ])
       end
 
@@ -39,20 +44,16 @@ module Snapshots
         let(:now) { DateTime.parse('2023-01-10') }
 
         it do
-          expect(described_class.calculate_timeframes('this-month')).to eq([
+          expect(described_class.calculate_timeframes('this-month', previous_timeframe: true)).to eq([
             end_of_yesterday.beginning_of_month - 1.month,
             end_of_yesterday - 1.month,
-            end_of_yesterday.beginning_of_month,
-            end_of_yesterday
           ])
         end
 
         it do
-          expect(described_class.calculate_timeframes('this-school-year')).to eq([
+          expect(described_class.calculate_timeframes('this-school-year', previous_timeframe: true)).to eq([
             School.school_year_start(end_of_yesterday) - 1.year,
-            end_of_yesterday - 1.year,
-            School.school_year_start(end_of_yesterday),
-            end_of_yesterday
+            end_of_yesterday - 1.year
           ])
         end
       end
@@ -62,11 +63,9 @@ module Snapshots
         let(:custom_end) { now - 30.minutes }
 
         it do
-          expect(described_class.calculate_timeframes('custom', custom_start: custom_start.to_s, custom_end: custom_end.to_s)).to eq([
+          expect(described_class.calculate_timeframes('custom', custom_start: custom_start.to_s, custom_end: custom_end.to_s, previous_timeframe: true)).to eq([
             (custom_start - (custom_end - custom_start)).beginning_of_day,
-            custom_start.end_of_day,
-            custom_start.beginning_of_day,
-            custom_end.end_of_day
+            custom_start.end_of_day
           ])
         end
       end

--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -46,7 +46,7 @@ module Snapshots
         it do
           expect(described_class.calculate_timeframes('this-month', previous_timeframe: true)).to eq([
             end_of_yesterday.beginning_of_month - 1.month,
-            end_of_yesterday - 1.month,
+            end_of_yesterday - 1.month
           ])
         end
 

--- a/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
@@ -95,8 +95,8 @@ module Snapshots
           let(:timeframe) { Snapshots::Timeframes.calculate_timeframes(Snapshots::Timeframes::DEFAULT_TIMEFRAME) }
           let(:query_args) do
             {
-              timeframe_start: timeframe[2],
-              timeframe_end: timeframe[3],
+              timeframe_start: timeframe[0],
+              timeframe_end: timeframe[1],
               school_ids: school_ids
             }
           end

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
@@ -31,15 +31,11 @@ module Snapshots
       let(:perform) { subject.perform(cache_key, query, user_id, timeframe, school_ids, filters) }
       let(:timeframe_end) { DateTime.now }
       let(:current_timeframe_start) { timeframe_end - 30.days }
-      let(:previous_timeframe_start) { current_timeframe_start - 30.days }
-      let(:previous_timeframe_end) { current_timeframe_start }
       let(:timeframe) {
         {
           'name' => timeframe_name,
-          'previous_start' => previous_timeframe_start.to_s,
-          'previous_end' => previous_timeframe_end.to_s,
-          'current_start' => current_timeframe_start.to_s,
-          'current_end' => timeframe_end.to_s
+          'timeframe_start' => current_timeframe_start.to_s,
+          'timeframe_end' => timeframe_end.to_s
         }
       }
 
@@ -60,15 +56,8 @@ module Snapshots
         })
       end
 
-      it 'should execute queries for both the current and previous timeframes' do
+      it 'should execute the query for the current timeframe' do
         expect(query_double).to receive(:run).with(expected_query_args)
-        expect(query_double).to receive(:run).with(
-          timeframe_start: previous_timeframe_start,
-          timeframe_end: previous_timeframe_end,
-          school_ids: school_ids,
-          grades: grades,
-          teacher_ids: teacher_ids,
-          classroom_ids: classroom_ids)
         expect(Rails.cache).to receive(:write)
         expect(SendPusherMessageWorker).to receive(:perform_async)
 
@@ -87,15 +76,8 @@ module Snapshots
       end
 
       context "params with string keys" do
-        it 'should execute queries for both the current and previous timeframes' do
+        it 'should execute the query for the timeframe' do
           expect(query_double).to receive(:run).with(expected_query_args)
-          expect(query_double).to receive(:run).with(
-            timeframe_start: previous_timeframe_start,
-            timeframe_end: current_timeframe_start,
-            school_ids: school_ids,
-            grades: grades,
-            teacher_ids: teacher_ids,
-            classroom_ids: classroom_ids)
           expect(Rails.cache).to receive(:write)
           expect(SendPusherMessageWorker).to receive(:perform_async)
 
@@ -115,14 +97,13 @@ module Snapshots
       it 'should write a payload to cache' do
         cache_ttl = 1
         previous_count = 100
-        previous_timeframe_query_result = { count: previous_count}
         current_count = 50
         current_timeframe_query_result = { count: current_count}
-        payload = { current: current_count, previous: previous_count }
+        payload = { count: current_count }
 
         expect(subject).to receive(:cache_expiry).and_return(cache_ttl)
 
-        expect(query_double).to receive(:run).and_return(current_timeframe_query_result, previous_timeframe_query_result)
+        expect(query_double).to receive(:run).and_return(current_timeframe_query_result)
         expect(Rails.cache).to receive(:write).with(cache_key, payload, expires_in: cache_ttl)
         expect(SendPusherMessageWorker).to receive(:perform_async)
 

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
@@ -27,7 +27,7 @@ module Snapshots
     it { expect { described_class::QUERIES.values }.not_to raise_error }
 
     context '#perform' do
-      let(:perform) { subject.perform(cache_key, query, user_id, timeframe, school_ids, filters) }
+      let(:perform) { subject.perform(cache_key, query, user_id, timeframe, school_ids, filters, nil) }
       let(:timeframe_end) { DateTime.now }
       let(:current_timeframe_start) { timeframe_end - 30.days }
       let(:timeframe) {
@@ -68,7 +68,7 @@ module Snapshots
           Sidekiq::Testing.inline! do
             expect(query_double).to receive(:run).with(expected_query_args)
 
-            described_class.perform_async(cache_key, query, user_id, timeframe, school_ids, filters)
+            described_class.perform_async(cache_key, query, user_id, timeframe, school_ids, filters, nil)
           end
         end
       end
@@ -79,7 +79,7 @@ module Snapshots
           expect(Rails.cache).to receive(:write)
           expect(SendPusherMessageWorker).to receive(:perform_async)
 
-          subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys)
+          subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys, nil)
         end
       end
 
@@ -109,7 +109,7 @@ module Snapshots
         expect(Rails.cache).to receive(:write)
         expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::PUSHER_EVENT, hashed_payload)
 
-        subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys)
+        subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys, nil)
       end
 
       context 'slow query reporting' do

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
@@ -30,13 +30,11 @@ module Snapshots
       let(:perform) { subject.perform(cache_key, query, user_id, timeframe, school_ids, filters) }
       let(:timeframe_end) { DateTime.now }
       let(:current_timeframe_start) { timeframe_end - 30.days }
-      let(:previous_timeframe_start) { current_timeframe_start - 30.days }
       let(:timeframe) {
         {
           'name' => timeframe_name,
-          'previous_start' => previous_timeframe_start.to_s,
-          'current_start' => current_timeframe_start.to_s,
-          'current_end' => timeframe_end.to_s
+          'timeframe_start' => current_timeframe_start.to_s,
+          'timeframe_end' => timeframe_end.to_s
         }
       }
       let(:expected_query_args) {


### PR DESCRIPTION
## WHAT
When fetching the current and previous counts for a given metric in Admin Snapshots, fetch the two values in parallel on the front-end instead of using a single endpoint/worker combo that we were using before which made two BigQuery queries in sequence.
## WHY
Parallelizing this data lookup should result in a reduction in the average time it takes before a user sees data on this page due to the cases where current data comes back alone in the new system faster than current+previous data could come back in the old system.
## HOW
- Add a new controller action for `previous_count` so that the front-end can fetch that data separately
- Create a new worker for processing `previous_count`, but it does exactly the same thing as `count` except it sends a different Pusher event name when it completes
- Modify the controller helpers so that when processing data for `previous_count` the previous period of the timeframe is passed to the worker
- Update count worker to only take a timeframe_start and timeframe_end for timeframe data rather than the old method of getting previous and current timeframe bounds (we now handle that split in the controller)
- Short-circuit the controller action so that if there is no valid timeframe data we don't bother trying to calculate anything (currently intended for use with `previous_count` when the timeframe is "all-time")
- Update the front-end to make two different API calls on component load (along with two different retry timers for those two loads)
- Register two different Pusher listeners so that we can handle callbacks for both current and previous count
- Move a bunch of the calculation logic that is intended to handle API data into an effect so that we can consolidate that code into one place despite having two different API calls that could come back in either order

### Notion Card Links
https://www.notion.so/quill/Split-Admin-Snapshot-Count-queries-into-two-different-API-Worker-Cache-flows-one-for-Current-Timefr-3796837d69c84170a4e110e3cfc48be9?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
