### PR TITLE
fix intermittently failing query_spec specs

### DIFF
--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -47,7 +47,8 @@ describe 'ScorebookQuery' do
     # have to do update_columns here because otherwise the publish date is offset by a callback
     unit_activity1.update_columns(publish_date: publish_date)
     results = Scorebook::Query.run(classroom.id)
-    expect(results[0]['scheduled']).to eq(true)
+    row = results.find {|r| r['activity_id'] == unit_activity1.activity_id}
+    expect(row['scheduled']).to eq(true)
   end
 
   it 'returns activities with publish dates in the past as not scheduled' do
@@ -55,7 +56,8 @@ describe 'ScorebookQuery' do
     # have to do update_columns here because otherwise the publish date is offset by a callback
     unit_activity1.update_columns(publish_date: publish_date)
     results = Scorebook::Query.run(classroom.id)
-    expect(results[0]['scheduled']).to eq(false)
+    row = results.find {|r| r['activity_id'] == unit_activity1.activity_id}
+    expect(row['scheduled']).to eq(false)
   end
 
   describe 'pack sequence status' do


### PR DESCRIPTION
## WHAT
Fix failing specs 

## WHY
Failing spec bad. 

## HOW
It's an order issue, not a time issue. It's not obvious, but 
`unit_activities.publish_date >= NOW() AS scheduled` can yield a nil value 

So when the order of the query results is not the intended order, an error occurs. 

I fixed this by retrieving the desired row from the result set, rather than taking the first row. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
n/a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  n/a spec change only
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
