### PR TITLE
lms/fix-argument-count-error

### DIFF
--- a/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
@@ -10,7 +10,7 @@ module Snapshots
       'data-export' => Snapshots::DataExportQuery
     }
 
-    def perform(cache_key, query, user_id, timeframe, school_ids, filters)
+    def perform(cache_key, query, user_id, timeframe, school_ids, filters, previous_timeframe)
       payload = generate_payload(query, timeframe, school_ids, filters)
       Rails.cache.write(cache_key, payload.to_a, expires_in: cache_expiry)
 

--- a/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
@@ -35,8 +35,8 @@ module Snapshots
       filters_symbolized = filters.symbolize_keys
 
       QUERIES[query].run(**{
-        timeframe_start: DateTime.parse(timeframe['current_start']),
-        timeframe_end: DateTime.parse(timeframe['current_end']),
+        timeframe_start: DateTime.parse(timeframe['timeframe_start']),
+        timeframe_end: DateTime.parse(timeframe['timeframe_end']),
         school_ids: school_ids
       }.merge(filters_symbolized))
     end

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -20,7 +20,8 @@ describe SnapshotsController, type: :controller do
     let(:controller_actions) {
       [
         [:count, 'active-classrooms'],
-        [:top_x, 'most-active-schools']
+        [:top_x, 'most-active-schools'],
+        [:data_export, 'data-export']
       ]
     }
     let(:previous_start) { now - 1.day }

--- a/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
@@ -66,7 +66,7 @@ module Snapshots
         expect(Rails.cache).to receive(:write)
         expect(SendPusherMessageWorker).to receive(:perform_async)
 
-        subject.perform(cache_key, query, user_id, timeframe, school_ids, filters)
+        subject.perform(cache_key, query, user_id, timeframe, school_ids, filters, nil)
       end
 
       context 'serialization/deserialization' do
@@ -75,7 +75,7 @@ module Snapshots
           Sidekiq::Testing.inline! do
             expect(query_double).to receive(:run).with(expected_query_args)
 
-            described_class.perform_async(cache_key, query, user_id, timeframe, school_ids, filters)
+            described_class.perform_async(cache_key, query, user_id, timeframe, school_ids, filters, nil)
           end
         end
       end
@@ -86,7 +86,7 @@ module Snapshots
           expect(Rails.cache).to receive(:write)
           expect(SendPusherMessageWorker).to receive(:perform_async)
 
-          subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys)
+          subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys, nil)
         end
       end
 
@@ -100,7 +100,7 @@ module Snapshots
         expect(Rails.cache).to receive(:write).with(cache_key, payload, expires_in: cache_ttl)
         expect(SendPusherMessageWorker).to receive(:perform_async)
 
-        subject.perform(cache_key, query, user_id, timeframe, school_ids, filters)
+        subject.perform(cache_key, query, user_id, timeframe, school_ids, filters, nil)
       end
 
       it 'should send a Pusher notification' do
@@ -111,7 +111,7 @@ module Snapshots
           school_ids: school_ids
         }.merge(filters))
 
-        subject.perform(cache_key, query, user_id, timeframe, school_ids, filters)
+        subject.perform(cache_key, query, user_id, timeframe, school_ids, filters, nil)
       end
     end
   end

--- a/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
@@ -35,13 +35,11 @@ module Snapshots
     context '#perform' do
       let(:timeframe_end) { DateTime.now }
       let(:current_timeframe_start) { timeframe_end - 30.days }
-      let(:previous_timeframe_start) { current_timeframe_start - 30.days }
       let(:timeframe) {
         {
           'name' => timeframe_name,
-          'previous_start' => previous_timeframe_start.to_s,
-          'current_start' => current_timeframe_start.to_s,
-          'current_end' => timeframe_end.to_s
+          'timeframe_start' => current_timeframe_start.to_s,
+          'timeframe_end' => timeframe_end.to_s
         }
       }
       let(:expected_query_args) {


### PR DESCRIPTION
## WHAT
Update data-export worker signature to match new call signature
## WHY
We updated the controller to always call jobs with 7 params even though only one of the worker classes being used here needs all 7, which is awkward.  I think we should almost certainly refactor this in a cleaner way rather than have intentionally unused params in method signatures, but I wanted to get this out quickly rather than let the bug linger for a week.

What we did was add an additional param to help the `Count` worker handle both "current" and "previous" timeframes (which currently need different Pusher events to be sent).  Because we've generalized the calling of these workers, I decided to update the `TopX` worker to also take the additional param even though it never used it.  This was awkward, but felt like an okay compromise.  I missed that `DataExport` worker is hooked into the same call stack, so it also needs this value.  Having unused params in two different classes makes that compromise a lot worse, and it definitely needs some kind of refactor.  However, given that I'm off this week, and that I can get a quick-and-dirty fix out the door before fully checking out, I figured it was worth doing this and following up next week.

NOTE: It may be worth holding off on merging this version of the fix and hold out for something cleaner and closer to what we want the end state to be given that the page that uses this worker is not public (it's another one of those that we've put into production, but without a public link to the page).
## HOW
Add an unused param to the method signature for the worker to match the new expected call

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-Sidekiq-Snapshots-CachePremiumReports-816ca6db3c8e46129aab1d677b1f08b6

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
