### PR TITLE
Add Checklist for new District Admin attaching to schools

### DIFF
--- a/services/QuillLMS/app/controllers/cms/district_admins_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/district_admins_controller.rb
@@ -54,6 +54,7 @@ class Cms::DistrictAdminsController < Cms::CmsController
 
     if district_admin.save!
       district_admin.attach_schools(school_ids)
+      attach_as_teacher_to_first_premium_school(user)
       admin_info = AdminInfo.find_or_create_by!(user: user)
       admin_info.update(approver_role: User::STAFF, approval_status: AdminInfo::APPROVED)
 
@@ -75,6 +76,13 @@ class Cms::DistrictAdminsController < Cms::CmsController
     else
       render json: { error: user.errors.messages }
     end
+  end
+
+  private def attach_as_teacher_to_first_premium_school(admin)
+    first_premium_school = admin.administered_schools.find { |s| s.subscription.present? }
+    return if first_premium_school.blank?
+
+    SchoolsUsers.create!(user: admin, school: first_premium_school)
   end
 
   private def user_params

--- a/services/QuillLMS/app/controllers/cms/district_admins_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/district_admins_controller.rb
@@ -7,10 +7,16 @@ class Cms::DistrictAdminsController < Cms::CmsController
   def create
     user = User.find_by(email: params[:email])
     school_ids = params[:school_ids]
-    if user
+    if user && @district.district_admins.exists?(user_id: user.id)
+      render json: { message: t('district_admin.already_assigned', district_name: @district.name) }
+    elsif user
       create_district_admin_user_for_existing_user(user, school_ids)
+      InternalTool::MadeDistrictAdminEmailWorker.perform_async(user.id, @district.id)
+      render json: { message: t('district_admin.existing_account') }, status: 200
     else
-      create_new_account_for_district_admin_user
+      user = create_new_account_for_district_admin_user
+      InternalTool::DistrictAdminAccountCreatedEmailWorker.perform_async(user.id, @district.id)
+      render json: { message: t('district_admin.new_account') }, status: 200
     end
   end
 
@@ -36,31 +42,13 @@ class Cms::DistrictAdminsController < Cms::CmsController
     params.require(:email)
   end
 
-  private def determine_district_admin_worker(user_id, district_id, new_user)
-    if new_user
-      InternalTool::DistrictAdminAccountCreatedEmailWorker.perform_async(user_id, district_id)
-    else
-      InternalTool::MadeDistrictAdminEmailWorker.perform_async(user_id, district_id)
-    end
-  end
-
-  private def create_district_admin_user_for_existing_user(user, school_ids, new_user: false)
-
-    if @district.district_admins.exists?(user_id: user.id)
-      return render json: { message: t('district_admin.already_assigned', district_name: @district.name) }
-    end
-
+  private def create_district_admin_user_for_existing_user(user, school_ids)
     district_admin = @district.district_admins.build(user_id: user.id)
-
     if district_admin.save!
       district_admin.attach_schools(school_ids)
       attach_as_teacher_to_first_premium_school(user)
       admin_info = AdminInfo.find_or_create_by!(user: user)
       admin_info.update(approver_role: User::STAFF, approval_status: AdminInfo::APPROVED)
-
-      determine_district_admin_worker(user.id, @district.id, new_user)
-      returned_message = new_user ? t('district_admin.new_account') : t('district_admin.existing_account')
-      render json: { message: returned_message }, status: 200
     else
       render json: { error: district_admin.errors.messages }
     end
@@ -68,11 +56,11 @@ class Cms::DistrictAdminsController < Cms::CmsController
 
   private def create_new_account_for_district_admin_user
     user = User.new(user_params)
-
     if user.save!
       user.refresh_token!
       ExpirePasswordTokenWorker.perform_in(30.days, user.id)
-      create_district_admin_user_for_existing_user(user, params[:school_ids], new_user: true)
+      create_district_admin_user_for_existing_user(user, params[:school_ids])
+      user
     else
       render json: { error: user.errors.messages }
     end
@@ -80,7 +68,7 @@ class Cms::DistrictAdminsController < Cms::CmsController
 
   private def attach_as_teacher_to_first_premium_school(admin)
     first_premium_school = admin.administered_schools.find { |s| s.subscription.present? }
-    return if first_premium_school.blank?
+    return if first_premium_school.blank? || admin.school == first_premium_school
 
     SchoolsUsers.create!(user: admin, school: first_premium_school)
   end

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -86,14 +86,14 @@ class Cms::DistrictsController < Cms::CmsController
   end
 
   private def schools_formatted_for_new_admin
-    @district.schools.map { |s|
+    @district.schools.map do |school|
       {
-        id: s.id,
-        name: s.name,
-        checked: s.subscription.present?,
-        has_subscription: s.subscription.present?
+        id: school.id,
+        name: school.name,
+        checked: school.subscription.present?,
+        has_subscription: school.subscription.present?
       }
-    }
+    end
   end
 
   private def text_search_inputs

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -42,6 +42,7 @@ class Cms::DistrictsController < Cms::CmsController
     @js_file = 'staff'
     @style_file = 'staff'
     @cms_district_path = cms_district_path(id)
+    @schools = @district.schools
   end
 
   def new_subscription

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -90,8 +90,8 @@ class Cms::DistrictsController < Cms::CmsController
       {
         id: s.id,
         name: s.name,
-        checked: s.subscriptions.first.present?,
-        has_subscription: s.subscriptions.first.present?
+        checked: s.subscription.present?,
+        has_subscription: s.subscription.present?
       }
     }
   end

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -42,7 +42,7 @@ class Cms::DistrictsController < Cms::CmsController
     @js_file = 'staff'
     @style_file = 'staff'
     @cms_district_path = cms_district_path(id)
-    @schools = @district.schools
+    @schools = schools_formatted_for_new_admin
   end
 
   def new_subscription
@@ -83,6 +83,17 @@ class Cms::DistrictsController < Cms::CmsController
 
   private def set_district
     @district = District.find(params[:id])
+  end
+
+  private def schools_formatted_for_new_admin
+    @district.schools.map { |s|
+      {
+        id: s.id,
+        name: s.name,
+        checked: s.subscriptions.first.present?,
+        has_subscription: s.subscriptions.first.present?
+      }
+    }
   end
 
   private def text_search_inputs

--- a/services/QuillLMS/app/models/district_admin.rb
+++ b/services/QuillLMS/app/models/district_admin.rb
@@ -29,7 +29,7 @@ class DistrictAdmin < ApplicationRecord
   def attach_schools(school_ids)
     admin
       .schools_admins
-      .create!(school_ids.map { |id| { school_id: id } } )
+      .create!(school_ids&.map { |id| { school_id: id } } )
   end
 
   def detach_schools

--- a/services/QuillLMS/app/models/district_admin.rb
+++ b/services/QuillLMS/app/models/district_admin.rb
@@ -20,17 +20,16 @@ class DistrictAdmin < ApplicationRecord
   belongs_to :user
   validates :user_id, uniqueness: { scope: :district_id }
 
-  after_create :attach_schools
   after_destroy :detach_schools
 
   def admin
     user
   end
 
-  def attach_schools
+  def attach_schools(school_ids)
     admin
       .schools_admins
-      .create!(unattached_district_schools.map { |school| { school_id: school.id } } )
+      .create!(school_ids.map { |id| { school_id: id } } )
   end
 
   def detach_schools

--- a/services/QuillLMS/app/models/district_admin.rb
+++ b/services/QuillLMS/app/models/district_admin.rb
@@ -37,6 +37,10 @@ class DistrictAdmin < ApplicationRecord
       .schools_admins
       .where(school: district_schools)
       .destroy_all
+
+    admin
+      .schools_users
+      &.destroy
   end
 
   private def unattached_district_schools

--- a/services/QuillLMS/app/views/cms/districts/new_admin.html.erb
+++ b/services/QuillLMS/app/views/cms/districts/new_admin.html.erb
@@ -1,5 +1,6 @@
 <%= react_component('NewAdminOrDistrictUserApp', props: {
   type: 'district',
   districtId: @district&.id,
-  returnUrl: @cms_district_path
+  returnUrl: @cms_district_path,
+  schools: @schools
 })%>

--- a/services/QuillLMS/client/app/bundles/Staff/components/newAdminOrDistrictUser.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/newAdminOrDistrictUser.tsx
@@ -11,10 +11,11 @@ interface NewAdminOrDistrictUserProps {
   type: string,
   returnUrl: string,
   schoolId?: number,
-  districtId?: number
+  districtId?: number,
+  schools?: any[]
 }
 
-const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAdminOrDistrictUserProps) => {
+const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId, schools }: NewAdminOrDistrictUserProps) => {
   const [firstName, setFirstName] = React.useState<string>('');
   const [lastName, setLastName] = React.useState<string>('');
   const [email, setEmail] = React.useState<string>('');
@@ -22,6 +23,7 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
   const [showSnackbar, setShowSnackbar] = React.useState<boolean>(false);
   const [snackbarText, setSnackbarText] = React.useState<string>('');
   const [loading, setLoading] = React.useState<boolean>(false);
+  const [schoolIds, setSchoolIds] = React.useState<Number[]>([]);
 
   useSnackbarMonitor(showSnackbar, setShowSnackbar, defaultSnackbarTimeout)
 
@@ -53,7 +55,8 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
       const params = {
         first_name: firstName.trim(),
         last_name: lastName.trim(),
-        email: email.trim()
+        email: email.trim(),
+        school_ids: schoolIds,
       }
       requestPost(requestUrl, params, (body) => {
         if(body.error) {
@@ -74,6 +77,39 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
 
   function handleCancelClick() {
     window.location.href = returnUrl
+  }
+
+  function handleCheckboxChange(schoolId) {
+    setSchoolIds((prevSchoolIds) => {
+      let updatedSchoolIds = prevSchoolIds.slice()
+      if (updatedSchoolIds.includes(schoolId)) {
+        updatedSchoolIds = updatedSchoolIds.filter(s => s !== schoolId)
+      } else {
+        updatedSchoolIds.push(schoolId)
+      }
+      return updatedSchoolIds;
+    });
+  };
+
+  function attachSchools() {
+    return (
+      <section>
+        <h3>Attach Schools</h3>
+        <p>The user will become an Admin for the following schools:</p>
+        {
+          schools.map((school) => (
+            <div key={school.id}>
+              <input
+                id={`checkbox-${school.id}`}
+                onChange={() => handleCheckboxChange(school.id)}
+                type="checkbox"
+              />
+              <label htmlFor={`checkbox-${school.id}`}>{school.name}</label>
+            </div>
+          ))
+        }
+      </section>
+    )
   }
 
   const header = type === ADMIN ? 'New Admin' : 'New District Admin'
@@ -107,6 +143,7 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId }: NewAd
           label="Email"
           value={email}
         />
+        {type !== ADMIN && attachSchools()}
         <section className="buttons-container">
           <button className="quill-button small primary contained" onClick={handleSubmitClick}>{innerSubmitButtonElement}</button>
           <button className="quill-button small secondary outlined" onClick={handleCancelClick}>Cancel</button>

--- a/services/QuillLMS/client/app/bundles/Staff/components/newAdminOrDistrictUser.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/newAdminOrDistrictUser.tsx
@@ -69,7 +69,7 @@ const NewAdminOrDistrictUser = ({ type, returnUrl, schoolId, districtId, schools
         first_name: firstName.trim(),
         last_name: lastName.trim(),
         email: email.trim(),
-        school_ids: checklistSchools.filter((s) => s.checked).map((s) => s.id),
+        school_ids: checklistSchools.filter(s => s.checked).map(s => s.id),
       }
       requestPost(requestUrl, params, (body) => {
         if(body.error) {

--- a/services/QuillLMS/client/app/bundles/Staff/styles/new_admin_user.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/new_admin_user.scss
@@ -27,5 +27,11 @@
         }
       }
     }
+    table {
+      overflow: visible;
+      th.data-table-header {
+        text-align: left !important;
+      }
+    }
   }
 }

--- a/services/QuillLMS/spec/controllers/cms/district_admins_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/district_admins_controller_spec.rb
@@ -15,29 +15,30 @@ describe Cms::DistrictAdminsController do
 
   describe '#create' do
     describe 'for a new user' do
+      let(:test_email) { 'test@email.com' }
 
       it 'creates the user admin info record as staff approved' do
-        post :create, params: { district_id: district1.id, email: 'test@email.com', first_name: 'Test', last_name: 'User' }
+        post :create, params: { district_id: district1.id, email: test_email, first_name: 'Test', last_name: 'User' }
 
-        new_user = User.find_by(email: 'test@email.com')
+        new_user = User.find_by(email: test_email)
         expect(new_user.admin_info.approver_role).to eq(User::STAFF)
         expect(new_user.admin_info.approval_status).to eq(AdminInfo::APPROVED)
       end
 
       it 'creates a new user account and district admin, and sends the expected email' do
         Sidekiq::Testing.inline! do
-          post :create, params: { district_id: district1.id, email: 'test@email.com', first_name: 'Test', last_name: 'User' }
+          post :create, params: { district_id: district1.id, email: test_email, first_name: 'Test', last_name: 'User' }
 
-          new_user = User.find_by(email: 'test@email.com')
+          new_user = User.find_by(email: test_email)
           expect(new_user).to be
           expect(DistrictAdmin.find_by_user_id(new_user.id)).to be
           expect(ActionMailer::Base.deliveries.last.subject).to eq('[Action Required] Test, a Quill district admin account was created for you')
-          expect(ActionMailer::Base.deliveries.last.to).to eq(['test@email.com'])
+          expect(ActionMailer::Base.deliveries.last.to).to eq([test_email])
         end
       end
 
       it 'attaches the user as admin to the specified schools' do
-        email = 'test@email.com'
+        email = test_email
         post :create, params: { district_id: district1.id, email: email, first_name: 'Test', last_name: 'User', school_ids: [school.id] }
 
         new_user = User.find_by(email: email)
@@ -45,7 +46,7 @@ describe Cms::DistrictAdminsController do
       end
 
       it 'if a specified school has premium, attaches the user to that school' do
-        email = 'test@email.com'
+        email = test_email
         create(:school_subscription, school: school)
         post :create, params: { district_id: district1.id, email: email, first_name: 'Test', last_name: 'User', school_ids: [school.id] }
 

--- a/services/QuillLMS/spec/models/district_admin_spec.rb
+++ b/services/QuillLMS/spec/models/district_admin_spec.rb
@@ -55,5 +55,16 @@ describe DistrictAdmin, type: :model, redis: true do
 
       it { expect { subject }.to not_change(SchoolsAdmins, :count) }
     end
+
+    context 'admin is teacher for a school' do
+      before do
+        school = create(:school)
+        create(:schools_users, user: user, school: school)
+      end
+
+      it 'should detach that admin as teacher from the school' do
+        expect { subject }.to change(SchoolsUsers, :count).from(1).to(0)
+      end
+    end
   end
 end

--- a/services/QuillLMS/spec/models/district_admin_spec.rb
+++ b/services/QuillLMS/spec/models/district_admin_spec.rb
@@ -21,12 +21,13 @@ describe DistrictAdmin, type: :model, redis: true do
   it { should belong_to(:district) }
   it { should belong_to(:user) }
 
-  it { is_expected.to callback(:attach_schools).after(:create) }
   it { is_expected.to callback(:detach_schools).after(:destroy) }
 
   let!(:user) { create(:user, email: 'test@quill.org') }
   let!(:district) { create(:district) }
   let!(:district_admin) { create(:district_admin, user: user, district: district) }
+  let!(:school1) { create(:school) }
+  let!(:school2) { create(:school) }
 
   describe '#admin' do
     it 'should return the user associated' do
@@ -35,14 +36,9 @@ describe DistrictAdmin, type: :model, redis: true do
   end
 
   describe '#attach_schools' do
-    let(:attach_school_to_district) { create(:school, district: district) }
-
-    it { expect { attach_school_to_district }.to change(SchoolsAdmins, :count).from(0).to(1) }
-
-    context 'school is already attached' do
-      before { attach_school_to_district }
-
-      it { expect { district_admin.attach_schools }.to not_change(SchoolsAdmins, :count) }
+    it 'should attach the specified schools to the district admin as administered schools' do
+      district_admin.attach_schools([school1.id, school2.id])
+      expect(district_admin.user.administered_schools).to match_array([school1, school2])
     end
   end
 

--- a/services/QuillLMS/spec/models/district_admin_spec.rb
+++ b/services/QuillLMS/spec/models/district_admin_spec.rb
@@ -26,8 +26,6 @@ describe DistrictAdmin, type: :model, redis: true do
   let!(:user) { create(:user, email: 'test@quill.org') }
   let!(:district) { create(:district) }
   let!(:district_admin) { create(:district_admin, user: user, district: district) }
-  let!(:school1) { create(:school) }
-  let!(:school2) { create(:school) }
 
   describe '#admin' do
     it 'should return the user associated' do
@@ -36,6 +34,9 @@ describe DistrictAdmin, type: :model, redis: true do
   end
 
   describe '#attach_schools' do
+    let!(:school1) { create(:school) }
+    let!(:school2) { create(:school) }
+
     it 'should attach the specified schools to the district admin as administered schools' do
       district_admin.attach_schools([school1.id, school2.id])
       expect(district_admin.user.administered_schools).to match_array([school1, school2])

--- a/services/QuillLMS/spec/models/segment_integration/user_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/user_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe SegmentIntegration::User do
 
     describe '#school_params' do
       it 'returns the expected params hash' do
+        admin.school = schools.first
+
         total_teachers_at_school = 2
         total_students_at_school = 40
         total_activities_completed_by_students_at_school = 400


### PR DESCRIPTION
## WHAT
Add a checklist feature when adding a new district admin. From this checklist, Quill staff can select which schools the admin gets privileges for. 
Also, automatically add the admin to the first school selected with Premium access. This gives them a Premium subscription so they can access full Quill features.

## WHY
This allows Quill staff to fine tune admin access and turn it on and off for different schools throughout a district. It saves them a lot of time because now they have to manually remove certain schools access after creating an admin.

## HOW
Create a front end checklist that passes checked schools to the back end. In the back end, attach schools from the passed parameters rather than attaching all schools automatically.

### Screenshots
![Screenshot 2023-10-26 at 5 21 32 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/cfdf1aa4-e070-4495-8495-e411acbb5a12)


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=9e8319cfdc764f0cb81ebca73964497a&pm=c)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
