### PR TITLE
Update Evidence scoring to give 100% if any responses are optimal

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/libs/conceptResults.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/libs/conceptResults.ts
@@ -1,14 +1,5 @@
 import { DIRECTIONS, } from '../components/studentView/promptStep'
 
-
-export const ATTEMPTS_TO_SCORE = {
-  1: 1.0,
-  2: 0.75,
-  3: 0.5,
-  4: 0.25,
-  5: 0.0
-}
-
 export const generateConceptResults = (currentActivity, submittedResponses, topicOptimalData) => {
   const conjunctionToQuestionNumber = {
     because: 1,
@@ -29,7 +20,7 @@ export const generateConceptResults = (currentActivity, submittedResponses, topi
         directions: (attempt == 1) ? DIRECTIONS : responses[index - 1].feedback,
         prompt: prompt.text,
         questionNumber: conjunctionToQuestionNumber[prompt.conjunction],
-        questionScore: ATTEMPTS_TO_SCORE[responses.length],
+        questionScore: responses.some((r) => r.optimal) ? 1.0 : 0.0
       }
 
       if (topicOptimalData && topicOptimalData.rule_types.includes(response.feedback_type)) {

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/libs/conceptResults.data.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/libs/conceptResults.data.ts
@@ -128,7 +128,7 @@ export const expectedPayload = {
         "directions":"Use information from the text to finish the sentence:",
         "prompt":"Type an answer, but",
         "questionNumber":2,
-        "questionScore":0.75
+        "questionScore":1
       }
     },
     {
@@ -141,7 +141,7 @@ export const expectedPayload = {
         "directions":"Remember, for this activity, avoid giving your opinion—your thoughts, feelings, or suggestions. Rewrite your response without the word must, and make sure that your response expresses an idea from the text.",
         "prompt":"Type an answer, but",
         "questionNumber":2,
-        "questionScore":0.75
+        "questionScore":1
       }
     },
     {
@@ -154,7 +154,7 @@ export const expectedPayload = {
         "directions":"Use information from the text to finish the sentence:",
         "prompt":"Type an answer, so",
         "questionNumber":3,
-        "questionScore":0.75
+        "questionScore":1
       }
     },
     {
@@ -167,7 +167,7 @@ export const expectedPayload = {
         "directions":"Use information from the text to finish the sentence:",
         "prompt":"Type an answer, so",
         "questionNumber":3,
-        "questionScore":0.75
+        "questionScore":1
       }
     },
     {
@@ -180,7 +180,7 @@ export const expectedPayload = {
         "directions":"Remember, for this activity, avoid giving your opinion—your thoughts, feelings, or suggestions. Rewrite your response without the word should, and make sure that your response expresses an idea from the text.",
         "prompt":"Type an answer, so",
         "questionNumber":3,
-        "questionScore":0.75
+        "questionScore":1
       }
     }
   ]

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/libs/conceptResults.test.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/libs/conceptResults.test.ts
@@ -33,4 +33,28 @@ describe("Getting concept results from a completed Evidence activity", () => {
         conceptResult.metadata.correct == 1
     )).length).toEqual(1)
   })
+
+  it("should score 1.0 if any responses are optimal", () => {
+    const result = generateConceptResults(currentActivity, submittedResponses, topicOptimalData)
+
+    expect(result[0].metadata.questionScore).toEqual(1.0)
+  })
+
+  it("should score 0.0 if no responses are optimal", () => {
+    const noOptimalResponses = {
+      "1": [
+        {
+          "concept_uid": "placeholder",
+          "entry":"Type an answer because some response may be provided.",
+          "feedback":"Thank you for your response.",
+          "feedback_type":"autoML",
+          "optimal":false,
+          "highlight":null
+        }
+      ]
+    }
+    const result = generateConceptResults(currentActivity, noOptimalResponses, topicOptimalData)
+
+    expect(result[0].metadata.questionScore).toEqual(0.0)
+  })
 });


### PR DESCRIPTION
## WHAT
Update Evidence scoring to give 100% if any responses are optimal
## WHY
The immediate goal is to ensure that if a student gets an optimal answer as their last attempt, we still give them a non-0 score so that the target skill gets flagged as achieved.
## HOW
Tweak the algorithm that attaches `questionScore` values to Evidence `ConceptResult` records since that score value is what we use to determine whether a student has successfully demonstrated a key skill or not.  Specifically, update the algorithm to give a student a score of 100 if they get an optimal answer on any attempt rather than scaling their score down to 0 based on how many attempts they make.

### Screenshots
OLD BEHAVIOR
![Screenshot 2023-11-10 at 10 50 49 AM](https://github.com/empirical-org/Empirical-Core/assets/331565/bd200c77-c0af-41e3-8964-b9aa43e1ed5c)
NEW BEHAVIOR
![Screenshot 2023-11-10 at 10 53 58 AM](https://github.com/empirical-org/Empirical-Core/assets/331565/6c87027e-e0cf-4902-9989-8ab1a2465084)

### Notion Card Links
https://www.notion.so/quill/Scoring-Change-Tag-Evidence-Sessions-As-Optimal-When-5th-Attempt-is-Optimal-fc5f145a6d3e4f91978fe6d9fafc8d04?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A