### PR TITLE
Admin csv export

### DIFF
--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -23,12 +23,13 @@ class SnapshotsController < ApplicationController
   WORKERS_FOR_ACTIONS = {
     "count" => Snapshots::CacheSnapshotCountWorker,
     "top_x" => Snapshots::CacheSnapshotTopXWorker,
-    "data_export" => Snapshots::CachePremiumReportsWorker
+    "data_export" => Snapshots::CachePremiumReportsWorker,
+    "create_report_download" => Snapshots::PremiumDownloadReportsWorker
   }
 
-  before_action :set_query, only: [:count, :top_x, :data_export]
-  before_action :validate_request, only: [:count, :top_x, :data_export]
-  before_action :authorize_request, only: [:count, :top_x, :data_export]
+  before_action :set_query, only: [:count, :top_x, :data_export, :create_report_download]
+  before_action :validate_request, only: [:count, :top_x, :data_export, :create_report_download]
+  before_action :authorize_request, only: [:count, :top_x, :data_export, :create_report_download]
 
   def count
     render json: retrieve_cache_or_enqueue_worker(WORKERS_FOR_ACTIONS[action_name])
@@ -36,6 +37,34 @@ class SnapshotsController < ApplicationController
 
   def top_x
     render json: retrieve_cache_or_enqueue_worker(WORKERS_FOR_ACTIONS[action_name])
+  end
+
+  def create_report_download
+    timeframe_start, timeframe_end = Snapshots::Timeframes.calculate_timeframes(snapshot_params[:timeframe],
+      custom_start: snapshot_params[:timeframe_custom_start],
+      custom_end: snapshot_params[:timeframe_custom_end],
+      previous_timeframe: snapshot_params[:previous_timeframe])
+
+    worker_params = [
+      @query,
+      current_user.id,
+      {
+        name: snapshot_params[:timeframe],
+        timeframe_start: timeframe_start,
+        timeframe_end: timeframe_end
+      },
+      snapshot_params[:school_ids],
+      snapshot_params[:headers_to_display],
+      {
+        grades: snapshot_params[:grades],
+        teacher_ids: snapshot_params[:teacher_ids],
+        classroom_ids: snapshot_params[:classroom_ids]
+      }
+
+    ]
+    WORKERS_FOR_ACTIONS[action_name].perform_async(*worker_params)
+
+    render json: { message: 'Generating report' }
   end
 
   def data_export
@@ -133,7 +162,6 @@ class SnapshotsController < ApplicationController
   end
 
   private def retrieve_cache_or_enqueue_worker(worker)
-
     timeframe_start, timeframe_end = Snapshots::Timeframes.calculate_timeframes(snapshot_params[:timeframe],
       custom_start: snapshot_params[:timeframe_custom_start],
       custom_end: snapshot_params[:timeframe_custom_end],
@@ -185,6 +213,7 @@ class SnapshotsController < ApplicationController
       :timeframe_custom_start,
       :timeframe_custom_end,
       :previous_timeframe,
+      headers_to_display: [],
       school_ids: [],
       grades: [],
       teacher_ids: [],

--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -24,12 +24,12 @@ class SnapshotsController < ApplicationController
     "count" => Snapshots::CacheSnapshotCountWorker,
     "top_x" => Snapshots::CacheSnapshotTopXWorker,
     "data_export" => Snapshots::CachePremiumReportsWorker,
-    "create_report_download" => Snapshots::PremiumDownloadReportsWorker
+    "create_csv_report_download" => Snapshots::PremiumDownloadReportsWorker
   }
 
-  before_action :set_query, only: [:count, :top_x, :data_export, :create_report_download]
-  before_action :validate_request, only: [:count, :top_x, :data_export, :create_report_download]
-  before_action :authorize_request, only: [:count, :top_x, :data_export, :create_report_download]
+  before_action :set_query, only: [:count, :top_x, :data_export, :create_csv_report_download]
+  before_action :validate_request, only: [:count, :top_x, :data_export, :create_csv_report_download]
+  before_action :authorize_request, only: [:count, :top_x, :data_export, :create_csv_report_download]
 
   def count
     render json: retrieve_cache_or_enqueue_worker(WORKERS_FOR_ACTIONS[action_name])
@@ -39,7 +39,7 @@ class SnapshotsController < ApplicationController
     render json: retrieve_cache_or_enqueue_worker(WORKERS_FOR_ACTIONS[action_name])
   end
 
-  def create_report_download
+  def create_csv_report_download
     timeframe_start, timeframe_end = Snapshots::Timeframes.calculate_timeframes(snapshot_params[:timeframe],
       custom_start: snapshot_params[:timeframe_custom_start],
       custom_end: snapshot_params[:timeframe_custom_end],

--- a/services/QuillLMS/app/mailers/premium_hub_user_mailer.rb
+++ b/services/QuillLMS/app/mailers/premium_hub_user_mailer.rb
@@ -15,6 +15,11 @@ class PremiumHubUserMailer < UserMailer
     mail to: user.email, subject: subject
   end
 
+  def admin_premium_download_report_email(file_url, email)
+    @file_url = file_url
+    mail to: email, subject: "TEST EMAIL"
+  end
+
   def admin_account_created_email(user, admin_name, school_name, is_reminder)
     @user = user
     @admin_name = admin_name

--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module Adapters
+  module Csv
+    class AdminPremiumDataExport
+      class UnhandledColumnError < StandardError; end
+
+      ORDERED_COLUMNS = %i(
+        student_name
+        student_email
+        completed_at
+        activity_name
+        activity_pack
+        activity_session_id
+        score
+        timespent
+        standard
+        tool
+        school_name
+        classroom_grade
+        teacher_name
+        classroom_name
+        student_id
+        classroom_id
+      )
+
+      def self.to_csv_string(bigquery_result, columns = ORDERED_COLUMNS)
+        validate_input!(bigquery_result, columns)
+
+        CSV.generate do |csv|
+          csv << columns.map(&:to_s)
+          bigquery_result.each do |row|
+            csv << columns.map { |key| row[key] }
+          end
+        end
+      end
+
+      def self.validate_input!(bigquery_result, columns)
+        bigquery_result.each do |row|
+          next if (row.keys - ORDERED_COLUMNS).empty?
+
+          raise UnhandledColumnError, "Unhandled column(s): #{row.keys - ORDERED_COLUMNS}"
+        end
+      end
+    end
+
+  end
+end

--- a/services/QuillLMS/app/queries/snapshots/untruncated_data_export_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/untruncated_data_export_query.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Snapshots
+  class UntruncatedDataExportQuery < DataExportQuery
+    def limit_clause
+      "LIMIT 10" # TODO: remove before live traffic
+    end
+  end
+end

--- a/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
+++ b/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class AdminReportCsvUploader < CarrierWave::Uploader::Base
-  attr_accessor :admin_id
+  attr_reader :admin_id
 
   fog_directory ENV.fetch('ADMIN_REPORT_FOG_DIRECTORY', 'admin-report-fog-directory-staging')
 
   FILENAME_PREFIX = 'ADMIN_REPORT_'
 
-  def initialize(model, mounted_as, admin_id:)
+  def initialize(model = nil, mounted_as = nil, admin_id:)
     @admin_id = admin_id
     super(model, mounted_as)
   end

--- a/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
+++ b/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AdminReportCsvUploader < CarrierWave::Uploader::Base
+  attr_accessor :admin_id
+
+  fog_directory ENV.fetch('ADMIN_REPORT_FOG_DIRECTORY', 'admin-report-fog-directory-staging')
+
+  FILENAME_PREFIX = 'ADMIN_REPORT_'
+
+  def initialize(model, mounted_as, admin_id:)
+    @admin_id = admin_id
+    super(model, mounted_as)
+  end
+
+  def fog_public
+    false
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+
+  def filename
+    # See: http://stackoverflow.com/questions/6920926/carrierwave-create-the-same-unique-filename-for-all-versioned-files
+    random_token = Digest::SHA2.hexdigest("#{Time.current.utc}--#{admin_id}").first(6)
+    date = Date.current.strftime("%m-%d-%y")
+    "#{FILENAME_PREFIX}#{admin_id}_#{date}_#{random_token}"
+  end
+end

--- a/services/QuillLMS/app/views/premium_hub_user_mailer/admin_premium_download_report_email.html.erb
+++ b/services/QuillLMS/app/views/premium_hub_user_mailer/admin_premium_download_report_email.html.erb
@@ -1,0 +1,13 @@
+<p>Hi user,</p>
+
+<a href=<%= @file_url%> rel="noopener noreferrer" target="_blank">Here is your requested report./a>
+
+<a href=<%= @constants[:links][:premium_hub]%> rel="noopener noreferrer" target="_blank">View the Premium Hub</a>
+
+<p>ℹ️ <strong>Need help?</strong></p>
+
+<p>If you have any questions or issues with your account, please reply to this email. You can also <a href=<%= @constants[:links][:premium]%> rel="noopener noreferrer" target="_blank">learn more about Quill Premium here</a> and <a href=<%= @constants[:links][:school_dashboard]%> rel="noopener noreferrer" target="_blank">learn more about the Premium Hub here</a>.</p>
+
+<p>Best regards,</p>
+
+<p><%= @constants[:signatures][:quill_team]%></p>

--- a/services/QuillLMS/app/workers/snapshots/premium_download_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/premium_download_reports_worker.rb
@@ -7,13 +7,13 @@ module Snapshots
     class CloudUploadError < StandardError; end
 
     QUERIES = {
-      'create_report_download' => Snapshots::UntruncatedDataExportQuery
+      'create_csv_report_download' => Snapshots::UntruncatedDataExportQuery
     }
     TEMPFILE_NAME = 'temp.csv'
 
     def perform(query, user_id, timeframe, school_ids, headers_to_display, filters)
       payload = generate_payload(query, timeframe, school_ids, filters)
-      uploader = AdminReportCsvUploader.new(nil, nil, admin_id: user_id)
+      uploader = AdminReportCsvUploader.new(admin_id: user_id)
 
       csv_tempfile = Tempfile.new(TEMPFILE_NAME)
       csv_tempfile << Adapters::Csv::AdminPremiumDataExport.to_csv_string(payload, headers_to_display)

--- a/services/QuillLMS/app/workers/snapshots/premium_download_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/premium_download_reports_worker.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Snapshots
+  class PremiumDownloadReportsWorker
+    include Sidekiq::Worker
+
+    class CloudUploadError < StandardError; end
+
+    QUERIES = {
+      'create_report_download' => Snapshots::UntruncatedDataExportQuery
+    }
+    TEMPFILE_NAME = 'temp.csv'
+
+    def perform(query, user_id, timeframe, school_ids, headers_to_display, filters)
+      payload = generate_payload(query, timeframe, school_ids, filters)
+      uploader = AdminReportCsvUploader.new(nil, nil, admin_id: user_id)
+
+      csv_tempfile = Tempfile.new(TEMPFILE_NAME)
+      csv_tempfile << Adapters::Csv::AdminPremiumDataExport.to_csv_string(payload, headers_to_display)
+
+      # store! returns nil on failure, rather than raising an exception.
+      # We address this gotcha by manually raising an exception.
+      upload_status = uploader.store!(csv_tempfile)
+      raise CloudUploadError, "Unable to upload CSV for user #{user_id}" unless upload_status
+
+      uploaded_file_url = uploader.url
+
+      email = ENV.fetch('TEST_EMAIL_ADDRESS', User.find(user_id).email) # TODO: remove after integration testing
+      PremiumHubUserMailer.admin_premium_download_report_email(uploaded_file_url, email).deliver_now!
+    end
+
+    private def generate_payload(query, timeframe, school_ids, filters)
+      timeframe_start = parse_datetime_string(timeframe['timeframe_start'])
+      timeframe_end = parse_datetime_string(timeframe['timeframe_end'])
+      filters_symbolized = filters.symbolize_keys
+
+      QUERIES[query].run(**{
+        timeframe_start:,
+        timeframe_end:,
+        school_ids:
+      }.merge(filters_symbolized))
+    end
+
+    private def parse_datetime_string(value)
+      return nil if value.nil?
+
+      DateTime.parse(value)
+    end
+
+  end
+end

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/dataExportTableAndFields.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/dataExportTableAndFields.test.tsx.snap
@@ -1,290 +1,326 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataExportTableAndFields component should match snapshot 1`] = `
-<div
-  className="data-export-container"
->
-  <section
-    className="fields-section"
+<Fragment>
+  <div
+    className="header"
   >
-    <h3>
-      Fields
-    </h3>
-    <div
-      className="fields-container"
-    >
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Student Email"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Student Email"
-        >
-          Student Email
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Completed Date"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Completed Date"
-        >
-          Completed Date
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Activity"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Activity"
-        >
-          Activity
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Activity Pack"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Activity Pack"
-        >
-          Activity Pack
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Score"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Score"
-        >
-          Score
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Time Spent"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Time Spent"
-        >
-          Time Spent
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Standard"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Standard"
-        >
-          Standard
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Tool"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Tool"
-        >
-          Tool
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="School"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="School"
-        >
-          School
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Grade"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Grade"
-        >
-          Grade
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Teacher"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Teacher"
-        >
-          Teacher
-        </label>
-      </div>
-      <div
-        className="checkbox-container"
-      >
-        <button
-          aria-label="Checked checkbox"
-          className="quill-checkbox selected"
-          id="Class"
-          onClick={[Function]}
-          type="button"
-        >
-          <img
-            alt="Checked checkbox"
-            src="undefined/images/shared/check-small-white.svg"
-          />
-        </button>
-        <label
-          htmlFor="Class"
-        >
-          Class
-        </label>
-      </div>
-    </div>
-  </section>
-  <section
-    className="preview-section"
-  >
-    <h3>
-      Preview
-    </h3>
-    <div
-      className="preview-disclaimer-container"
+    <h1>
+      Data Export
+    </h1>
+    <button
+      className="quill-button download-report-button contained primary medium focus-on-light"
+      onClick={[Function]}
+      type="button"
     >
       <img
-        alt="Information icon"
-        src="undefined/images/pages/evidence/icons-information-small.svg"
+        alt="White arrow pointing down icon"
+        src="undefined/images/icons/downward-arrow-icon-white.svg"
       />
-      <p>
-        This preview is limited to the first 10 results. Your download will include all activities.
-      </p>
-    </div>
-  </section>
-  <Spinner />
-</div>
+      <span>
+        Download
+      </span>
+    </button>
+  </div>
+  <div
+    className="filter-button-container"
+  >
+    <button
+      className="interactive-wrapper focus-on-light"
+      type="button"
+    >
+      <img
+        alt="Filter icon with three vertical dots and 3 horizontal lines"
+        src="undefined/images/icons/icons-filter.svg"
+      />
+      Filters
+    </button>
+  </div>
+  <div
+    className="data-export-container"
+  >
+    <section
+      className="fields-section"
+    >
+      <h3>
+        Fields
+      </h3>
+      <div
+        className="fields-container"
+      >
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Student Email"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Student Email"
+          >
+            Student Email
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Completed Date"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Completed Date"
+          >
+            Completed Date
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Activity"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Activity"
+          >
+            Activity
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Activity Pack"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Activity Pack"
+          >
+            Activity Pack
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Score"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Score"
+          >
+            Score
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Time Spent"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Time Spent"
+          >
+            Time Spent
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Standard"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Standard"
+          >
+            Standard
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Tool"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Tool"
+          >
+            Tool
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="School"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="School"
+          >
+            School
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Grade"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Grade"
+          >
+            Grade
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Teacher"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Teacher"
+          >
+            Teacher
+          </label>
+        </div>
+        <div
+          className="checkbox-container"
+        >
+          <button
+            aria-label="Checked checkbox"
+            className="quill-checkbox selected"
+            id="Class"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="Checked checkbox"
+              src="undefined/images/shared/check-small-white.svg"
+            />
+          </button>
+          <label
+            htmlFor="Class"
+          >
+            Class
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      className="preview-section"
+    >
+      <h3>
+        Preview
+      </h3>
+      <div
+        className="preview-disclaimer-container"
+      >
+        <img
+          alt="Information icon"
+          src="undefined/images/pages/evidence/icons-information-small.svg"
+        />
+        <p>
+          This preview is limited to the first 10 results. Your download will include all activities.
+        </p>
+      </div>
+    </section>
+    <Spinner />
+  </div>
+</Fragment>
 `;

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
 import * as moment from 'moment';
+import * as React from 'react';
 
-import { requestPost, } from '../../../modules/request'
-import { unorderedArraysAreEqual, } from '../../../modules/unorderedArraysAreEqual'
-import { DataTable, Spinner, informationIcon, smallWhiteCheckIcon, noResultsMessage } from '../../Shared';
+import { requestPost, } from '../../../modules/request';
+import { unorderedArraysAreEqual, } from '../../../modules/unorderedArraysAreEqual';
+import { DataTable, Spinner, filterIcon, informationIcon, noResultsMessage, smallWhiteCheckIcon, whiteArrowPointingDownIcon } from '../../Shared';
 
 const STANDARD_WIDTH = "152px";
 const STUDENT_NAME = "Student Name";
@@ -25,6 +25,7 @@ const PUSHER_EVENT_KEY = "data-export-cached";
 interface DataExportTableAndFieldsProps {
   customTimeframeEnd: string;
   customTimeframeStart: string;
+  openMobileFilterMenu: Function;
   pusherChannel?: any;
   queryKey: string;
   searchCount: number;
@@ -35,7 +36,7 @@ interface DataExportTableAndFieldsProps {
   selectedTimeframe: string;
 }
 
-export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, pusherChannel }: DataExportTableAndFieldsProps) => {
+export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, openMobileFilterMenu, pusherChannel }: DataExportTableAndFieldsProps) => {
   const [showStudentEmail, setShowStudentEmail] = React.useState<boolean>(true);
   const [showSchool, setShowSchool] = React.useState<boolean>(true);
   const [showGrade, setShowGrade] = React.useState<boolean>(true);
@@ -128,7 +129,6 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
   }, [searchCount])
 
   function getData() {
-
     const searchParams = {
       query: queryKey,
       timeframe: selectedTimeframe,
@@ -151,6 +151,22 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
         setData(formattedData)
         setLoading(false)
       }
+    })
+  }
+
+  function startCsvDownload() {
+    const requestParams = {
+      query: 'create_report_download',
+      timeframe: selectedTimeframe,
+      timeframe_custom_start: customTimeframeStart,
+      timeframe_custom_end: customTimeframeEnd,
+      school_ids: selectedSchoolIds,
+      teacher_ids: selectedTeacherIds,
+      classroom_ids: selectedClassroomIds,
+      grades: selectedGrades,
+      headers_to_display: getHeaders().map(header => header.attribute)
+    }
+    requestPost('/snapshots/create_report_download', requestParams, (body) => {
     })
   }
 
@@ -242,30 +258,46 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
   }
 
   return(
-    <div className="data-export-container">
-      <section className="fields-section">
-        <h3>Fields</h3>
-        <div className="fields-container">
-          {renderCheckboxes()}
-        </div>
-      </section>
-      <section className="preview-section">
-        <h3>Preview</h3>
-        <div className="preview-disclaimer-container">
-          <img alt={informationIcon.alt} src={informationIcon.src} />
-          <p>This preview is limited to the first 10 results. Your download will include all activities.</p>
-        </div>
-      </section>
-      {loading && <Spinner />}
-      {!loading && <DataTable
-        className="data-export-table reporting-format"
-        defaultSortAttribute="completed_at"
-        defaultSortDirection="desc"
-        emptyStateMessage={noResultsMessage('activity')}
-        headers={getHeaders()}
-        rows={data || []}
-      />}
-    </div>
+    <React.Fragment>
+      <div className="header">
+        <h1>Data Export</h1>
+        <button className="quill-button download-report-button contained primary medium focus-on-light" onClick={startCsvDownload} type="button">
+          <img alt={whiteArrowPointingDownIcon.alt} src={whiteArrowPointingDownIcon.src} />
+          <span>Download</span>
+        </button>
+      </div>
+      <div className="filter-button-container">
+        <button className="interactive-wrapper focus-on-light" onClick={openMobileFilterMenu} type="button">
+          <img alt={filterIcon.alt} src={filterIcon.src} />
+          Filters
+        </button>
+      </div>
+
+      <div className="data-export-container">
+        <section className="fields-section">
+          <h3>Fields</h3>
+          <div className="fields-container">
+            {renderCheckboxes()}
+          </div>
+        </section>
+        <section className="preview-section">
+          <h3>Preview</h3>
+          <div className="preview-disclaimer-container">
+            <img alt={informationIcon.alt} src={informationIcon.src} />
+            <p>This preview is limited to the first 10 results. Your download will include all activities.</p>
+          </div>
+        </section>
+        {loading && <Spinner />}
+        {!loading && <DataTable
+          className="data-export-table reporting-format"
+          defaultSortAttribute="completed_at"
+          defaultSortDirection="desc"
+          emptyStateMessage={noResultsMessage('activity')}
+          headers={getHeaders()}
+          rows={data || []}
+        />}
+      </div>
+    </React.Fragment>
   )
 }
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -154,9 +154,9 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
     })
   }
 
-  function startCsvDownload() {
+  function createCsvReportDownload() {
     const requestParams = {
-      query: 'create_report_download',
+      query: 'create_csv_report_download',
       timeframe: selectedTimeframe,
       timeframe_custom_start: customTimeframeStart,
       timeframe_custom_end: customTimeframeEnd,
@@ -166,7 +166,7 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
       grades: selectedGrades,
       headers_to_display: getHeaders().map(header => header.attribute)
     }
-    requestPost('/snapshots/create_report_download', requestParams, (body) => {
+    requestPost('/snapshots/create_csv_report_download', requestParams, (body) => {
     })
   }
 
@@ -261,7 +261,7 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
     <React.Fragment>
       <div className="header">
         <h1>Data Export</h1>
-        <button className="quill-button download-report-button contained primary medium focus-on-light" onClick={startCsvDownload} type="button">
+        <button className="quill-button download-report-button contained primary medium focus-on-light" onClick={createCsvReportDownload} type="button">
           <img alt={whiteArrowPointingDownIcon.alt} src={whiteArrowPointingDownIcon.src} />
           <span>Download</span>
         </button>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/DataExportContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/DataExportContainer.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react'
+import * as React from 'react';
 
-import { FULL, restrictedPage, mapItemsIfNotAll } from '../shared';
-import { Spinner, filterIcon, whiteArrowPointingDownIcon } from '../../Shared/index'
+import { Spinner } from '../../Shared/index';
 import DataExportTableAndFields from '../components/dataExportTableAndFields';
+import { FULL, mapItemsIfNotAll, restrictedPage } from '../shared';
 
 export const DataExportContainer = ({
   accessType,
@@ -19,7 +19,6 @@ export const DataExportContainer = ({
   selectedTeachers,
   allTeachers,
   selectedTimeframe,
-  handleClickDownloadReport,
   openMobileFilterMenu
 }) => {
 
@@ -33,23 +32,11 @@ export const DataExportContainer = ({
 
   return (
     <main className="data-export-main">
-      <div className="header">
-        <h1>Data Export</h1>
-        <button className="quill-button download-report-button contained primary medium focus-on-light" onClick={handleClickDownloadReport} type="button">
-          <img alt={whiteArrowPointingDownIcon.alt} src={whiteArrowPointingDownIcon.src} />
-          <span>Download</span>
-        </button>
-      </div>
-      <div className="filter-button-container">
-        <button className="interactive-wrapper focus-on-light" onClick={openMobileFilterMenu} type="button">
-          <img alt={filterIcon.alt} src={filterIcon.src} />
-          Filters
-        </button>
-      </div>
       <DataExportTableAndFields
         customTimeframeEnd={customEndDate?.toDate()}
         customTimeframeStart={customStartDate?.toDate()}
         key="data-export-table-and-fields"
+        openMobileFilterMenu={openMobileFilterMenu}
         pusherChannel={pusherChannel}
         queryKey="data-export"
         searchCount={searchCount}

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -733,7 +733,7 @@ EmpiricalGrammar::Application.routes.draw do
       post :previous_count
       post :top_x
       post :data_export
-      post :create_report_download
+      post :create_csv_report_download
     end
   end
 

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -733,6 +733,7 @@ EmpiricalGrammar::Application.routes.draw do
       post :previous_count
       post :top_x
       post :data_export
+      post :create_report_download
     end
   end
 

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -35,12 +35,12 @@ describe SnapshotsController, type: :controller do
       allow(DateTime).to receive(:current).and_return(now)
     end
 
-    describe '#create_report_download' do
-      let(:query) { 'create_report_download' }
+    describe '#create_csv_report_download' do
+      let(:query) { 'create_csv_report_download' }
       let(:grades) { ['Kindergarten', '1'] }
       let(:teacher_ids) { ['4', '5'] }
       let(:classroom_ids) { ['7', '8'] }
-      let!(:headers_to_display) { %w(student_name student_email) }
+      let(:headers_to_display) { %w(student_name student_email) }
 
       before do
         allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
@@ -48,7 +48,7 @@ describe SnapshotsController, type: :controller do
 
       it 'should trigger PremiumDownloadReportsWorker with correct payload' do
         expected_worker_params = [
-          'create_report_download',
+          'create_csv_report_download',
           user.id,
           {
             name: timeframe_name,
@@ -66,7 +66,7 @@ describe SnapshotsController, type: :controller do
 
         expect(Snapshots::PremiumDownloadReportsWorker).to receive(:perform_async).with(*expected_worker_params)
 
-        post :create_report_download, params: {
+        post :create_csv_report_download, params: {
           query:,
           timeframe: timeframe_name,
           school_ids:,

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -35,6 +35,49 @@ describe SnapshotsController, type: :controller do
       allow(DateTime).to receive(:current).and_return(now)
     end
 
+    describe '#create_report_download' do
+      let(:query) { 'create_report_download' }
+      let(:grades) { ['Kindergarten', '1'] }
+      let(:teacher_ids) { ['4', '5'] }
+      let(:classroom_ids) { ['7', '8'] }
+      let!(:headers_to_display) { %w(student_name student_email) }
+
+      before do
+        allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
+      end
+
+      it 'should trigger PremiumDownloadReportsWorker with correct payload' do
+        expected_worker_params = [
+          'create_report_download',
+          user.id,
+          {
+            name: timeframe_name,
+            timeframe_start: current_start,
+            timeframe_end: current_end
+          },
+          school_ids,
+          headers_to_display,
+          {
+            grades: grades,
+            teacher_ids: teacher_ids,
+            classroom_ids: classroom_ids
+          }
+        ]
+
+        expect(Snapshots::PremiumDownloadReportsWorker).to receive(:perform_async).with(*expected_worker_params)
+
+        post :create_report_download, params: {
+          query:,
+          timeframe: timeframe_name,
+          school_ids:,
+          grades:,
+          teacher_ids:,
+          headers_to_display:,
+          classroom_ids:
+        }
+      end
+    end
+
     context 'cache key generation' do
       let(:query) { 'most-active-schools' }
       let(:grades) { ['Kindergarten', '1'] }

--- a/services/QuillLMS/spec/mailers/premium_hub_user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/premium_hub_user_mailer_spec.rb
@@ -45,6 +45,18 @@ describe PremiumHubUserMailer, type: :mailer do
     end
   end
 
+  describe 'admin_premium_download_report_email' do
+    let(:file_url) { 's3.csv' }
+    let(:email) { 'a@b.org' }
+    let(:mail) { described_class.admin_premium_download_report_email(file_url, email) }
+
+    it 'rendering should include the correct file path' do
+      body_contains_expected_content = mail.body.include?("s3.csv")
+      expect(body_contains_expected_content).to eq(true)
+      expect(mail.to).to eq([email])
+    end
+  end
+
   describe 'teacher_link_school_email' do
     let(:user) { build(:user) }
     let(:admin_user) { build(:user) }

--- a/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
+++ b/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Adapters::Csv::AdminPremiumDataExport do
+  subject { described_class }
+
+  describe '#to_csv_string' do
+    let(:valid_input) {
+      [{
+        activity_name: 'Test Activity',
+        activity_pack: 'Test Pack',
+        activity_session_id: 12345,
+        classroom_grade: '9',
+        classroom_id: 67890,
+        classroom_name: 'Test Classroom',
+        completed_at: Time.current,
+        school_name: 'Test School',
+        score: 0.95,
+        standard: 'Test Standard',
+        student_email: 'test@example.com',
+        student_id: 112233,
+        student_name: 'Test Student',
+        teacher_name: 'Test Teacher',
+        timespent: 200,
+        tool: 'Test Tool'
+      }]
+    }
+
+    context 'with valid input' do
+      it 'returns a CSV string' do
+        expect(subject.to_csv_string(valid_input)).to be_a(String)
+        expect(subject.to_csv_string(valid_input)).to include('Test Activity')
+      end
+
+      it 'handles subsets of valid columns and orders them according to ORDERED_COLUMNS' do
+        expected_result = "student_name,activity_name\nTest Student,Test Activity\n"
+        expect(subject.to_csv_string(valid_input, [:student_name, :activity_name])).to eq expected_result
+      end
+    end
+
+    context 'with invalid input' do
+      let(:invalid_input) { valid_input.first.merge(extra_column: 'Extraneous') }
+
+      it 'raises a ColumnMismatchError' do
+        expect { subject.to_csv_string([invalid_input]) }.to raise_error(described_class::UnhandledColumnError)
+      end
+    end
+  end
+
+
+end

--- a/services/QuillLMS/spec/workers/snapshots/premium_download_reports_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/premium_download_reports_worker_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Snapshots::PremiumDownloadReportsWorker do
+  subject { described_class.new }
+
+  describe '#perform' do
+    let(:query) { 'create_report_download' }
+    let(:user_id) { create(:user).id }
+    let(:timeframe) { { 'current_start' => '2023-01-01', 'current_end' => '2023-12-31' } }
+    let(:school_ids) { [1, 2, 3] }
+    let(:filters) { { 'filter1' => 'value1' } }
+    let(:mock_payload) { double }
+    let(:mock_csv) { "mock,csv,data" }
+    let(:csv_tempfile) { Tempfile.new('mock.csv') }
+    let(:headers_to_display) { [] }
+
+    before do
+      allow(Snapshots::UntruncatedDataExportQuery).to receive(:run).and_return(mock_payload)
+      allow(Adapters::Csv::AdminPremiumDataExport).to receive(:to_csv_string).and_return(mock_csv)
+      allow(Tempfile).to receive(:new).and_return(csv_tempfile)
+    end
+
+    context 'upload succeeds' do
+      let(:mock_uploader) { double(store!: [], url: 'a_url') }
+
+      before do
+        allow(AdminReportCsvUploader).to receive(:new).and_return(mock_uploader)
+      end
+
+      it 'does not raise an error' do
+        expect { subject.perform(query, user_id, timeframe, school_ids, headers_to_display, filters) }.not_to raise_error
+      end
+
+    end
+
+    context 'upload fails' do
+      let(:mock_uploader) { double(store!: false) }
+
+      before do
+        allow(AdminReportCsvUploader).to receive(:new).and_return(mock_uploader)
+      end
+
+      it 'raises a CloudUploadError' do
+        expect { subject.perform(query, user_id, timeframe, school_ids, headers_to_display, filters) }
+          .to raise_error(described_class::CloudUploadError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT 

User story: When an admin clicks the `Download` button in the `premium_hub/data_exports` page, they should receive an email with a link to the CSV file.

# HOW

- new query, which is identical to the DataExport query except for a null LIMIT clause
- an adapter to translate the BigQuery payload into a CSV file
- a class to upload the CSV file to S3
- set up appropriate S3 buckets and permissions
- a worker to orchestrate everything 

Two items arriving in a following PR:
- add a spinner UX for the button click
- Peter Sharkey will provide final email text and snackbar copy, to replace the stub text that is in this PR.

## WHY
We want admins to be able to download CSV admin reports in a streamlined way.

Since the page that drives this feature is not currently surfaced to users, this PR can be deployed as-is


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=1039497a407e4e94b1a988530861d7c1&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
