### PR TITLE
color palette updates

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/variables.scss
+++ b/services/QuillLMS/app/assets/stylesheets/variables.scss
@@ -1,6 +1,6 @@
 $sitewidepagewidth: 1200px;
 
-// standardized to Figma Color Palette (https://www.figma.com/file/5TNa9Tn6TNVCmNjzbDTaMI/Quill---Product---Web?type=design&node-id=6417-242132&mode=dev) as of 8/10/23
+// standardized to Figma Color Palette (https://www.figma.com/file/5TNa9Tn6TNVCmNjzbDTaMI/Quill---Product---Web?type=design&node-id=6417-242132&mode=dev) as of 10/25/23
 $quill-black: #000;
 $quill-grey-90: #373737;
 $quill-grey-80: #404040;
@@ -19,6 +19,34 @@ $quill-grey-3: #EBEBEB;
 $quill-grey-2: #F1F1F1;
 $quill-grey-1: #F8F8F8;
 $quill-white: #FFF;
+
+$quill-black-transparent-90: rgba(0, 0, 0, 0.9);
+$quill-black-transparent-80: rgba(0, 0, 0, 0.8);
+$quill-black-transparent-70: rgba(0, 0, 0, 0.7);
+$quill-black-transparent-60: rgba(0, 0, 0, 0.6);
+$quill-black-transparent-50: rgba(0, 0, 0, 0.5);
+$quill-black-transparent-40: rgba(0, 0, 0, 0.4);
+$quill-black-transparent-30: rgba(0, 0, 0, 0.3);
+$quill-black-transparent-20: rgba(0, 0, 0, 0.2);
+$quill-black-transparent-10: rgba(0, 0, 0, 0.1);
+$quill-white-transparent-90: rgba(255, 255, 255, 0.9);
+$quill-white-transparent-80: rgba(255, 255, 255, 0.8);
+$quill-white-transparent-70: rgba(255, 255, 255, 0.7);
+$quill-white-transparent-60: rgba(255, 255, 255, 0.6);
+$quill-white-transparent-50: rgba(255, 255, 255, 0.5);
+$quill-white-transparent-40: rgba(255, 255, 255, 0.4);
+$quill-white-transparent-30: rgba(255, 255, 255, 0.3);
+$quill-white-transparent-20: rgba(255, 255, 255, 0.2);
+$quill-white-transparent-10: rgba(255, 255, 255, 0.1);
+$quill-green-transparent-90: rgba(6, 128, 107, 0.9);
+$quill-green-transparent-80: rgba(6, 128, 107, 0.8);
+$quill-green-transparent-70: rgba(6, 128, 107, 0.7);
+$quill-green-transparent-60: rgba(6, 128, 107, 0.6);
+$quill-green-transparent-50: rgba(6, 128, 107, 0.5);
+$quill-green-transparent-40: rgba(6, 128, 107, 0.4);
+$quill-green-transparent-30: rgba(6, 128, 107, 0.3);
+$quill-green-transparent-20: rgba(6, 128, 107, 0.2);
+$quill-green-transparent-10: rgba(6, 128, 107, 0.1);
 
 $quill-green: #06806B;
 $quill-green-50: #099A81;
@@ -42,6 +70,11 @@ $quill-green-vibrant-5: #FAFFF5;
 $quill-green-vibrant-1: #FAFFF6;
 
 $quill-viridian: #235E62;
+$quill-viridian-50: #8CCBCE;
+$quill-viridian-20: #A7DADD;
+$quill-viridian-10: #CAEEF0;
+$quill-viridian-5: #DAF5F6;
+$quill-viridian-1: #F4FDFE;
 
 $quill-teal: #2C7F9B;
 $quill-teal-50: #8DCFE2;
@@ -79,11 +112,11 @@ $quill-red-5: #FEEDEC;
 $quill-red-1: #FFF6F5;
 
 $quill-maroon: #C04500;
-$quill-maroon-50: #E36E2C;
-$quill-maroon-20: #FFB489;
-$quill-maroon-10: #FFDCC8;
-$quill-maroon-5: #FCEAE1;
-$quill-maroon-1: #FDF5F0;
+$quill-maroon-50: #CD703B;
+$quill-maroon-20: #E8AB88;
+$quill-maroon-10: #F1CFBC;
+$quill-maroon-5: #F6E5DC;
+$quill-maroon-1: #FFF6F1;
 
 $quill-gold: #DF9E3D;
 $quill-gold-50: #ECB55A;

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/colorPalette.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/colorPalette.tsx
@@ -75,6 +75,21 @@ const greys = [
   }
 ]
 
+const transparentColorTitlesAndVariableNames = [
+  {
+    title: 'Quill Black',
+    variableName: 'quill-black-transparent'
+  },
+  {
+    title: 'Quill White',
+    variableName: 'quill-white-transparent'
+  },
+  {
+    title: 'Quill Green',
+    variableName: 'quill-green-transparent'
+  }
+]
+
 const baseColorTitlesAndVariableNames = [
   {
     title: 'Quill Green',
@@ -123,6 +138,7 @@ const baseColorTitlesAndVariableNames = [
 ]
 
 const colorNumbers = [null, 50, 20, 10, 5, 1]
+const transparentColorNumbers = [90, 80, 70, 60, 50, 40, 30, 20, 10]
 
 const renderElement =(title, variableName) => (
   <div className="element" key={variableName}>
@@ -152,6 +168,23 @@ const ColorPalette = () => {
       </div>
     )
   })
+
+  const transparentColorRows = transparentColorTitlesAndVariableNames.map(color => {
+    const colors = transparentColorNumbers.map(number => {
+      let title = color.title
+      let variableName = color.variableName
+      title+= ` - ${number}%`
+      variableName+= `-${number}`
+
+      return renderElement(title, variableName)
+    })
+    return (
+      <div className="color-row" key={`${color.variableName}-row`}>
+        {colors}
+      </div>
+    )
+  })
+
   return (
     <div id="color-palette">
       <h2 className="style-guide-h2">Color Palette</h2>
@@ -160,6 +193,10 @@ const ColorPalette = () => {
         <div className="color-row">
           {greys.map(grey => renderElement(grey.title, grey.variableName))}
         </div>
+      </div>
+      <div className="element-container">
+        <h4 className="style-guide-h4">Transparent</h4>
+        {transparentColorRows}
       </div>
       <div className="element-container">
         <h4 className="style-guide-h4">Colors</h4>

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/colorPalette.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/colorPalette.tsx
@@ -104,6 +104,10 @@ const baseColorTitlesAndVariableNames = [
     variableName: "quill-green-vibrant"
   },
   {
+    title: 'Quill Viridian',
+    variableName: "quill-viridian"
+  },
+  {
     title: 'Quill Teal',
     variableName: "quill-teal"
   },

--- a/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
@@ -135,261 +135,148 @@
     max-width: 16%;
     border-bottom: 1px solid #d6d5d6;
     border-right: 1px solid #d6d5d6;
+    position: relative;
     div {
       width: 40px;
       height: 40px;
     }
   }
-  .quill-black {
-    background-color: $quill-black;
-  }
-  .quill-grey-90 {
-    background-color: $quill-grey-90;
-  }
-  .quill-grey-80 {
-    background-color: $quill-grey-80;
-  }
-  .quill-grey-70 {
-    background-color: $quill-grey-70;
-  }
-  .quill-grey-60 {
-    background-color: $quill-grey-60;
-  }
-  .quill-grey-50 {
-    background-color: $quill-grey-50;
-  }
-  .quill-grey-40 {
-    background-color: $quill-grey-40;
-  }
-  .quill-grey-35 {
-    background-color: $quill-grey-35;
-  }
-  .quill-grey-30 {
-    background-color: $quill-grey-30;
-  }
-  .quill-grey-25 {
-    background-color: $quill-grey-25;
-  }
-  .quill-grey-20 {
-    background-color: $quill-grey-20;
-  }
-  .quill-grey-15 {
-    background-color: $quill-grey-15;
-  }
-  .quill-grey-10 {
-    background-color: $quill-grey-10;
-  }
-  .quill-grey-5 {
-    background-color: $quill-grey-5;
-  }
-  .quill-grey-3 {
-    background-color: $quill-grey-3;
-  }
-  .quill-grey-2 {
-    background-color: $quill-grey-2;
-  }
-  .quill-grey-1 {
-    background-color: $quill-grey-1;
-  }
-  .quill-white {
-    background-color: $quill-white;
-  }
-  .quill-green {
-    background-color: $quill-green;
-  }
-  .quill-green-50 {
-    background-color: $quill-green-50;
-  }
-  .quill-green-20 {
-    background-color: $quill-green-20;
-  }
-  .quill-green-10 {
-    background-color: $quill-green-10;
-  }
-  .quill-green-5 {
-    background-color: $quill-green-5;
-  }
-  .quill-green-1 {
-    background-color: $quill-green-1;
-  }
-  .quill-green-warm {
-    background-color: $quill-green-warm;
-  }
-  .quill-green-warm-50 {
-    background-color: $quill-green-warm-50;
-  }
-  .quill-green-warm-20 {
-    background-color: $quill-green-warm-20;
-  }
-  .quill-green-warm-10 {
-    background-color: $quill-green-warm-10;
-  }
-  .quill-green-warm-5 {
-    background-color: $quill-green-warm-5;
-  }
-  .quill-green-warm-1 {
-    background-color: $quill-green-warm-1;
-  }
-  .quill-green-vibrant {
-    background-color: $quill-green-vibrant;
-  }
-  .quill-green-vibrant-50 {
-    background-color: $quill-green-vibrant-50;
-  }
-  .quill-green-vibrant-20 {
-    background-color: $quill-green-vibrant-20;
-  }
-  .quill-green-vibrant-10 {
-    background-color: $quill-green-vibrant-10;
-  }
-  .quill-green-vibrant-5 {
-    background-color: $quill-green-vibrant-5;
-  }
-  .quill-green-vibrant-1 {
-    background-color: $quill-green-vibrant-1;
-  }
-  .quill-teal {
-    background-color: $quill-teal;
-  }
-  .quill-teal-50 {
-    background-color: $quill-teal-50;
-  }
-  .quill-teal-20 {
-    background-color: $quill-teal-20;
-  }
-  .quill-teal-10 {
-    background-color: $quill-teal-10;
-  }
-  .quill-teal-5 {
-    background-color: $quill-teal-5;
-  }
-  .quill-teal-1 {
-    background-color: $quill-teal-1;
-  }
-  .quill-blue {
-    background-color: $quill-blue;
-  }
-  .quill-blue-50 {
-    background-color: $quill-blue-50;
-  }
-  .quill-blue-20 {
-    background-color: $quill-blue-20;
-  }
-  .quill-blue-10 {
-    background-color: $quill-blue-10;
-  }
-  .quill-blue-5 {
-    background-color: $quill-blue-5;
-  }
-  .quill-blue-1 {
-    background-color: $quill-blue-1;
-  }
-  .quill-purple {
-    background-color: $quill-purple;
-  }
-  .quill-purple-50 {
-    background-color: $quill-purple-50;
-  }
-  .quill-purple-20 {
-    background-color: $quill-purple-20;
-  }
-  .quill-purple-10 {
-    background-color: $quill-purple-10;
-  }
-  .quill-purple-5 {
-    background-color: $quill-purple-5;
-  }
-  .quill-purple-1 {
-    background-color: $quill-purple-1;
-  }
-  .quill-violet {
-    background-color: $quill-violet;
-  }
-  .quill-violet-50 {
-    background-color: $quill-violet-50;
-  }
-  .quill-violet-20 {
-    background-color: $quill-violet-20;
-  }
-  .quill-violet-10 {
-    background-color: $quill-violet-10;
-  }
-  .quill-violet-5 {
-    background-color: $quill-violet-5;
-  }
-  .quill-violet-1 {
-    background-color: $quill-violet-1;
-  }
-  .quill-red {
-    background-color: $quill-red;
-  }
-  .quill-red-50 {
-    background-color: $quill-red-50;
-  }
-  .quill-red-20 {
-    background-color: $quill-red-20;
-  }
-  .quill-red-10 {
-    background-color: $quill-red-10;
-  }
-  .quill-red-5 {
-    background-color: $quill-red-5;
-  }
-  .quill-red-1 {
-    background-color: $quill-red-1;
-  }
-  .quill-maroon {
-    background-color: $quill-maroon;
-  }
-  .quill-maroon-50 {
-    background-color: $quill-maroon-50;
-  }
-  .quill-maroon-20 {
-    background-color: $quill-maroon-20;
-  }
-  .quill-maroon-10 {
-    background-color: $quill-maroon-10;
-  }
-  .quill-maroon-5 {
-    background-color: $quill-maroon-5;
-  }
-  .quill-maroon-1 {
-    background-color: $quill-maroon-1;
-  }
-  .quill-gold {
-    background-color: $quill-gold;
-  }
-  .quill-gold-50 {
-    background-color: $quill-gold-50;
-  }
-  .quill-gold-20 {
-    background-color: $quill-gold-20;
-  }
-  .quill-gold-10 {
-    background-color: $quill-gold-10;
-  }
-  .quill-gold-5 {
-    background-color: $quill-gold-5;
-  }
-  .quill-gold-1 {
-    background-color: $quill-gold-1;
-  }
-  .quill-gold-dark {
-    background-color: $quill-gold-dark;
-  }
-  .quill-gold-dark-50 {
-    background-color: $quill-gold-dark-50;
-  }
-  .quill-gold-dark-20 {
-    background-color: $quill-gold-dark-20;
-  }
-  .quill-gold-dark-10 {
-    background-color: $quill-gold-dark-10;
-  }
-  .quill-gold-dark-5 {
-    background-color: $quill-gold-dark-5;
-  }
-  .quill-gold-dark-1 {
-    background-color: $quill-gold-dark-1;
+
+  $colors: (
+    quill-black: $quill-black,
+    quill-grey-90: $quill-grey-90,
+    quill-grey-80: $quill-grey-80,
+    quill-grey-70: $quill-grey-70,
+    quill-grey-60: $quill-grey-60,
+    quill-grey-50: $quill-grey-50,
+    quill-grey-40: $quill-grey-40,
+    quill-grey-35: $quill-grey-35,
+    quill-grey-30: $quill-grey-30,
+    quill-grey-25: $quill-grey-25,
+    quill-grey-20: $quill-grey-20,
+    quill-grey-15: $quill-grey-15,
+    quill-grey-10: $quill-grey-10,
+    quill-grey-5: $quill-grey-5,
+    quill-grey-3: $quill-grey-3,
+    quill-grey-2: $quill-grey-2,
+    quill-grey-1: $quill-grey-1,
+    quill-white: $quill-white,
+
+    quill-black-transparent-90: $quill-black-transparent-90,
+    quill-black-transparent-80: $quill-black-transparent-80,
+    quill-black-transparent-70: $quill-black-transparent-70,
+    quill-black-transparent-60: $quill-black-transparent-60,
+    quill-black-transparent-50: $quill-black-transparent-50,
+    quill-black-transparent-40: $quill-black-transparent-40,
+    quill-black-transparent-30: $quill-black-transparent-30,
+    quill-black-transparent-20: $quill-black-transparent-20,
+    quill-black-transparent-10: $quill-black-transparent-10,
+    quill-white-transparent-90: $quill-white-transparent-90,
+    quill-white-transparent-80: $quill-white-transparent-80,
+    quill-white-transparent-70: $quill-white-transparent-70,
+    quill-white-transparent-60: $quill-white-transparent-60,
+    quill-white-transparent-50: $quill-white-transparent-50,
+    quill-white-transparent-40: $quill-white-transparent-40,
+    quill-white-transparent-30: $quill-white-transparent-30,
+    quill-white-transparent-20: $quill-white-transparent-20,
+    quill-white-transparent-10: $quill-white-transparent-10,
+    quill-green-transparent-90: $quill-green-transparent-90,
+    quill-green-transparent-80: $quill-green-transparent-80,
+    quill-green-transparent-70: $quill-green-transparent-70,
+    quill-green-transparent-60: $quill-green-transparent-60,
+    quill-green-transparent-50: $quill-green-transparent-50,
+    quill-green-transparent-40: $quill-green-transparent-40,
+    quill-green-transparent-30: $quill-green-transparent-30,
+    quill-green-transparent-20: $quill-green-transparent-20,
+    quill-green-transparent-10: $quill-green-transparent-10,
+
+    quill-green: $quill-green,
+    quill-green-50: $quill-green-50,
+    quill-green-20: $quill-green-20,
+    quill-green-10: $quill-green-10,
+    quill-green-5: $quill-green-5,
+    quill-green-1: $quill-green-1,
+    quill-green-warm: $quill-green-warm,
+    quill-green-warm-50: $quill-green-warm-50,
+    quill-green-warm-20: $quill-green-warm-20,
+    quill-green-warm-10: $quill-green-warm-10,
+    quill-green-warm-5: $quill-green-warm-5,
+    quill-green-warm-1: $quill-green-warm-1,
+    quill-green-vibrant: $quill-green-vibrant,
+    quill-green-vibrant-50: $quill-green-vibrant-50,
+    quill-green-vibrant-20: $quill-green-vibrant-20,
+    quill-green-vibrant-10: $quill-green-vibrant-10,
+    quill-green-vibrant-5: $quill-green-vibrant-5,
+    quill-green-vibrant-1: $quill-green-vibrant-1,
+    quill-viridian: $quill-viridian,
+    quill-viridian-50: $quill-viridian-50,
+    quill-viridian-20: $quill-viridian-20,
+    quill-viridian-10: $quill-viridian-10,
+    quill-viridian-5: $quill-viridian-5,
+    quill-viridian-1: $quill-viridian-1,
+    quill-teal: $quill-teal,
+    quill-teal-50: $quill-teal-50,
+    quill-teal-20: $quill-teal-20,
+    quill-teal-10: $quill-teal-10,
+    quill-teal-5: $quill-teal-5,
+    quill-teal-1: $quill-teal-1,
+    quill-blue: $quill-blue,
+    quill-blue-50: $quill-blue-50,
+    quill-blue-20: $quill-blue-20,
+    quill-blue-10: $quill-blue-10,
+    quill-blue-5: $quill-blue-5,
+    quill-blue-1: $quill-blue-1,
+    quill-purple: $quill-purple,
+    quill-purple-50: $quill-purple-50,
+    quill-purple-20: $quill-purple-20,
+    quill-purple-10: $quill-purple-10,
+    quill-purple-5: $quill-purple-5,
+    quill-purple-1: $quill-purple-1,
+    quill-violet: $quill-violet,
+    quill-violet-50: $quill-violet-50,
+    quill-violet-20: $quill-violet-20,
+    quill-violet-10: $quill-violet-10,
+    quill-violet-5: $quill-violet-5,
+    quill-violet-1: $quill-violet-1,
+    quill-red: $quill-red,
+    quill-red-50: $quill-red-50,
+    quill-red-20: $quill-red-20,
+    quill-red-10: $quill-red-10,
+    quill-red-5: $quill-red-5,
+    quill-red-1: $quill-red-1,
+    quill-maroon: $quill-maroon,
+    quill-maroon-50: $quill-maroon-50,
+    quill-maroon-20: $quill-maroon-20,
+    quill-maroon-10: $quill-maroon-10,
+    quill-maroon-5: $quill-maroon-5,
+    quill-maroon-1: $quill-maroon-1,
+    quill-gold: $quill-gold,
+    quill-gold-50: $quill-gold-50,
+    quill-gold-20: $quill-gold-20,
+    quill-gold-10: $quill-gold-10,
+    quill-gold-5: $quill-gold-5,
+    quill-gold-1: $quill-gold-1,
+    quill-gold-dark: $quill-gold-dark,
+    quill-gold-dark-50: $quill-gold-dark-50,
+    quill-gold-dark-20: $quill-gold-dark-20,
+    quill-gold-dark-10: $quill-gold-dark-10,
+    quill-gold-dark-5: $quill-gold-dark-5,
+    quill-gold-dark-1: $quill-gold-dark-1
+  );
+
+  @each $name, $color in $colors {
+    .#{$name} {
+      background-color: $color;
+      &::before {
+        content: "#{$color}";
+        display: block;
+        position: absolute;
+        top: 0px;
+        text-align: center;
+        width: 100%;
+        left: 0;
+        top: 140px;
+      }
+    }
   }
 }


### PR DESCRIPTION
## WHAT
Update maroon hex codes, add viridian and transparent colors, then update the color palette to display new colors and also show the hex codes/rgba codes for the colors.

## WHY
Just trying to keep our color palette up to date and functional.

## HOW
Mostly CSS and a little React.

### Screenshots
<img width="341" alt="Screenshot 2023-10-25 at 11 53 32 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/673ba237-fc15-4b4a-a0d2-e87095565e3a">


### Notion Card Links
https://www.notion.so/quill/Update-Quill-Color-Palette-Quill-Maroon-Ramp-87974e8872454822b715302999367b7c?pvs=4

https://www.notion.so/quill/Add-Quill-Viridian-to-Color-Palette-and-Backpack-4eb5b3e9ba804752b4a72a37069f8f4b?pvs=4

https://www.notion.so/quill/Quill-Color-Palette-Add-Semi-Transparent-Values-ffd10393437b4c14893ab137466530a8?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - mostly CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES