### PR TITLE
fix a bunch of css so that pdf reports look better

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/progress-reports-2018.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/progress-reports-2018.scss
@@ -220,3 +220,28 @@
     }
   }
 }
+
+@media print {
+  .activities-scores-by-classroom, .concepts-overview, .standards-all-classrooms, .individual-standard {
+    table {
+      width: 100%;
+    }
+    td, th {
+      width: 20% !important;
+    }
+  }
+
+  .concept-student-concepts, .individual-student {
+    table, .ReactTable {
+      width: 100%;
+      page-break-inside: unset !important;
+    }
+    td, th {
+      width: 18% !important;
+    }
+  }
+
+  .standards-all-classrooms, .individual-student {
+    zoom: 90%;
+  }
+}

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/student-overview.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/student-overview.scss
@@ -100,7 +100,7 @@
     }
 
     .activity-name {
-      width: 40%;
+      max-width: 40%;
       a {
         color: $quill-grey-40;
         &.standard {color: #027360;}
@@ -202,6 +202,29 @@
     overflow-x: auto;
     .student-overview-table {
       width: max-content !important;
+    }
+  }
+}
+
+@media print {
+  #student-overview {
+    zoom: 85%;
+    .student-overview-table {
+      .activity-image, .activity-name {
+        padding-left: 0px;
+      }
+      .unit-name {
+        padding-left: 0px;
+      }
+      td, th {
+        padding-right: 8px;
+      }
+    }
+    .activity-image {
+      max-width: 0px;
+      .icon-wrapper {
+        display: none;
+      }
     }
   }
 }

--- a/services/QuillLMS/app/assets/stylesheets/print.scss
+++ b/services/QuillLMS/app/assets/stylesheets/print.scss
@@ -38,13 +38,12 @@
   .progress-reports-2018 {
     padding-top: 0px;
     padding-bottom: 0px;
-    .meta-overview, .dropdown-container {
+    .meta-overview p, .dropdown-container {
       display: none;
     }
 
     > .student-name {
       display: block;
-      padding: 1rem;
     }
     .rt-tr {
       display: flex;
@@ -59,6 +58,10 @@
         display: none;
       }
     }
+  }
+
+  .gray-background-accommodate-footer, .white-background-accommodate-footer {
+    padding-bottom: 0px;
   }
 
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/concepts_students_progress_report.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/concepts_students_progress_report.jsx
@@ -180,7 +180,7 @@ export default class ConceptsStudentsProgressReport extends React.Component {
     const selectedClassroom = dropdownClassrooms.find(c => String(c.id) === String(selectedClassroomId))
 
     return (
-      <div className='progress-reports-2018'>
+      <div className='progress-reports-2018 concepts-overview'>
         <div className="meta-overview flex-row space-between">
           <div className='header-and-info'>
             <h1>Concept Results</h1>


### PR DESCRIPTION
## WHAT
Adjust a bunch of CSS, mostly around standardizing cell and header widths, so that printed reports look decent.

## WHY
These were looking very wonky as PDFs.

## HOW
Just mess around with the CSS until the reports looked legible and decent.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-formatting-on-downloadable-Premium-reports-PDFs-9ad8a63b562e4bd79d1a56e0a3843ec5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A