### PR TITLE
Add an "Instant" sidekiq queue for Pusher jobs

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -3,9 +3,11 @@ web: bundle exec puma -C ./config/puma.rb
 # Note, using MALLOC_ARENA_MAX=2 based on this article:
 # https://github.com/mperham/sidekiq/wiki/Deployment#heroku
 
-worker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical -q critical_external -q default
+worker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q instant -q critical -q critical_external -q default
 
 reportworker: MAX_THREADS=$SIDEKIQ_REPORTWORKER_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q default -q low -q critical -q critical_external
+
+instantworker: MAX_THREADS=$SIDEKIQ_INSTANT_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q instant
 
 # Backup workers that we can use in case we need to isolate external jobs from the queue
 externalworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q critical_external

--- a/services/QuillLMS/Procfile.static
+++ b/services/QuillLMS/Procfile.static
@@ -1,7 +1,7 @@
 # Run Rails without hot reloading (static assets).
 rails: rails s -b 0.0.0.0
 
-worker: bundle exec sidekiq -v -q default -q critical -q critical_external
+worker: bundle exec sidekiq -v -q instant -q default -q critical -q critical_external
 reportworker: bundle exec sidekiq -v -q low
 
 # Build client assets, watching for changes.

--- a/services/QuillLMS/app/workers/send_pusher_message_worker.rb
+++ b/services/QuillLMS/app/workers/send_pusher_message_worker.rb
@@ -2,7 +2,7 @@
 
 class SendPusherMessageWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+  sidekiq_options queue: SidekiqQueue::INSTANT
 
   def perform(user_id, pusher_event, payload = nil)
     return unless user_id && pusher_event

--- a/services/QuillLMS/config/initializers/sidekiq.rb
+++ b/services/QuillLMS/config/initializers/sidekiq.rb
@@ -13,7 +13,7 @@ end
 module SidekiqQueue
   # QUEUE DEFINITIONS
 
-  # INSTANT: Consitently low-latency jobs that should also be the highest priority
+  # INSTANT: Consitently low-latency jobs that should also always be the highest priority
   # e.g. Pusher jobs that are fast and the last step to updating the UI
   INSTANT = 'instant'
   # CRITICAL: Jobs that impact the user experience,

--- a/services/QuillLMS/config/initializers/sidekiq.rb
+++ b/services/QuillLMS/config/initializers/sidekiq.rb
@@ -13,18 +13,21 @@ end
 module SidekiqQueue
   # QUEUE DEFINITIONS
 
+  # INSTANT: Consitently low-latency jobs that should also be the highest priority
+  # e.g. Pusher jobs that are fast and the last step to updating the UI
+  INSTANT = 'instant'
   # CRITICAL: Jobs that impact the user experience,
   # e.g. that the user may be waiting on, like student imports
   CRITICAL = 'critical'
+  # Critical Jobs that rely on outside APIs, e.g. Google Classroom APIs
+  # Giving them their own queue in case we need to isolate them during an API provider issue
+  CRITICAL_EXTERNAL = 'critical_external'
   # DEFAULT: Jobs should run soon, but won't have an effect on the user experience
   # if they are delayed. These should not be long-running jobs, put those in LOW.
   DEFAULT = 'default'
   # LOW: Jobs that might be long-running that we don't want to clog up the main workers
   # and that can be delayed.
   LOW = 'low'
-  # Critical Jobs that rely on outside APIs, e.g. Google Classroom APIs
-  # Giving them their own queue in case we need to isolate them during an API provider issue
-  CRITICAL_EXTERNAL = 'critical_external'
   # Migration jobs are intended to backfill large, complicated model changes
   # Giving them their own queue lets us turn migrations entirely off rather
   # than risking normal workers getting tied up on complex migration work


### PR DESCRIPTION
## WHAT
Adding a new queue and worker config for "instant" jobs: fast jobs that should always run first.
## WHY
The Pusher jobs are getting caught behind other jobs in the critical queue. This is having a big impact on the Usage snapshot report which fires off 50 query jobs that each fire off a pusher job to notify the frontend. Because of that volume of query jobs (50) and the number of workers we typically have (18-34), the pusher jobs get caught behind the remaining query jobs, so even though the queries finish, the front end doesn't know about it until most of the queries finish. 
## HOW
Add a new highest priority queue, and add a worker type just for those jobs to give them an additional outlet.

### Notion Card Links

https://www.notion.so/quill/Improve-the-Admin-Usage-Snapshot-Report-metric-load-times-8d08aa3720a249488b3aec47eee3c703
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Still fixing spurious-ish tests on this, not sure why I am getting Redis failures yet. This code change is change (changing a queue), doesn't need a test.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
