### PR TITLE
Fix intermittent spec failure

### DIFF
--- a/services/QuillLMS/spec/factories/activity_sessions.rb
+++ b/services/QuillLMS/spec/factories/activity_sessions.rb
@@ -72,7 +72,7 @@ FactoryBot.define do
       classroom_unit = activity_session.classroom_unit
       UnitActivity.find_or_create_by(activity: activity_session.activity, unit_id: classroom_unit.unit_id)
       StudentsClassrooms.find_or_create_by(student_id: activity_session.user_id, classroom_id: classroom_unit.classroom_id )
-      create(:concept_result, activity_session: activity_session)
+      ConceptResult.find_or_create_by(activity_session: activity_session)
     end
 
     trait :retry do


### PR DESCRIPTION
## WHAT
Fix an intermittent spec failure involving [report_demo_creator_spec](https://quill.slack.com/archives/C05DP57UPAQ/p1687966296331309)

## WHY
The activity session record seems to already exist.

## HOW
Change the create to find_or_create_by

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
