### PR TITLE
add spec scaffolding and basic specs for DataExportQuery

### DIFF
--- a/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
@@ -65,11 +65,11 @@ module Snapshots
 
       context 'basic shape tests' do
         # TODO: this test should pass when the production query bug is fixed
-        xit 'should have one row per activity session' do
-          expect(results.map{|r| r[:activity_session_id] }.uniq).to eq(
-            results.map{|r| r[:activity_session_id] }
-          )
-        end
+        # it 'should have one row per activity session' do
+        #   expect(results.map{|r| r[:activity_session_id] }.uniq).to eq(
+        #     results.map{|r| r[:activity_session_id] }
+        #   )
+        # end
 
         it { expect(results.count).to eq 10 }
 

--- a/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Snapshots
+  describe DataExportQuery do
+    include_context 'Snapshots Period CTE'
+
+    context 'big_query_snapshot', :big_query_snapshot do
+      let(:num_classrooms) { 1 }
+      let(:num_concepts) { 11 }
+
+      let(:activity_category_activities) { create_list(:activity_category_activity, num_concepts) }
+      let(:activity_categories) { activity_category_activities.map { |aca| aca.activity_category } }
+
+      let(:standards) { [ create(:standard) ] }
+      let(:activity_classifications) { [create(:activity_classification)]}
+      let(:activities) do
+        create_list(
+          :activity,
+          2,
+          activity_classification_id: activity_classifications.first.id,
+          standard_id: standards.first.id
+        )
+      end
+
+      let(:units) { Unit.all }
+
+      # Note that we're setting assigned_student_ids to an arbitrary one-length array because we don't actually need to reference the students in question, so any number "works" here.
+      let(:classroom_units) do
+        classrooms.map { |classroom| create_list(:classroom_unit, num_concepts, classroom: classroom, assigned_student_ids: [1]) }.flatten
+      end
+      let(:activity_sessions) do
+        classroom_units.map do |classroom_unit|
+          create(:activity_session, classroom_unit: classroom_unit, timespent: rand(1..100), activity: activities.first)
+        end
+      end
+      # We have one activity connected to each concept.
+      # We have a number of classroom_units equal to the number of concepts.
+      # We want to assign one concept to all classroom_units, the next concept to all but one, the next to all but two, and so on so that each concept is used a different number of times.
+      # let(:unit_activity_bundles) do
+      #   classroom_units.map.with_index do |classroom_unit, classroom_unit_index|
+      #     Array(0..(num_concepts - (1 + classroom_unit_index))).map do |target_activity_index|
+      #       create(:unit_activity, activity: activities[target_activity_index], unit: classroom_unit.unit)
+      #     end
+      #   end
+      # end
+
+      let(:runner_context) {
+        [
+          classrooms,
+          teachers,
+          classrooms_teachers,
+          schools,
+          schools_users,
+          classroom_units,
+          activity_categories,
+          activities,
+          activity_category_activities,
+          classroom_units,
+          activity_classifications,
+          activity_sessions,
+          standards,
+          units
+        ]
+      }
+
+      let(:cte_records) { [runner_context] }
+
+      context 'query LIMITs and shape' do
+        let(:expected_result) do
+          # (0..9).map { |i| { count: unit_activity_bundles[i].length, value: activity_categories[i].name} }
+        end
+        it do
+          binding.pry
+
+        end
+        #it { expect(results).to eq(expected_result) }
+      end
+
+      context 'classroom_units created outside of timeframe' do
+        before do
+          classroom_units.each { |cu| cu.update(created_at: timeframe_start - 1.day) }
+        end
+
+        xit { expect(results).to eq([]) }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
@@ -10,13 +10,10 @@ module Snapshots
       let(:num_classrooms) { 1 }
       let(:num_concepts) { 11 }
 
-      let(:activity_category_activities) { create_list(:activity_category_activity, num_concepts) }
-      let(:activity_categories) { activity_category_activities.map { |aca| aca.activity_category } }
+      let(:students) { create_list(:user, 3, role: 'student') }
 
-      let(:students) { create_list(:user, 3, role: 'student')}
-
-      let(:standards) { [ create(:standard) ] }
-      let(:activity_classifications) { [create(:activity_classification)]}
+      let(:standards) { [create(:standard)] }
+      let(:activity_classifications) { [create(:activity_classification)] }
       let(:activities) do
         create_list(
           :activity,
@@ -45,16 +42,6 @@ module Snapshots
           )
         end
       end
-      # We have one activity connected to each concept.
-      # We have a number of classroom_units equal to the number of concepts.
-      # We want to assign one concept to all classroom_units, the next concept to all but one, the next to all but two, and so on so that each concept is used a different number of times.
-      # let(:unit_activity_bundles) do
-      #   classroom_units.map.with_index do |classroom_unit, classroom_unit_index|
-      #     Array(0..(num_concepts - (1 + classroom_unit_index))).map do |target_activity_index|
-      #       create(:unit_activity, activity: activities[target_activity_index], unit: classroom_unit.unit)
-      #     end
-      #   end
-      # end
 
       let(:runner_context) {
         [
@@ -64,9 +51,7 @@ module Snapshots
           schools,
           schools_users,
           classroom_units,
-          activity_categories,
           activities,
-          activity_category_activities,
           classroom_units,
           activity_classifications,
           activity_sessions,
@@ -79,11 +64,14 @@ module Snapshots
       let(:cte_records) { [runner_context] }
 
       context 'basic shape tests' do
+        # TODO: this test should pass when the production query bug is fixed
         xit 'should have one row per activity session' do
           expect(results.map{|r| r[:activity_session_id] }.uniq).to eq(
             results.map{|r| r[:activity_session_id] }
           )
         end
+
+        it { expect(results.count).to eq 10 }
 
         it 'each row contains the expected fields' do
           expected_fields = %i(
@@ -105,19 +93,11 @@ module Snapshots
           results.each do |row|
             expect(row.keys.to_set > expected_fields.to_set).to be true
           end
-          #binding.pry
-          puts "ROWS: #{results.count}"
         end
 
       end
 
-      context 'classroom_units created outside of timeframe' do
-        before do
-          classroom_units.each { |cu| cu.update(created_at: timeframe_start - 1.day) }
-        end
 
-        xit { expect(results).to eq([]) }
-      end
     end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
@@ -79,7 +79,11 @@ module Snapshots
       let(:cte_records) { [runner_context] }
 
       context 'basic shape tests' do
-        it { expect(results.count).to eq 10 }
+        xit 'should have one row per activity session' do
+          expect(results.map{|r| r[:activity_session_id] }.uniq).to eq(
+            results.map{|r| r[:activity_session_id] }
+          )
+        end
 
         it 'each row contains the expected fields' do
           expected_fields = %i(
@@ -101,7 +105,8 @@ module Snapshots
           results.each do |row|
             expect(row.keys.to_set > expected_fields.to_set).to be true
           end
-
+          #binding.pry
+          puts "ROWS: #{results.count}"
         end
 
       end


### PR DESCRIPTION
## WHAT
Adds specs to this query. The bug in the query requires a product discussion, so I'm checking in some basic specs and scaffolding while waiting for the final specification. 

## WHY
Specs help support the existing query and will make fixing the query easier in the future. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/blocked-DataExportQuery-is-returning-too-many-rows-bfd731c3c1914ca690ebf078afbc5b5a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | no - spec only
Self-Review: Have you done an initial self-review of the code below on Github? | n/a
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
