### PR TITLE
add google integration change banners

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/banner.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/banner.scss
@@ -17,6 +17,7 @@
     p {
       text-align: center;
       padding-right: 0px;
+      margin: 0px 30px;
     }
   }
   &#student-feedback-banner {

--- a/services/QuillLMS/app/assets/stylesheets/shared/banner.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/banner.scss
@@ -1,5 +1,5 @@
 .banner {
-  background-color: #014f92;
+  background-color: $quill-viridian;
   padding: 16px 0px;
   display: none;
   &#webinar-banner-one-off {
@@ -7,6 +7,17 @@
   }
   &.webinar-banner {
     display: block;
+  }
+  &.google-integration-change-banner {
+    button {
+      position: absolute;
+      top: 16;
+      right: 16px;
+    }
+    p {
+      text-align: center;
+      padding-right: 0px;
+    }
   }
   &#student-feedback-banner {
     .interactive-wrapper {
@@ -24,8 +35,6 @@
   }
   a {
     text-decoration: underline;
-    font-weight: bold;
-    cursor: pointer;
   }
   .banner-icon {
     padding-left: 15px;

--- a/services/QuillLMS/app/assets/stylesheets/shared/banner.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/banner.scss
@@ -18,16 +18,18 @@
     color: $quill-white;
   }
   p {
-    padding-left: 16px;
     padding-right: 24px;
     flex: 1;
     margin-bottom: 0px;
   }
   a {
     text-decoration: underline;
+    font-weight: bold;
+    cursor: pointer;
   }
   .banner-icon {
     padding-left: 15px;
+    padding-right: 16px;
   }
   #close-banner {
     cursor: pointer;

--- a/services/QuillLMS/app/assets/stylesheets/variables.scss
+++ b/services/QuillLMS/app/assets/stylesheets/variables.scss
@@ -41,6 +41,8 @@ $quill-green-vibrant-10: #EBF8E0;
 $quill-green-vibrant-5: #FAFFF5;
 $quill-green-vibrant-1: #FAFFF6;
 
+$quill-viridian: #235E62;
+
 $quill-teal: #2C7F9B;
 $quill-teal-50: #8DCFE2;
 $quill-teal-20: #AADAE9;

--- a/services/QuillLMS/app/views/application/_google_integration_change_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_google_integration_change_banner.html.erb
@@ -5,35 +5,42 @@
   <div class="banner google-integration-change-banner" id="google-login-and-signup-banner">
     <div class="content-container">
       <p>Having trouble signing in with Google? Create a password for Quill or request app verification. <a href="<%= banner_link %>" rel="noopener noreferrer" target="_blank">Learn more</a></p>
-      <button class="interactive-wrapper" id="close-google-login-and-signup-banner"><img alt="" src="<%= "#{ENV['CDN_URL']}/images/icons/close-white.svg" %>"></button>
     </div>
   </div>
 <% elsif current_user&.teacher? && current_user&.google_id %>
   <div class="banner google-integration-change-banner" id="google-teacher-banner">
     <div class="content-container">
       <p>Google Classroom teachers, if your students are having trouble signing in, ask them to create a Quill password or request app verification. <a href="<%= banner_link %>" rel="noopener noreferrer" target="_blank">Learn more</a></p>
-      <button class="interactive-wrapper" id="close-google-teacher-banner"><img alt="" src="<%= "#{ENV['CDN_URL']}/images/icons/close-white.svg" %>"></button>
     </div>
+    <button aria-label="Dismiss the banner" class="interactive-wrapper" id="close-google-teacher-banner"><img alt="" src="<%= "#{ENV['CDN_URL']}/images/icons/close-white.svg" %>"></button>
   </div>
 <% end %>
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    const banners = {
-      'google-teacher-banner': 'google_teacher_banner_closed',
-      'google-login-and-signup-banner': 'google_login_and_signup_banner_closed'
-    };
+    const bannerId = 'google-teacher-banner'
+    const cookieName = 'google_teacher_banner_closed'
 
-    for (let [bannerId, cookieName] of Object.entries(banners)) {
+    const bannerElement = document.getElementById(bannerId);
+    const closeButton = document.getElementById(`close-${bannerId}`);
+
+    if (bannerElement && closeButton) {
       if (document.cookie.indexOf(`${cookieName}=1`) === -1) {
-        document.getElementById(bannerId).style.display = 'block';
+        bannerElement.style.display = 'block';
       }
 
-      document.getElementById(`close-${bannerId}`).addEventListener('click', function(e) {
+      closeButton.addEventListener('click', function(e) {
         e.preventDefault();
-        document.getElementById(bannerId).style.display = 'none';
+        bannerElement.style.display = 'none';
         document.cookie = `${cookieName}=1; path=/`;
       });
     }
+
+    const loginSignupBanner = document.getElementById('google-login-and-signup-banner');
+
+    if (document.cookie.indexOf('google_login_and_signup_banner_closed=1') === -1 && loginSignupBanner) {
+      loginSignupBanner.style.display = 'block';
+    }
+
   });
 </script>

--- a/services/QuillLMS/app/views/application/_google_integration_change_banner.html.erb
+++ b/services/QuillLMS/app/views/application/_google_integration_change_banner.html.erb
@@ -1,0 +1,39 @@
+<% current_path = request.env['PATH_INFO'] %>
+<% banner_link = "https://support.quill.org/en/articles/8496308-how-to-sign-into-a-google-linked-quill-account-with-a-quill-password" %>
+
+<% if Date.today < Date.new(2023, 12, 23) && ['session/new', 'sign-up/student', 'sign-up/teacher'].any? { |str| current_path.include?(str) } %>
+  <div class="banner google-integration-change-banner" id="google-login-and-signup-banner">
+    <div class="content-container">
+      <p>Having trouble signing in with Google? Create a password for Quill or request app verification. <a href="<%= banner_link %>" rel="noopener noreferrer" target="_blank">Learn more</a></p>
+      <button class="interactive-wrapper" id="close-google-login-and-signup-banner"><img alt="" src="<%= "#{ENV['CDN_URL']}/images/icons/close-white.svg" %>"></button>
+    </div>
+  </div>
+<% elsif current_user&.teacher? && current_user&.google_id %>
+  <div class="banner google-integration-change-banner" id="google-teacher-banner">
+    <div class="content-container">
+      <p>Google Classroom teachers, if your students are having trouble signing in, ask them to create a Quill password or request app verification. <a href="<%= banner_link %>" rel="noopener noreferrer" target="_blank">Learn more</a></p>
+      <button class="interactive-wrapper" id="close-google-teacher-banner"><img alt="" src="<%= "#{ENV['CDN_URL']}/images/icons/close-white.svg" %>"></button>
+    </div>
+  </div>
+<% end %>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const banners = {
+      'google-teacher-banner': 'google_teacher_banner_closed',
+      'google-login-and-signup-banner': 'google_login_and_signup_banner_closed'
+    };
+
+    for (let [bannerId, cookieName] of Object.entries(banners)) {
+      if (document.cookie.indexOf(`${cookieName}=1`) === -1) {
+        document.getElementById(bannerId).style.display = 'block';
+      }
+
+      document.getElementById(`close-${bannerId}`).addEventListener('click', function(e) {
+        e.preventDefault();
+        document.getElementById(bannerId).style.display = 'none';
+        document.cookie = `${cookieName}=1; path=/`;
+      });
+    }
+  });
+</script>

--- a/services/QuillLMS/app/views/layouts/application.html.erb
+++ b/services/QuillLMS/app/views/layouts/application.html.erb
@@ -21,6 +21,7 @@
       <%= content_tag(:div, "<p>#{value}</p><i class='fas fa-times-circle' aria-hidden='true'></i>".html_safe, {class: "flash #{key}", onClick: "$(this).slideUp(300)"}) %>
     <% end %>
     <%= render partial: 'application/preview_student_banner' %>
+    <%= render partial: 'application/google_integration_change_banner' %>
     <%= render partial: 'application/demo_account_banner' %>
     <%= render partial: 'application/webinar_banner' %>
     <% if ENV['UPGRADE'] && ENV['UPGRADE_END_TIME'] && Time.current < Time.parse(ENV['UPGRADE_END_TIME'])%>


### PR DESCRIPTION
## WHAT
Add banners to sign up/log in pages for teachers and students, as well as signed-in pages for Google teachers.

## WHY
We want to alert users who may be having trouble signing in about the recent change to Google integrations.

## HOW
Largely reuse design and logic from other, similar banners. Note: Jack is deciding about what color these should be (the existing one doesn't exist in our new Color Palette), so I'll be making that change before this goes live, but wanted to get it up for review prior to that since the color change is trivial.

### Screenshots
<img width="1358" alt="Screenshot 2023-10-20 at 8 33 18 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/8ba49bdf-5559-4c22-9959-e7c6a726b061">
<img width="1224" alt="Screenshot 2023-10-20 at 8 30 47 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/016a279d-38bf-4b7d-b28c-9b88e3e70834">
<img width="1119" alt="Screenshot 2023-10-20 at 8 19 19 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/4bed8b86-5d68-49a9-ace7-e1d23f29cb53">


### Notion Card Links
https://www.notion.so/quill/Banner-Request-Banner-on-Sign-In-Page-Announcing-Google-Change-e4950dba9875415fb5172f161636cafc

https://www.notion.so/quill/Banner-for-Google-Teachers-Only-Announcing-that-their-students-can-create-a-password-1327ea5116044eaba5f42d0965bb2b99

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - no tests for erb files
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES