### PR TITLE
Lms/fix admin diagnostic percentage bug

### DIFF
--- a/services/QuillLMS/app/controllers/snapshots_controller.rb
+++ b/services/QuillLMS/app/controllers/snapshots_controller.rb
@@ -204,7 +204,9 @@ class SnapshotsController < ApplicationController
       {
         name: snapshot_params[:timeframe],
         timeframe_start: timeframe_start,
-        timeframe_end: timeframe_end
+        timeframe_end: timeframe_end,
+        custom_start: snapshot_params[:timeframe_custom_start],
+        custom_end: snapshot_params[:timeframe_custom_end]
       },
       snapshot_params[:school_ids],
       {

--- a/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
@@ -17,8 +17,8 @@ module Snapshots
       filter_hash = PayloadHasher.run([
         query,
         timeframe['name'],
-        timeframe['custom_start']&.to_s&.split('T')&.first,
-        timeframe['custom_end']&.to_s&.split('T')&.first,
+        timeframe['custom_start'],
+        timeframe['custom_end'],
         school_ids,
         filters['grades'],
         filters['teacher_ids'],

--- a/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
@@ -17,19 +17,15 @@ module Snapshots
       filter_hash = PayloadHasher.run([
         query,
         timeframe['name'],
+        timeframe['custom_start']&.to_s&.split('T')&.first,
+        timeframe['custom_end']&.to_s&.split('T')&.first,
         school_ids,
         filters['grades'],
         filters['teacher_ids'],
         filters['classroom_ids']
       ].flatten)
 
-      SendPusherMessageWorker.perform_async(user_id, PUSHER_EVENT, {
-        hash: filter_hash,
-        timeframe: {
-          custom_start: timeframe['custom_start'],
-          custom_end: timeframe['custom_end']
-        }
-      })
+      SendPusherMessageWorker.perform_async(user_id, PUSHER_EVENT, filter_hash)
     end
 
     private def cache_expiry

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -53,7 +53,13 @@ module Snapshots
       ].flatten)
 
       pusher_event = previous_timeframe ? PREVIOUS_TIMEFRAME_PUSHER_EVENT : CURRENT_TIMEFRAME_PUSHER_EVENT
-      SendPusherMessageWorker.perform_async(user_id, pusher_event, filter_hash)
+      SendPusherMessageWorker.perform_async(user_id, pusher_event, {
+        hash: filter_hash,
+        timeframe: {
+          start: timeframe['timeframe_start'],
+          end: timeframe['timeframe_end']
+        }
+      })
     end
 
     private def cache_expiry

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -51,7 +51,7 @@ module Snapshots
         school_ids,
         filters['grades'],
         filters['teacher_ids'],
-        filters['classroom_ids'],
+        filters['classroom_ids']
       ].flatten)
 
       SendPusherMessageWorker.perform_async(user_id, pusher_event_name(query, previous_timeframe: previous_timeframe), filter_hash)

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -46,8 +46,8 @@ module Snapshots
       filter_hash = PayloadHasher.run([
         query,
         timeframe['name'],
-        timeframe['custom_start']&.to_s&.split('T')&.first,
-        timeframe['custom_end']&.to_s&.split('T')&.first,
+        timeframe['custom_start'],
+        timeframe['custom_end'],
         school_ids,
         filters['grades'],
         filters['teacher_ids'],

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -46,19 +46,15 @@ module Snapshots
       filter_hash = PayloadHasher.run([
         query,
         timeframe['name'],
+        timeframe['custom_start']&.to_s&.split('T')&.first,
+        timeframe['custom_end']&.to_s&.split('T')&.first,
         school_ids,
         filters['grades'],
         filters['teacher_ids'],
-        filters['classroom_ids']
+        filters['classroom_ids'],
       ].flatten)
 
-      SendPusherMessageWorker.perform_async(user_id, pusher_event_name(query, previous_timeframe: previous_timeframe), {
-        hash: filter_hash,
-        timeframe: {
-          custom_start: timeframe['custom_start'],
-          custom_end: timeframe['custom_end']
-        }
-      })
+      SendPusherMessageWorker.perform_async(user_id, pusher_event_name(query, previous_timeframe: previous_timeframe), filter_hash)
     end
 
     private def pusher_event_name(query, previous_timeframe: false)

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -52,14 +52,18 @@ module Snapshots
         filters['classroom_ids']
       ].flatten)
 
-      pusher_event = previous_timeframe ? PREVIOUS_TIMEFRAME_PUSHER_EVENT : CURRENT_TIMEFRAME_PUSHER_EVENT
-      SendPusherMessageWorker.perform_async(user_id, pusher_event, {
+      SendPusherMessageWorker.perform_async(user_id, pusher_event_name(query, previous_timeframe: previous_timeframe), {
         hash: filter_hash,
         timeframe: {
           start: timeframe['timeframe_start'],
           end: timeframe['timeframe_end']
         }
       })
+    end
+
+    private def pusher_event_name(query, previous_timeframe: false)
+      pusher_event = previous_timeframe ? PREVIOUS_TIMEFRAME_PUSHER_EVENT : CURRENT_TIMEFRAME_PUSHER_EVENT
+      "#{pusher_event}:#{query}"
     end
 
     private def cache_expiry

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_count_worker.rb
@@ -55,8 +55,8 @@ module Snapshots
       SendPusherMessageWorker.perform_async(user_id, pusher_event_name(query, previous_timeframe: previous_timeframe), {
         hash: filter_hash,
         timeframe: {
-          start: timeframe['timeframe_start'],
-          end: timeframe['timeframe_end']
+          custom_start: timeframe['custom_start'],
+          custom_end: timeframe['custom_end']
         }
       })
     end

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -34,19 +34,15 @@ module Snapshots
       filter_hash = PayloadHasher.run([
         query,
         timeframe['name'],
+        timeframe['custom_start']&.to_s&.split('T')&.first,
+        timeframe['custom_end']&.to_s&.split('T')&.first,
         school_ids,
         filters['grades'],
         filters['teacher_ids'],
         filters['classroom_ids']
       ].flatten)
 
-      SendPusherMessageWorker.perform_async(user_id, pusher_event_name(query), {
-        hash: filter_hash,
-        timeframe: {
-          custom_start: timeframe['custom_start'],
-          custom_end: timeframe['custom_end']
-        }
-      })
+      SendPusherMessageWorker.perform_async(user_id, pusher_event_name(query), filter_hash)
     end
 
     private def pusher_event_name(query)

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -40,13 +40,17 @@ module Snapshots
         filters['classroom_ids']
       ].flatten)
 
-      SendPusherMessageWorker.perform_async(user_id, PUSHER_EVENT, {
+      SendPusherMessageWorker.perform_async(user_id, pusher_event_name(query), {
         hash: filter_hash,
         timeframe: {
           start: timeframe['timeframe_start'],
           end: timeframe['timeframe_end']
         }
       })
+    end
+
+    private def pusher_event_name(query)
+      "#{PUSHER_EVENT}:#{query}"
     end
 
     private def cache_expiry

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -40,7 +40,13 @@ module Snapshots
         filters['classroom_ids']
       ].flatten)
 
-      SendPusherMessageWorker.perform_async(user_id, PUSHER_EVENT, filter_hash)
+      SendPusherMessageWorker.perform_async(user_id, PUSHER_EVENT, {
+        hash: filter_hash,
+        timeframe: {
+          start: timeframe['timeframe_start'],
+          end: timeframe['timeframe_end']
+        }
+      })
     end
 
     private def cache_expiry

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -34,8 +34,8 @@ module Snapshots
       filter_hash = PayloadHasher.run([
         query,
         timeframe['name'],
-        timeframe['custom_start']&.to_s&.split('T')&.first,
-        timeframe['custom_end']&.to_s&.split('T')&.first,
+        timeframe['custom_start'],
+        timeframe['custom_end'],
         school_ids,
         filters['grades'],
         filters['teacher_ids'],

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -43,8 +43,8 @@ module Snapshots
       SendPusherMessageWorker.perform_async(user_id, pusher_event_name(query), {
         hash: filter_hash,
         timeframe: {
-          start: timeframe['timeframe_start'],
-          end: timeframe['timeframe_end']
+          custom_start: timeframe['custom_start'],
+          custom_end: timeframe['custom_end']
         }
       })
     end

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -57,6 +57,8 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
   const [showSnackbar, setShowSnackbar] = React.useState<boolean>(false);
   const [data, setData] = React.useState<any>(null);
   const [pusherMessage, setPusherMessage] = React.useState<any>(null)
+  const [customTimeframeStartString, setCustomTimeframeStartString] = React.useState(null)
+  const [customTimeframeEndString, setCustomTimeframeEndString] = React.useState(null)
 
   useSnackbarMonitor(showSnackbar, setShowSnackbar, defaultSnackbarTimeout)
 
@@ -136,6 +138,18 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
   }, [searchCount])
 
   React.useEffect(() => {
+    if (!customTimeframeStart) return
+
+    setCustomTimeframeStartString(customTimeframeStart.toISOString())
+  }, [customTimeframeStart])
+
+  React.useEffect(() => {
+    if (!customTimeframeEnd) return
+
+    setCustomTimeframeEndString(customTimeframeEnd.toISOString())
+  }, [customTimeframeEnd])
+
+  React.useEffect(() => {
     if (!pusherMessage) return
 
     if (filtersMatchHash(pusherMessage)) getData()
@@ -192,8 +206,8 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
     const filterTarget = [].concat(
       queryKey,
       selectedTimeframe,
-      customTimeframeStart?.toISOString().split('T',1)[0],
-      customTimeframeEnd?.toISOString().split('T',1)[0],
+      customTimeframeStartString,
+      customTimeframeEndString,
       selectedSchoolIds,
       selectedGrades,
       selectedTeacherIds,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -138,9 +138,7 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
   React.useEffect(() => {
     if (!pusherMessage) return
 
-    const { hash, timeframe, } = pusherMessage
-
-    if (filtersMatchHash(hash) && customTimeframeMatches(timeframe)) getData()
+    if (filtersMatchHash(pusherMessage)) getData()
   }, [pusherMessage])
 
   function getData() {
@@ -194,6 +192,8 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
     const filterTarget = [].concat(
       queryKey,
       selectedTimeframe,
+      customTimeframeStart?.toISOString().split('T',1)[0],
+      customTimeframeEnd?.toISOString().split('T',1)[0],
       selectedSchoolIds,
       selectedGrades,
       selectedTeacherIds,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -219,17 +219,6 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
     return hashMessage == filterHash
   }
 
-  function customTimeframeMatches(timeframe) {
-    if (!customTimeframeStart || !customTimeframeEnd) return true
-
-    const remoteStart = timeframe?.custom_start?.split('T', 1)[0]
-    const remoteEnd = timeframe?.custom_end?.split('T', 1)[0]
-    const localStart = customTimeframeStart?.toISOString()?.split('T', 1)[0]
-    const localEnd = customTimeframeEnd?.toISOString()?.split('T', 1)[0]
-
-    return remoteStart == localStart && remoteEnd == localEnd
-  }
-
   function initializePusher() {
     pusherChannel?.bind(PUSHER_EVENT_KEY, (body) => {
       const { message, } = body

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -147,11 +147,23 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     return hashMessage == filterHash
   }
 
+  function customTimeframeMatches(timeframe) {
+    if (!customTimeframeStart || !customTimeframeEnd) return true
+
+    const remoteStart = timeframe?.start?.split('T', 1)[0]
+    const remoteEnd = timeframe?.end?.split('T', 1)[0]
+    const localStart = customTimeframeStart?.toISOString()?.split('T', 1)[0]
+    const localEnd = customTimeframeEnd?.toISOString()?.split('T', 1)[0]
+
+    return remoteStart == localStart && remoteEnd == localEnd
+  }
+
   function initializePusher() {
     pusherChannel?.bind(PUSHER_CURRENT_EVENT_KEY, (body) => {
       const { message, } = body
+      const { hash, timeframe, } = message
 
-      if (filtersMatchHash(message)) getCurrentData()
+      if (filtersMatchHash(hash) && customTimeframeMatches(timeframe)) getCurrentData()
     });
 
     pusherChannel?.bind(PUSHER_PREVIOUS_EVENT_KEY, (body) => {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -45,6 +45,8 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
   const [previousRetryTimeout, setPreviousRetryTimeout] = React.useState(null)
   const [pusherCurrentMessage, setPusherCurrentMessage] = React.useState(null)
   const [pusherPreviousMessage, setPusherPreviousMessage] = React.useState(null)
+  const [customTimeframeStartString, setCustomTimeframeStartString] = React.useState(null)
+  const [customTimeframeEndString, setCustomTimeframeEndString] = React.useState(null)
 
   React.useEffect(() => {
     initializePusher()
@@ -56,6 +58,18 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     getCurrentData()
     getPreviousData()
   }, [searchCount])
+
+  React.useEffect(() => {
+    if (!customTimeframeStart) return
+
+    setCustomTimeframeStartString(customTimeframeStart.toISOString())
+  }, [customTimeframeStart])
+
+  React.useEffect(() => {
+    if (!customTimeframeEnd) return
+
+    setCustomTimeframeEndString(customTimeframeEnd.toISOString())
+  }, [customTimeframeEnd])
 
   React.useEffect(() => {
     if (!pusherCurrentMessage) return
@@ -145,8 +159,8 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     const filterTarget = [].concat(
       queryKey,
       selectedTimeframe,
-      customTimeframeStart?.toISOString().split('T',1)[0],
-      customTimeframeEnd?.toISOString().split('T',1)[0],
+      customTimeframeStartString
+      customTimeframeEndString,
       selectedSchoolIds,
       selectedGrades,
       selectedTeacherIds,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -60,17 +60,13 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
   React.useEffect(() => {
     if (!pusherCurrentMessage) return
 
-    const { hash, timeframe, } = pusherCurrentMessage
-
-    if (filtersMatchHash(hash) && customTimeframeMatches(timeframe)) getCurrentData()
+    if (filtersMatchHash(pusherCurrentMessage)) getCurrentData()
   }, [pusherCurrentMessage])
 
   React.useEffect(() => {
     if (!pusherPreviousMessage) return
 
-    const { hash, timeframe, } = pusherPreviousMessage
-
-    if (filtersMatchHash(hash) && customTimeframeMatches(timeframe)) getPreviousData()
+    if (filtersMatchHash(pusherPreviousMessage)) getPreviousData()
   }, [pusherPreviousMessage])
 
   React.useEffect(() => {
@@ -149,6 +145,8 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     const filterTarget = [].concat(
       queryKey,
       selectedTimeframe,
+      customTimeframeStart?.toISOString().split('T',1)[0],
+      customTimeframeEnd?.toISOString().split('T',1)[0],
       selectedSchoolIds,
       selectedGrades,
       selectedTeacherIds,
@@ -158,17 +156,6 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     const filterHash = hashPayload(filterTarget)
 
     return hashMessage == filterHash
-  }
-
-  function customTimeframeMatches(timeframe) {
-    if (!customTimeframeStart || !customTimeframeEnd) return true
-
-    const remoteStart = timeframe?.custom_start?.split('T', 1)[0]
-    const remoteEnd = timeframe?.custom_end?.split('T', 1)[0]
-    const localStart = customTimeframeStart?.toISOString()?.split('T', 1)[0]
-    const localEnd = customTimeframeEnd?.toISOString()?.split('T', 1)[0]
-
-    return remoteStart == localStart && remoteEnd == localEnd
   }
 
   function initializePusher() {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -159,14 +159,14 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
   }
 
   function initializePusher() {
-    pusherChannel?.bind(PUSHER_CURRENT_EVENT_KEY, (body) => {
+    pusherChannel?.bind(`${PUSHER_CURRENT_EVENT_KEY}:${queryKey}`, (body) => {
       const { message, } = body
       const { hash, timeframe, } = message
 
       if (filtersMatchHash(hash) && customTimeframeMatches(timeframe)) getCurrentData()
     });
 
-    pusherChannel?.bind(PUSHER_PREVIOUS_EVENT_KEY, (body) => {
+    pusherChannel?.bind(`${PUSHER_PREVIOUS_EVENT_KEY}:${queryKey}`, (body) => {
       const { message, } = body
 
       if (filtersMatchHash(message)) getPreviousData()

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -159,7 +159,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     const filterTarget = [].concat(
       queryKey,
       selectedTimeframe,
-      customTimeframeStartString
+      customTimeframeStartString,
       customTimeframeEndString,
       selectedSchoolIds,
       selectedGrades,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -156,17 +156,6 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
     return hashMessage == filterHash
   }
 
-  function customTimeframeMatches(timeframe) {
-    if (!customTimeframeStart || !customTimeframeEnd) return true
-
-    const remoteStart = timeframe?.custom_start?.split('T', 1)[0]
-    const remoteEnd = timeframe?.custom_end?.split('T', 1)[0]
-    const localStart = customTimeframeStart?.toISOString()?.split('T', 1)[0]
-    const localEnd = customTimeframeEnd?.toISOString()?.split('T', 1)[0]
-
-    return remoteStart == localStart && remoteEnd == localEnd
-  }
-
   function initializePusher() {
     pusherChannel?.bind(`${PUSHER_EVENT_KEY}:${queryKey}`, (body) => {
       const { message, } = body

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -89,9 +89,7 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
   React.useEffect(() => {
     if (!pusherMessage) return
 
-    const { hash, timeframe, } = pusherMessage
-
-    if (filtersMatchHash(hash) && customTimeframeMatches(timeframe)) getData()
+    if (filtersMatchHash(pusherMessage)) getData()
   }, [pusherMessage])
 
   function resetToDefault() {
@@ -131,6 +129,8 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
     const filterTarget = [].concat(
       queryKey,
       selectedTimeframe,
+      customTimeframeStart?.toISOString().split('T',1)[0],
+      customTimeframeEnd?.toISOString().split('T',1)[0],
       selectedSchoolIds,
       selectedGrades,
       selectedTeacherIds,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -147,7 +147,7 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
   }
 
   function initializePusher() {
-    pusherChannel?.bind(PUSHER_EVENT_KEY, (body) => {
+    pusherChannel?.bind(`${PUSHER_EVENT_KEY}:${queryKey}`, (body) => {
       const { message, } = body
       const { hash, timeframe, } = message
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -22,6 +22,7 @@ interface SnapshotRankingProps {
 }
 
 const PUSHER_EVENT_KEY = 'admin-snapshot-top-x-cached'
+const RETRY_TIMEOUT = 20000
 
 const RankingModal = ({ label, closeModal, headers, data, }) => {
   return (
@@ -73,6 +74,7 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
   const [loading, setLoading] = React.useState(false)
   const [retryTimeout, setRetryTimeout] = React.useState(null)
   const [showModal, setShowModal] = React.useState(false)
+  const [pusherMessage, setPusherMessage] = React.useState(null)
 
   React.useEffect(() => {
     initializePusher()
@@ -81,12 +83,16 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
   React.useEffect(() => {
     resetToDefault()
 
-    setRetryTimeout(setTimeout(getData, 20000))
+    getData()
   }, [searchCount])
 
   React.useEffect(() => {
-    if (retryTimeout) getData()
-  }, [retryTimeout])
+    if (!pusherMessage) return
+
+    const { hash, timeframe, } = pusherMessage
+
+    if (filtersMatchHash(hash) && customTimeframeMatches(timeframe)) getData()
+  }, [pusherMessage])
 
   function resetToDefault() {
     setData(passedData || null)
@@ -106,15 +112,16 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
 
     requestPost(`/snapshots/top_x`, searchParams, (body) => {
       if (!body.hasOwnProperty('results')) {
+        setRetryTimeout(setTimeout(getData, RETRY_TIMEOUT))
         setLoading(true)
       } else {
+        clearTimeout(retryTimeout)
+
         const { results, } = body
         // We consider `null` to be a lack of data, so if the result is `[]` we need to explicitly `setData(null)`
         const data = results.length > 0 ? results : null
         setData(data)
-        if (retryTimeout) {
-          clearTimeout(retryTimeout)
-        }
+
         setLoading(false)
       }
     })
@@ -138,8 +145,8 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
   function customTimeframeMatches(timeframe) {
     if (!customTimeframeStart || !customTimeframeEnd) return true
 
-    const remoteStart = timeframe?.start?.split('T', 1)[0]
-    const remoteEnd = timeframe?.end?.split('T', 1)[0]
+    const remoteStart = timeframe?.custom_start?.split('T', 1)[0]
+    const remoteEnd = timeframe?.custom_end?.split('T', 1)[0]
     const localStart = customTimeframeStart?.toISOString()?.split('T', 1)[0]
     const localEnd = customTimeframeEnd?.toISOString()?.split('T', 1)[0]
 
@@ -149,9 +156,7 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
   function initializePusher() {
     pusherChannel?.bind(`${PUSHER_EVENT_KEY}:${queryKey}`, (body) => {
       const { message, } = body
-      const { hash, timeframe, } = message
-
-      if (filtersMatchHash(hash) && customTimeframeMatches(timeframe)) getData()
+      setPusherMessage(message)
     });
   };
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -75,6 +75,8 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
   const [retryTimeout, setRetryTimeout] = React.useState(null)
   const [showModal, setShowModal] = React.useState(false)
   const [pusherMessage, setPusherMessage] = React.useState(null)
+  const [customTimeframeStartString, setCustomTimeframeStartString] = React.useState(null)
+  const [customTimeframeEndString, setCustomTimeframeEndString] = React.useState(null)
 
   React.useEffect(() => {
     initializePusher()
@@ -85,6 +87,18 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
 
     getData()
   }, [searchCount])
+
+  React.useEffect(() => {
+    if (!customTimeframeStart) return
+
+    setCustomTimeframeStartString(customTimeframeStart.toISOString())
+  }, [customTimeframeStart])
+
+  React.useEffect(() => {
+    if (!customTimeframeEnd) return
+
+    setCustomTimeframeEndString(customTimeframeEnd.toISOString())
+  }, [customTimeframeEnd])
 
   React.useEffect(() => {
     if (!pusherMessage) return
@@ -129,8 +143,8 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
     const filterTarget = [].concat(
       queryKey,
       selectedTimeframe,
-      customTimeframeStart?.toISOString().split('T',1)[0],
-      customTimeframeEnd?.toISOString().split('T',1)[0],
+      customTimeframeStartString,
+      customTimeframeEndString,
       selectedSchoolIds,
       selectedGrades,
       selectedTeacherIds,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -135,11 +135,23 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
     return hashMessage == filterHash
   }
 
+  function customTimeframeMatches(timeframe) {
+    if (!customTimeframeStart || !customTimeframeEnd) return true
+
+    const remoteStart = timeframe?.start?.split('T', 1)[0]
+    const remoteEnd = timeframe?.end?.split('T', 1)[0]
+    const localStart = customTimeframeStart?.toISOString()?.split('T', 1)[0]
+    const localEnd = customTimeframeEnd?.toISOString()?.split('T', 1)[0]
+
+    return remoteStart == localStart && remoteEnd == localEnd
+  }
+
   function initializePusher() {
     pusherChannel?.bind(PUSHER_EVENT_KEY, (body) => {
       const { message, } = body
+      const { hash, timeframe, } = message
 
-      if (filtersMatchHash(message)) getData()
+      if (filtersMatchHash(hash) && customTimeframeMatches(timeframe)) getData()
     });
   };
 

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -279,6 +279,7 @@ describe SnapshotsController, type: :controller do
 
         context 'most-active-schools query for TopX' do
           let(:query) { 'most-active-schools' }
+
           it 'should trigger a job to cache data if the cache is empty for top_x' do
             allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
             expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
@@ -313,7 +314,7 @@ describe SnapshotsController, type: :controller do
           let(:grades) { ["Kindergarten", "1", "2"] }
           let(:teacher_ids) { ['3', '4'] }
           let(:classroom_ids) { ['5', '6', '7'] }
-      
+
           it 'should include school_ids and grades in the call to the cache worker if they are in params' do
 
             allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -202,61 +202,63 @@ describe SnapshotsController, type: :controller do
         let(:previous_end) { 'PREVIOUS_END' }
         let(:current_start) { 'CURRENT_TIMEFRAME' }
         let(:current_end) { 'TIMEFRAME_END' }
-
-        it 'should trigger a job to cache data if the cache is empty for counts' do
-          query_name = 'active-classrooms'
-
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
-          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-          expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(cache_key,
-            query_name,
+        let(:query) { 'active-classrooms' }
+        let(:previous_timeframe_flag) { nil }
+        let(:custom_start) { nil }
+        let(:custom_end) { nil }
+        let(:grades) { nil }
+        let(:teacher_ids) { nil }
+        let(:classroom_ids) { nil }
+        let(:expected_worker_params) do
+          [
+            cache_key,
+            query,
             user.id,
             {
               name: timeframe_name,
               timeframe_start: current_start,
-              timeframe_end: current_end
+              timeframe_end: current_end,
+              custom_start: custom_start&.to_s,
+              custom_end: custom_end&.to_s
             },
             school_ids,
             {
-              grades: nil,
-              teacher_ids: nil,
-              classroom_ids: nil
+              grades:,
+              teacher_ids:,
+              classroom_ids:
             },
-            nil)
+            previous_timeframe_flag
+          ]
+        end
 
-          get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
+        it 'should trigger a job to cache data if the cache is empty for counts' do
+          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
+          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+          expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(*expected_worker_params)
+
+          get :count, params: { query:, timeframe: timeframe_name, school_ids: }
 
           json_response = JSON.parse(response.body)
 
           expect(json_response).to eq("message" => "Generating snapshot")
         end
 
-        it 'should trigger a job to cache data if the cache is empty for previous_counts' do
-          query_name = 'active-classrooms'
+        context 'previous_timeframe param is true' do
+          let(:previous_timeframe_flag) { "true" }
+          let(:current_start) { previous_start }
+          let(:current_end) { previous_end }
 
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(previous_timeframe)
-          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-          expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(cache_key,
-            query_name,
-            user.id,
-            {
-              name: timeframe_name,
-              timeframe_start: previous_start,
-              timeframe_end: previous_end
-            },
-            school_ids,
-            {
-              grades: nil,
-              teacher_ids: nil,
-              classroom_ids: nil
-            },
-            "true")
+          it 'should trigger a job to cache data if the cache is empty for previous_counts' do
+            allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(previous_timeframe)
+            expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+            expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(*expected_worker_params)
 
-          get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids, previous_timeframe: true }
+            get :count, params: { query:, timeframe: timeframe_name, school_ids:, previous_timeframe: previous_timeframe_flag}
 
-          json_response = JSON.parse(response.body)
+            json_response = JSON.parse(response.body)
 
-          expect(json_response).to eq("message" => "Generating snapshot")
+            expect(json_response).to eq("message" => "Generating snapshot")
+          end
         end
 
         context 'all-time timeframe' do
@@ -275,114 +277,68 @@ describe SnapshotsController, type: :controller do
           end
         end
 
-        it 'should trigger a job to cache data if the cache is empty for top_x' do
-          query_name = 'most-active-schools'
+        context 'most-active-schools query for TopX' do
+          let(:query) { 'most-active-schools' }
+          it 'should trigger a job to cache data if the cache is empty for top_x' do
+            allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
+            expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+            expect(Snapshots::CacheSnapshotTopXWorker).to receive(:perform_async).with(*expected_worker_params)
 
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
-          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-          expect(Snapshots::CacheSnapshotTopXWorker).to receive(:perform_async).with(cache_key,
-            query_name,
-            user.id,
-            {
-              name: timeframe_name,
-              timeframe_start: current_start,
-              timeframe_end: current_end
-            },
-            school_ids,
-            {
-              grades: nil,
-              teacher_ids: nil,
-              classroom_ids: nil
-            },
-            nil)
+            get :top_x, params: { query:, timeframe: timeframe_name, school_ids: }
 
-          get :top_x, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
+            json_response = JSON.parse(response.body)
 
-          json_response = JSON.parse(response.body)
-
-          expect(json_response).to eq("message" => "Generating snapshot")
+            expect(json_response).to eq("message" => "Generating snapshot")
+          end
         end
 
-        it 'should trigger a job to cache data if the cache is empty for data_export' do
-          query_name = 'data-export'
+        context 'data-export query for DataExport' do
+          let(:query) { 'data-export' }
 
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
-          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-          expect(Snapshots::CachePremiumReportsWorker).to receive(:perform_async).with(cache_key,
-            query_name,
-            user.id,
-            {
-              name: timeframe_name,
-              timeframe_start: current_start,
-              timeframe_end: current_end
-            },
-            school_ids,
-            {
-              grades: nil,
-              teacher_ids: nil,
-              classroom_ids: nil
-            },
-            nil)
+          it 'should trigger a job to cache data if the cache is empty for data_export' do
+            allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
+            expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+            expect(Snapshots::CachePremiumReportsWorker).to receive(:perform_async).with(*expected_worker_params)
 
-          get :data_export, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
+            get :data_export, params: { query:, timeframe: timeframe_name, school_ids: }
 
-          json_response = JSON.parse(response.body)
+            json_response = JSON.parse(response.body)
 
-          expect(json_response).to eq("message" => "Generating snapshot")
+            expect(json_response).to eq("message" => "Generating snapshot")
+          end
         end
 
-        it 'should include school_ids and grades in the call to the cache worker if they are in params' do
-          query_name = 'active-classrooms'
-          grades = ["Kindergarten", "1", "2"]
-          teacher_ids = ['3', '4']
-          classroom_ids = ['5', '6', '7']
+        context 'school_ids and grades specified' do
+          let(:query) { 'active-classrooms' }
+          let(:grades) { ["Kindergarten", "1", "2"] }
+          let(:teacher_ids) { ['3', '4'] }
+          let(:classroom_ids) { ['5', '6', '7'] }
+      
+          it 'should include school_ids and grades in the call to the cache worker if they are in params' do
 
-          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
-          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-          expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(cache_key,
-            query_name,
-            user.id,
-            {
-              name: timeframe_name,
-              timeframe_start: current_start,
-              timeframe_end: current_end
-            },
-            school_ids,
-            {
-              grades: grades,
-              teacher_ids: teacher_ids,
-              classroom_ids: classroom_ids
-            },
-            nil)
+            allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
+            expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+            expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(*expected_worker_params)
 
-          get :count, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids, grades: grades, teacher_ids: teacher_ids, classroom_ids: classroom_ids }
+            get :count, params: { query:, timeframe: timeframe_name, school_ids:, grades:, teacher_ids:, classroom_ids: }
+          end
         end
 
-        it 'should properly calculate custom timeframes' do
-          query_name = 'active-classrooms'
-          timeframe_name = 'custom'
-          current_end = DateTime.now.change(usec: 0)
-          timeframe_length = 3.days
-          current_start = current_end - timeframe_length
+        context 'custom timeframe calculation' do
+          let(:query) { 'active-classrooms' }
+          let(:timeframe_name) { 'custom' }
+          let(:custom_end) { DateTime.now.change(usec: 0) }
+          let(:timeframe_length) { 3.days }
+          let(:custom_start) { custom_end - timeframe_length }
+          let(:current_start) { custom_start }
+          let(:current_end) { custom_end }
 
-          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
-          expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(cache_key,
-            query_name,
-            user.id,
-            {
-              name: timeframe_name,
-              timeframe_start: current_start,
-              timeframe_end: current_end
-            },
-            school_ids,
-            {
-              grades: nil,
-              teacher_ids: nil,
-              classroom_ids: nil
-            },
-            nil)
+          it 'should properly calculate custom timeframes' do
+            expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+            expect(Snapshots::CacheSnapshotCountWorker).to receive(:perform_async).with(*expected_worker_params)
 
-          get :count, params: { query: query_name, timeframe: timeframe_name, timeframe_custom_start: current_start.to_s, timeframe_custom_end: current_end.to_s, school_ids: school_ids }
+            get :count, params: { query:, timeframe: timeframe_name, timeframe_custom_start: custom_start.to_s, timeframe_custom_end: custom_end.to_s, school_ids: }
+          end
         end
       end
     end

--- a/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
@@ -102,12 +102,23 @@ module Snapshots
       end
 
       it 'should send a Pusher notification' do
+        filter_hash = PayloadHasher.run([
+          query,
+          timeframe['name'],
+          school_ids,
+          filters['grades'],
+          filters['teacher_ids'],
+          filters['classroom_ids']
+        ].flatten)
+
         expect(Rails.cache).to receive(:write)
         expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::PUSHER_EVENT, {
-          query: query,
-          timeframe: timeframe_name,
-          school_ids: school_ids
-        }.merge(filters))
+          hash: filter_hash,
+          timeframe: {
+            custom_start: nil,
+            custom_end: nil
+          }
+        })
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters, nil)
       end

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
@@ -60,8 +60,8 @@ module Snapshots
         PayloadHasher.run([
           query,
           timeframe_name,
-          custom_timeframe_start&.to_s&.split('T')&.first,
-          custom_timeframe_end&.to_s&.split('T')&.first,
+          custom_timeframe_start,
+          custom_timeframe_end,
           school_ids,
           grades,
           teacher_ids,

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
@@ -39,6 +39,7 @@ module Snapshots
           'timeframe_end' => timeframe_end.to_s
         }
       }
+      let(:timeframe_pusher_payload) { { start: current_timeframe_start.to_s, end: timeframe_end.to_s } }
 
       let(:expected_query_args) {
         {
@@ -123,7 +124,10 @@ module Snapshots
         ].flatten)
 
         expect(Rails.cache).to receive(:write)
-        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::CURRENT_TIMEFRAME_PUSHER_EVENT, hashed_payload)
+        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::CURRENT_TIMEFRAME_PUSHER_EVENT, {
+          hash: hashed_payload,
+          timeframe: timeframe_pusher_payload
+        })
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys, previous_timeframe)
       end

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
@@ -56,6 +56,18 @@ module Snapshots
           classroom_ids: classroom_ids
         }
       }
+      let(:hashed_payload) do
+        PayloadHasher.run([
+          query,
+          timeframe_name,
+          custom_timeframe_start&.to_s&.split('T')&.first,
+          custom_timeframe_end&.to_s&.split('T')&.first,
+          school_ids,
+          grades,
+          teacher_ids,
+          classroom_ids
+        ].flatten)
+      end
 
       before do
         stub_const("Snapshots::CacheSnapshotCountWorker::QUERIES", {
@@ -120,20 +132,8 @@ module Snapshots
       end
 
       it 'should send a Pusher notification' do
-        hashed_payload = PayloadHasher.run([
-          query,
-          timeframe_name,
-          school_ids,
-          grades,
-          teacher_ids,
-          classroom_ids
-        ].flatten)
-
         expect(Rails.cache).to receive(:write)
-        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, expected_pusher_event, {
-          hash: hashed_payload,
-          timeframe: timeframe_pusher_payload
-        })
+        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, expected_pusher_event, hashed_payload)
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys, previous_timeframe)
       end
@@ -143,7 +143,7 @@ module Snapshots
         let(:custom_timeframe_end) { timeframe_end }
 
         it do
-          expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, expected_pusher_event, { hash: anything, timeframe: timeframe_pusher_payload })
+          expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, expected_pusher_event, anything)
 
           subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys, previous_timeframe)
         end

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
@@ -32,15 +32,19 @@ module Snapshots
       let(:perform) { subject.perform(cache_key, query, user_id, timeframe, school_ids, filters, previous_timeframe) }
       let(:timeframe_end) { DateTime.now }
       let(:current_timeframe_start) { timeframe_end - 30.days }
+      let(:custom_timeframe_start) { nil }
+      let(:custom_timeframe_end) { nil }
       let(:timeframe) {
         {
           'name' => timeframe_name,
           'timeframe_start' => current_timeframe_start.to_s,
-          'timeframe_end' => timeframe_end.to_s
+          'timeframe_end' => timeframe_end.to_s,
+          'custom_start' => custom_timeframe_start&.to_s,
+          'custom_end' => custom_timeframe_end&.to_s
         }
       }
       let(:expected_pusher_event) { "#{described_class::CURRENT_TIMEFRAME_PUSHER_EVENT}:#{query}" }
-      let(:timeframe_pusher_payload) { { start: current_timeframe_start.to_s, end: timeframe_end.to_s } }
+      let(:timeframe_pusher_payload) { { custom_start: custom_timeframe_start&.to_s, custom_end: custom_timeframe_end&.to_s } }
 
       let(:expected_query_args) {
         {
@@ -132,6 +136,17 @@ module Snapshots
         })
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys, previous_timeframe)
+      end
+
+      context 'custom timeframe params' do
+        let(:custom_timeframe_start) { current_timeframe_start }
+        let(:custom_timeframe_end) { timeframe_end }
+
+        it do
+          expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, expected_pusher_event, { hash: anything, timeframe: timeframe_pusher_payload })
+
+          subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys, previous_timeframe)
+        end
       end
 
       context 'slow query reporting' do

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_count_worker_spec.rb
@@ -39,6 +39,7 @@ module Snapshots
           'timeframe_end' => timeframe_end.to_s
         }
       }
+      let(:expected_pusher_event) { "#{described_class::CURRENT_TIMEFRAME_PUSHER_EVENT}:#{query}" }
       let(:timeframe_pusher_payload) { { start: current_timeframe_start.to_s, end: timeframe_end.to_s } }
 
       let(:expected_query_args) {
@@ -61,16 +62,17 @@ module Snapshots
       it 'should execute the query for the current timeframe' do
         expect(query_double).to receive(:run).with(expected_query_args)
         expect(Rails.cache).to receive(:write)
-        expect(SendPusherMessageWorker).to receive(:perform_async).with(anything, described_class::CURRENT_TIMEFRAME_PUSHER_EVENT, anything)
+        expect(SendPusherMessageWorker).to receive(:perform_async).with(anything, expected_pusher_event, anything)
 
         perform
       end
 
       context 'when previous_timeframe param is passed with a value' do
         let(:previous_timeframe) { 'true' }
+        let(:expected_pusher_event) { "#{described_class::PREVIOUS_TIMEFRAME_PUSHER_EVENT}:#{query}" }
 
         it do
-          expect(SendPusherMessageWorker).to receive(:perform_async).with(anything, described_class::PREVIOUS_TIMEFRAME_PUSHER_EVENT, anything)
+          expect(SendPusherMessageWorker).to receive(:perform_async).with(anything, expected_pusher_event, anything)
 
           perform
         end
@@ -124,7 +126,7 @@ module Snapshots
         ].flatten)
 
         expect(Rails.cache).to receive(:write)
-        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::CURRENT_TIMEFRAME_PUSHER_EVENT, {
+        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, expected_pusher_event, {
           hash: hashed_payload,
           timeframe: timeframe_pusher_payload
         })

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
@@ -57,8 +57,8 @@ module Snapshots
         PayloadHasher.run([
           query,
           timeframe_name,
-          custom_timeframe_start&.to_s&.split('T')&.first,
-          custom_timeframe_end&.to_s&.split('T')&.first,
+          custom_timeframe_start,
+          custom_timeframe_end,
           school_ids,
           grades,
           teacher_ids,

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
@@ -37,6 +37,7 @@ module Snapshots
           'timeframe_end' => timeframe_end.to_s
         }
       }
+      let(:timeframe_pusher_payload) { { start: current_timeframe_start.to_s, end: timeframe_end.to_s } }
       let(:expected_query_args) {
         {
           timeframe_start: current_timeframe_start,
@@ -107,7 +108,10 @@ module Snapshots
         ].flatten)
 
         expect(Rails.cache).to receive(:write)
-        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::PUSHER_EVENT, hashed_payload)
+        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::PUSHER_EVENT, {
+          hash: hashed_payload,
+          timeframe: timeframe_pusher_payload
+        })
 
         subject.perform(cache_key, query, user_id, timeframe, school_ids, filters_with_string_keys, nil)
       end

--- a/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_snapshot_top_x_worker_spec.rb
@@ -37,6 +37,7 @@ module Snapshots
           'timeframe_end' => timeframe_end.to_s
         }
       }
+      let(:expected_pusher_event) { "#{described_class::PUSHER_EVENT}:#{query}" }
       let(:timeframe_pusher_payload) { { start: current_timeframe_start.to_s, end: timeframe_end.to_s } }
       let(:expected_query_args) {
         {
@@ -108,7 +109,7 @@ module Snapshots
         ].flatten)
 
         expect(Rails.cache).to receive(:write)
-        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::PUSHER_EVENT, {
+        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, expected_pusher_event, {
           hash: hashed_payload,
           timeframe: timeframe_pusher_payload
         })


### PR DESCRIPTION
## WHAT
- Tweak the way we initialize Pusher listeners in the Count so that there is only one listener per widget
- Pass the `custom_timeframe` related keys that are sent to the controller through to the workers so that they can include the contents of those values in the hashed key to be sent back to the front-end via Pusher
- Add `queryKey` to the Pusher event names rather than using the same name for all queries
- Handle comparison of Pusher hashes to front-end hashes in React effect
- Tweak the retry logic for Snapshot Admin frontends so that they're triggered by requests for data rather than during component initialization
- Make updates to the DataExport front-end and back-end to bring it in line with Admin Snapshot logic
- - Special focus on using hashes in Pusher payloads
## WHY
- Having multiple listeners was combining with another issue to cause Pusher messages to cause multiple different filter configurations to request data from cache, resulting in the data flickering behind the scenes as different values rapidly loaded from cache
- This was the other half of the issue causing flickering.  We added additional information to the Pusher payload to include "custom" timeframe start and end data from the initial request.  The Pusher payload included information to try to avoid requesting data for "old" filter values that the front-end checked before requesting data from cache.  However, the only thing that was being done to differentiate timeframes was to check their names.  When using a "custom" timeframe, the timeframe name was always `custom`.  This meant that if you requested data for a custom timeframe, and then did so for another timeframe, you could initiate a race condition where either the first or second filter config could come back from Pusher, and the front-end couldn't tell the difference.
- This is a small performance tweak.  What we were doing is having every individual widget subscribe to all Pusher messages for each other widget of the same type.  This meant that widgets were processing each message from Pusher for widgets of their type and then throwing away the messages that were for the wrong report.  This update means that most Pusher messages that are processed by the front-end are relevant (rather than the old system where most were discarded).
- Comparing Pusher payload hashes to a hash of the current local filter state (to ensure that if you changed filters before all the data came back for your earlier filters, the front-end didn't load data for the previous filters when the Sidekiq job eventually completed) was sometimes failing to recognize good matches.  This appears to have been related to an encapsulation issue.  Moving the logic for the comparison into a React effect got us around encapsulation.
- Moving retry logic into the request code does two things: 1) simplifies the code used for retry setup (by not using an effect), and 2) it allows us to do multiple retries as if the retry call still doesn't get data it can set up another retry timer
- This code had drifted from the updates made for Admin Snapshot code.  Most of this wasn't a big deal, but failing to carry over the hashing of the Pusher payload would likely result in the same "Pusher payload too large" errors we were getting in Admin Snapshots that led to hashing in the first place.
## HOW
- Remove the `initializePusher` call from the `searchCount` effect in `snapsthotCount.ts`
- Modify `SnapshotController` so that it passes the custom timeframe params through to the worker, include those params in the payload hashed and sent through Pusher, update the front-end hash comparison code with the new params that are included in the hash
- Update both front-end and back-end Pusher logic to expect event names to include the query name
- Update `initializePusher` logic so that when Pusher messages are received they get pushed into state and hook the evaluation logic into a React effect that monitors that state
- Instead of calling `setTimeout` during the `searchCount` effect, do it when processing results from API calls such that when the backend doesn't have data in cache we establish a re-load timeout, and when there is data we clear the timeout
- Just generally update the code in the front-end and worker for Data Export to be in line with what we're doing in Count and Ranking

### Screenshots
(We expect an "optimal" run of the page to involve 90 requests: 19 current counts + 19 previous counts + 7 rankings, each of which gets called once to initialize workers and then a second time to load data from cache.  In production we're seeing a number of cases where it's much higher.)
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/8a0798fb-f947-45ae-8c03-530e886c4b71)
(This is what we're consistently seeing in the new branch.  The extra 1 request is the new call to save the filter settings to the back-end.)
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/634c5ce7-cb32-4df9-b9df-327d6c4d1da4)


### Notion Card Links
https://www.notion.so/quill/Percentages-Jumping-on-Usage-Snapshot-dashboard-f2e3a9af6062473a8277f0dac98ffcf1?pvs=4
https://www.notion.so/quill/Usage-Snaphot-too-many-requests-for-count-c23482dc11aa4baabaad1f8619738209?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
