### PR TITLE
Fix Delete Lesson button for Quill Lessons Staff panel

### DIFF
--- a/services/QuillLessonsServer/src/handlers/lessons.js
+++ b/services/QuillLessonsServer/src/handlers/lessons.js
@@ -57,10 +57,10 @@ export function createOrUpdateClassroomLesson({
 
 export function deleteClassroomLesson({
   connection,
-  activityId
+  classroomLessonId
 }) {
   r.table('classroom_lessons')
-    .filter({id: activityId})
+    .filter({id: classroomLessonId})
     .delete()
     .run(connection)
 }


### PR DESCRIPTION
## WHAT
This button has been broken. This PR fixes it so staff can now delete Quill Lessons.

## WHY
So Staff can perform some much-needed Quill Lessons cleanup.

## HOW
The server was simply looking up the wrong parameter name from the passed in JSON object. Change the name to be the correct parameter name, so it can pass the LessonId into the database delete call.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Lessons-Fixes-Restoring-Functionality-of-the-Delete-Button-3966d322f5b147038cc2efd87f208de7?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests for this part of the codebase. Tested on staging instead.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
