### PR TITLE
Allow apostrophes in local part of email address

### DIFF
--- a/services/QuillLMS/app/controllers/invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/invitations_controller.rb
@@ -6,35 +6,29 @@ class InvitationsController < ApplicationController
 
 
   def create_coteacher_invitation
-    begin
-      validate_email_and_classroom_ids
-      @pending_invite = find_or_create_coteacher_invite_from_current_user
-      raise StandardError, @pending_invite.errors[:base].join(" ") unless @pending_invite.valid?
+    validate_email_and_classroom_ids
+    @pending_invite = find_or_create_coteacher_invite_from_current_user
+    raise StandardError, @pending_invite.errors[:base].join(" ") unless @pending_invite.valid?
 
-      assign_classrooms_to_invitee
-      invoke_email_worker
-      render json: { invite_id: @pending_invite.id }
-    rescue => e
-      render json: { error: e.message }, status: 422
-    end
+    assign_classrooms_to_invitee
+    invoke_email_worker
+    render json: { invite_id: @pending_invite.id }
+  rescue => e
+    render json: { error: e.message }, status: 422
   end
 
   def destroy_pending_invitations_to_specific_invitee
-    begin
-      Invitation.find_by(invitation_type: params[:invitation_type], inviter_id: current_user.id, invitee_email: params[:invitee_email], archived: false).destroy
-      render json: {}
-    rescue => e
-      render json: { error: e.message }, status: 422
-    end
+    Invitation.find_by(invitation_type: params[:invitation_type], inviter_id: current_user.id, invitee_email: params[:invitee_email], archived: false).destroy
+    render json: {}
+  rescue => e
+    render json: { error: e.message }, status: 422
   end
 
   def destroy_pending_invitations_from_specific_inviter
-    begin
-      Invitation.find_by(invitation_type: params[:invitation_type], inviter_id: params[:inviter_id], invitee_email: current_user.email, archived: false).destroy
-      render json: {}
-    rescue => e
-      render json: { error: e.message }, status: 422
-    end
+    Invitation.find_by(invitation_type: params[:invitation_type], inviter_id: params[:inviter_id], invitee_email: current_user.email, archived: false).destroy
+    render json: {}
+  rescue => e
+    render json: { error: e.message }, status: 422
   end
 
   private def invoke_email_worker
@@ -59,7 +53,7 @@ class InvitationsController < ApplicationController
   end
 
   private def validate_email_format
-    return if @invitee_email =~ User::VALID_EMAIL_REGEX
+    return if ValidatesEmailFormatOf.validate_email_format(@invitee_email).nil?
 
     raise StandardError, "Please make sure you've entered a valid email."
   end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -93,7 +93,6 @@ class User < ApplicationRecord
   TEACHER_INFO_ROLES = [TEACHER, INDIVIDUAL_CONTRIBUTOR, ADMIN]
   ROLES              = [TEACHER, STUDENT, STAFF, SALES_CONTACT, ADMIN]
   SAFE_ROLES         = [STUDENT, TEACHER, SALES_CONTACT, ADMIN]
-  VALID_EMAIL_REGEX = /\A[\w+\-.']+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
 
   ALPHA = 'alpha'
   BETA = 'beta'
@@ -408,7 +407,7 @@ class User < ApplicationRecord
   end
 
   def username_cannot_be_an_email
-    return unless username =~ VALID_EMAIL_REGEX
+    return unless ValidatesEmailFormatOf.validate_email_format(username).nil?
 
     if new_record?
       errors.add(:username, :invalid)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -93,7 +93,7 @@ class User < ApplicationRecord
   TEACHER_INFO_ROLES = [TEACHER, INDIVIDUAL_CONTRIBUTOR, ADMIN]
   ROLES              = [TEACHER, STUDENT, STAFF, SALES_CONTACT, ADMIN]
   SAFE_ROLES         = [STUDENT, TEACHER, SALES_CONTACT, ADMIN]
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+  VALID_EMAIL_REGEX = /\A[\w+\-.']+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
 
   ALPHA = 'alpha'
   BETA = 'beta'

--- a/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe InvitationsController, type: :controller do
+RSpec.describe InvitationsController, type: :controller do
   let(:classroom) { create(:classroom) }
   let(:user) { classroom.owner }
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -324,7 +324,6 @@ RSpec.describe User, type: :model do
     it "should give the correct value for all the constants" do
       expect(User::ROLES).to eq(%w(teacher student staff sales-contact admin))
       expect(User::SAFE_ROLES).to eq(%w(student teacher sales-contact admin))
-      expect(User::VALID_EMAIL_REGEX).to eq(/\A[\w+\-.']+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i)
     end
   end
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe User, type: :model do
     it "should give the correct value for all the constants" do
       expect(User::ROLES).to eq(%w(teacher student staff sales-contact admin))
       expect(User::SAFE_ROLES).to eq(%w(student teacher sales-contact admin))
-      expect(User::VALID_EMAIL_REGEX).to eq(/\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i)
+      expect(User::VALID_EMAIL_REGEX).to eq(/\A[\w+\-.']+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i)
     end
   end
 


### PR DESCRIPTION
## WHAT
Remove `VALID_EMAIL_REGEX` and use the validates_email_format_of gem to validate the format of an email.

## WHY
The VALID_EMAIL_REGEX is used when verifying invitee emails.  However this regex is missing an apostrophe which is [valid](https://stackoverflow.com/a/8527264) when occurrring before the '@'.  We have a user who can't be invited as a co-teacher since they have an apostrophe in their name.

Since we already have a gem used to validate emails when users are created, we should use the same mechanism for the invitee email format validation


## HOW
Update the code to call `ValidatesEmailFormatOf.validate_email_format(email)` and remove references to the REGEX.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Loading-circle-when-attempting-to-invite-a-co-teacher-9ccecb9e4f09433ab1ff8ebe18f13015?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
