### PR TITLE
lms/restrict-period-query-to-owner-teachers

### DIFF
--- a/services/QuillLMS/app/queries/snapshots/active_teachers_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/active_teachers_query.rb
@@ -18,5 +18,10 @@ module Snapshots
     def relevant_date_column
       "user_logins.created_at"
     end
+
+    # For this query we want to count all teachers, not just classroom owners
+    def owner_teachers_only_where_clause
+      ""
+    end
   end
 end

--- a/services/QuillLMS/app/queries/snapshots/period_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/period_query.rb
@@ -35,6 +35,7 @@ module Snapshots
           #{grades_where_clause}
           #{teacher_ids_where_clause}
           #{classroom_ids_where_clause}
+          #{owner_teachers_only_where_clause}
       SQL
     end
 
@@ -67,6 +68,10 @@ module Snapshots
       return "" if classroom_ids.blank?
 
       "AND classrooms.id IN (#{classroom_ids.join(',')})"
+    end
+
+    def owner_teachers_only_where_clause
+      "AND classrooms_teachers.role = '#{ClassroomsTeacher::ROLE_TYPES[:owner]}'"
     end
   end
 end

--- a/services/QuillLMS/app/queries/snapshots/teacher_accounts_created_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/teacher_accounts_created_query.rb
@@ -16,5 +16,10 @@ module Snapshots
     def relevant_date_column
       "users.created_at"
     end
+
+    # For this query we want to count all teachers, not just classroom owners
+    def owner_teachers_only_where_clause
+      ""
+    end
   end
 end

--- a/services/QuillLMS/spec/queries/snapshots/active_teachers_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/active_teachers_query_spec.rb
@@ -22,6 +22,14 @@ module Snapshots
         let(:cte_records) { [runner_context, user_logins] }
 
         it { expect(results).to eq(count: teachers.length) }
+
+        context 'when users are coteachers instead of classroom owners' do
+          before do
+            classrooms_teachers.each { |classroom_teacher| classroom_teacher.update(role: ClassroomsTeacher::ROLE_TYPES[:coteacher]) }
+          end
+
+          it { expect(results).to eq(count: teachers.length) }
+        end
       end
 
       context 'multiple valid user_logins for each user' do

--- a/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
@@ -12,7 +12,7 @@ module Snapshots
         end
 
         def select_clause
-          "SELECT DISTINCT classrooms.id"
+          "SELECT classrooms.id"
         end
 
         def relevant_date_column
@@ -24,7 +24,7 @@ module Snapshots
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Period CTE'
 
-      let(:cte_records) do
+      let(:base_cte_records) do
         [
           classrooms,
           teachers,
@@ -34,9 +34,23 @@ module Snapshots
         ]
       end
 
+      let(:cte_records) { base_cte_records }
+
       let(:results) { test_period_query.run(**query_args, runner: runner) }
 
       it { expect(results).to match_array(classroom_ids) }
+
+      context 'classroom with co teachers' do
+        let(:coteacher_classrooms_teachers) { classrooms.map { |classroom| create(:classrooms_teacher, classroom: classroom, role: ClassroomsTeacher::ROLE_TYPES[:coteacher]) } }
+        let(:coteachers) { coteacher_classrooms_teachers.map { |ct| ct.user } }
+        let(:coteacher_schools_users) { coteachers.map { |coteacher| create(:schools_users, user: coteacher, school: schools.first)  } }
+
+        let(:teacher_ids) { nil }
+        let(:cte_records) { base_cte_records + [coteacher_classrooms_teachers, coteachers, coteacher_schools_users] }
+
+
+        it { expect(results).to match_array(classroom_ids) }
+      end
 
       context 'filter params' do
         let(:filters) { {} }

--- a/services/QuillLMS/spec/queries/snapshots/teacher_accounts_created_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/teacher_accounts_created_query_spec.rb
@@ -19,6 +19,14 @@ module Snapshots
 
       it { expect(results).to eq(count: teachers.length) }
 
+      context 'when users are coteachers instead of classroom owners' do
+        before do
+          classrooms_teachers.each { |classroom_teacher| classroom_teacher.update(role: ClassroomsTeacher::ROLE_TYPES[:coteacher]) }
+        end
+
+        it { expect(results).to eq(count: teachers.length) }
+      end
+
       context 'with users created outside of timeframe' do
         before do
           teachers.each { |teacher| teacher.update(created_at: timeframe_start - 1.day) }


### PR DESCRIPTION
## WHAT
- Restrict PeriodQueries to only include owner teachers
- Modify two queries (`ActiveTeachers` and `TeacherAccountsCreated`) so that they ignore the new restriction since they are explicit exceptions to the new rule
## WHY
This lets us avoid double-counting cases where a classroom has a coteacher and we aren't using DISTINCT to avoid said double-count and protects us from the need to guarantee DISTINCT clauses in future queries to avoid double counting in cases where the presence of a co-teacher will result in doubling (or tripling, etc.) rows because multiple teachers are associated with, say, a `ClassroomUnit`.
## HOW
Just add a new WHERE clause to the base `PeriodQuery` that excludes users who are not classroom owners from our queries.  And in cases where a teacher is a teacher for one class and a coteacher for another class, only include data for which the teacher is an owner.

### Notion Card Links
https://www.notion.so/quill/Update-PeriodQuery-so-that-it-only-includes-data-for-owner-teachers-4d404ad519734594a732d01020c439ef?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
