### PR TITLE
fix bug where hidden menu still takes up space on sections of report

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
@@ -124,6 +124,7 @@
   .filter-menu-closed {
     margin: 0 auto;
     position: relative;
+    width: 100%;
     max-width: 1328px; // same as main
     .show-filter-menu-button {
       top: 32px;


### PR DESCRIPTION
## WHAT
Fix bug where the Usage Snapshot Report wasn't taking up the full width of the page, even once the filter menu was hidden.  

## WHY
This is the whole point of this feature.

## HOW
Just add a `width: 100%` rule to the container so that it always takes up all available space.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/On-the-Usage-Snapshot-report-the-hide-filters-button-does-not-work-as-expected-on-sections-other-th-f2eab2e714bd4074a37f4f717ac3d167

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - just CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES