### PR TITLE
add migrations, model file, and specs for the admin report filter selections table

### DIFF
--- a/services/QuillLMS/app/models/admin_report_filter_selection.rb
+++ b/services/QuillLMS/app/models/admin_report_filter_selection.rb
@@ -28,7 +28,7 @@ class AdminReportFilterSelection < ApplicationRecord
   REPORTS = [
     DATA_EXPORT = 'data_export',
     USAGE_SNAPSHOT_REPORT = 'usage_snapshot_report',
-    GROWTH_DIAGNOSTIC_REPORT = 'growth_diagnostic_report',
+    GROWTH_DIAGNOSTIC_REPORT = 'growth_diagnostic_report'
   ]
 
   validates :report, :inclusion=> { :in => REPORTS }

--- a/services/QuillLMS/app/models/admin_report_filter_selection.rb
+++ b/services/QuillLMS/app/models/admin_report_filter_selection.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: admin_report_filter_selections
+#
+#  id                :bigint           not null, primary key
+#  filter_selections :jsonb
+#  report            :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint           not null
+#
+# Indexes
+#
+#  index_admin_report_filter_selections_on_report   (report)
+#  index_admin_report_filter_selections_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class AdminReportFilterSelection < ApplicationRecord
+  belongs_to :user
+
+  validates :user_id, presence: true
+
+  REPORTS = [
+    DATA_EXPORT = 'data_export',
+    USAGE_SNAPSHOT_REPORT = 'usage_snapshot_report',
+    GROWTH_DIAGNOSTIC_REPORT = 'growth_diagnostic_report',
+  ]
+
+  validates :report, :inclusion=> { :in => REPORTS }
+end

--- a/services/QuillLMS/db/migrate/20231018141022_create_admin_report_filter_selections.rb
+++ b/services/QuillLMS/db/migrate/20231018141022_create_admin_report_filter_selections.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateAdminReportFilterSelections < ActiveRecord::Migration[7.0]
+  def change
+    create_table :admin_report_filter_selections do |t|
+      t.string :report, index: true, null: false
+      t.jsonb :filter_selections
+      t.references :user, index: true, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -762,6 +762,39 @@ ALTER SEQUENCE public.admin_infos_id_seq OWNED BY public.admin_infos.id;
 
 
 --
+-- Name: admin_report_filter_selections; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.admin_report_filter_selections (
+    id bigint NOT NULL,
+    report character varying NOT NULL,
+    filter_selections jsonb,
+    user_id bigint NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: admin_report_filter_selections_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.admin_report_filter_selections_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: admin_report_filter_selections_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.admin_report_filter_selections_id_seq OWNED BY public.admin_report_filter_selections.id;
+
+
+--
 -- Name: announcements; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5471,6 +5504,13 @@ ALTER TABLE ONLY public.admin_infos ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
+-- Name: admin_report_filter_selections id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.admin_report_filter_selections ALTER COLUMN id SET DEFAULT nextval('public.admin_report_filter_selections_id_seq'::regclass);
+
+
+--
 -- Name: announcements id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6498,6 +6538,14 @@ ALTER TABLE ONLY public.admin_approval_requests
 
 ALTER TABLE ONLY public.admin_infos
     ADD CONSTRAINT admin_infos_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: admin_report_filter_selections admin_report_filter_selections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.admin_report_filter_selections
+    ADD CONSTRAINT admin_report_filter_selections_pkey PRIMARY KEY (id);
 
 
 --
@@ -7771,6 +7819,20 @@ CREATE INDEX index_admin_approval_requests_on_admin_info_id ON public.admin_appr
 --
 
 CREATE INDEX index_admin_infos_on_user_id ON public.admin_infos USING btree (user_id);
+
+
+--
+-- Name: index_admin_report_filter_selections_on_report; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_admin_report_filter_selections_on_report ON public.admin_report_filter_selections USING btree (report);
+
+
+--
+-- Name: index_admin_report_filter_selections_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_admin_report_filter_selections_on_user_id ON public.admin_report_filter_selections USING btree (user_id);
 
 
 --
@@ -9929,6 +9991,14 @@ ALTER TABLE ONLY public.activity_survey_responses
 
 
 --
+-- Name: admin_report_filter_selections fk_rails_f3c9548131; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.admin_report_filter_selections
+    ADD CONSTRAINT fk_rails_f3c9548131 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: content_partner_activities fk_rails_f7c9018094; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10497,6 +10567,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230801140455'),
 ('20230801140522'),
 ('20230912150456'),
-('20230929135017');
+('20230929135017'),
+('20231018141022');
 
 

--- a/services/QuillLMS/spec/factories/admin_report_filter_selections.rb
+++ b/services/QuillLMS/spec/factories/admin_report_filter_selections.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: admin_report_filter_selections
+#
+#  id                :bigint           not null, primary key
+#  filter_selections :jsonb
+#  report            :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint           not null
+#
+# Indexes
+#
+#  index_admin_report_filter_selections_on_report   (report)
+#  index_admin_report_filter_selections_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :admin_report_filter_selection do
+    association :user, factory: :user
+    report { AdminReportFilterSelection::REPORTS.sample }
+  end
+end

--- a/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
+++ b/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: admin_report_filter_selections
+#
+#  id                :bigint           not null, primary key
+#  filter_selections :jsonb
+#  report            :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint           not null
+#
+# Indexes
+#
+#  index_admin_report_filter_selections_on_report   (report)
+#  index_admin_report_filter_selections_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+describe AdminReportFilterSelection, type: :model, redis: true do
+  it { should belong_to(:user) }
+
+  it { should validate_presence_of(:user_id) }
+
+  let(:admin_report_filter_selection) { create(:admin_report_filter_selection) }
+
+  describe '#report' do
+    it "should allow valid values" do
+      AdminReportFilterSelection::REPORTS.each do |v|
+        admin_report_filter_selection.report = v
+        expect(admin_report_filter_selection).to be_valid
+      end
+    end
+
+    it "should not allow invalid values" do
+      admin_report_filter_selection.report = nil
+      expect(admin_report_filter_selection).not_to be_valid
+
+      admin_report_filter_selection.report = 'other'
+      expect(admin_report_filter_selection).not_to be_valid
+    end
+  end
+
+end


### PR DESCRIPTION
## WHAT
Add migrations, model file, and specs for the admin_report_filter_selections table.

## WHY
I'm going to use this table to store the filter selections for the admin reports.

## HOW
See "What".

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Save-a-user-s-filter-selections-on-the-new-admin-reports-6012eccc6d1a47ed9f42d632cce33299?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES