### PR TITLE
add wipe_question_cache method and add spec

### DIFF
--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -78,7 +78,7 @@ class Response < ApplicationRecord
   end
 
   def wipe_question_cache
-    Rails.cache.delete(Response.questions_cache_key(question_uid))
+    Rails.cache.delete(::Response.questions_cache_key(question_uid))
   end
 
   def self.questions_cache_key(question_uid)

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -78,7 +78,7 @@ class Response < ApplicationRecord
   end
 
   def wipe_question_cache
-    Rails.cache.delete(::Response.questions_cache_key(question_uid))
+    Rails.cache.delete(self.class.questions_cache_key(question_uid))
   end
 
   def self.questions_cache_key(question_uid)

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -3,8 +3,9 @@ require 'elasticsearch/model'
 class Response < ApplicationRecord
   include Elasticsearch::Model
   include ResponseScopes
-  after_create_commit :create_index_in_elastic_search, :wipe_question_cache
-  after_update_commit :update_index_in_elastic_search, :wipe_question_cache
+  after_create_commit :create_index_in_elastic_search
+  after_update_commit :update_index_in_elastic_search
+  after_commit :wipe_question_cache, on: [:create, :update]
   before_destroy :destroy_index_in_elastic_search, :wipe_question_cache
 
   validates :question_uid, uniqueness: { scope: :text }

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -78,7 +78,7 @@ class Response < ApplicationRecord
   end
 
   def wipe_question_cache
-    Rails.cache.delete(questions_cache_key(question_uid))
+    Rails.cache.delete(Response.questions_cache_key(question_uid))
   end
 
   def self.questions_cache_key(question_uid)

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -79,6 +79,8 @@ class Response < ApplicationRecord
   end
 
   def conditional_wipe_question_cache
+    puts 'saved_changes.keys', saved_changes.keys
+    puts "saved_changes.keys - ['count', 'child_count', 'first_attempt_count']", saved_changes.keys - ['count', 'child_count', 'first_attempt_count']
     unless (saved_changes.keys - ['count', 'child_count', 'first_attempt_count']).empty?
       wipe_question_cache
     end

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -3,9 +3,9 @@ require 'elasticsearch/model'
 class Response < ApplicationRecord
   include Elasticsearch::Model
   include ResponseScopes
-  after_create_commit :create_index_in_elastic_search
-  after_update_commit :update_index_in_elastic_search
-  before_destroy :destroy_index_in_elastic_search
+  after_create_commit :create_index_in_elastic_search, :wipe_question_cache
+  after_update_commit :update_index_in_elastic_search, :wipe_question_cache
+  before_destroy :destroy_index_in_elastic_search, :wipe_question_cache
 
   validates :question_uid, uniqueness: { scope: :text }
 
@@ -75,6 +75,10 @@ class Response < ApplicationRecord
 
   def destroy_index_in_elastic_search
     __elasticsearch__.delete_document
+  end
+
+  def wipe_question_cache
+    Rails.cache.delete(questions_cache_key(question_uid))
   end
 
   def self.questions_cache_key(question_uid)

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -79,9 +79,7 @@ class Response < ApplicationRecord
   end
 
   def conditional_wipe_question_cache
-    puts 'saved_changes.keys', saved_changes.keys
-    puts "saved_changes.keys - ['count', 'child_count', 'first_attempt_count']", saved_changes.keys - ['count', 'child_count', 'first_attempt_count']
-    unless (saved_changes.keys - ['count', 'child_count', 'first_attempt_count']).empty?
+    unless (saved_changes.keys - ['count', 'child_count', 'first_attempt_count', 'updated_at', 'created_at']).empty?
       wipe_question_cache
     end
   end

--- a/services/QuillCMS/spec/models/response_spec.rb
+++ b/services/QuillCMS/spec/models/response_spec.rb
@@ -1,84 +1,84 @@
 require "rails_helper"
 
 RSpec.describe Response do
-  context "ActiveRecord callbacks" do
-    it "after_create_commit calls #create_index_in_elastic_search and #wipe_question_cache" do
-      response = Response.new()
-      expect(response).to receive(:create_index_in_elastic_search)
-      expect(response).to receive(:conditional_wipe_question_cache)
-      response.save
-    end
-
-    it "after_update_commit calls #update_index_in_elastic_search and #conditional_wipe_question_cache" do
-      response = Response.create()
-      expect(response).to receive(:update_index_in_elastic_search)
-      expect(response).to receive(:conditional_wipe_question_cache)
-      response.update(text: 'covfefe')
-    end
-
-    it "before_destroy calls #destroy_index_in_elastic_search and #wipe_question_cache" do
-      response = Response.create()
-      expect(response).to receive(:destroy_index_in_elastic_search)
-      expect(response).to receive(:wipe_question_cache)
-      response.destroy
-    end
-
-  end
-
-  describe "validates unique question_uid + text" do
-    let(:response) { create(:response) }
-
-    it "should be invalid if you have a duplicate question_uid and text" do
-      new_response = Response.create(question_uid: response.question_uid, text: response.text)
-      expect(new_response.valid?).to be false
-      expect(new_response.errors.messages[:question_uid]).to eq(["has already been taken"])
-    end
-
-    it "should be valid if you have a duplicate question_uid and new text" do
-      new_response = Response.create(question_uid: response.question_uid, text: 'New unique text')
-      expect(new_response.valid?).to be true
-    end
-
-    it "should be valid if you have a new question_uid with duplicate text" do
-      new_response = Response.create(question_uid: 'unique-question-uid', text: response.text)
-      expect(new_response.valid?).to be true
-    end
-  end
-
-  describe '#wipe_question_cache' do
-    let(:question_uid) { 'some-unique-uid' }
-    let(:cache_key) { Response.questions_cache_key(question_uid) }
-
-    before do
-      Rails.cache.write(cache_key, 'cached content')
-    end
-
-    it 'clears the cache for the given question UID' do
-      expect(Rails.cache.read(cache_key)).to eq('cached content')
-
-      response = Response.create(question_uid: question_uid)
-      response.wipe_question_cache
-
-      expect(Rails.cache.read(cache_key)).to be_nil
-    end
-  end
+  # context "ActiveRecord callbacks" do
+  #   it "after_create_commit calls #create_index_in_elastic_search and #wipe_question_cache" do
+  #     response = Response.new()
+  #     expect(response).to receive(:create_index_in_elastic_search)
+  #     expect(response).to receive(:conditional_wipe_question_cache)
+  #     response.save
+  #   end
+  #
+  #   it "after_update_commit calls #update_index_in_elastic_search and #conditional_wipe_question_cache" do
+  #     response = Response.create()
+  #     expect(response).to receive(:update_index_in_elastic_search)
+  #     expect(response).to receive(:conditional_wipe_question_cache)
+  #     response.update(text: 'covfefe')
+  #   end
+  #
+  #   it "before_destroy calls #destroy_index_in_elastic_search and #wipe_question_cache" do
+  #     response = Response.create()
+  #     expect(response).to receive(:destroy_index_in_elastic_search)
+  #     expect(response).to receive(:wipe_question_cache)
+  #     response.destroy
+  #   end
+  #
+  # end
+  #
+  # describe "validates unique question_uid + text" do
+  #   let(:response) { create(:response) }
+  #
+  #   it "should be invalid if you have a duplicate question_uid and text" do
+  #     new_response = Response.create(question_uid: response.question_uid, text: response.text)
+  #     expect(new_response.valid?).to be false
+  #     expect(new_response.errors.messages[:question_uid]).to eq(["has already been taken"])
+  #   end
+  #
+  #   it "should be valid if you have a duplicate question_uid and new text" do
+  #     new_response = Response.create(question_uid: response.question_uid, text: 'New unique text')
+  #     expect(new_response.valid?).to be true
+  #   end
+  #
+  #   it "should be valid if you have a new question_uid with duplicate text" do
+  #     new_response = Response.create(question_uid: 'unique-question-uid', text: response.text)
+  #     expect(new_response.valid?).to be true
+  #   end
+  # end
+  #
+  # describe '#wipe_question_cache' do
+  #   let(:question_uid) { 'some-unique-uid' }
+  #   let(:cache_key) { Response.questions_cache_key(question_uid) }
+  #
+  #   before do
+  #     Rails.cache.write(cache_key, 'cached content')
+  #   end
+  #
+  #   it 'clears the cache for the given question UID' do
+  #     expect(Rails.cache.read(cache_key)).to eq('cached content')
+  #
+  #     response = Response.create(question_uid: question_uid)
+  #     response.wipe_question_cache
+  #
+  #     expect(Rails.cache.read(cache_key)).to be_nil
+  #   end
+  # end
 
   describe '#conditional_wipe_question_cache' do
   let!(:response) { Response.create() }
 
-  context 'when non-count attributes are updated' do
-    it 'calls wipe_question_cache' do
-      expect(response).to receive(:wipe_question_cache)
-      response.update(text: 'new text')
-    end
-  end
-
-  context 'when both count and non-count attributes are updated' do
-    it 'calls wipe_question_cache' do
-      expect(response).to receive(:wipe_question_cache)
-      response.update(text: 'new text', count: 10)
-    end
-  end
+  # context 'when non-count attributes are updated' do
+  #   it 'calls wipe_question_cache' do
+  #     expect(response).to receive(:wipe_question_cache)
+  #     response.update(text: 'new text')
+  #   end
+  # end
+  #
+  # context 'when both count and non-count attributes are updated' do
+  #   it 'calls wipe_question_cache' do
+  #     expect(response).to receive(:wipe_question_cache)
+  #     response.update(text: 'new text', count: 10)
+  #   end
+  # end
 
   context 'when only count, child_count, or first_attempt_count are updated' do
     it 'does not call wipe_question_cache when count is updated' do

--- a/services/QuillCMS/spec/models/response_spec.rb
+++ b/services/QuillCMS/spec/models/response_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Response do
   end
 
   describe '#conditional_wipe_question_cache' do
-  let(:response) { Response.create() }
+  let!(:response) { Response.create() }
 
   context 'when non-count attributes are updated' do
     it 'calls wipe_question_cache' do

--- a/services/QuillCMS/spec/models/response_spec.rb
+++ b/services/QuillCMS/spec/models/response_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Response do
       expect do
         response = Response.create(question_uid: question_uid)
         response.wipe_question_cache
-      end.to change(Rails.cache.read(cache_key)).from('cached content').to(nil)
+      end.to change { Rails.cache.read(cache_key) }.from('cached content').to(nil)
     end
   end
 

--- a/services/QuillCMS/spec/models/response_spec.rb
+++ b/services/QuillCMS/spec/models/response_spec.rb
@@ -1,84 +1,84 @@
 require "rails_helper"
 
 RSpec.describe Response do
-  # context "ActiveRecord callbacks" do
-  #   it "after_create_commit calls #create_index_in_elastic_search and #wipe_question_cache" do
-  #     response = Response.new()
-  #     expect(response).to receive(:create_index_in_elastic_search)
-  #     expect(response).to receive(:conditional_wipe_question_cache)
-  #     response.save
-  #   end
-  #
-  #   it "after_update_commit calls #update_index_in_elastic_search and #conditional_wipe_question_cache" do
-  #     response = Response.create()
-  #     expect(response).to receive(:update_index_in_elastic_search)
-  #     expect(response).to receive(:conditional_wipe_question_cache)
-  #     response.update(text: 'covfefe')
-  #   end
-  #
-  #   it "before_destroy calls #destroy_index_in_elastic_search and #wipe_question_cache" do
-  #     response = Response.create()
-  #     expect(response).to receive(:destroy_index_in_elastic_search)
-  #     expect(response).to receive(:wipe_question_cache)
-  #     response.destroy
-  #   end
-  #
-  # end
-  #
-  # describe "validates unique question_uid + text" do
-  #   let(:response) { create(:response) }
-  #
-  #   it "should be invalid if you have a duplicate question_uid and text" do
-  #     new_response = Response.create(question_uid: response.question_uid, text: response.text)
-  #     expect(new_response.valid?).to be false
-  #     expect(new_response.errors.messages[:question_uid]).to eq(["has already been taken"])
-  #   end
-  #
-  #   it "should be valid if you have a duplicate question_uid and new text" do
-  #     new_response = Response.create(question_uid: response.question_uid, text: 'New unique text')
-  #     expect(new_response.valid?).to be true
-  #   end
-  #
-  #   it "should be valid if you have a new question_uid with duplicate text" do
-  #     new_response = Response.create(question_uid: 'unique-question-uid', text: response.text)
-  #     expect(new_response.valid?).to be true
-  #   end
-  # end
-  #
-  # describe '#wipe_question_cache' do
-  #   let(:question_uid) { 'some-unique-uid' }
-  #   let(:cache_key) { Response.questions_cache_key(question_uid) }
-  #
-  #   before do
-  #     Rails.cache.write(cache_key, 'cached content')
-  #   end
-  #
-  #   it 'clears the cache for the given question UID' do
-  #     expect(Rails.cache.read(cache_key)).to eq('cached content')
-  #
-  #     response = Response.create(question_uid: question_uid)
-  #     response.wipe_question_cache
-  #
-  #     expect(Rails.cache.read(cache_key)).to be_nil
-  #   end
-  # end
+  context "ActiveRecord callbacks" do
+    it "after_create_commit calls #create_index_in_elastic_search and #wipe_question_cache" do
+      response = Response.new()
+      expect(response).to receive(:create_index_in_elastic_search)
+      expect(response).to receive(:conditional_wipe_question_cache)
+      response.save
+    end
+
+    it "after_update_commit calls #update_index_in_elastic_search and #conditional_wipe_question_cache" do
+      response = Response.create()
+      expect(response).to receive(:update_index_in_elastic_search)
+      expect(response).to receive(:conditional_wipe_question_cache)
+      response.update(text: 'covfefe')
+    end
+
+    it "before_destroy calls #destroy_index_in_elastic_search and #wipe_question_cache" do
+      response = Response.create()
+      expect(response).to receive(:destroy_index_in_elastic_search)
+      expect(response).to receive(:wipe_question_cache)
+      response.destroy
+    end
+
+  end
+
+  describe "validates unique question_uid + text" do
+    let(:response) { create(:response) }
+
+    it "should be invalid if you have a duplicate question_uid and text" do
+      new_response = Response.create(question_uid: response.question_uid, text: response.text)
+      expect(new_response.valid?).to be false
+      expect(new_response.errors.messages[:question_uid]).to eq(["has already been taken"])
+    end
+
+    it "should be valid if you have a duplicate question_uid and new text" do
+      new_response = Response.create(question_uid: response.question_uid, text: 'New unique text')
+      expect(new_response.valid?).to be true
+    end
+
+    it "should be valid if you have a new question_uid with duplicate text" do
+      new_response = Response.create(question_uid: 'unique-question-uid', text: response.text)
+      expect(new_response.valid?).to be true
+    end
+  end
+
+  describe '#wipe_question_cache' do
+    let(:question_uid) { 'some-unique-uid' }
+    let(:cache_key) { Response.questions_cache_key(question_uid) }
+
+    before do
+      Rails.cache.write(cache_key, 'cached content')
+    end
+
+    it 'clears the cache for the given question UID' do
+      expect(Rails.cache.read(cache_key)).to eq('cached content')
+
+      response = Response.create(question_uid: question_uid)
+      response.wipe_question_cache
+
+      expect(Rails.cache.read(cache_key)).to be_nil
+    end
+  end
 
   describe '#conditional_wipe_question_cache' do
   let!(:response) { Response.create() }
 
-  # context 'when non-count attributes are updated' do
-  #   it 'calls wipe_question_cache' do
-  #     expect(response).to receive(:wipe_question_cache)
-  #     response.update(text: 'new text')
-  #   end
-  # end
-  #
-  # context 'when both count and non-count attributes are updated' do
-  #   it 'calls wipe_question_cache' do
-  #     expect(response).to receive(:wipe_question_cache)
-  #     response.update(text: 'new text', count: 10)
-  #   end
-  # end
+  context 'when non-count attributes are updated' do
+    it 'calls wipe_question_cache' do
+      expect(response).to receive(:wipe_question_cache)
+      response.update(text: 'new text')
+    end
+  end
+
+  context 'when both count and non-count attributes are updated' do
+    it 'calls wipe_question_cache' do
+      expect(response).to receive(:wipe_question_cache)
+      response.update(text: 'new text', count: 10)
+    end
+  end
 
   context 'when only count, child_count, or first_attempt_count are updated' do
     it 'does not call wipe_question_cache when count is updated' do

--- a/services/QuillCMS/spec/models/response_spec.rb
+++ b/services/QuillCMS/spec/models/response_spec.rb
@@ -54,48 +54,46 @@ RSpec.describe Response do
     end
 
     it 'clears the cache for the given question UID' do
-      expect(Rails.cache.read(cache_key)).to eq('cached content')
-
-      response = Response.create(question_uid: question_uid)
-      response.wipe_question_cache
-
-      expect(Rails.cache.read(cache_key)).to be_nil
+      expect do
+        response = Response.create(question_uid: question_uid)
+        response.wipe_question_cache
+      end.to change(Rails.cache.read(cache_key)).from('cached content').to(nil)
     end
   end
 
   describe '#conditional_wipe_question_cache' do
-  let!(:response) { Response.create() }
+    let!(:response) { Response.create() }
 
-  context 'when non-count attributes are updated' do
-    it 'calls wipe_question_cache' do
-      expect(response).to receive(:wipe_question_cache)
-      response.update(text: 'new text')
+    context 'when non-count attributes are updated' do
+      it 'calls wipe_question_cache' do
+        expect(response).to receive(:wipe_question_cache)
+        response.update(text: 'new text')
+      end
+    end
+
+    context 'when both count and non-count attributes are updated' do
+      it 'calls wipe_question_cache' do
+        expect(response).to receive(:wipe_question_cache)
+        response.update(text: 'new text', count: 10)
+      end
+    end
+
+    context 'when only count, child_count, or first_attempt_count are updated' do
+      it 'does not call wipe_question_cache when count is updated' do
+        expect(response).not_to receive(:wipe_question_cache)
+        response.update(count: 5)
+      end
+
+      it 'does not call wipe_question_cache when child_count is updated' do
+        expect(response).not_to receive(:wipe_question_cache)
+        response.update(child_count: 3)
+      end
+
+      it 'does not call wipe_question_cache when first_attempt_count is updated' do
+        expect(response).not_to receive(:wipe_question_cache)
+        response.update(first_attempt_count: 2)
+      end
     end
   end
-
-  context 'when both count and non-count attributes are updated' do
-    it 'calls wipe_question_cache' do
-      expect(response).to receive(:wipe_question_cache)
-      response.update(text: 'new text', count: 10)
-    end
-  end
-
-  context 'when only count, child_count, or first_attempt_count are updated' do
-    it 'does not call wipe_question_cache when count is updated' do
-      expect(response).not_to receive(:wipe_question_cache)
-      response.update(count: 5)
-    end
-
-    it 'does not call wipe_question_cache when child_count is updated' do
-      expect(response).not_to receive(:wipe_question_cache)
-      response.update(child_count: 3)
-    end
-
-    it 'does not call wipe_question_cache when first_attempt_count is updated' do
-      expect(response).not_to receive(:wipe_question_cache)
-      response.update(first_attempt_count: 2)
-    end
-  end
-end
 
 end

--- a/services/QuillCMS/spec/models/response_spec.rb
+++ b/services/QuillCMS/spec/models/response_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe Response do
     it "after_create_commit calls #create_index_in_elastic_search and #wipe_question_cache" do
       response = Response.new()
       expect(response).to receive(:create_index_in_elastic_search)
-      expect(response).to receive(:wipe_question_cache)
+      expect(response).to receive(:conditional_wipe_question_cache)
       response.save
     end
 
-    it "after_update_commit calls #update_index_in_elastic_search" do
+    it "after_update_commit calls #update_index_in_elastic_search and #conditional_wipe_question_cache" do
       response = Response.create()
       expect(response).to receive(:update_index_in_elastic_search)
-      expect(response).to receive(:wipe_question_cache)
+      expect(response).to receive(:conditional_wipe_question_cache)
       response.update(text: 'covfefe')
     end
 
-    it "after_update_commit calls #destroy_index_in_elastic_search" do
+    it "before_destroy calls #destroy_index_in_elastic_search and #wipe_question_cache" do
       response = Response.create()
       expect(response).to receive(:destroy_index_in_elastic_search)
       expect(response).to receive(:wipe_question_cache)
@@ -62,5 +62,40 @@ RSpec.describe Response do
       expect(Rails.cache.read(cache_key)).to be_nil
     end
   end
+
+  describe '#conditional_wipe_question_cache' do
+  let(:response) { Response.create() }
+
+  context 'when non-count attributes are updated' do
+    it 'calls wipe_question_cache' do
+      expect(response).to receive(:wipe_question_cache)
+      response.update(text: 'new text')
+    end
+  end
+
+  context 'when both count and non-count attributes are updated' do
+    it 'calls wipe_question_cache' do
+      expect(response).to receive(:wipe_question_cache)
+      response.update(text: 'new text', count: 10)
+    end
+  end
+
+  context 'when only count, child_count, or first_attempt_count are updated' do
+    it 'does not call wipe_question_cache when count is updated' do
+      expect(response).not_to receive(:wipe_question_cache)
+      response.update(count: 5)
+    end
+
+    it 'does not call wipe_question_cache when child_count is updated' do
+      expect(response).not_to receive(:wipe_question_cache)
+      response.update(child_count: 3)
+    end
+
+    it 'does not call wipe_question_cache when first_attempt_count is updated' do
+      expect(response).not_to receive(:wipe_question_cache)
+      response.update(first_attempt_count: 2)
+    end
+  end
+end
 
 end


### PR DESCRIPTION
## WHAT
Update the CMS so that we wipe the questions cache when responses are created, updated, or deleted.

## WHY
We were seeing a bug with newly-added questions where grading changes were not being reflected in what was coming out of the cache, which persists for 24 hours and never gets deleted otherwise, so turk users were unable to progress past certain questions.

## HOW
Add a `wipe_question_cache` function to the `Response` model so that changes to non-count variables will wipe the cache, allowing users to get the updated grading. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Query-to-pull-turk-responses-broken-271d4032c6c64761ba2c3defd59a1dba?d=d40b61cc98e44cff83973508969f58cc

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A