### PR TITLE
QA change requests for Admin CSV download feature

### DIFF
--- a/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
+++ b/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
@@ -3,7 +3,9 @@
 class AdminReportCsvUploader < CarrierWave::Uploader::Base
   attr_reader :admin_id
 
+  FILE_EXPIRATION = 365 * 24 * 60 * 60
   fog_directory ENV.fetch('ADMIN_REPORT_FOG_DIRECTORY', 'admin-report-fog-directory-staging')
+  fog_authenticated_url_expiration FILE_EXPIRATION
 
   FILENAME_PREFIX = 'ADMIN_REPORT_'
 

--- a/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
+++ b/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
@@ -3,7 +3,10 @@
 class AdminReportCsvUploader < CarrierWave::Uploader::Base
   attr_reader :admin_id
 
-  FILE_EXPIRATION = 365 * 24 * 60 * 60
+  # Max value is 604800, 7 days
+  # See: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+  FILE_EXPIRATION = 604800
+
   fog_directory ENV.fetch('ADMIN_REPORT_FOG_DIRECTORY', 'admin-report-fog-directory-staging')
   fog_authenticated_url_expiration FILE_EXPIRATION
 

--- a/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
+++ b/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
@@ -23,6 +23,6 @@ class AdminReportCsvUploader < CarrierWave::Uploader::Base
     # See: http://stackoverflow.com/questions/6920926/carrierwave-create-the-same-unique-filename-for-all-versioned-files
     random_token = Digest::SHA2.hexdigest("#{Time.current.utc}--#{admin_id}").first(6)
     date = Date.current.strftime("%m-%d-%y")
-    "#{FILENAME_PREFIX}#{admin_id}_#{date}_#{random_token}"
+    "#{FILENAME_PREFIX}#{admin_id}_#{date}_#{random_token}.csv"
   end
 end

--- a/services/QuillLMS/app/views/premium_hub_user_mailer/admin_premium_download_report_email.html.erb
+++ b/services/QuillLMS/app/views/premium_hub_user_mailer/admin_premium_download_report_email.html.erb
@@ -2,7 +2,7 @@
 
 <p> The CSV data export that you requested on <%= @human_date %> is ready to download. </p>
 
-<a href=<%= @file_url%> rel="noopener noreferrer" target="_blank">Download</a>
+<a clicktracking=off href=<%= @file_url%> rel="noopener noreferrer" target="_blank">Download</a>
 
 <p>Best regards,</p>
 

--- a/services/QuillLMS/app/workers/snapshots/premium_download_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/premium_download_reports_worker.rb
@@ -24,7 +24,8 @@ module Snapshots
       upload_status = uploader.store!(csv_tempfile)
       raise CloudUploadError, "Unable to upload CSV for user #{user_id}" unless upload_status
 
-      uploaded_file_url = uploader.url
+      # The response-content-disposition param triggers browser file download instead of screen rendering
+      uploaded_file_url = uploader.url(query: {"response-content-disposition" => "attachment;"})
 
       email = ENV.fetch('TEST_EMAIL_ADDRESS', user.email) # TODO: remove after integration testing
       PremiumHubUserMailer.admin_premium_download_report_email(user.first_name, uploaded_file_url, email).deliver_now!


### PR DESCRIPTION
## WHAT / HOW
Change requests from Peter Sharkey's QA of the admin CSV download feature:

1. set asset expiry of carrierwave presigned urls to max allowable: 7 days
2. File should auto-download, rather than render in browser 
3. add '.csv' file extension

## HOW
1. carrierwave config
2. carrierwave config 
3. trivial

## WHY
1. So that if the admin checks for their download after a coffee break, it's still available
2. PS's preferred UX
3. Files with CSV contents should have a CSV file extension.

Note: Sendgrid is interfering with the autodownload directive: Clicking the sendgrid-transformed link from the incoming email does not trigger a download. Copy pasting the link into a new browser tab triggers the download. I need to investigate this issue. 

### Notion Card Links
n/a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  config change only
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
