### PR TITLE
persist custom dates for saved filter selections

### DIFF
--- a/services/QuillLMS/app/controllers/admin_report_filter_selections_controller.rb
+++ b/services/QuillLMS/app/controllers/admin_report_filter_selections_controller.rb
@@ -30,6 +30,8 @@ class AdminReportFilterSelectionsController < ApplicationController
       .permit(
         :report,
         filter_selections: [
+          :custom_start_date,
+          :custom_end_date,
           timeframe: [:value, :name, :default, :label],
           schools: [:id, :name, :label, :value],
           teachers: [:id, :name, :label, :value],

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import queryString from 'query-string';
+import moment from 'moment';
 import * as _ from 'lodash'
 import * as Pusher from 'pusher-js';
 import { Routes, Route } from "react-router-dom-v5-compat";
@@ -155,27 +156,29 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
     return location.pathname.slice(location.pathname.lastIndexOf("/") + 1, location.pathname.length)
   }
 
-  function setSelectedAndLastSubmitted(grades, schools, teachers, classrooms, timeframe) {
+  function setSelectedAndLastSubmitted(grades, schools, teachers, classrooms, timeframe, startDate, endDate) {
     setSelectedGrades(grades)
     setSelectedSchools(schools)
     setSelectedTeachers(teachers)
     setSelectedClassrooms(classrooms)
     setSelectedTimeframe(timeframe)
+    setCustomStartDate(startDate)
+    setCustomEndDate(endDate)
 
     setLastSubmittedGrades(grades)
     setLastSubmittedSchools(schools)
     setLastSubmittedTeachers(teachers)
     setLastSubmittedClassrooms(classrooms)
     setLastSubmittedTimeframe(timeframe)
-
-    setLastUsedTimeframe(timeframe)
+    setLastSubmittedCustomStartDate(startDate)
+    setLastSubmittedCustomEndDate(endDate)
   }
 
   function getFilterSelections() {
     requestPost('/admin_report_filter_selections/show', { report: reportPath() }, (selections) => {
       if (selections) {
-        const { grades, schools, teachers, classrooms, timeframe, } = selections.filter_selections
-        setSelectedAndLastSubmitted(grades, schools, teachers, classrooms, timeframe)
+        const { grades, schools, teachers, classrooms, timeframe, custom_start_date, custom_end_date, } = selections.filter_selections
+        setSelectedAndLastSubmitted(grades, schools, teachers, classrooms, timeframe, moment(custom_start_date), moment(custom_end_date))
       }
       setLoadingSavedFilterSelections(false)
     })
@@ -188,6 +191,8 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
       teachers: selectedTeachers,
       classrooms: selectedClassrooms,
       grades: selectedGrades,
+      custom_start_date: customStartDate,
+      custom_end_date: customEndDate
 
     }
     const params = {
@@ -230,7 +235,7 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
       if (allClassrooms?.length !== classroomOptions.length) { setAllClassrooms(classroomOptions) }
 
       if (loadingFilters && (!selectedGrades || !selectedSchools || !selectedTeachers || !selectedClassrooms || !selectedTimeframe)) {
-        setSelectedAndLastSubmitted(gradeOptions, schoolOptions, teacherOptions, classroomOptions, timeframe)
+        setSelectedAndLastSubmitted(gradeOptions, schoolOptions, teacherOptions, classroomOptions, timeframe, null, null)
       }
 
       if (loadingFilters) {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -178,7 +178,9 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
     requestPost('/admin_report_filter_selections/show', { report: reportPath() }, (selections) => {
       if (selections) {
         const { grades, schools, teachers, classrooms, timeframe, custom_start_date, custom_end_date, } = selections.filter_selections
-        setSelectedAndLastSubmitted(grades, schools, teachers, classrooms, timeframe, moment(custom_start_date), moment(custom_end_date))
+        const startDate = custom_start_date ? moment(custom_start_date) : null
+        const endDate = custom_end_date ? moment(custom_end_date) : null
+        setSelectedAndLastSubmitted(grades, schools, teachers, classrooms, timeframe, startDate, endDate)
       }
       setLoadingSavedFilterSelections(false)
     })


### PR DESCRIPTION
## WHAT
Make sure we're saving the custom start and end dates along with the timeframe when they've been selected.

## WHY
Otherwise the frontend is in a weird state because the timeframe itself is saved but it doesn't know what dates to use.

## HOW
Just add these values to the ones that get sent to the backend and then handle them if there are returned values.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - testing locally with staging data
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A