### PR TITLE
admin csv QA

### DIFF
--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -58,7 +58,7 @@ module Adapters
       end
 
       def self.validate_input!(bigquery_result, sym_columns)
-        if !(ORDERED_COLUMNS.keys.to_set >= sym_columns.to_set)
+        if (ORDERED_COLUMNS.keys & sym_columns).length != sym_columns.length
           raise UnhandledColumnError, "Requested column(s) not supported: #{sym_columns - ORDERED_COLUMNS.keys}"
         end
 

--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -47,7 +47,7 @@ module Adapters
         when :timespent
           (value / 60).to_i
         when :score
-          value&.round(2)
+          value.respond_to?(:*) ? "#{(value*100).round(0)}%" : ''
         else
           value
         end
@@ -58,7 +58,7 @@ module Adapters
       end
 
       def self.validate_input!(bigquery_result, sym_columns)
-        if sym_columns.to_set > ORDERED_COLUMNS.keys.to_set
+        if !(ORDERED_COLUMNS.keys.to_set >= sym_columns.to_set)
           raise UnhandledColumnError, "Requested column(s) not supported: #{sym_columns - ORDERED_COLUMNS.keys}"
         end
 

--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -58,7 +58,7 @@ module Adapters
       end
 
       def self.validate_input!(bigquery_result, sym_columns)
-        if !(sym_columns.to_set <= ORDERED_COLUMNS.keys.to_set)
+        if sym_columns.to_set > ORDERED_COLUMNS.keys.to_set
           raise UnhandledColumnError, "Requested column(s) not supported: #{sym_columns - ORDERED_COLUMNS.keys}"
         end
 

--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -6,43 +6,56 @@ module Adapters
   module Csv
     class AdminPremiumDataExport
       class UnhandledColumnError < StandardError; end
+      class BigQueryResultMissingRequestedColumnError < StandardError; end
 
-      ORDERED_COLUMNS = %i(
-        student_name
-        student_email
-        completed_at
-        activity_name
-        activity_pack
-        activity_session_id
-        score
-        timespent
-        standard
-        tool
-        school_name
-        classroom_grade
-        teacher_name
-        classroom_name
-        student_id
-        classroom_id
-      )
+      ORDERED_COLUMNS = {
+        student_name: 'Student Name',
+        student_email: 'Student Email',
+        completed_at: 'Completed Date',
+        activity_name: 'Activity',
+        activity_pack: 'Activity Pack',
+        score: 'Score',
+        timespent: 'Time Spent',
+        standard: 'Standard',
+        tool: 'Tool',
+        school_name: 'School',
+        classroom_grade: 'Grade',
+        teacher_name: 'Teacher',
+        classroom_name: 'Class',
+      }
 
-      def self.to_csv_string(bigquery_result, columns = ORDERED_COLUMNS)
+      def self.to_csv_string(bigquery_result, columns = ORDERED_COLUMNS.keys)
         sym_columns = columns.map(&:to_sym)
-        validate_input!(bigquery_result)
+        validate_input!(bigquery_result, sym_columns)
 
         CSV.generate do |csv|
-          csv << sym_columns.map(&:to_s)
+          csv << human_displayable_csv_headers(sym_columns)
           bigquery_result.each do |row|
             csv << sym_columns.map { |key| row[key] }
           end
         end
       end
 
-      def self.validate_input!(bigquery_result)
-        bigquery_result.each do |row|
-          next if (row.keys - ORDERED_COLUMNS).empty?
+      def self.human_displayable_csv_headers(sym_columns)
+        sym_columns.map{|col| ORDERED_COLUMNS[col] }
+      end
 
-          raise UnhandledColumnError, "Unhandled column(s): #{row.keys - ORDERED_COLUMNS}"
+      # def self.transform_cell(sym_column, value)
+      # end
+
+      def self.row_contains_requested_columns?(row, requested_columns)
+        (row.keys & requested_columns).length == requested_columns.length
+      end
+
+      def self.validate_input!(bigquery_result, sym_columns)
+        if !(sym_columns.to_set <= ORDERED_COLUMNS.keys.to_set)
+          raise UnhandledColumnError, "Requested column(s) not supported: #{sym_columns - ORDERED_COLUMNS.keys}"
+        end
+
+        bigquery_result.each do |row|
+          next if row_contains_requested_columns?(row, sym_columns)
+
+          raise BigQueryResultMissingRequestedColumnError, "Row keys: #{row.keys} Column keys: #{sym_columns}"
         end
       end
     end

--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -9,19 +9,19 @@ module Adapters
       class BigQueryResultMissingRequestedColumnError < StandardError; end
 
       ORDERED_COLUMNS = {
-        student_name: 'Student Name',
-        student_email: 'Student Email',
-        completed_at: 'Completed Date',
-        activity_name: 'Activity',
-        activity_pack: 'Activity Pack',
-        score: 'Score',
-        timespent: 'Time Spent',
-        standard: 'Standard',
-        tool: 'Tool',
-        school_name: 'School',
-        classroom_grade: 'Grade',
-        teacher_name: 'Teacher',
-        classroom_name: 'Class',
+        student_name:     'Student Name',
+        student_email:    'Student Email',
+        completed_at:     'Completed Date',
+        activity_name:    'Activity',
+        activity_pack:    'Activity Pack',
+        score:            'Score',
+        timespent:        'Time Spent (Mins)',
+        standard:         'Standard',
+        tool:             'Tool',
+        school_name:      'School',
+        classroom_grade:  'Grade',
+        teacher_name:     'Teacher',
+        classroom_name:   'Class',
       }
 
       def self.to_csv_string(bigquery_result, columns = ORDERED_COLUMNS.keys)
@@ -31,7 +31,7 @@ module Adapters
         CSV.generate do |csv|
           csv << human_displayable_csv_headers(sym_columns)
           bigquery_result.each do |row|
-            csv << sym_columns.map { |key| row[key] }
+            csv << sym_columns.map { |key| format_cell(key, row[key]) }
           end
         end
       end
@@ -40,8 +40,16 @@ module Adapters
         sym_columns.map{|col| ORDERED_COLUMNS[col] }
       end
 
-      # def self.transform_cell(sym_column, value)
-      # end
+      def self.format_cell(sym_column, value)
+        case sym_column
+        when :completed_at
+          value&.strftime("%F")
+        when :timespent
+          (value / 60).to_i
+        else
+          value
+        end
+      end
 
       def self.row_contains_requested_columns?(row, requested_columns)
         (row.keys & requested_columns).length == requested_columns.length

--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -45,9 +45,9 @@ module Adapters
         when :completed_at
           value&.strftime("%F")
         when :timespent
-          (value / 60).to_i
+          (value / 60)
         when :score
-          value.respond_to?(:*) ? "#{(value*100).round(0)}%" : ''
+          value.is_a?(Numeric) ? "#{(value*100).round(0)}%" : ''
         else
           value
         end

--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -46,6 +46,8 @@ module Adapters
           value&.strftime("%F")
         when :timespent
           (value / 60).to_i
+        when :score
+          value&.round(2)
         else
           value
         end

--- a/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
+++ b/services/QuillLMS/app/uploaders/admin_report_csv_uploader.rb
@@ -17,6 +17,10 @@ class AdminReportCsvUploader < CarrierWave::Uploader::Base
     super(model, mounted_as)
   end
 
+  def fog_attributes
+    { 'Content-Type' => 'text/csv' }
+  end
+
   def fog_public
     false
   end

--- a/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
+++ b/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
@@ -5,6 +5,12 @@ require 'rails_helper'
 describe Adapters::Csv::AdminPremiumDataExport do
   subject { described_class }
 
+  describe '#format_cell' do
+    it { expect(described_class.format_cell(:completed_at, DateTime.new(2020,1,1))).to eq ('2020-01-01')}
+    it { expect(described_class.format_cell(:activity_pack, 'foo')).to eq ('foo')}
+    it { expect(described_class.format_cell(:timespent, 61)).to eq (1)}
+  end
+
   describe '#to_csv_string' do
     let(:valid_input) {
       [{

--- a/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
+++ b/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
@@ -9,6 +9,8 @@ describe Adapters::Csv::AdminPremiumDataExport do
     it { expect(described_class.format_cell(:completed_at, DateTime.new(2020,1,1))).to eq ('2020-01-01')}
     it { expect(described_class.format_cell(:activity_pack, 'foo')).to eq ('foo')}
     it { expect(described_class.format_cell(:timespent, 61)).to eq (1)}
+    it { expect(described_class.format_cell(:score, 0.667)).to eq (0.67)}
+    it { expect(described_class.format_cell(:not_a_special_case, 1.5)).to eq (1.5)}
   end
 
   describe '#to_csv_string' do

--- a/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
+++ b/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
@@ -6,11 +6,11 @@ describe Adapters::Csv::AdminPremiumDataExport do
   subject { described_class }
 
   describe '#format_cell' do
-    it { expect(described_class.format_cell(:completed_at, DateTime.new(2020,1,1))).to eq ('2020-01-01')}
-    it { expect(described_class.format_cell(:activity_pack, 'foo')).to eq ('foo')}
-    it { expect(described_class.format_cell(:timespent, 61)).to eq (1)}
-    it { expect(described_class.format_cell(:score, 0.667)).to eq (0.67)}
-    it { expect(described_class.format_cell(:not_a_special_case, 1.5)).to eq (1.5)}
+    it { expect(described_class.format_cell(:completed_at, DateTime.new(2020,1,1))).to eq('2020-01-01')}
+    it { expect(described_class.format_cell(:activity_pack, 'foo')).to eq('foo')}
+    it { expect(described_class.format_cell(:timespent, 61)).to eq(1)}
+    it { expect(described_class.format_cell(:score, 0.667)).to eq(0.67)}
+    it { expect(described_class.format_cell(:not_a_special_case, 1.5)).to eq(1.5)}
   end
 
   describe '#to_csv_string' do
@@ -62,7 +62,7 @@ describe Adapters::Csv::AdminPremiumDataExport do
       end
 
       context 'BigQuery payload lacks the requested columns' do
-        let(:payload_missing_columns) { [valid_input.first.reject{|k,v| k == :activity_name}] }
+        let(:payload_missing_columns) { [valid_input.first.except(:activity_name)] }
 
         it do
           expect { subject.to_csv_string(payload_missing_columns) }.to raise_error(described_class::BigQueryResultMissingRequestedColumnError)

--- a/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
+++ b/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
@@ -9,7 +9,7 @@ describe Adapters::Csv::AdminPremiumDataExport do
     it { expect(described_class.format_cell(:completed_at, DateTime.new(2020,1,1))).to eq('2020-01-01')}
     it { expect(described_class.format_cell(:activity_pack, 'foo')).to eq('foo')}
     it { expect(described_class.format_cell(:timespent, 61)).to eq(1)}
-    it { expect(described_class.format_cell(:score, 0.667)).to eq(0.67)}
+    it { expect(described_class.format_cell(:score, 0.66777)).to eq('67%')}
     it { expect(described_class.format_cell(:not_a_special_case, 1.5)).to eq(1.5)}
   end
 


### PR DESCRIPTION
## WHAT
QA items for Admin CSV download:

1. Set MIMEtype when generating a presigned S3 URL. 
2. Format specific CSV column values 

## WHY
1. Otherwise, Chrome will change the downloaded file's extension from `csv -> txt`
2. So that they look better to the user. 

## HOW
1. Fog gem config 
2. Add a switch statement in the CSV generator class, which applies various transforms. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Admin-Data-Export-QA-November-6-f1bfffdb6c7d45a9b2705c6883456e6d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
