### PR TITLE
Fix google teacher set password tracking

### DIFF
--- a/services/QuillLMS/app/controllers/password_reset_controller.rb
+++ b/services/QuillLMS/app/controllers/password_reset_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class PasswordResetController < ApplicationController
-
   before_action :set_title
 
   def index
@@ -16,7 +15,7 @@ class PasswordResetController < ApplicationController
         render json: { message: 'Oops! You have a Clever account. Log in that way instead.', type: 'email' }, status: 401
       else
         user.refresh_token!
-        user.unlink_google_account! if user.teacher?
+        unlink_teacher_or_admin_google_account(user)
         UserMailer.password_reset_email(user).deliver_now!
         flash[:notice] = 'We sent you an email with instructions on how to reset your password.'
         flash.keep(:notice)
@@ -51,4 +50,11 @@ class PasswordResetController < ApplicationController
     @title = "Password Reset"
   end
 
+  private def unlink_teacher_or_admin_google_account(user)
+    return unless user.google_id
+    return unless user.teacher? || user.admin?
+
+    Analytics::SegmentAnalytics.new.track_google_teacher_set_password(user)
+    user.unlink_google_account!
+  end
 end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -236,7 +236,7 @@ class User < ApplicationRecord
   before_validation :prep_authentication_terms
   before_save :capitalize_name, if: proc { will_save_change_to_name? && !skip_capitalize_names_callback }
   before_save :set_time_zone, unless: :time_zone
-  before_update :track_google_user_set_password, if: proc { google_user_set_password? }
+  before_update :track_google_student_set_password, if: proc { google_student_set_password? }
   after_save :update_invitee_email_address, if: proc { saved_change_to_email? }
   after_save :check_for_school
   after_create :generate_referrer_id, if: proc { teacher? }
@@ -877,16 +877,12 @@ class User < ApplicationRecord
     update!(google_id: nil, signed_up_with_google: false)
   end
 
-  def track_google_user_set_password
-    if student?
-      Analytics::SegmentAnalytics.new.track_google_student_set_password(self, teacher_of_student)
-    elsif teacher? || admin?
-      Analytics::SegmentAnalytics.new.track_google_teacher_set_password(self)
-    end
+  def track_google_student_set_password
+    Analytics::SegmentAnalytics.new.track_google_student_set_password(self, teacher_of_student)
   end
 
-  def google_user_set_password?
-    google_id.present? && password_digest_changed? && password_digest_was.nil?
+  def google_student_set_password?
+    student? && google_id.present? && password_digest_changed? && password_digest_was.nil?
   end
 
   private def validate_flags

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2340,73 +2340,19 @@ RSpec.describe User, type: :model do
     subject { user.track_google_student_set_password }
 
     let(:analytics_instance) { double('Analytics') }
-    let(:user) { create(:user, google_id: 'abc123', role: role) }
+    let(:user) { create(:user, google_id: 'abc123') }
+    let(:teacher) { double('Teacher') }
 
     before do
       allow(Analytics::SegmentAnalytics).to receive(:new).and_return(analytics_instance)
       allow(analytics_instance).to receive(:track_google_student_set_password)
+      allow(user).to receive(:teacher_of_student).and_return(teacher)
     end
 
-    context 'google_student_set_password? is false' do
-      let(:role) { 'user' }
-
-      before { allow(user).to receive(:google_student_set_password?).and_return(false) }
-
-      it 'tracks nothing' do
-        expect(analytics_instance).not_to receive(:track_google_student_set_password)
-        user.password =  'password'
-        subject
-      end
-    end
-
-    context 'google_student_set_password? is true' do
-      before { allow(user).to receive(:google_student_set_password?).and_return(true) }
-
-      context 'user is a student' do
-        let(:role) { User::STUDENT }
-        let(:teacher) { double('Teacher') }
-
-        before { allow(user).to receive(:teacher_of_student).and_return(teacher) }
-
-        it 'tracks google student set password' do
-          expect(analytics_instance).to receive(:track_google_student_set_password).with(user, teacher)
-          expect(analytics_instance).not_to receive(:track_google_teacher_set_password)
-          user.password = 'password'
-          subject
-        end
-      end
-
-      context 'user is a teacher' do
-        let(:role) { User::TEACHER }
-
-        it 'tracks google teacher set password' do
-          expect(analytics_instance).not_to receive(:track_google_student_set_password)
-          expect(analytics_instance).to receive(:track_google_teacher_set_password).with(user)
-          user.password = 'password'
-          subject
-        end
-      end
-
-      context 'user is an admin' do
-        let(:role) { User::ADMIN }
-
-        it 'tracks google teacher set password' do
-          expect(analytics_instance).not_to receive(:track_google_student_set_password)
-          expect(analytics_instance).to receive(:track_google_teacher_set_password).with(user)
-          user.password = 'password'
-          subject
-        end
-      end
-
-      context 'user is not a student, teacher or admin' do
-        let(:role) { 'user' }
-
-        it 'tracks nothing' do
-          expect(analytics_instance).not_to receive(:track_google_student_set_password)
-          expect(analytics_instance).not_to receive(:track_google_teacher_set_password)
-          user.password = 'password'
-        end
-      end
+    it 'tracks google student set password' do
+      expect(analytics_instance).to receive(:track_google_student_set_password).with(user, teacher)
+      user.password = 'password'
+      subject
     end
   end
 end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2285,19 +2285,25 @@ RSpec.describe User, type: :model do
 
         it { is_expected.to eq true }
       end
-
     end
   end
 
-  describe '#google_user_set_password?' do
-    subject { user.google_user_set_password? }
+  describe '#google_student_set_password?' do
+    subject { user.google_student_set_password? }
 
-    let(:user) { create(:user, google_id: google_id, password: password) }
-    let(:role) { 'user' }
+    let(:user) { create(:user, google_id: google_id, password: password, role: role) }
+    let(:role) { User::STUDENT}
+    let(:google_id) { 'abc123' }
+    let(:password) { 'password' }
+
+    context 'user is not a student' do
+      let(:role) { User::TEACHER }
+
+      it { expect(subject).to eq false }
+    end
 
     context 'google_id is not present' do
       let(:google_id) { nil }
-      let(:password) { 'password' }
 
       it 'is not a google user so false' do
         user.password = 'new_password'
@@ -2305,39 +2311,33 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'google_id is present' do
-      let(:google_id) { 'abc123' }
+    context 'password_digest has not changed' do
+      it { expect(subject).to eq false }
+    end
 
-      context 'password_digest has not changed' do
-        let(:password) { nil }
+    context 'password_digest has changed' do
+      context 'password_digest was not nil' do
+        let(:password) { 'password' }
 
-        it { expect(subject).to eq false }
+        it 'already had a password' do
+          user.password = nil
+          expect(subject).to eq false
+        end
       end
 
-      context 'password_digest has changed' do
-        context 'password_digest was not nil' do
-          let(:password) { 'password' }
+      context 'password_digest was nil' do
+        let(:password) { nil }
 
-          it 'already had a password' do
-            user.password = nil
-            expect(subject).to eq false
-          end
-        end
-
-        context 'password_digest was nil' do
-          let(:password) { nil }
-
-          it 'sets a password' do
-            user.password = 'password'
-            expect(subject).to eq true
-          end
+        it 'sets a password' do
+          user.password = 'password'
+          expect(subject).to eq true
         end
       end
     end
   end
 
-  describe '#track_google_user_set_password' do
-    subject { user.track_google_user_set_password }
+  describe '#track_google_student_set_password' do
+    subject { user.track_google_student_set_password }
 
     let(:analytics_instance) { double('Analytics') }
     let(:user) { create(:user, google_id: 'abc123', role: role) }
@@ -2345,24 +2345,22 @@ RSpec.describe User, type: :model do
     before do
       allow(Analytics::SegmentAnalytics).to receive(:new).and_return(analytics_instance)
       allow(analytics_instance).to receive(:track_google_student_set_password)
-      allow(analytics_instance).to receive(:track_google_teacher_set_password)
     end
 
-    context 'google_user_set_password? is false' do
+    context 'google_student_set_password? is false' do
       let(:role) { 'user' }
 
-      before { allow(user).to receive(:google_user_set_password?).and_return(false) }
+      before { allow(user).to receive(:google_student_set_password?).and_return(false) }
 
       it 'tracks nothing' do
         expect(analytics_instance).not_to receive(:track_google_student_set_password)
-        expect(analytics_instance).not_to receive(:track_google_teacher_set_password)
         user.password =  'password'
         subject
       end
     end
 
-    context 'google_user_set_password? is true' do
-      before { allow(user).to receive(:google_user_set_password?).and_return(true) }
+    context 'google_student_set_password? is true' do
+      before { allow(user).to receive(:google_student_set_password?).and_return(true) }
 
       context 'user is a student' do
         let(:role) { User::STUDENT }


### PR DESCRIPTION
## WHAT
Tracking for google user set password  was added [yesterday](https://github.com/empirical-org/Empirical-Core/pull/11173).  This PR fixes the implementation of the tracking for teachers and admins.

## WHY
 The current implementation doesn't work since the google_id gets reset earlier in the process, so by the time the callback is checked, the google_id is nil.

## HOW
Add tracking for teachers and admins ini the password reset controller.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
