### PR TITLE
lms/admin-snapshot-cache-with-filters

### DIFF
--- a/services/QuillLMS/app/workers/cache_admin_snapshots_worker.rb
+++ b/services/QuillLMS/app/workers/cache_admin_snapshots_worker.rb
@@ -4,17 +4,17 @@ class CacheAdminSnapshotsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
+  REPORT_NAME = 'usage_snapshot_report'
+
   def perform(admin_id)
     @user = User.find_by_id(admin_id)
     return unless @user
-
-    @school_ids = @user.schools_admins.pluck(:school_id)
 
     current_start, current_end = Snapshots::Timeframes.calculate_timeframes(Snapshots::Timeframes::DEFAULT_TIMEFRAME)
     previous_start, previous_end = Snapshots::Timeframes.calculate_timeframes(Snapshots::Timeframes::DEFAULT_TIMEFRAME, previous_timeframe: true)
 
     Snapshots::CacheSnapshotCountWorker::QUERIES.keys.each do |query|
-      Snapshots::CacheSnapshotCountWorker.perform_async(*generate_worker_payload(query, previous_start, previous_end))
+      Snapshots::CacheSnapshotCountWorker.perform_async(*generate_worker_payload(query, previous_start, previous_end, previous_timeframe: true))
       Snapshots::CacheSnapshotCountWorker.perform_async(*generate_worker_payload(query, current_start, current_end))
     end
 
@@ -23,12 +23,23 @@ class CacheAdminSnapshotsWorker
     end
   end
 
-  private def generate_worker_payload(query, timeframe_start, timeframe_end)
+  private def generate_worker_payload(query, timeframe_start, timeframe_end, previous_timeframe: nil)
+    stored_filters = AdminReportFilterSelection.find_by(user: @user, report: REPORT_NAME)&.filter_selections
+
+    school_filters = stored_filters.fetch('schools', []).blank? ? @user.schools_admins.pluck(:school_id) : map_values(stored_filters.fetch('schools', []))
+
+    non_school_filters = {
+      grades: map_values(stored_filters.fetch('grades', [])),
+      teacher_ids: map_values(stored_filters.fetch('teachers', [])),
+      classroom_ids: map_values(stored_filters.fetch('classrooms', []))
+    }
+
     cache_key = Snapshots::CacheKeys.generate_key(query,
       Snapshots::Timeframes::DEFAULT_TIMEFRAME,
       timeframe_start,
       timeframe_end,
-      @school_ids
+      school_filters,
+      additional_filters: non_school_filters
     )
 
     [
@@ -40,9 +51,13 @@ class CacheAdminSnapshotsWorker
         timeframe_start:,
         timeframe_end:
       },
-      @school_ids,
-      {},
-      nil
+      school_filters,
+      non_school_filters,
+      previous_timeframe
     ]
+  end
+
+  private def map_values(source_array)
+    source_array.map { |h| h['value'] }
   end
 end


### PR DESCRIPTION
## WHAT
Update overnight cache worker to use stored filters

NOTE: This code is intended to supplement work done in #11171, and should be tested again in staging after that PR is merged.
## WHY
We want to pre-cache the first report that the user loads, and if they have stored filters those are the ones that will load when they navigate to the snapshot page.  So we should cache the data for that version of the report.
## HOW
In the code that constructs the payload to send to the cache workers, check to see if the admin in question has stored filters.  If they do, apply the data from those filters to the payloads sent to the workers so that the report matching those filters is the one cached.


### Notion Card Links
https://www.notion.so/quill/Cache-Admin-Snapshot-queries-overnight-for-every-admin-using-the-default-filters-da22a602494146628c8d00cefb81a29e?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
