### PR TITLE
Clean up sessions controller dead code

### DIFF
--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -553,7 +553,7 @@ EmpiricalGrammar::Application.routes.draw do
   get '/finish_sign_up', to: 'sessions#finish_sign_up'
   post '/session/login_through_ajax', to: 'sessions#login_through_ajax'
   post '/session/set_post_auth_redirect', to: 'sessions#set_post_auth_redirect'
-  resource :session
+  resource :session, only: [:new, :destroy]
 
   resource :account, only: [:new, :create, :edit, :update, :show] do
     post :role, on: :member

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -5,78 +5,6 @@ require 'rails_helper'
 describe SessionsController, type: :controller do
   it { should use_before_action :signed_in! }
 
-  describe '#create' do
-    let!(:user) { create(:user) }
-
-    before do
-      user.update(password: "test123")
-      user.reload
-    end
-
-    context 'when user is nil' do
-      it 'should report login failiure' do
-        post :create, params: { user: { email: "test@whatever.com" } }
-        expect(response).to redirect_to "/session/new"
-      end
-    end
-
-    context 'when user has signed up with google' do
-      before do
-        allow_any_instance_of(User).to receive(:signed_up_with_google) { true }
-      end
-
-      it 'should report login failiure' do
-        post :create, params: { user: { email: user.email } }
-        expect(flash[:error]).to eq 'You signed up with Google, please log in with Google using the link above.'
-        expect(response).to redirect_to "/session/new"
-      end
-    end
-
-    context 'when user has signed up with clever' do
-      before do
-        allow_any_instance_of(User).to receive(:clever_id) { 1 }
-      end
-
-      it 'should report login failiure' do
-        post :create, params: { user: { email: user.email } }
-        expect(flash[:error]).to eq 'You signed up with Clever, please log in with Clever using the link above.'
-        expect(response).to redirect_to "/session/new"
-      end
-    end
-
-    context 'when user has no password digest' do
-      before do
-        allow_any_instance_of(User).to receive(:password_digest) { nil }
-      end
-
-      it 'should report login failiure' do
-        post :create, params: { user: { email: user.email } }
-        expect(flash[:error]).to eq 'Something went wrong verifying your password. Please use the "Forgot password?" link below to reset it.'
-        expect(response).to redirect_to "/session/new"
-      end
-    end
-
-    context 'when user is authenticated' do
-      context 'when redirect present' do
-        it 'should redirect to the given url' do
-          post :create, params: { user: { email: user.email, password: "test123" }, redirect: root_path }
-          expect(response).to redirect_to root_path
-        end
-      end
-
-      context 'when redirect not present' do
-        before do
-          user.update(password: "test123")
-        end
-
-        it 'should redirect to profile path' do
-          post :create, params: { user: { email: user.email, password: "test123" } }
-          expect(response).to redirect_to profile_path
-        end
-      end
-    end
-  end
-
   describe '#login_through_ajax' do
     let!(:user) { create(:user) }
 
@@ -86,14 +14,14 @@ describe SessionsController, type: :controller do
     end
 
     context 'when user is nil' do
-      it 'should report login failiure' do
+      it 'should report login failure' do
         post :login_through_ajax, params: { user: { email: "test@whatever.com" } }, as: :json
         expect(response.body).to eq({message: 'An account with this email or username does not exist. Try again.', type: 'email'}.to_json)
       end
     end
 
     context 'when user has a non-authenticating role' do
-      it 'should report login failiure' do
+      it 'should report login failure' do
         user.update(role: User::SALES_CONTACT)
         post :login_through_ajax, params: { user: { email: user.email } }, as: :json
         expect(response.body).to eq({message: 'An account with this email or username does not exist. Try again.', type: 'email'}.to_json)
@@ -105,9 +33,18 @@ describe SessionsController, type: :controller do
         allow_any_instance_of(User).to receive(:signed_up_with_google) { true }
       end
 
-      it 'should report login failiure' do
+      it 'should report login failure' do
         post :login_through_ajax, params: { user: { email: user.email } }, as: :json
         expect(response.body).to eq({message: 'Oops! You have a Google account. Log in that way instead.', type: 'email'}.to_json)
+      end
+    end
+
+    context 'when user has signed up with clever' do
+      before { allow_any_instance_of(User).to receive(:clever_id) { 1 } }
+
+      it 'should report login failure' do
+        post :login_through_ajax, params: { user: { email: user.email } }
+        expect(response.body).to eq({message: 'Oops! You have a Clever account. Log in that way instead.', type: 'email'}.to_json)
       end
     end
 
@@ -116,7 +53,7 @@ describe SessionsController, type: :controller do
         allow_any_instance_of(User).to receive(:password_digest) { nil }
       end
 
-      it 'should report login failiure' do
+      it 'should report login failure' do
         post :login_through_ajax, params: { user: { email: user.email } }, as: :json
         expect(response.body).to eq({message: 'Something went wrong verifying your password. Please use the "Forgot password?" link below to reset it.', type: 'email'}.to_json)
       end

--- a/services/QuillLMS/spec/requests/sign_in_spec.rb
+++ b/services/QuillLMS/spec/requests/sign_in_spec.rb
@@ -2,25 +2,29 @@
 
 require 'rails_helper'
 
-describe 'Sign in', type: :request do
-  before do
-    User.create(email: 'student@quill.org',
-                name: 'John Smith',
-                username: 'student1',
-                password: '12345',
-                password_confirmation: '12345',
-                role: 'student')
-  end
+RSpec.describe 'Sign in', type: :request do
+  subject { post '/session/login_through_ajax', params: params, as: :json }
 
-  describe 'POST /session' do
-    it 'creates with valid attributes' do
-      post '/session', params: { user: {email: 'student@quill.org', password: '12345'} }
-      expect(response).to redirect_to(profile_path)
+  let(:user) { create(:user) }
+
+  describe 'POST /session/login_through_ajax' do
+    context 'with valid params' do
+      let(:params) { { user: { email: user.email, password: user.password } } }
+
+      it 'is authorized' do
+        subject
+        expect(response).to have_http_status(:success)
+        expect(JSON.parse(response.body)).to eq({ 'redirect' => '/' })
+      end
     end
 
-    it 'does not create with invalid attributes' do
-      post '/session', params: { user: {email: 'student@quill.org', password: 'wrong'} }
-      expect(response).to_not redirect_to(profile_path)
+    context 'with invalid params' do
+      let(:params) { { user: { email: user.email, password: 'wrong-password' } } }
+
+      it 'is unauthorized' do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/requests/sign_up_spec.rb
+++ b/services/QuillLMS/spec/requests/sign_up_spec.rb
@@ -90,7 +90,7 @@ describe 'Sign up', type: :request do
 
       it 'allows student to sign in' do
         sign_in(expected_student_email, expected_student_password)
-        expect(response).to redirect_to(profile_path)
+        expect(response).to have_http_status(:success)
         expect(User.find(session[:user_id])).to_not eq(nil)
       end
 

--- a/services/QuillLMS/spec/support/helpers/session_helper.rb
+++ b/services/QuillLMS/spec/support/helpers/session_helper.rb
@@ -10,10 +10,13 @@ module SessionHelper
     }.merge(hash)
   end
 
-  def sign_in *args
+  def sign_in(*args)
     user = args.first if args.length == 1
     email, password = user ? [user.email || user.username, user.password] : args
     password = password.presence || '123456'
-    post '/session', params: { user: {email: email, password: password} }
+
+    post '/session/login_through_ajax',
+      params: { user: { email: email, password: password } },
+      as: :json
   end
 end


### PR DESCRIPTION
## WHAT
Remove `create` endpoint from `SessionsController` and some related code

## WHY
The create endpoint looks to be dead code.  In preparation for some [updates](https://www.notion.so/quill/Allow-users-connected-to-Google-to-sign-in-with-an-email-or-username-Part-1-1df0445245e045298a9abd986b8947b8?pvs=4) to login for students under Google Workspace for Educators, the method `login_through_ajax` is the one we actually use.

I suspect `create` was used at one point but then transitioned over to `login_through_ajax` but old code was not removed and methods such as `report_that_route_is_still_in_use` were put to see if this was accidentally not dead code.

Also session#create was used in the `sign_in` helper which probably added some inertia to its removal.

## HOW
Remove the method `#create`.
Explicitly specify `new` and `destroy` routes in config/routes.rb

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
