### PR TITLE
Bugfix and Speed Improvements on Regex Rules Admin Panel

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
@@ -92,11 +92,9 @@ const RuleViewForm = ({
 
   const queryClient = useQueryClient()
 
-  const promptIds = activityData.prompts.map(p => p.id)
-
   // cache ruleSets data for handling rule suborder
   const { data: rulesData } = useQuery({
-    queryKey: [`rules-${activityId}-${rule_type}`, activityId, promptIds.join(','), rule_type],
+    queryKey: [`rules-${activityId}-${rule_type}`, activityId, null, rule_type],
     queryFn: fetchRules,
   });
 
@@ -171,10 +169,9 @@ const RuleViewForm = ({
     deleteRule(ruleId).then((response) => {
       toggleShowDeleteRuleModal();
       // update ruleSets cache to remove delete ruleSet
-      queryClient.refetchQueries([`rules-${activityId}-${RULES_BASED_1}`])
-      queryClient.refetchQueries([`rules-${activityId}-${RULES_BASED_2}`])
-      queryClient.refetchQueries([`rules-${activityId}-${RULES_BASED_3}`])
-      history.push(`/activities/${activityId}/${returnLinkRuleType}`);
+      queryClient.refetchQueries([`rules-${activityId}-${rule_type}`]).then(() => {
+        history.push(`/activities/${activityId}/${returnLinkRuleType}`);
+      });
     });
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
@@ -96,7 +96,7 @@ const RuleViewForm = ({
 
   // cache ruleSets data for handling rule suborder
   const { data: rulesData } = useQuery({
-    queryKey: [`rules-${activityId}-${rule_type}`, null, promptIds.join(','), rule_type],
+    queryKey: [`rules-${activityId}-${rule_type}`, activityId, promptIds.join(','), rule_type],
     queryFn: fetchRules,
   });
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useQuery, useQueryClient } from 'react-query';
 import { Link, withRouter } from 'react-router-dom';
 
+import { RULES_BASED_1, RULES_BASED_2, RULES_BASED_3 } from '../../../../../constants/evidence';
 import { LOW_CONFIDENCE, PLAGIARISM, regexRuleTypes, ruleOptimalOptions } from '../../../../../constants/evidence';
 import { Spinner } from '../../../../Shared/index';
 import { formatPrompts } from '../../../helpers/evidence/promptHelpers';
@@ -119,9 +120,7 @@ const RuleViewForm = ({
 
   React.useEffect(() => {
     if(!rulesCount && rulesData && rulesData.rules) {
-      console.log("Setting rule count")
       const { rules } = rulesData;
-      console.log(rules.length)
       setRulesCount(rules.length);
     }
     else if(!universalRulesCount && universalRulesData && universalRulesData.universalRules) {
@@ -172,7 +171,9 @@ const RuleViewForm = ({
     deleteRule(ruleId).then((response) => {
       toggleShowDeleteRuleModal();
       // update ruleSets cache to remove delete ruleSet
-      queryClient.refetchQueries(`rules-${activityId}`);
+      queryClient.refetchQueries([`rules-${activityId}-${RULES_BASED_1}`])
+      queryClient.refetchQueries([`rules-${activityId}-${RULES_BASED_2}`])
+      queryClient.refetchQueries([`rules-${activityId}-${RULES_BASED_3}`])
       history.push(`/activities/${activityId}/${returnLinkRuleType}`);
     });
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { useQuery, useQueryClient } from 'react-query';
 import { Link, withRouter } from 'react-router-dom';
 
-import { RULES_BASED_1, RULES_BASED_2, RULES_BASED_3 } from '../../../../../constants/evidence';
 import { LOW_CONFIDENCE, PLAGIARISM, regexRuleTypes, ruleOptimalOptions } from '../../../../../constants/evidence';
 import { Spinner } from '../../../../Shared/index';
 import { formatPrompts } from '../../../helpers/evidence/promptHelpers';
@@ -95,7 +94,7 @@ const RuleViewForm = ({
   // cache ruleSets data for handling rule suborder
   const { data: rulesData } = useQuery({
     queryKey: [`rules-${activityId}-${rule_type}`, activityId, null, rule_type],
-    queryFn: fetchRules,
+    queryFn: fetchRules
   });
 
   // cache ruleSets data for handling universal rule suborder

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
@@ -91,9 +91,11 @@ const RuleViewForm = ({
 
   const queryClient = useQueryClient()
 
+  const promptIds = activityData.prompts.map(p => p.id)
+
   // cache ruleSets data for handling rule suborder
   const { data: rulesData } = useQuery({
-    queryKey: [`rules-${activityId}`, activityId],
+    queryKey: [`rules-${activityId}`, null, promptIds.join(','), rule_type],
     queryFn: fetchRules
   });
 
@@ -117,7 +119,9 @@ const RuleViewForm = ({
 
   React.useEffect(() => {
     if(!rulesCount && rulesData && rulesData.rules) {
+      console.log("Setting rule count")
       const { rules } = rulesData;
+      console.log(rules.length)
       setRulesCount(rules.length);
     }
     else if(!universalRulesCount && universalRulesData && universalRulesData.universalRules) {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleViewForm.tsx
@@ -95,8 +95,8 @@ const RuleViewForm = ({
 
   // cache ruleSets data for handling rule suborder
   const { data: rulesData } = useQuery({
-    queryKey: [`rules-${activityId}`, null, promptIds.join(','), rule_type],
-    queryFn: fetchRules
+    queryKey: [`rules-${activityId}-${rule_type}`, null, promptIds.join(','), rule_type],
+    queryFn: fetchRules,
   });
 
   // cache ruleSets data for handling universal rule suborder

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
@@ -69,9 +69,11 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
       const { name, id, regex_rules, suborder, prompt_ids } = rule;
       const ruleLink = (<Link to={`/activities/${activityId}/regex-rules/${id}`}>View</Link>);
       const promptsIcons = getPromptsIcons(activityData, prompt_ids);
+
+      // for priority, return a 1-indexed suborder instead of 0-indexed for human readability
       return {
         id,
-        priority: typeof suborder === 'string' ? parseInt(suborder) : suborder,
+        priority: typeof suborder === 'string' ? (parseInt(suborder) + 1) : (suborder + 1),
         name,
         incorrect_sequence: renderRegexTags(regex_rules, 'incorrect'),
         required_sequence: renderRegexTags(regex_rules, 'required'),
@@ -106,7 +108,7 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
     return(
       <DataTable
         className="rules-table regex-index-table"
-        defaultSortAttribute="name"
+        defaultSortAttribute="priority"
         headers={dataTableFields}
         isReorderable={true}
         reorderCallback={handleReorder}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
@@ -36,7 +36,7 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
 
   const { data: rulesBased1Data } = useQuery(
     // cache rules data for updates
-    [`rules-${activityId}-${RULES_BASED_1}`, null, promptIds, RULES_BASED_1],
+    [`rules-${activityId}-${RULES_BASED_1}`, activityId, promptIds, RULES_BASED_1],
     fetchRules,
     {
       enabled: !!promptIds,
@@ -45,7 +45,7 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
 
   const { data: rulesBased2Data } = useQuery(
     // cache rules data for updates
-    [`rules-${activityId}-${RULES_BASED_2}`, null, promptIds, RULES_BASED_2],
+    [`rules-${activityId}-${RULES_BASED_2}`, activityId, promptIds, RULES_BASED_2],
     fetchRules,
     {
       enabled: !!promptIds,
@@ -54,7 +54,7 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
 
   const { data: rulesBased3Data } = useQuery(
     // cache rules data for updates
-    [`rules-${activityId}-${RULES_BASED_3}`, null, promptIds, RULES_BASED_3],
+    [`rules-${activityId}-${RULES_BASED_3}`, activityId, promptIds, RULES_BASED_3],
     fetchRules,
     {
       enabled: !!promptIds,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
@@ -67,20 +67,19 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
     }
     const formattedRows = rulesData && rulesData.rules && rulesData.rules.map((rule: RuleInterface) => {
       const { name, id, regex_rules, suborder, prompt_ids } = rule;
-      const ruleLink = (<Link to={`/activities/${activityId}/regex-rules/${id}`}>View</Link>);
+      const nameLink = (<Link to={`/activities/${activityId}/regex-rules/${id}`}>{name}</Link>);
       const promptsIcons = getPromptsIcons(activityData, prompt_ids);
 
       // for priority, return a 1-indexed suborder instead of 0-indexed for human readability
       return {
         id,
         priority: typeof suborder === 'string' ? (parseInt(suborder) + 1) : (suborder + 1),
-        name,
+        name: nameLink,
         incorrect_sequence: renderRegexTags(regex_rules, 'incorrect'),
         required_sequence: renderRegexTags(regex_rules, 'required'),
         because_prompt: promptsIcons[BECAUSE],
         but_prompt: promptsIcons[BUT],
         so_prompt: promptsIcons[SO],
-        view: ruleLink
       }
     });
     return formattedRows.sort(firstBy('priority').thenBy('id'));
@@ -153,7 +152,6 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
     { name: "Because", attribute:"because_prompt", width: "50px" },
     { name: "But", attribute:"but_prompt", width: "50px" },
     { name: "So", attribute:"so_prompt", width: "50px" },
-    { name: "", attribute:"view", width: "50px" },
   ];
   const addRulesBased1Link = <Link to={{ pathname: `/activities/${activityId}/regex-rules/new`, state: { ruleType: RULES_BASED_1 }}}>Add Sentence Structure Regex Rule</Link>;
   const addRulesBased2Link = <Link to={{ pathname: `/activities/${activityId}/regex-rules/new`, state: { ruleType: RULES_BASED_2 }}}>Add Post-Topic Regex Rule</Link>;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
@@ -14,6 +14,9 @@ import { fetchRules, updateRuleOrders, } from '../../../utils/evidence/ruleAPIs'
 const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ match }) => {
   const { params } = match;
   const { activityId } = params;
+  const [regexOneLoading, setRegexOneLoading] = React.useState<boolean>(false);
+  const [regexTwoLoading, setRegexTwoLoading] = React.useState<boolean>(false);
+  const [regexThreeLoading, setRegexThreeLoading] = React.useState<boolean>(false);
 
   const queryClient = useQueryClient()
 
@@ -41,10 +44,33 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
     fetchRules
   );
 
+  function setRegexIsLoading(ruleType, isLoading) {
+    if (ruleType === RULES_BASED_1) {
+      setRegexOneLoading(isLoading)
+    } else if (ruleType === RULES_BASED_2) {
+      setRegexTwoLoading(isLoading)
+    } else {
+      setRegexThreeLoading(isLoading)
+    }
+  }
+
+  function getRegexIsLoading(ruleType) {
+    if (ruleType === RULES_BASED_1) {
+      return regexOneLoading
+    } else if (ruleType === RULES_BASED_2) {
+      return regexTwoLoading
+    } else {
+      return regexThreeLoading
+    }
+  }
+
   function handleReorder(sortInfo, ruleType) {
+    setRegexIsLoading(ruleType, true)
     const idsInOrder = sortInfo.map(item => item.key)
     updateRuleOrders(idsInOrder).then((response) => {
-      queryClient.refetchQueries([`rules-${activityId}-${ruleType}`])
+      queryClient.refetchQueries([`rules-${activityId}-${ruleType}`]).then((response) => {
+        setRegexIsLoading(ruleType, false)
+      })
     });
   }
 
@@ -89,6 +115,12 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
         <section className="no-rules-section">
           <p>{`No ${ruleTypeHumanReadable} Regex rules.`}</p>
         </section>
+      );
+    } else if (getRegexIsLoading(ruleTypeForEndpoint)) {
+      return(
+        <div className="loading-spinner-container">
+          <Spinner />
+        </div>
       );
     }
     return(

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
@@ -26,23 +26,23 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
     queryFn: fetchActivity
   });
 
-  const { data: rulesBased1Data } = useQuery(
+  const { data: rulesBased1Data } = useQuery({
     // cache rules data for updates
-    [`rules-${activityId}-${RULES_BASED_1}`, activityId, null, RULES_BASED_1],
-    fetchRules
-  );
+    queryKey: [`rules-${activityId}-${RULES_BASED_1}`, activityId, null, RULES_BASED_1],
+    queryFn: fetchRules
+  });
 
-  const { data: rulesBased2Data } = useQuery(
+  const { data: rulesBased2Data } = useQuery({
     // cache rules data for updates
-    [`rules-${activityId}-${RULES_BASED_2}`, activityId, null, RULES_BASED_2],
-    fetchRules
-  );
+    queryKey: [`rules-${activityId}-${RULES_BASED_2}`, activityId, null, RULES_BASED_2],
+    queryFn: fetchRules
+  });
 
-  const { data: rulesBased3Data } = useQuery(
+  const { data: rulesBased3Data } = useQuery({
     // cache rules data for updates
-    [`rules-${activityId}-${RULES_BASED_3}`, activityId, null, RULES_BASED_3],
-    fetchRules
-  );
+    queryKey: [`rules-${activityId}-${RULES_BASED_3}`, activityId, null, RULES_BASED_3],
+    queryFn: fetchRules
+  });
 
   function setRegexIsLoading(ruleType, isLoading) {
     if (ruleType === RULES_BASED_1) {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/regexRules/regexRulesIndex.tsx
@@ -34,23 +34,32 @@ const RegexRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = ({ ma
     }
   }, [activityData]);
 
-  const { data: rulesBased1Data } = useQuery({
+  const { data: rulesBased1Data } = useQuery(
     // cache rules data for updates
-    queryKey: [`rules-${activityId}-${RULES_BASED_1}`, null, promptIds, RULES_BASED_1],
-    queryFn: fetchRules
-  });
+    [`rules-${activityId}-${RULES_BASED_1}`, null, promptIds, RULES_BASED_1],
+    fetchRules,
+    {
+      enabled: !!promptIds,
+    }
+  );
 
-  const { data: rulesBased2Data } = useQuery({
+  const { data: rulesBased2Data } = useQuery(
     // cache rules data for updates
-    queryKey: [`rules-${activityId}-${RULES_BASED_2}`, null, promptIds, RULES_BASED_2],
-    queryFn: fetchRules
-  });
+    [`rules-${activityId}-${RULES_BASED_2}`, null, promptIds, RULES_BASED_2],
+    fetchRules,
+    {
+      enabled: !!promptIds,
+    }
+  );
 
-  const { data: rulesBased3Data } = useQuery({
+  const { data: rulesBased3Data } = useQuery(
     // cache rules data for updates
-    queryKey: [`rules-${activityId}-${RULES_BASED_3}`, null, promptIds, RULES_BASED_3],
-    queryFn: fetchRules
-  });
+    [`rules-${activityId}-${RULES_BASED_3}`, null, promptIds, RULES_BASED_3],
+    fetchRules,
+    {
+      enabled: !!promptIds,
+    }
+  );
 
   function handleReorder(sortInfo) {
     const idsInOrder = sortInfo.map(item => item.key)

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -312,7 +312,7 @@ export const buildRule = ({
   });
 
   // Admin prefer order to be 1-indexed rather than 0-indexed
-  const order = universal ? (universalRulesCount + 1) : (rulesCount + 1);
+  const order = universal ? universalRulesCount : rulesCount;
 
   let newOrUpdatedRule: any = {
     concept_uid: ruleConceptUID,

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -310,7 +310,9 @@ export const buildRule = ({
   Object.keys(rulePrompts).forEach(key => {
     rulePrompts[key].checked && promptIds.push(rulePrompts[key].id);
   });
-  const order = universal ? universalRulesCount : rulesCount;
+
+  // Admin prefer order to be 1-indexed rather than 0-indexed
+  const order = universal ? (universalRulesCount + 1) : (rulesCount + 1);
 
   let newOrUpdatedRule: any = {
     concept_uid: ruleConceptUID,

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -431,7 +431,9 @@ export async function handleSubmitRule({
 }
 
 export function getRulesUrl(activityId: string, promptId: string, ruleType: string) {
-  if (activityId) {
+  if (activityId && ruleType) {
+    return `activities/${activityId}/rules?rule_type=${ruleType}`
+  } else if (activityId) {
     return `activities/${activityId}/rules`
   } else if (!ruleType) {
     throw new Error('A rule type must be specified.')

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -311,7 +311,6 @@ export const buildRule = ({
     rulePrompts[key].checked && promptIds.push(rulePrompts[key].id);
   });
 
-  // Admin prefer order to be 1-indexed rather than 0-indexed
   const order = universal ? universalRulesCount : rulesCount;
 
   let newOrUpdatedRule: any = {

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -71,18 +71,13 @@ module Evidence
     end
 
     # GET /activities/1/rules.json
+    # params [:id, :rule_type]
     def rules
-      rule_type = rules_params[:rule_type]
       @activity = Evidence::Activity.includes(
         prompts: { rules: [:plagiarism_texts, { feedbacks: :highlights }, :label, :regex_rules, :hint, :prompts]}
       ).find(params[:id])
-      if rule_type.present?
-        rules = @activity.prompts&.map {|p| p.rules.where(rule_type: rule_type)}
-      else
-        rules = @activity.prompts&.map {|p| p.rules}
-      end
 
-      render json: rules&.flatten&.uniq
+      render json: activity_rules_by_rule_type(@activity, rules_params[:rule_type])
     end
 
     # GET /activities/1/change_logs.json
@@ -197,6 +192,15 @@ module Evidence
         passages_attributes: [:id, :text, :image_link, :image_alt_text, :image_caption, :image_attribution, :highlight_prompt, :essential_knowledge_text],
         prompts_attributes: [:id, :conjunction, :text, :max_attempts, :max_attempts_feedback, :first_strong_example, :second_strong_example]
       )
+    end
+
+    private def activity_rules_by_rule_type(activity, rule_type)
+      if rule_type.present?
+        rules = activity.prompts&.map {|p| p.rules.where(rule_type: rule_type)}
+      else
+        rules = activity.prompts&.map {|p| p.rules}
+      end
+      rules&.flatten&.uniq
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -195,10 +195,8 @@ module Evidence
     end
 
     private def activity_rules_by_rule_type(activity, rule_type)
-      if rule_type.present?
-        rules = activity.prompts&.map {|p| p.rules.where(rule_type: rule_type)}
-      else
-        rules = activity.prompts&.map {|p| p.rules}
+      rules = activity.prompts&.map do |prompt|
+        rule_type.present? ? prompt.rules.where(rule_type: rule_type) : prompt.rules
       end
       rules&.flatten&.uniq
     end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -72,11 +72,17 @@ module Evidence
 
     # GET /activities/1/rules.json
     def rules
+      rule_type = rules_params[:rule_type]
       @activity = Evidence::Activity.includes(
         prompts: { rules: [:plagiarism_texts, { feedbacks: :highlights }, :label, :regex_rules, :hint, :prompts]}
       ).find(params[:id])
-      rules = @activity.prompts&.map {|p| p.rules}&.flatten&.uniq
-      render json: rules
+      if rule_type.present?
+        rules = @activity.prompts&.map {|p| p.rules.where(rule_type: rule_type)}
+      else
+        rules = @activity.prompts&.map {|p| p.rules}
+      end
+
+      render json: rules&.flatten&.uniq
     end
 
     # GET /activities/1/change_logs.json
@@ -174,6 +180,10 @@ module Evidence
 
     private def seed_data_params
       params.permit(:id, :nouns, :use_passage, label_configs: {}, activity: {})
+    end
+
+    private def rules_params
+      params.permit(:rule_type)
     end
 
     private def activity_params

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -333,6 +333,16 @@ module Evidence
         expect(rule.id).to(eq(parsed_response[0]["id"]))
       end
 
+      it 'should filter rule by rule_type' do
+        grammar_rule = create(:evidence_rule, :rule_type => (Rule::TYPE_GRAMMAR), :prompts => ([prompt]))
+        automl_rule = create(:evidence_rule, :rule_type => (Rule::TYPE_AUTOML), :prompts => ([prompt]))
+        get(:rules, :params => ({ :id => activity.id, :rule_type => (Rule::TYPE_GRAMMAR) }))
+        parsed_response = JSON.parse(response.body)
+        expect(response.code.to_i).to(eq(200))
+        expect(parsed_response.size).to eq(1)
+        expect(grammar_rule.id).to(eq(parsed_response[0]["id"]))
+      end
+
       it 'should return feedbacks and highlights associated with the rules' do
         get(:rules, :params => ({ :id => activity.id }))
         parsed_response = JSON.parse(response.body)


### PR DESCRIPTION
## WHAT
This page has very slow load times, mostly due to unnecessary API calls fetching all rules for a rule type or activity rather than the specific needed rules. This PR fixes slow load times and adds some requested features like loading spinners.

## WHY
Admin use this page a lot and they currently have a lot of trouble creating and editing regex rules efficiently because of slow load times.

## HOW
**Back-end:** Add a parameter to the backend endpoint activity/rules that specifies a rule_type. Only fetch rules for that rule type if the parameter is specified.
**Front-end:** 
-Only fetch rules of the specified activity_id and rule_type when calling the Rules API, instead of fetching all rules.
-Loading spinners: Add separate loading spinners for each regex rule section that appear after an update_rule_order call, so the admin know when a call is being made and they don't have to continuously reorder the rules attempting to see changes.
-Update order bugfix: add a .then() clause so the refresh is only called after the rule order call has returned. Only fetch rules for the updated rule_type, not all rules.
-Delete rule bugfix: After delete, add a .then() clause to refetch query so we can be sure the API is called after the rule is deleted.

### Screenshots
![Screenshot 2023-11-09 at 3 46 48 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/09a994e3-5128-4b8b-98d0-67bfe5f37a9c)


### Notion Card Links
https://www.notion.so/quill/Improve-Performance-of-Creating-and-Deleting-Regex-Rules-616f66e402c1416f9ab5df57dfa15c46?pvs=4
https://www.notion.so/quill/Update-the-Regex-Rules-Page-to-more-easily-access-the-View-link-d20145415c544eed9bc6c8581b417e9e?pvs=4
https://www.notion.so/quill/Investigate-Regex-Rules-Priority-Sequencing-78e763c8b92c4844be226a2a3862b6c0?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes