### PR TITLE
Remove a open positions from career page

### DIFF
--- a/services/QuillLMS/config/careers.yml
+++ b/services/QuillLMS/config/careers.yml
@@ -1,10 +1,2 @@
 default:
   open_positions:
-    -
-      category: 'Curriculum'
-      title: 'Associate Curriculum Product Manager'
-      url: 'https://wellfound.com/l/2yV9kT'
-    -
-      category: 'Curriculum'
-      title: 'Social Studies Curriculum Developer'
-      url: 'https://wellfound.com/l/2yXg2x'


### PR DESCRIPTION
## WHAT
Remove Associate Curriculum Product Manager and Social Studies Curriculum Developer positions from Careers page

## WHY
The positions have been filled

## HOW
Update the yaml file.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Remove-Associate-Curriculum-Product-Manager-and-Social-Studies-Curriculum-Developer-positions-from-C-812291d087d847edb967e07f5de4f61c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
