### PR TITLE
Truncate long classroom names

### DIFF
--- a/services/QuillLMS/app/services/canvas_integration/classroom_creator.rb
+++ b/services/QuillLMS/app/services/canvas_integration/classroom_creator.rb
@@ -57,7 +57,7 @@ module CanvasIntegration
     end
 
     private def valid_name
-      ::DuplicateNameResolver.run(data[:name], other_owned_classroom_names)
+      ::ValidNameBuilder.run(data[:name], other_owned_classroom_names)
     end
   end
 end

--- a/services/QuillLMS/app/services/canvas_integration/classroom_updater.rb
+++ b/services/QuillLMS/app/services/canvas_integration/classroom_updater.rb
@@ -54,7 +54,7 @@ module CanvasIntegration
     end
 
     private def valid_name
-      ::DuplicateNameResolver.run(data[:name], other_owned_classroom_names)
+      ::ValidNameBuilder.run(data[:name], other_owned_classroom_names)
     end
   end
 end

--- a/services/QuillLMS/app/services/clever_integration/classroom_creator.rb
+++ b/services/QuillLMS/app/services/clever_integration/classroom_creator.rb
@@ -49,7 +49,7 @@ module CleverIntegration
     end
 
     private def valid_name
-      ::DuplicateNameResolver.run(data[:name], other_owned_classroom_names)
+      ::ValidNameBuilder.run(data[:name], other_owned_classroom_names)
     end
   end
 end

--- a/services/QuillLMS/app/services/clever_integration/classroom_updater.rb
+++ b/services/QuillLMS/app/services/clever_integration/classroom_updater.rb
@@ -63,7 +63,7 @@ module CleverIntegration
     end
 
     private def valid_name
-      ::DuplicateNameResolver.run(data[:name], other_owned_classroom_names)
+      ::ValidNameBuilder.run(data[:name], other_owned_classroom_names)
     end
   end
 end

--- a/services/QuillLMS/app/services/duplicate_name_resolver.rb
+++ b/services/QuillLMS/app/services/duplicate_name_resolver.rb
@@ -4,9 +4,12 @@ class DuplicateNameResolver < ApplicationService
   attr_reader :name, :existing_names, :max_before_randomized
 
   MAX_BEFORE_RANDOMIZED = 10
+  MAX_STRING_LENGTH = 255
+  RANDOM_STRING_LENGTH = SecureRandom.urlsafe_base64.length
+  TRUNCATE_LENGTH = MAX_STRING_LENGTH - RANDOM_STRING_LENGTH
 
-  def initialize(name, existing_names, max_before_randomized=MAX_BEFORE_RANDOMIZED)
-    @name = name
+  def initialize(name, existing_names, max_before_randomized=MAX_BEFORE_RANDOMIZED, truncate_length=TRUNCATE_LENGTH)
+    @name = name.truncate(truncate_length)
     @existing_names = existing_names
     @max_before_randomized = max_before_randomized
   end

--- a/services/QuillLMS/app/services/google_integration/classroom_creator.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_creator.rb
@@ -49,7 +49,7 @@ module GoogleIntegration
     end
 
     private def valid_name
-      ::DuplicateNameResolver.run(data[:name], other_owned_classroom_names)
+      ::ValidNameBuilder.run(data[:name], other_owned_classroom_names)
     end
   end
 end

--- a/services/QuillLMS/app/services/google_integration/classroom_updater.rb
+++ b/services/QuillLMS/app/services/google_integration/classroom_updater.rb
@@ -49,7 +49,7 @@ module GoogleIntegration
     end
 
     private def valid_name
-      ::DuplicateNameResolver.run(data[:name], other_owned_classroom_names)
+      ::ValidNameBuilder.run(data[:name], other_owned_classroom_names)
     end
   end
 end

--- a/services/QuillLMS/app/services/valid_name_builder.rb
+++ b/services/QuillLMS/app/services/valid_name_builder.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-class DuplicateNameResolver < ApplicationService
+class ValidNameBuilder < ApplicationService
   attr_reader :name, :existing_names, :max_before_randomized
 
   MAX_BEFORE_RANDOMIZED = 10
-  MAX_STRING_LENGTH = 255
-  RANDOM_STRING_LENGTH = SecureRandom.urlsafe_base64.length
-  TRUNCATE_LENGTH = MAX_STRING_LENGTH - RANDOM_STRING_LENGTH
+  MAX_LENGTH = 255
+  RANDOM_STRING_SUFFIX_LENGTH = SecureRandom.urlsafe_base64.length + 1
 
-  def initialize(name, existing_names, max_before_randomized=MAX_BEFORE_RANDOMIZED, truncate_length=TRUNCATE_LENGTH)
-    @name = name.truncate(truncate_length)
+  def initialize(name, existing_names, max_before_randomized=MAX_BEFORE_RANDOMIZED, max_length=MAX_LENGTH)
+    @name = name.truncate([max_length - RANDOM_STRING_SUFFIX_LENGTH, 0].max)
     @existing_names = existing_names
     @max_before_randomized = max_before_randomized
   end

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_creator_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_creator_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CanvasIntegration::ClassroomCreator do
     it { expect { subject }.to change(ClassroomsTeacher, :count).from(1).to(2) }
 
     context "teacher owns other classrooms with names #{name}_1, ... #{name}_max" do
-      let(:max) { ::DuplicateNameResolver::MAX_BEFORE_RANDOMIZED }
+      let(:max) { ::ValidNameBuilder::MAX_BEFORE_RANDOMIZED }
 
       before do
         2.upto(max) do |n|

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_updater_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_updater_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe CanvasIntegration::ClassroomUpdater do
     end
 
     context 'teacher owns other classrooms with names other_name1, ... other_name_[max]' do
-      let(:max) { ::DuplicateNameResolver::MAX_BEFORE_RANDOMIZED }
+      let(:max) { ::ValidNameBuilder::MAX_BEFORE_RANDOMIZED }
 
       before do
         2.upto(max) do |n|

--- a/services/QuillLMS/spec/services/clever_integration/classroom_creator_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/classroom_creator_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CleverIntegration::ClassroomCreator do
     it { expect { subject }.to change(ClassroomsTeacher, :count).from(1).to(2) }
 
     context "teacher owns other classrooms with names #{name}_1, ... #{name}_max" do
-      let(:max) { ::DuplicateNameResolver::MAX_BEFORE_RANDOMIZED }
+      let(:max) { ::ValidNameBuilder::MAX_BEFORE_RANDOMIZED }
 
       before do
         2.upto(max) do |n|

--- a/services/QuillLMS/spec/services/clever_integration/classroom_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/classroom_updater_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe CleverIntegration::ClassroomUpdater do
     end
 
     context 'teacher owns other classrooms with names other_name1, ... other_name_[max]' do
-      let(:max) { ::DuplicateNameResolver::MAX_BEFORE_RANDOMIZED }
+      let(:max) { ::ValidNameBuilder::MAX_BEFORE_RANDOMIZED }
 
       before do
         2.upto(max) do |n|

--- a/services/QuillLMS/spec/services/duplicate_name_resolver_spec.rb
+++ b/services/QuillLMS/spec/services/duplicate_name_resolver_spec.rb
@@ -3,33 +3,47 @@
 require 'rails_helper'
 
 RSpec.describe DuplicateNameResolver do
-  let(:name) { 'name' }
-
   subject { described_class.run(name, existing_names) }
+
+  let(:name) { 'name' }
 
   context "#{name} is not in existing names" do
     let(:existing_names) { [] }
 
-    it { expect(subject).to eq name }
+    it { is_expected.to eq name }
   end
 
   context "#{name} is in existing names" do
     let(:max) { described_class::MAX_BEFORE_RANDOMIZED }
     let(:existing_names) { [name] }
 
-    it { expect(subject).to eq "#{name}_1"}
+    it { is_expected.to eq "#{name}_1" }
 
     context "duplicates up to penulimate are also in existing names" do
       let(:existing_names) { [name] + 1.upto(max - 1).map { |n| "#{name}_#{n}" } }
 
-      it { expect(subject).to eq "#{name}_#{max}" }
+      it { is_expected.to eq "#{name}_#{max}" }
     end
 
     context "duplicates up to max are also in existing names" do
       let(:existing_names) { [name] + 1.upto(max).map { |n| "#{name}_#{n}" } }
 
-      it { expect(subject).not_to eq nil }
-      it { expect(subject).not_to eq "#{name}_#{max}" }
+      it { is_expected.not_to eq nil }
+      it { is_expected.not_to eq "#{name}_#{max}" }
+    end
+  end
+
+  context "name is longer than TRUNCATE_LENGTH" do
+    let(:name) { 'a' * (described_class::TRUNCATE_LENGTH * 500)  }
+    let(:existing_names) { [] }
+    let(:truncated_name) { name.truncate(described_class::TRUNCATE_LENGTH) }
+
+    it { is_expected.to eq truncated_name }
+
+    context "truncated name is in existing names" do
+      let(:existing_names) { [truncated_name] }
+
+      it { is_expected.to eq "#{truncated_name}_1" }
     end
   end
 end

--- a/services/QuillLMS/spec/services/google_integration/classroom_creator_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_creator_spec.rb
@@ -55,7 +55,7 @@ module GoogleIntegration
       it { expect { subject }.to change(ClassroomsTeacher, :count).from(1).to(2) }
 
       context "teacher owns other classrooms with names #{name}_1, ... #{name}_max" do
-        let(:max) { ::DuplicateNameResolver::MAX_BEFORE_RANDOMIZED }
+        let(:max) { ::ValidNameBuilder::MAX_BEFORE_RANDOMIZED }
 
         before do
           2.upto(max) do |n|

--- a/services/QuillLMS/spec/services/google_integration/classroom_updater_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/classroom_updater_spec.rb
@@ -96,7 +96,7 @@ module GoogleIntegration
       end
 
       context 'teacher owns other classrooms with names other_name1, ... other_name_[max]' do
-        let(:max) { ::DuplicateNameResolver::MAX_BEFORE_RANDOMIZED }
+        let(:max) { ::ValidNameBuilder::MAX_BEFORE_RANDOMIZED }
 
         before do
           2.upto(max) do |n|

--- a/services/QuillLMS/spec/services/valid_name_builder_spec.rb
+++ b/services/QuillLMS/spec/services/valid_name_builder_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DuplicateNameResolver do
+RSpec.describe ValidNameBuilder do
   subject { described_class.run(name, existing_names) }
 
   let(:name) { 'name' }
@@ -33,10 +33,10 @@ RSpec.describe DuplicateNameResolver do
     end
   end
 
-  context "name is longer than TRUNCATE_LENGTH" do
-    let(:name) { 'a' * (described_class::TRUNCATE_LENGTH * 500)  }
+  context "name is longer than MAX_LENGTH" do
+    let(:name) { 'a' * (described_class::MAX_LENGTH + 1)  }
     let(:existing_names) { [] }
-    let(:truncated_name) { name.truncate(described_class::TRUNCATE_LENGTH) }
+    let(:truncated_name) { name.truncate(described_class::MAX_LENGTH - described_class::RANDOM_STRING_SUFFIX_LENGTH) }
 
     it { is_expected.to eq truncated_name }
 


### PR DESCRIPTION
## WHAT
Fix an issue with teachers being unable to import classrooms with very long names (700+ characters)

## WHY
The classroom name field is a `string` type which in older versions of postgres is capped at length 255.  When a teacher attempts to import a classroom with a longer name, the import process fails due to this constraint.

## HOW
Truncate names any longer than 233 characters(255 characters minus a random string length that might be added for duplicate name resolving)

Rename `DuplicateNameResolver` to `ValidNameBuilder` since it incorporates truncation and duplicates resolving.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teachers-at-District-Cannot-Import-Clever-Classes-Class-Name-Issue-ecce211fe7fe42a7a229c893354a116b?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
