### PR TITLE
Update copy for no-classrooms-to-import

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/assign_students.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/assign_students.tsx
@@ -145,7 +145,12 @@ const AssignStudents = ({
 
       if (body.quill_retrieval_processing) { return }
 
-      setProviderClassrooms(body.classrooms.filter(classroom => !classroom.alreadyImported))
+      if (providerConfig?.isGoogle) {
+        setProviderClassrooms(body.classrooms.filter(classroom => !classroom.alreadyImported && classroom.is_owner))
+      } else {
+        setProviderClassrooms(body.classrooms.filter(classroom => !classroom.alreadyImported))
+      }
+
       setProviderClassroomsLoading(false)
     })
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/active_classrooms.tsx
@@ -214,7 +214,13 @@ const ActiveClassrooms = ({
       if (body.quill_retrieval_processing) { return }
 
       setAllProviderClassrooms(body.classrooms)
-      setProviderClassrooms(body.classrooms.filter(classroom => !classroom.alreadyImported && classroom.is_owner))
+
+      if (providerConfig?.isGoogle) {
+        setProviderClassrooms(body.classrooms.filter(classroom => !classroom.alreadyImported && classroom.is_owner))
+      } else {
+        setProviderClassrooms(body.classrooms.filter(classroom => !classroom.alreadyImported))
+      }
+
       setProviderClassroomsLoading(false)
     })
   }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/no_classrooms_to_import_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/no_classrooms_to_import_modal.tsx
@@ -16,7 +16,7 @@ const AVERAGE_TOOLTIP_ITEM_HEIGHT = 40 // update when CSS changes -- currently 2
 const NoClassroomsToImportModal = ({ close, provider, allProviderClassrooms }: NoClassroomsToImportModalProps) => {
   const providerTitle = providerConfigLookup[provider].title
 
-  const unownedClassrooms = allProviderClassrooms.filter(classroom => !classroom.is_owner)
+  const unownedClassrooms = provider === 'Google' ? allProviderClassrooms.filter(classroom => !classroom.is_owner) : []
   const importedAndArchivedClassrooms = allProviderClassrooms.filter(classroom => classroom.archived && classroom.alreadyImported)
 
   let notSeeingClassesSection
@@ -24,7 +24,7 @@ const NoClassroomsToImportModal = ({ close, provider, allProviderClassrooms }: N
   if (unownedClassrooms.length || importedAndArchivedClassrooms.length) {
     const importedAndArchivedClassroomsSection = importedAndArchivedClassrooms.length ? (
       <p>
-        You have&nbsp;<b>{importedAndArchivedClassrooms.length} synced Google Classroom{importedAndArchivedClassrooms.length > 1 ? 's' : ''} <a href="/teachers/classrooms/archived">archived in Quill</a></b>
+        You have&nbsp;<b>{importedAndArchivedClassrooms.length} synced {provider} Classroom{importedAndArchivedClassrooms.length > 1 ? 's' : ''} <a href="/teachers/classrooms/archived">archived in Quill</a></b>
         <Tooltip
           averageItemHeight={AVERAGE_TOOLTIP_ITEM_HEIGHT}
           tooltipText={importedAndArchivedClassrooms.map(c => c.name)}
@@ -35,7 +35,7 @@ const NoClassroomsToImportModal = ({ close, provider, allProviderClassrooms }: N
 
     const unownedClassroomsSection = unownedClassrooms.length ? (
       <p>
-        There {unownedClassrooms.length > 1 ? 'are' : 'is'}&nbsp;<b>{unownedClassrooms.length} Google Classroom{unownedClassrooms.length > 1 ? 's' : ''}</b>&nbsp;you have access to, but don&#39;t own
+        There {unownedClassrooms.length > 1 ? 'are' : 'is'}&nbsp;<b>{unownedClassrooms.length} {provider} Classroom{unownedClassrooms.length > 1 ? 's' : ''}</b>&nbsp;you have access to, but don&#39;t own
         <Tooltip
           averageItemHeight={AVERAGE_TOOLTIP_ITEM_HEIGHT}
           tooltipText={unownedClassrooms.map(c => c.name)}


### PR DESCRIPTION
## WHAT
1. Adjust  copy for the no-classrooms-to-import modal
2. Restrict unowned classrooms check to Google only

## WHY
1. For the relevant Clever teachers, it's listing 'Google Classrooms' that are not importable when it should be 'Clever classrooms'
2. Clever and Canvas provider do not use the `is_owner` attribute so we are unfortunately filtering out all importable classrooms for these.

## HOW
1. Update the string to use `{provider}`.
2. Add a check for google provider.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Google-Classroom-copy-in-Clever-synced-Quill-account-c1c59b7594d641539d3c610dcfb7b27b?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
