### PR TITLE
Fix logic with google link-to account

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/link_provider_account_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/link_provider_account_modal.tsx
@@ -20,7 +20,7 @@ const LinkProviderAccountModal = ({ link, close, provider, user }: LinkProviderA
     const buttonText = 'Link Account'
     let buttonClass = 'quill-button contained primary medium';
 
-    if (!termsAccepted) {
+    if (termsAccepted) {
       if (provider === 'Google') { return <AuthGoogleAccessForm offlineAccess={true} text={buttonText} /> }
 
       return <a className={buttonClass} href={link}>{buttonText}</a>
@@ -70,7 +70,7 @@ const LinkProviderAccountModal = ({ link, close, provider, user }: LinkProviderA
             onClick={close}
             type="button"
           >
-          Cancel
+            Cancel
           </button>
           {renderLinkAccountButton()}
         </div>


### PR DESCRIPTION
## WHAT
Fix a checkbox bug where clicking a terms of service disables a button

## WHY
`!termsAccepted` is showing the reverse of what should be shown.

## HOW
Change the condition on if-else clause to use the correct boolean.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Link-your-account-to-Google-workflow-from-the-My-Classes-page-is-not-working-correctly-f02f0f59c7e645629ae7eeb6a6531391?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Manual check
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
