### PR TITLE
fix import for file that no longer exists

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -3,9 +3,8 @@ import * as React from 'react';
 
 import { requestPost, } from '../../../modules/request';
 import { unorderedArraysAreEqual, } from '../../../modules/unorderedArraysAreEqual';
-import { DataTable, Snackbar, Spinner, defaultSnackbarTimeout, filterIcon, informationIcon, noResultsMessage, smallWhiteCheckIcon } from '../../Shared';
+import { DataTable, Snackbar, Spinner, LightButtonLoadingSpinner, defaultSnackbarTimeout, filterIcon, informationIcon, noResultsMessage, smallWhiteCheckIcon, } from '../../Shared';
 import useSnackbarMonitor from '../../Shared/hooks/useSnackbarMonitor';
-import ButtonLoadingIndicator from '../../Teacher/components/shared/button_loading_indicator';
 import { hashPayload, } from '../shared'
 
 const STANDARD_WIDTH = "152px";
@@ -302,7 +301,7 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
     let buttonClassName = "quill-button download-report-button contained primary medium focus-on-light"
 
     if (downloadButtonBusy) {
-      buttonContent = <React.Fragment>Download<ButtonLoadingIndicator /></React.Fragment>
+      buttonContent = <React.Fragment>Download<LightButtonLoadingSpinner /></React.Fragment>
       buttonClassName += ' disabled'
     }
 


### PR DESCRIPTION
## WHAT
Replace bad import with new LightButtonLoadingSpinner.

## WHY
Since I made my PR for the loading spinner updates, this file had been changed, and was now importing a file that no longer exists.

## HOW
Just replace the import.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A