### PR TITLE
admin reports: only save filterSelections to backend if selectedX is different from allX

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import queryString from 'query-string';
 import moment from 'moment';
 import * as _ from 'lodash'
 import * as Pusher from 'pusher-js';
@@ -189,14 +188,14 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
   function saveFilterSelections() {
     const filterSelections = {
       timeframe: selectedTimeframe,
-      schools: selectedSchools,
-      teachers: selectedTeachers,
-      classrooms: selectedClassrooms,
+      schools: unorderedArraysAreEqual(selectedSchools, allSchools) ? null : selectedSchools,
+      teachers: unorderedArraysAreEqual(selectedTeachers, allTeachers) ? null : selectedTeachers,
+      classrooms: unorderedArraysAreEqual(selectedClassrooms, allClassrooms) ? null : selectedClassrooms,
       grades: selectedGrades,
       custom_start_date: customStartDate,
       custom_end_date: customEndDate
-
     }
+
     const params = {
       admin_report_filter_selection: {
         filter_selections: filterSelections,
@@ -236,11 +235,17 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
       if (allTeachers?.length !== teacherOptions.length) { setAllTeachers(teacherOptions) }
       if (allClassrooms?.length !== classroomOptions.length) { setAllClassrooms(classroomOptions) }
 
-      if (loadingFilters && (!selectedGrades || !selectedSchools || !selectedTeachers || !selectedClassrooms || !selectedTimeframe)) {
-        setSelectedAndLastSubmitted(gradeOptions, schoolOptions, teacherOptions, classroomOptions, timeframe, null, null)
-      }
-
       if (loadingFilters) {
+        setSelectedAndLastSubmitted(
+          selectedGrades || gradeOptions,
+          selectedSchools || schoolOptions,
+          selectedTeachers || teacherOptions,
+          selectedClassrooms || classroomOptions,
+          selectedTimeframe || timeframe,
+          null,
+          null
+        );
+
         setOriginalAllSchools(allSchoolOptions)
         setOriginalAllClassrooms(allClassroomOptions)
         setOriginalAllTeachers(allTeacherOptions)


### PR DESCRIPTION
## WHAT
Update the `PremiumFilterableReportsContainer` to only save a given filterSelection to the backend if `selectedX` is different from `allX`, and reciprocally, correctly interpret `null` values coming out of backend to mean `allSelected`.

## WHY
Thomas noticed an edge case where the fact that `allX` was being persisted to the backend as an array meant that the addition of new schools, teachers, or classrooms would result in those new values not being selected when we loaded the filters, which is potentially confusing UX. This fixes that.

## HOW
Just update behavior around the two request calls.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Tweak-Admin-report-filter-saving-logic-to-understand-all-selected-logic-76c2ed187e9a40dc835ba74640e450c9?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES