### PR TITLE
default target skill display for evidence

### DIFF
--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -37,9 +37,7 @@ class GradesController < ApplicationController
 
     questions = activity_session.concept_results.group_by { |cr| cr.question_number }
 
-    is_evidence = activity_session.classification.key == ActivityClassification::EVIDENCE_KEY
-
-    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, is_evidence) }
+    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, activity_session) }
 
     correct_key_target_skill_concepts = key_target_skill_concepts.filter { |ktsc| ktsc[:correct] }
 

--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -37,7 +37,9 @@ class GradesController < ApplicationController
 
     questions = activity_session.concept_results.group_by { |cr| cr.question_number }
 
-    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question) }
+    is_evidence = activity_session.classification.key == ActivityClassification::EVIDENCE_KEY
+
+    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, is_evidence) }
 
     correct_key_target_skill_concepts = key_target_skill_concepts.filter { |ktsc| ktsc[:correct] }
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -513,6 +513,10 @@ class ActivitySession < ApplicationRecord
     end
   end
 
+  def is_evidence?
+    classification.key == ActivityClassification::EVIDENCE_KEY
+  end
+
   private def correctly_assigned
     if classroom_unit && (classroom_unit.validate_assigned_student(user_id) == false)
       ErrorNotifier.report(StudentNotAssignedActivityError.new)

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -250,7 +250,7 @@ module PublicProgressReports
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
-  def get_key_target_skill_concept_for_question(concept_results, is_evidence=false)
+  def get_key_target_skill_concept_for_question(concept_results, is_evidence: false)
     default = {
       name: is_evidence ? 'Writing with Evidence' : 'Conventions of Language',
       correct: get_score_for_question(concept_results) > 0

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -250,7 +250,7 @@ module PublicProgressReports
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
-  def get_key_target_skill_concept_for_question(concept_results, is_evidence: false)
+  def get_key_target_skill_concept_for_question(concept_results, is_evidence)
     default = {
       name: is_evidence ? 'Writing with Evidence' : 'Conventions of Language',
       correct: get_score_for_question(concept_results) > 0

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -212,7 +212,6 @@ module PublicProgressReports
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def format_concept_results(activity_session, concept_results)
-    is_evidence = activity_session.classification.key == ActivityClassification::EVIDENCE_KEY
     concept_results.group_by{|cr| cr.question_number}.map { |key, cr|
 
       # if we don't sort them, we can't rely on the first result being the first attemptNum
@@ -225,7 +224,7 @@ module PublicProgressReports
         prompt: prompt_text,
         answer: cr.first.answer,
         score: get_score_for_question(cr),
-        key_target_skill_concept: get_key_target_skill_concept_for_question(cr, is_evidence),
+        key_target_skill_concept: get_key_target_skill_concept_for_question(cr, activity_session),
         concepts: cr.map { |crs|
           attempt_number = crs.attempt_number
           direct = crs.concept_result_directions&.text || crs.concept_result_instructions&.text || ""
@@ -250,9 +249,9 @@ module PublicProgressReports
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
-  def get_key_target_skill_concept_for_question(concept_results, is_evidence)
+  def get_key_target_skill_concept_for_question(concept_results, activity_session)
     default = {
-      name: is_evidence ? 'Writing with Evidence' : 'Conventions of Language',
+      name: activity_session.is_evidence? ? 'Writing with Evidence' : 'Conventions of Language',
       correct: get_score_for_question(concept_results) > 0
     }
 

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -212,6 +212,7 @@ module PublicProgressReports
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def format_concept_results(activity_session, concept_results)
+    is_evidence = activity_session.classification.key == ActivityClassification::EVIDENCE_KEY
     concept_results.group_by{|cr| cr.question_number}.map { |key, cr|
 
       # if we don't sort them, we can't rely on the first result being the first attemptNum
@@ -224,7 +225,7 @@ module PublicProgressReports
         prompt: prompt_text,
         answer: cr.first.answer,
         score: get_score_for_question(cr),
-        key_target_skill_concept: get_key_target_skill_concept_for_question(cr),
+        key_target_skill_concept: get_key_target_skill_concept_for_question(cr, is_evidence),
         concepts: cr.map { |crs|
           attempt_number = crs.attempt_number
           direct = crs.concept_result_directions&.text || crs.concept_result_instructions&.text || ""
@@ -249,9 +250,9 @@ module PublicProgressReports
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
-  def get_key_target_skill_concept_for_question(concept_results)
+  def get_key_target_skill_concept_for_question(concept_results, is_evidence=false)
     default = {
-      name: 'Conventions of Language',
+      name: is_evidence ? 'Writing with Evidence' : 'Conventions of Language',
       correct: get_score_for_question(concept_results) > 0
     }
 

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -1095,4 +1095,12 @@ end
       it { expect { subject }.to change { SaveUserPackSequenceItemsWorker.jobs.size }.by(1) }
     end
   end
+
+  context 'is_evidence?' do
+    let!(:evidence_activity_session) { create(:evidence_activity_session) }
+    let!(:diagnostic_activity_session) { create(:activity_session) }
+
+    it { expect(evidence_activity_session.is_evidence?).to eq(true) }
+    it { expect(diagnostic_activity_session.is_evidence?).to eq(false) }
+  end
 end

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -369,7 +369,7 @@ describe PublicProgressReports, type: :model do
     it 'should return a default key target skill concept if the first concept result has no extra metadata' do
       concept_result =  create(:concept_result)
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result])).to eq(default)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], false)).to eq(default)
     end
 
     it 'should return the evidence default key target skill concept if the first concept result has no extra metadata and it was an evidence session' do
@@ -381,13 +381,13 @@ describe PublicProgressReports, type: :model do
     it 'should return a default key target skill concept if the first concept result does not have a question_concept_uid' do
       concept_result =  create(:concept_result, extra_metadata: { question_uid: 'blah' })
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result])).to eq(default)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], false)).to eq(default)
     end
 
     it 'should return a default key target skill concept if the first concept result has a question_concept_uid that is not in the database' do
       concept_result =  create(:concept_result, extra_metadata: { question_concept_uid: 'blah' })
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result])).to eq(default)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], false)).to eq(default)
     end
 
     it 'should return a key target skill concept with the parent of the question\'s concept that is correct if the student reached an optimal response' do
@@ -402,7 +402,7 @@ describe PublicProgressReports, type: :model do
         name: concept.parent.name
       }
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([incorrect_concept_result, correct_concept_result])).to eq(expected)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([incorrect_concept_result, correct_concept_result], false)).to eq(expected)
     end
 
     it 'should return a key target skill concept with the parent of the question\'s concept that is incorrect if the student did not reach an optimal response' do
@@ -416,7 +416,7 @@ describe PublicProgressReports, type: :model do
         name: concept.parent.name
       }
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([incorrect_concept_result])).to eq(expected)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([incorrect_concept_result], false)).to eq(expected)
     end
 
   end

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -369,25 +369,26 @@ describe PublicProgressReports, type: :model do
     it 'should return a default key target skill concept if the first concept result has no extra metadata' do
       concept_result =  create(:concept_result)
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], false)).to eq(default)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], concept_result.activity_session)).to eq(default)
     end
 
     it 'should return the evidence default key target skill concept if the first concept result has no extra metadata and it was an evidence session' do
-      concept_result =  create(:concept_result)
+      evidence_activity_session = create(:evidence_activity_session)
+      concept_result =  create(:concept_result, activity_session: evidence_activity_session)
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], true)).to eq(evidence_default)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], concept_result.activity_session)).to eq(evidence_default)
     end
 
     it 'should return a default key target skill concept if the first concept result does not have a question_concept_uid' do
       concept_result =  create(:concept_result, extra_metadata: { question_uid: 'blah' })
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], false)).to eq(default)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], concept_result.activity_session)).to eq(default)
     end
 
     it 'should return a default key target skill concept if the first concept result has a question_concept_uid that is not in the database' do
       concept_result =  create(:concept_result, extra_metadata: { question_concept_uid: 'blah' })
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], false)).to eq(default)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], concept_result.activity_session)).to eq(default)
     end
 
     it 'should return a key target skill concept with the parent of the question\'s concept that is correct if the student reached an optimal response' do
@@ -402,7 +403,7 @@ describe PublicProgressReports, type: :model do
         name: concept.parent.name
       }
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([incorrect_concept_result, correct_concept_result], false)).to eq(expected)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([incorrect_concept_result, correct_concept_result], correct_concept_result.activity_session)).to eq(expected)
     end
 
     it 'should return a key target skill concept with the parent of the question\'s concept that is incorrect if the student did not reach an optimal response' do
@@ -416,7 +417,7 @@ describe PublicProgressReports, type: :model do
         name: concept.parent.name
       }
 
-      expect(FakeReports.new.get_key_target_skill_concept_for_question([incorrect_concept_result], false)).to eq(expected)
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([incorrect_concept_result], incorrect_concept_result.activity_session)).to eq(expected)
     end
 
   end

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -359,10 +359,23 @@ describe PublicProgressReports, type: :model do
       }
     }
 
+    let!(:evidence_default) {
+      {
+        name: 'Writing with Evidence',
+        correct: true
+      }
+    }
+
     it 'should return a default key target skill concept if the first concept result has no extra metadata' do
       concept_result =  create(:concept_result)
 
       expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result])).to eq(default)
+    end
+
+    it 'should return the evidence default key target skill concept if the first concept result has no extra metadata and it was an evidence session' do
+      concept_result =  create(:concept_result)
+
+      expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], true)).to eq(evidence_default)
     end
 
     it 'should return a default key target skill concept if the first concept result does not have a question_concept_uid' do


### PR DESCRIPTION
## WHAT
Update the default target skill displayed for Evidence activities.

## WHY
The default is "Conventions of Language", which doesn't really make sense for evidence activities.

## HOW
Just update the function to take an optional second argument if it's an Evidence activity, in which case we use a different default target skill.

### Screenshots
<img width="314" alt="Screenshot 2023-10-25 at 9 22 59 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/d56abfa5-0631-485f-adf9-05c64053e506">
<img width="951" alt="Screenshot 2023-10-25 at 9 22 48 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/4e1c2d60-b91a-44b7-8da8-6784cf98eef1">


### Notion Card Links
https://www.notion.so/quill/Change-Default-Target-Skill-Display-Language-for-Evidence-Sessions-32f25d2da8ea41a9a61cd33cce3818cd?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES