### PR TITLE
stop showing default model feedback for human suboptimals in connect

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/question.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/question.tsx
@@ -343,9 +343,7 @@ export default class PlayLessonQuestion extends React.Component<PlayLessonQuesti
         if (negativeConceptWithConceptFeedback) {
           return <ConceptExplanation {...conceptsFeedback.data[negativeConceptWithConceptFeedback.conceptUID]} />
         }
-      }
-
-      if (latestAttempt.response.concept_results) {
+      } else if (latestAttempt.response.concept_results) {
         const negativeConcepts = this.getNegativeConceptResultsForResponse(latestAttempt.response.concept_results);
         const negativeConceptWithConceptFeedback = negativeConcepts.find(c => {
           return conceptsFeedback.data[c.conceptUID]


### PR DESCRIPTION
## WHAT
Don't show default model feedback for human-graded suboptimal responses in Connect.

## WHY
We should only show relevant model feedback.

## HOW
This bug hinged on the fact that some responses get both `conceptResults` and `concept_results` -- a significant piece of tech debt that I'm going to bring up with Dan/in an eng meeting. In the meanwhile, I followed the pattern we use in Grammar by introducing an `else if` here rather than a second `if` that overwrote the first conditional.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Human-Sub-Optimal-responses-getting-model-concept-in-Connect-004e7b08672c4885a138490136375758

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES