### PR TITLE
add extra attributes to results summary payload

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -21,7 +21,10 @@ module ResultsSummary
 
     {
       student_results: student_results,
-      skill_group_summaries: @skill_group_summaries
+      skill_group_summaries: @skill_group_summaries,
+      activity_id: activity_id,
+      classroom_id: classroom_id,
+      unit_id: unit_id
     }
   end
 

--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -22,6 +22,7 @@ module ResultsSummary
     {
       student_results: student_results,
       skill_group_summaries: @skill_group_summaries,
+      # @TODO - remove these last three attributes once we work out the bug described in this PR: https://github.com/empirical-org/Empirical-Core/pull/11245
       activity_id: activity_id,
       classroom_id: classroom_id,
       unit_id: unit_id

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -27,6 +27,9 @@ describe ResultsSummary do
   describe '#results_summary' do
     it 'should return data with the student results and skill group summaries' do
       expect(results_summary(unit_activity.activity_id, classroom.id, nil)).to eq({
+        activity_id: unit_activity.activity_id,
+        classroom_id: classroom.id,
+        unit_id: nil,
         skill_group_summaries: [
           {
             name: skill_group_activity.skill_group.name,


### PR DESCRIPTION
## WHAT
Add extra attributes to results summary payload so we can hopefully track down a weird bug.

## WHY
We're occasionally (looks like three reports in the last two sprints) seeing a bug where teachers wind up with a totally unrelated classroom's data in their diagnostic results summary cache. This problem has been tricky to track down, both because the cache either gets overwritten or wiped within 24 hours and also because there's just very little to go on in terms of how this might be happening. Even when I have caught it in the replicable window, it's clear that the wrong data is in the cache but all the methods that should be populating the cache appear to work as intended. I'm hoping that adding a little more data will give us more insight into how this might be happening. If anyone else has any ideas, please let me know.

## HOW
Just add more data about what's actually getting passed into this method so we can see where things might be going wrong. This seems redundant, but I'm hoping we'll see that what's getting passed in is not what we expect, and then we can work from there. If the correct classroom, unit, and activity ids are getting passed in but the student results are still unrelated, we'll know it's the code in this file that's not working as expected rather than the caching or controller logic.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Students-who-are-not-rostered-in-a-class-appearing-in-Student-results-report-2264796d865144a98178856820d17983?pvs=4
https://www.notion.so/quill/Students-that-are-not-rostered-in-class-appearing-in-Student-results-report-c2245d18791744a58a1950418b4dfd15

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A