### PR TITLE
lms/fix-admin-snapshot-filter-edge-case

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -144,7 +144,7 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
   }, [customTimeframeStart])
 
   React.useEffect(() => {
-    if (!customTimeframeEnd) return
+    if (!customTimeframeEnd) return setCustomTimeframeEndString(null)
 
     setCustomTimeframeEndString(customTimeframeEnd.toISOString())
   }, [customTimeframeEnd])

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -63,13 +63,13 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
     if (!customTimeframeStart) return setCustomTimeframeStartString(null)
 
     setCustomTimeframeStartString(customTimeframeStart.toISOString())
-  }, [selectedTimeframe, customTimeframeStart])
+  }, [customTimeframeStart])
 
   React.useEffect(() => {
     if (!customTimeframeEnd) return setCustomTimeframeEndString(null)
 
     setCustomTimeframeEndString(customTimeframeEnd.toISOString())
-  }, [selectedTimeframe, customTimeframeEnd])
+  }, [customTimeframeEnd])
 
   React.useEffect(() => {
     if (!pusherCurrentMessage) return

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -60,16 +60,16 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
   }, [searchCount])
 
   React.useEffect(() => {
-    if (!customTimeframeStart) return
+    if (!customTimeframeStart) return setCustomTimeframeStartString(null)
 
     setCustomTimeframeStartString(customTimeframeStart.toISOString())
-  }, [customTimeframeStart])
+  }, [selectedTimeframe, customTimeframeStart])
 
   React.useEffect(() => {
-    if (!customTimeframeEnd) return
+    if (!customTimeframeEnd) return setCustomTimeframeEndString(null)
 
     setCustomTimeframeEndString(customTimeframeEnd.toISOString())
-  }, [customTimeframeEnd])
+  }, [selectedTimeframe, customTimeframeEnd])
 
   React.useEffect(() => {
     if (!pusherCurrentMessage) return

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotRanking.tsx
@@ -95,7 +95,7 @@ const SnapshotRanking = ({ label, queryKey, headers, searchCount, selectedGrades
   }, [customTimeframeStart])
 
   React.useEffect(() => {
-    if (!customTimeframeEnd) return
+    if (!customTimeframeEnd) return setCustomTimeframeEndString(null)
 
     setCustomTimeframeEndString(customTimeframeEnd.toISOString())
   }, [customTimeframeEnd])


### PR DESCRIPTION
## WHAT
Make sure to reset custom filter values when changing timeframe type
## WHY
There was a bug with the Pusher event subscriptions in cases where an admin sets a custom timeframe and then immediately changes to a non-custom timeframe.  This was causing page loads to slow down.
## HOW
Reset the Pusher comparison logic whenever timeframe selection is changed away from custom.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage on React effects
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A