### PR TITLE
Add segment event to track google users that set a password (#11173)

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -236,7 +236,8 @@ class User < ApplicationRecord
   before_validation :prep_authentication_terms
   before_save :capitalize_name, if: proc { will_save_change_to_name? && !skip_capitalize_names_callback }
   before_save :set_time_zone, unless: :time_zone
-  after_save  :update_invitee_email_address, if: proc { saved_change_to_email? }
+  before_update :track_google_user_set_password, if: proc { google_user_set_password? }
+  after_save :update_invitee_email_address, if: proc { saved_change_to_email? }
   after_save :check_for_school
   after_create :generate_referrer_id, if: proc { teacher? }
   after_create :generate_default_notification_email_frequency, if: :teacher?
@@ -874,6 +875,18 @@ class User < ApplicationRecord
 
   def unlink_google_account!
     update!(google_id: nil, signed_up_with_google: false)
+  end
+
+  def track_google_user_set_password
+    if student?
+      Analytics::SegmentAnalytics.new.track_google_student_set_password(self, teacher_of_student)
+    elsif teacher? || admin?
+      Analytics::SegmentAnalytics.new.track_google_teacher_set_password(self)
+    end
+  end
+
+  def google_user_set_password?
+    google_id.present? && password_digest_changed? && password_digest_was.nil?
   end
 
   private def validate_flags

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -108,6 +108,27 @@ module Analytics
       })
     end
 
+    def track_google_student_set_password(student, teacher)
+      return if teacher.nil? || student.nil?
+
+      identify(teacher)
+      track(
+        event: Analytics::SegmentIo::BackgroundEvents::GOOGLE_STUDENT_SET_PASSWORD,
+        properties: { student_id: student.id },
+        user_id: teacher.id
+      )
+    end
+
+    def track_google_teacher_set_password(teacher)
+      return if teacher.nil?
+
+      identify(teacher)
+      track(
+        event: Analytics::SegmentIo::BackgroundEvents::GOOGLE_TEACHER_SET_PASSWORD,
+        user_id: teacher.id
+      )
+    end
+
     # rubocop:disable Metrics/CyclomaticComplexity
     def track_classroom_creation(classroom)
       # TODO: Remove early return once this bug is fixed

--- a/services/QuillLMS/app/services/analytics/segment_io.rb
+++ b/services/QuillLMS/app/services/analytics/segment_io.rb
@@ -79,6 +79,9 @@ module Analytics
       # teacher invited admin
       ADMIN_INVITED_BY_TEACHER = "Admin invited by teacher"
       TEACHER_INVITED_ADMIN = "Teacher invited admin"
+      # Google user has password added
+      GOOGLE_STUDENT_SET_PASSWORD = "Google user set a password | student"
+      GOOGLE_TEACHER_SET_PASSWORD = "Google user set a password | teacher"
     end
 
     module Properties

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2288,5 +2288,128 @@ RSpec.describe User, type: :model do
 
     end
   end
+
+  describe '#google_user_set_password?' do
+    subject { user.google_user_set_password? }
+
+    let(:user) { create(:user, google_id: google_id, password: password) }
+    let(:role) { 'user' }
+
+    context 'google_id is not present' do
+      let(:google_id) { nil }
+      let(:password) { 'password' }
+
+      it 'is not a google user so false' do
+        user.password = 'new_password'
+        expect(subject).to eq false
+      end
+    end
+
+    context 'google_id is present' do
+      let(:google_id) { 'abc123' }
+
+      context 'password_digest has not changed' do
+        let(:password) { nil }
+
+        it { expect(subject).to eq false }
+      end
+
+      context 'password_digest has changed' do
+        context 'password_digest was not nil' do
+          let(:password) { 'password' }
+
+          it 'already had a password' do
+            user.password = nil
+            expect(subject).to eq false
+          end
+        end
+
+        context 'password_digest was nil' do
+          let(:password) { nil }
+
+          it 'sets a password' do
+            user.password = 'password'
+            expect(subject).to eq true
+          end
+        end
+      end
+    end
+  end
+
+  describe '#track_google_user_set_password' do
+    subject { user.track_google_user_set_password }
+
+    let(:analytics_instance) { double('Analytics') }
+    let(:user) { create(:user, google_id: 'abc123', role: role) }
+
+    before do
+      allow(Analytics::SegmentAnalytics).to receive(:new).and_return(analytics_instance)
+      allow(analytics_instance).to receive(:track_google_student_set_password)
+      allow(analytics_instance).to receive(:track_google_teacher_set_password)
+    end
+
+    context 'google_user_set_password? is false' do
+      let(:role) { 'user' }
+
+      before { allow(user).to receive(:google_user_set_password?).and_return(false) }
+
+      it 'tracks nothing' do
+        expect(analytics_instance).not_to receive(:track_google_student_set_password)
+        expect(analytics_instance).not_to receive(:track_google_teacher_set_password)
+        user.password =  'password'
+        subject
+      end
+    end
+
+    context 'google_user_set_password? is true' do
+      before { allow(user).to receive(:google_user_set_password?).and_return(true) }
+
+      context 'user is a student' do
+        let(:role) { User::STUDENT }
+        let(:teacher) { double('Teacher') }
+
+        before { allow(user).to receive(:teacher_of_student).and_return(teacher) }
+
+        it 'tracks google student set password' do
+          expect(analytics_instance).to receive(:track_google_student_set_password).with(user, teacher)
+          expect(analytics_instance).not_to receive(:track_google_teacher_set_password)
+          user.password = 'password'
+          subject
+        end
+      end
+
+      context 'user is a teacher' do
+        let(:role) { User::TEACHER }
+
+        it 'tracks google teacher set password' do
+          expect(analytics_instance).not_to receive(:track_google_student_set_password)
+          expect(analytics_instance).to receive(:track_google_teacher_set_password).with(user)
+          user.password = 'password'
+          subject
+        end
+      end
+
+      context 'user is an admin' do
+        let(:role) { User::ADMIN }
+
+        it 'tracks google teacher set password' do
+          expect(analytics_instance).not_to receive(:track_google_student_set_password)
+          expect(analytics_instance).to receive(:track_google_teacher_set_password).with(user)
+          user.password = 'password'
+          subject
+        end
+      end
+
+      context 'user is not a student, teacher or admin' do
+        let(:role) { 'user' }
+
+        it 'tracks nothing' do
+          expect(analytics_instance).not_to receive(:track_google_student_set_password)
+          expect(analytics_instance).not_to receive(:track_google_teacher_set_password)
+          user.password = 'password'
+        end
+      end
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/segment_analytics_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Analytics::SegmentAnalytics do
+RSpec.describe Analytics::SegmentAnalytics do
   let(:analytics) { described_class.new }
   let(:track_calls) { analytics.backend.track_calls }
   let(:identify_calls) { analytics.backend.identify_calls }
@@ -487,6 +487,74 @@ describe Analytics::SegmentAnalytics do
       expect(identify_calls.size).to eq(1)
       expect(track_calls.size).to eq(0)
       expect(identify_calls[0][:traits].length).to eq(11)
+    end
+  end
+
+  context '#track_google_student_set_password' do
+    subject { analytics.track_google_student_set_password(student, teacher) }
+
+    context 'teacher is nil' do
+      let(:teacher) { nil }
+      let(:student) { nil }
+
+      it 'tracks no events' do
+        subject
+        expect(identify_calls.size).to eq 0
+        expect(track_calls.size).to eq 0
+      end
+    end
+
+    context 'teacher is present' do
+      let(:teacher) { create(:teacher) }
+
+      context 'student is nil' do
+        let(:student) { nil }
+
+        it 'tracks no events' do
+          subject
+          expect(identify_calls.size).to eq 0
+          expect(track_calls.size).to eq 0
+        end
+      end
+
+      context 'student is present' do
+        let(:student) { create(:student) }
+
+        it 'tracks an event with information about the student and teacher' do
+          subject
+          expect(identify_calls.size).to eq 1
+          expect(track_calls.size).to eq 1
+          expect(track_calls[0][:event]).to eq Analytics::SegmentIo::BackgroundEvents::GOOGLE_STUDENT_SET_PASSWORD
+          expect(track_calls[0][:user_id]).to eq teacher.id
+          expect(track_calls[0][:properties][:student_id]).to eq student.id
+        end
+      end
+    end
+  end
+
+  context '#track_google_teacher_set_password' do
+    subject { analytics.track_google_teacher_set_password(teacher) }
+
+    context 'teacher is nil' do
+      let(:teacher) { nil }
+
+      it 'tracks no events' do
+        subject
+        expect(identify_calls.size).to eq 0
+        expect(track_calls.size).to eq 0
+      end
+    end
+
+    context 'teacher is present' do
+      let(:teacher) { create(:teacher) }
+
+      it 'tracks an event with information about the student and teacher' do
+        subject
+        expect(identify_calls.size).to eq 1
+        expect(track_calls.size).to eq 1
+        expect(track_calls[0][:event]).to eq Analytics::SegmentIo::BackgroundEvents::GOOGLE_TEACHER_SET_PASSWORD
+        expect(track_calls[0][:user_id]).to eq teacher.id
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/services/complete_account_creation_spec.rb
+++ b/services/QuillLMS/spec/services/complete_account_creation_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe CompleteAccountCreation do
+RSpec.describe CompleteAccountCreation do
 
   it 'triggers account creation when user is a teacher' do
     user = create(:user, role: 'teacher')


### PR DESCRIPTION
* Add segment event to track google users that set a password

* Linter error

* Fix some specs

* Change callback to before_update

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
