### PR TITLE
Allow google users to reset their non-existent password

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/session.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/session.scss
@@ -87,7 +87,7 @@
         margin: auto;
         justify-content: center;
         border-radius: 4px;
-        box-shadow: 0 0 0 1px #bdbdbd;
+        box-shadow: 0 0 0 1px $quill-grey-20;
         background-color: $quill-white;
         font-size: 15px;
         font-weight: 600 !important;
@@ -102,8 +102,42 @@
           margin-right: 8px;
         }
         &:first-of-type {
-          margin-bottom: 24px;
+          margin-bottom: 16px;
         }
+      }
+    }
+
+    .google-tbd {
+      text-align: left;
+      font-size: 12px;
+      border-radius: var(--radius-radius-sm, 8px);
+      padding: 12px;
+      box-shadow: 0 0 0 1px $quill-grey-20;
+      margin-bottom: 16px;
+      background-color: $quill-grey-1;
+      h4 {
+        font-size: 12px;
+        font-weight: 700;
+        display: flex;
+        margin-bottom: 8px;
+        align-items: center;
+      }
+      img {
+        margin-right: 4px;
+      }
+      p {
+        margin-bottom: 8px;
+      }
+      a {
+        padding: 0px;
+        border: none;
+        box-shadow: none;
+        height: auto;
+        margin: 0px !important;
+        justify-content: flex-start;
+        font-size: 12px;
+        color: $quill-green;
+        background-color: transparent;
       }
     }
 

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -129,7 +129,7 @@ class ApplicationController < ActionController::Base
 
   protected def confirm_valid_session
     return if current_user.nil? || session.nil? || session[:staff_id] || admin_impersonating_user?(current_user)
-    return unless reset_session? || current_user.google_access_expired?
+    return unless reset_session? || current_user.google_access_expired_and_no_password?
 
     reset_session_and_redirect_to_sign_in
   end

--- a/services/QuillLMS/app/controllers/password_reset_controller.rb
+++ b/services/QuillLMS/app/controllers/password_reset_controller.rb
@@ -12,12 +12,11 @@ class PasswordResetController < ApplicationController
     user = User.find_by_email(params[:user][:email])
 
     if user && !user.sales_contact? && params[:user][:email].present?
-      if user.google_id
-        render json: { message: 'Oops! You have a Google account. Log in that way instead.', type: 'email' }, status: 401
-      elsif user.clever_id
+      if user.clever_id
         render json: { message: 'Oops! You have a Clever account. Log in that way instead.', type: 'email' }, status: 401
       else
         user.refresh_token!
+        user.unlink_google_account!
         UserMailer.password_reset_email(user).deliver_now!
         flash[:notice] = 'We sent you an email with instructions on how to reset your password.'
         flash.keep(:notice)

--- a/services/QuillLMS/app/controllers/password_reset_controller.rb
+++ b/services/QuillLMS/app/controllers/password_reset_controller.rb
@@ -16,7 +16,7 @@ class PasswordResetController < ApplicationController
         render json: { message: 'Oops! You have a Clever account. Log in that way instead.', type: 'email' }, status: 401
       else
         user.refresh_token!
-        user.unlink_google_account!
+        user.unlink_google_account! if user.teacher?
         UserMailer.password_reset_email(user).deliver_now!
         flash[:notice] = 'We sent you an email with instructions on how to reset your password.'
         flash.keep(:notice)

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -26,7 +26,7 @@ class SessionsController < ApplicationController
     @user =  User.find_by_username_or_email(email_or_username)
     if @user.nil? || @user.sales_contact?
       render json: {message: 'An account with this email or username does not exist. Try again.', type: 'email'}, status: :unauthorized
-    elsif @user.signed_up_with_google || @user.google_id
+    elsif @user.google_id && @user.password_digest.nil?
       render json: {message: 'Oops! You have a Google account. Log in that way instead.', type: 'email'}, status: :unauthorized
     elsif @user.clever_id
       render json: {message: 'Oops! You have a Clever account. Log in that way instead.', type: 'email'}, status: :unauthorized

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -868,6 +868,10 @@ class User < ApplicationRecord
     update!(clever_id: nil, google_id: nil, signed_up_with_google: false)
   end
 
+  def unlink_google_account!
+    update!(google_id: nil, signed_up_with_google: false)
+  end
+
   private def validate_flags
     invalid_flags = flags - VALID_FLAGS
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -710,6 +710,10 @@ class User < ApplicationRecord
     google_id.present? && auth_credential.present? && auth_credential.google_access_expired?
   end
 
+  def google_access_expired_and_no_password?
+    google_access_expired? && password_digest.nil?
+  end
+
   # Note this is an incremented count, so could be off.
   def completed_activity_count
     user_activity_classifications.sum(:count)

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/__tests__/__snapshots__/login_form.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/__tests__/__snapshots__/login_form.test.tsx.snap
@@ -41,6 +41,26 @@ exports[`LoginForm it should render 1`] = `
               </span>
             </button>
           </form>
+          <div
+            class="google-tbd"
+          >
+            <h4>
+              <img
+                alt=""
+                src="undefined/images/icons/description-information.svg"
+              />
+               Having trouble logging in with Google?
+            </h4>
+            <p>
+              If you're a Google user, you can also log in using your email address. You just need to create a password.
+            </p>
+            <a
+              class="inline-link"
+              href="/password_reset"
+            >
+              Create a password
+            </a>
+          </div>
           <button
             type="button"
           >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
@@ -149,13 +149,8 @@ class LoginFormApp extends React.Component {
             <div className="auth-section">
               <AuthGoogleAccessForm text='Log in with Google' />
               <div className="google-tbd">
-                <img alt="" src={informationSrc} />
-                <h4>Having trouble logging in with Google?</h4>
-                <div className="google-tbd-text">
-                  <p>If you're a Google user, you can also log in using your email address. You just need to create a password</p>
-                </div>
-              </div>
-              <div>
+                <h4><img alt="" src={informationSrc} /> Having trouble logging in with Google?</h4>
+                <p>If you're a Google user, you can also log in using your email address. You just need to create a password.</p>
                 <a className="inline-link" href="/password_reset">Create a password</a>
               </div>
               <button onClick={this.handleCleverClick} type="button">

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/login/login_form.jsx
@@ -8,6 +8,7 @@ import PasswordWrapper from '../shared/password_wrapper';
 import PasswordInfo from './password_info.jsx';
 
 const smallWhiteCheckSrc = `${process.env.CDN_URL}/images/shared/check-small-white.svg`
+const informationSrc = `${process.env.CDN_URL}/images/icons/description-information.svg`
 
 class LoginFormApp extends React.Component {
   constructor(props) {
@@ -147,6 +148,16 @@ class LoginFormApp extends React.Component {
           <div className="account-container text-center">
             <div className="auth-section">
               <AuthGoogleAccessForm text='Log in with Google' />
+              <div className="google-tbd">
+                <img alt="" src={informationSrc} />
+                <h4>Having trouble logging in with Google?</h4>
+                <div className="google-tbd-text">
+                  <p>If you're a Google user, you can also log in using your email address. You just need to create a password</p>
+                </div>
+              </div>
+              <div>
+                <a className="inline-link" href="/password_reset">Create a password</a>
+              </div>
               <button onClick={this.handleCleverClick} type="button">
                 <img alt="Clever icon" src={`${process.env.CDN_URL}/images/shared/clever_icon.svg`} />
                 <span>Log in with Clever</span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/classroom_student_section.tsx
@@ -497,7 +497,7 @@ const ClassroomStudentSection = ({
       const { name, username, email, id, provider, last_active, number_of_completed_activities, } = student
       const checked = !!selectedStudentIds.includes(id)
       const synced = syncedStatus(student, classroomProvider)
-      const logInMethod = provider ? provider : 'Username'
+      const logInMethod = provider === 'Google' ? 'Google or email' : (provider || 'Username');
 
       return {
         synced,

--- a/services/QuillLMS/spec/controllers/application_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/application_controller_spec.rb
@@ -73,10 +73,10 @@ describe ApplicationController, type: :controller do
         end
       end
 
-      context "when a reset_session? and current_user.google_access_expired? both false" do
+      context "when a reset_session? and current_user.google_access_expired_and_no_password? both false" do
         before do
           allow(controller).to receive(:reset_session?).and_return(false)
-          allow(user).to receive(:google_access_expired?).and_return(false)
+          allow(user).to receive(:google_access_expired_and_no_password?).and_return(false)
         end
 
         it do
@@ -94,8 +94,8 @@ describe ApplicationController, type: :controller do
         end
       end
 
-      context "when current_user.google_access_expired? is true" do
-        before { allow(user).to receive(:google_access_expired?).and_return(true) }
+      context "when current_user.google_access_expired_and_no_password? is true" do
+        before { allow(user).to receive(:google_access_expired_and_no_password?).and_return(true) }
 
         it do
           expect(controller).to receive(:reset_session_and_redirect_to_sign_in)

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -35,7 +35,7 @@ describe SessionsController, type: :controller do
 
       it 'should report login failure' do
         post :login_through_ajax, params: { user: { email: user.email } }, as: :json
-        expect(response.body).to eq({message: 'Oops! You have a Google account. Log in that way instead.', type: 'email'}.to_json)
+        expect(response.body).to eq({message: 'Wrong password. Try again or click Forgot password to reset it.', type: 'password'}.to_json)
       end
     end
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1905,7 +1905,7 @@ describe User, type: :model do
       context 'district_premium? is false' do
         before { allow(user).to receive(:district_premium?).and_return(false) }
 
-        it { expect(subject).to be_falsey }
+        it { expect(subject).to eq falsey }
       end
 
       context 'district_premium? is true' do
@@ -1931,7 +1931,7 @@ describe User, type: :model do
   describe '#learn_worlds_access_override?' do
     subject { user.learn_worlds_access_override? }
 
-    it { expect(subject).to be_falsey }
+    it { expect(subject).to eq falsey }
 
     context 'override exists' do
       before do
@@ -2227,6 +2227,65 @@ describe User, type: :model do
 
       it { expect { subject }.not_to change(user, :google_id) }
       it { expect { subject }.not_to change(user, :signed_up_with_google) }
+    end
+  end
+
+  describe '#google_access_expired?' do
+    subject { user.google_access_expired? }
+
+    let(:user) { create(:user) }
+
+    context 'google_id is not present' do
+      before { allow(user).to receive(:google_id).and_return(nil) }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'google_id is present' do
+      before { allow(user).to receive(:google_id).and_return('some-google-id') }
+
+      context 'auth credential is not present' do
+        it { is_expected.to eq false }
+      end
+
+      context 'auth_credential is not expired' do
+        before { create(:google_auth_credential, user: user)  }
+
+        it { is_expected.to eq false }
+      end
+
+      context 'auth_credential is expired' do
+        before { create(:google_auth_credential, :expired, user: user)  }
+
+        it { is_expected.to eq true }
+      end
+    end
+  end
+
+  describe '#google_access_expired_and_no_password?' do
+    subject { user.google_access_expired_and_no_password? }
+
+    context 'google_access_expired? is false' do
+      before { allow(user).to receive(:google_access_expired?).and_return(false) }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'google_access_expired? is true' do
+      before { allow(user).to receive(:google_access_expired?).and_return(true) }
+
+      context 'password digest is not nil' do
+        before { allow(user).to receive(:password_digest).and_return('some-password-digest') }
+
+        it { is_expected.to eq false }
+      end
+
+      context 'password digest is nil' do
+        before { allow(user).to receive(:password_digest).and_return(nil) }
+
+        it { is_expected.to eq true }
+      end
+
     end
   end
 end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2211,5 +2211,23 @@ describe User, type: :model do
       it { expect { subject }.not_to change(user, :clever_id) }
     end
   end
+
+  describe '#unlink_google_account!' do
+    subject { user.unlink_google_account! }
+
+    context 'user has google_account' do
+      let(:user) { create(:teacher, :signed_up_with_google) }
+
+      it { expect { subject }.to change(user, :google_id).from(user.google_id).to(nil) }
+      it { expect { subject }.to change(user, :signed_up_with_google).from(true).to(false) }
+    end
+
+    context 'user does not have google_account' do
+      let(:user) { create(:teacher) }
+
+      it { expect { subject }.not_to change(user, :google_id) }
+      it { expect { subject }.not_to change(user, :signed_up_with_google) }
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -58,7 +58,7 @@
 require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
-describe User, type: :model do
+RSpec.describe User, type: :model do
 
   it { is_expected.to callback(:capitalize_name).before(:save) }
   it { is_expected.to callback(:generate_student_username_if_absent).before(:validation) }
@@ -1905,7 +1905,7 @@ describe User, type: :model do
       context 'district_premium? is false' do
         before { allow(user).to receive(:district_premium?).and_return(false) }
 
-        it { expect(subject).to eq falsey }
+        it { expect(subject).to eq false }
       end
 
       context 'district_premium? is true' do
@@ -1931,7 +1931,7 @@ describe User, type: :model do
   describe '#learn_worlds_access_override?' do
     subject { user.learn_worlds_access_override? }
 
-    it { expect(subject).to eq falsey }
+    it { expect(subject).to eq false }
 
     context 'override exists' do
       before do


### PR DESCRIPTION
## WHAT
Allow google users the ability to 'reset' their password.

## WHY
This will provide a mechanism for google users to switch to username/password authentication.
The process of 'creating-a-password' will also have the side effect of unlinking _teacher_ accounts from Google.

There's two roles to consider in relation to the login problem and whether or not to drop the google_id from the user:

1) Student
The frontend UI and background job sync rely on google_id less for the student role.  Also, depending on the teacher's permissions, the student's google_id might change from nil back to the original so I would argue just keep it for consistency.

2) Teacher
Initially, the scope was targeting students only, but apparently some teachers might accidentally be set as under 18 (e.g. see this [thread](https://support.google.com/a/thread/168978251?hl=en&msgid=169381975)), so we have to plan for the case where they will also be restricted.  In this case we _do_ want to unlink their google account when `creating-a-password`.   Various background jobs run for a google teacher that rely on the google_id as a proxy for access.  Keeping the google_id will result in these background job running unnecessarily causing errors that will pollute the sidekiq queues.  Also, the frontend UI for various pages will present buttons to the teacher that are incorrect (e.g. Import Google Classrooms students) when they actually don't have access to this.

While this does present an asymmetry with respect to when google_id is kept, the other three cases have downsides (i.e. incorrect frontend UI buttons and background job failures) that warrant this approach.

## HOW
Remove check for google_id in the PasswordResetController
Unlink google account before sending the password_reset email.

### ****ADDENDUM
Added code to handle expired google access that was triggering a confirm session loop.  Instead check for users who have `google_access_expired` and have not gone through the 'create-a-password' route.

### Screenshots
<img width="615" alt="Screenshot 2023-10-19 at 8 57 07 AM" src="https://github.com/empirical-org/Empirical-Core/assets/2057805/186bb9e3-976a-44be-9527-166d90ce3959">

### Notion Card Links
https://www.notion.so/quill/Allow-users-connected-to-Google-to-sign-in-with-an-email-or-username-Part-1-1df0445245e045298a9abd986b8947b8?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  YES
