### PR TITLE
ensure csv headers are coerced to symbols

### DIFF
--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -27,17 +27,18 @@ module Adapters
       )
 
       def self.to_csv_string(bigquery_result, columns = ORDERED_COLUMNS)
-        validate_input!(bigquery_result, columns)
+        sym_columns = columns.map(&:to_sym)
+        validate_input!(bigquery_result)
 
         CSV.generate do |csv|
-          csv << columns.map(&:to_s)
+          csv << sym_columns.map(&:to_s)
           bigquery_result.each do |row|
-            csv << columns.map { |key| row[key] }
+            csv << sym_columns.map { |key| row[key] }
           end
         end
       end
 
-      def self.validate_input!(bigquery_result, columns)
+      def self.validate_input!(bigquery_result)
         bigquery_result.each do |row|
           next if (row.keys - ORDERED_COLUMNS).empty?
 

--- a/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
+++ b/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
@@ -37,6 +37,11 @@ describe Adapters::Csv::AdminPremiumDataExport do
         expected_result = "student_name,activity_name\nTest Student,Test Activity\n"
         expect(subject.to_csv_string(valid_input, [:student_name, :activity_name])).to eq expected_result
       end
+
+      it 'coerces custom columns from strings to symbols' do
+        expected_result = "student_name,activity_name\nTest Student,Test Activity\n"
+        expect(subject.to_csv_string(valid_input, ['student_name', 'activity_name'])).to eq expected_result
+      end
     end
 
     context 'with invalid input' do


### PR DESCRIPTION
## WHAT
When custom header filters are passed to the CSV download feature, ensure they are symbols, not strings. 

## WHY
Because we use the headers to access BigQuery hashes, which use symbols for keys. 



### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
none

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
