### PR TITLE
Add Google::Cloud::DeadlineExceededError to retry

### DIFF
--- a/services/QuillLMS/engines/evidence/app/services/evidence/vertex_ai/text_classifier.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/vertex_ai/text_classifier.rb
@@ -7,7 +7,13 @@ module Evidence
       DISPLAY_NAMES = 'displayNames'
       PREDICT_API_TIMEOUT = 5.0
 
-      PREDICTION_EXCEPTION_CLASSES = [Google::Cloud::InternalError, Google::Cloud::UnknownError]
+      PREDICTION_EXCEPTION_CLASSES = [
+        Google::Cloud::InternalError,
+        Google::Cloud::UnknownError,
+        Google::Cloud::DeadlineExceededError
+      ].freeze
+
+
       PREDICTION_NUM_RETRIES = 1
 
       attr_reader :endpoint_external_id, :text


### PR DESCRIPTION
## WHAT
Add `Google::Cloud::DeadlineExceededError` to list of exception classes for retry.

## WHY
These errors pop-up in evidence errors automated channel.  It's worth seeing if one retry will solve this.

## HOW
Add classname to exception class.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No,
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
