### PR TITLE
usage snapshot UI fixes

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
@@ -121,10 +121,12 @@
       justify-content: flex-end;
     }
   }
+  .filter-menu-closed, .filter-menu-open {
+    width: 100%;
+  }
   .filter-menu-closed {
     margin: 0 auto;
     position: relative;
-    width: 100%;
     max-width: 1328px; // same as main
     .show-filter-menu-button {
       top: 32px;
@@ -328,7 +330,7 @@
             line-height: 21px;
           }
         }
-        &.positive, &.negative, &.none {
+        &.positive, &.negative, &.no-change {
           .count {
             color: $quill-grey-90;
           }

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotCount.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`SnapshotCount component size medium should match snapshot 1`] = `
   size="medium"
 >
   <section
-    className="snapshot-item snapshot-count medium "
+    className="snapshot-item snapshot-count medium no-change"
   >
     <div
       className="count-and-label"
@@ -301,7 +301,7 @@ exports[`SnapshotCount component size medium when there is no data  should match
   size="medium"
 >
   <section
-    className="snapshot-item snapshot-count medium "
+    className="snapshot-item snapshot-count medium no-change"
   >
     <div
       className="count-and-label"
@@ -377,7 +377,7 @@ exports[`SnapshotCount component size small when it is coming soon should match 
   size="small"
 >
   <section
-    className="snapshot-item snapshot-count small "
+    className="snapshot-item snapshot-count small no-change"
   >
     <div
       className="count-and-label"
@@ -627,7 +627,7 @@ exports[`SnapshotCount component size small when there is no data  should match 
   size="small"
 >
   <section
-    className="snapshot-item snapshot-count small "
+    className="snapshot-item snapshot-count small no-change"
   >
     <div
       className="count-and-label"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/__snapshots__/snapshotSection.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`SnapshotSection component when the section is Classrooms should match s
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -241,7 +241,7 @@ exports[`SnapshotSection component when the section is Classrooms should match s
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -314,7 +314,7 @@ exports[`SnapshotSection component when the section is Classrooms should match s
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -386,7 +386,7 @@ exports[`SnapshotSection component when the section is Classrooms should match s
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -695,7 +695,7 @@ exports[`SnapshotSection component when the section is Highlights should match s
             size="medium"
           >
             <section
-              className="snapshot-item snapshot-count medium "
+              className="snapshot-item snapshot-count medium no-change"
             >
               <div
                 className="count-and-label"
@@ -768,7 +768,7 @@ exports[`SnapshotSection component when the section is Highlights should match s
             size="medium"
           >
             <section
-              className="snapshot-item snapshot-count medium "
+              className="snapshot-item snapshot-count medium no-change"
             >
               <div
                 className="count-and-label"
@@ -1043,7 +1043,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -1116,7 +1116,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -1189,7 +1189,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -1262,7 +1262,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -1607,7 +1607,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -1680,7 +1680,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -1753,7 +1753,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -1826,7 +1826,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -1898,7 +1898,7 @@ exports[`SnapshotSection component when the section is Practice should match sna
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -2616,7 +2616,7 @@ exports[`SnapshotSection component when the section is Users should match snapsh
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -2689,7 +2689,7 @@ exports[`SnapshotSection component when the section is Users should match snapsh
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -2762,7 +2762,7 @@ exports[`SnapshotSection component when the section is Users should match snapsh
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"
@@ -2835,7 +2835,7 @@ exports[`SnapshotSection component when the section is Users should match snapsh
             size="small"
           >
             <section
-              className="snapshot-item snapshot-count small "
+              className="snapshot-item snapshot-count small no-change"
             >
               <div
                 className="count-and-label"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -32,6 +32,7 @@ interface SnapshotCountProps {
 
 const PUSHER_CURRENT_EVENT_KEY = 'admin-snapshot-count-cached'
 const PUSHER_PREVIOUS_EVENT_KEY = 'admin-snapshot-previous-count-cached'
+const NOT_APPLICABLE = 'N/A'
 
 const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, selectedSchoolIds, selectedTeacherIds, selectedClassroomIds, selectedTimeframe, customTimeframeStart, customTimeframeEnd, passedCount, passedPrevious, passedChange, passedChangeDirection, singularLabel, pusherChannel, }: SnapshotCountProps) => {
   const [count, setCount] = React.useState(passedCount || null)
@@ -64,7 +65,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
   }, [previousRetryTimeout])
 
   React.useEffect(() => {
-    if (!previous || count === 'N/A' || count === null) {
+    if (!previous || count === NOT_APPLICABLE || count === null) {
       setChangeDirection(NONE)
       return
     }
@@ -112,7 +113,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
       const { results, } = body
       const { count } = results
 
-      setCount((count === null) ? 'N/A' : Math.round(count || 0))
+      setCount((count === null) ? NOT_APPLICABLE : Math.round(count || 0))
 
       setLoading(false)
     })
@@ -160,7 +161,12 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     });
   };
 
-  const className = `snapshot-item snapshot-count ${size} ${(changeDirection !== NONE) ? changeDirection : ''}`
+  let className = `snapshot-item snapshot-count ${size}`
+  if (changeDirection === NONE && count !== NOT_APPLICABLE) {
+    className += ' no-change'
+  } else if (changeDirection !== NONE) {
+    className += ` ${changeDirection}`
+  }
 
   let icon
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -332,7 +332,7 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
   return (
     <div className="filterable-reports-container white-background">
       {filterMenu}
-      <div className={showFilters ? '' : 'filter-menu-closed'}>
+      <div className={showFilters ? 'filter-menu-open' : 'filter-menu-closed'}>
         {showFilters ? null : renderShowFilterMenuButton()}
         <Routes>
           <Route element={<DiagnosticGrowthReportsContainer {...sharedProps} />} path='/teachers/premium_hub/diagnostic_growth_report' />

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/PremiumFilterableReportsContainer.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/PremiumFilterableReportsContainer.test.tsx.snap
@@ -464,7 +464,7 @@ exports[`PremiumFilterableReportsContainer it should render 1`] = `
       </div>
     </section>
     <div
-      class=""
+      class="filter-menu-open"
     />
   </div>
 </DocumentFragment>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/UsageSnapshotsContainer.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/UsageSnapshotsContainer.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
               class="counts"
             >
               <section
-                class="snapshot-item snapshot-count medium "
+                class="snapshot-item snapshot-count medium no-change"
               >
                 <div
                   class="count-and-label"
@@ -176,7 +176,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count medium "
+                class="snapshot-item snapshot-count medium no-change"
               >
                 <div
                   class="count-and-label"
@@ -224,7 +224,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
               class="counts"
             >
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -247,7 +247,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -270,7 +270,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -293,7 +293,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -404,7 +404,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
               class="first-row"
             >
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -427,7 +427,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -450,7 +450,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -473,7 +473,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -622,7 +622,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
               class="third-and-fourth-row"
             >
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -645,7 +645,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -668,7 +668,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -691,7 +691,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -714,7 +714,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -906,7 +906,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
               class="counts"
             >
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -929,7 +929,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -952,7 +952,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"
@@ -975,7 +975,7 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
                 </div>
               </section>
               <section
-                class="snapshot-item snapshot-count small "
+                class="snapshot-item snapshot-count small no-change"
               >
                 <div
                   class="count-and-label"


### PR DESCRIPTION
## WHAT
Fix bugs where the wrong text color was being displayed for snapshot counts with no change (as opposed to null counts), and where the sections weren't taking up the full width when the filter menu was minimized.

## WHY
We want this report to be free of visual bugs.

## HOW
Just CSS/HTML updates.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/The-metric-text-color-on-the-Usage-Snapshot-report-is-incorrect-for-some-metrics-caf5d0256a46419fa27d7bb970c7f646?pvs=4
https://www.notion.so/quill/Some-section-widths-on-the-Usage-Snapshot-report-do-not-seem-correct-when-the-filters-are-hidden-8ef8458610344b99b39198f720ad383c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES