### PR TITLE
Update secure headers for google

### DIFF
--- a/services/QuillLMS/config/initializers/react_on_rails.rb
+++ b/services/QuillLMS/config/initializers/react_on_rails.rb
@@ -11,5 +11,5 @@ ReactOnRails.configure do |config|
   config.replay_console = true
   config.logging_on_server = true
   config.prerender = false
-  config.trace = Rails.env.development?
+  config.trace = ENV.fetch('REACT_ON_RAILS_TRACE', Rails.env.development?).to_s == 'true'
 end

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -20,7 +20,8 @@ SecureHeaders::Configuration.default do |config|
       "https://*.youtube.com",
       "https://*.amazonaws.com",
       "https://*.loom.com",
-      "https://*.salesmate.io"
+      "https://*.salesmate.io",
+      "https://td.doubleclick.net/"
     ],
 
     object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
@@ -129,7 +130,8 @@ SecureHeaders::Configuration.default do |config|
       "http://localhost:3100",
       "ws://localhost:3200",
       "https://checkout.stripe.com",
-      "https://capture-api.ap3prod.com"
+      "https://capture-api.ap3prod.com",
+      "https://pagead2.googlesyndication.com/"
     ]
   }
 


### PR DESCRIPTION
## WHAT
1. Update secure headers configuration with Google Ads domains
2. Add ENV variable for toggling react-on-rails tracing

## WHY
1.  While working on a support ticket, I noticed some unrelated errors in the console ![Screenshot 2023-10-27 at 10 50 56 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/d71b33b6-d266-4b11-8755-bbdb60f34938)
2. It's nice to turn off some console.log messages locally if you don't want it

## HOW
1. Add "https://pagead2.googlesyndication.com/" to "connect-src" and "https://td.doubleclick.net/" to "frame-src"
2. Add `REACT_ON_RAILS_TRACE` variable to ReactOnRails configuration. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Configuration change.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
