### PR TITLE
Sentry fix/ undefined method `premium_state' for nil:NilClass

### DIFF
--- a/services/QuillLMS/app/views/pages/teacher_premium.html.erb
+++ b/services/QuillLMS/app/views/pages/teacher_premium.html.erb
@@ -1,6 +1,6 @@
 <% base_image_url = "#{ENV['CDN_URL']}/images/pages/teacher_premium" %>
 
-<%= render 'teachers/shared/scorebook_tabs' %>
+<%= render 'teachers/shared/scorebook_tabs' if current_user %>
 <div class="white-background-accommodate-footer teacher-premium">
   <div class="navbar-divider-bar"></div>
   <div class="container">


### PR DESCRIPTION
## WHAT
add fix for Sentry error: Undefined method `premium_state' for nil:NilClass

## WHY
we don't want users to experience this error

## HOW
when users are trying to access the `/teacher_premium` page while not authenticated, the page crashes when it tries to load the scorebook tabs-- this just adds a `current_user` check for those tabs

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Undefined-method-premium_state-for-nil-NilClass-b37c3778cb664e6bad99b087090a13fb?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- small change, manually verified
Have you deployed to Staging? | no-- small change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
