### PR TITLE
fix new admin page on schools path

### DIFF
--- a/services/QuillLMS/app/views/cms/schools/new_admin.html.erb
+++ b/services/QuillLMS/app/views/cms/schools/new_admin.html.erb
@@ -1,5 +1,6 @@
 <%= react_component('NewAdminOrDistrictUserApp', props: {
   type: 'admin',
   schoolId: @school&.id,
-  returnUrl: @cms_school_path
+  returnUrl: @cms_school_path,
+  schools: [@school]
 })%>


### PR DESCRIPTION
## WHAT
Fix bug where staff members are unable to add a new admin via the schools page.

## WHY
We want to be able to perform this functionality.

## HOW
Just update the new admin school erb file to pass the `schools` attribute, which is required for this page.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Unable-to-Add-Admin-in-CMS-b39212d23b144b4c95de0eae4ca253a9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests for erb files
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A