### PR TITLE
add bang operator to google update to try to track down bug

### DIFF
--- a/services/QuillLMS/app/services/google_integration/user.rb
+++ b/services/QuillLMS/app/services/google_integration/user.rb
@@ -15,7 +15,7 @@ class GoogleIntegration::User
     @user ||= begin
       find_user_by_google_id_or_email.tap do |user|
         new_attributes = user_params(user)
-        user.new_record? ? user.assign_attributes(new_attributes) : user.update(new_attributes)
+        user.new_record? ? user.assign_attributes(new_attributes) : user.update!(new_attributes)
       end
     end
   end


### PR DESCRIPTION
## WHAT
Add a bang operator to the `.update!` call when Google values get set to see why they aren't being set for this user.

## WHY
We're having a weird bug I can't reproduce with a user who can't link their account with Google. They aren't having a google_id get set, so I'm hoping adding this bang operator will throw an error that gives us more information.

## HOW
Add an exclamation point.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-cannot-link-their-Quill-account-to-their-Google-account-465165bd6eef49bd9025299ecdfa861f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - just trying to get an error thrown
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? |  YES