### PR TITLE
Add a page reload after deleting lessons

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lesson.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lesson.jsx
@@ -51,7 +51,6 @@ class Lesson extends React.Component {
     const { params } = match;
     const { lessonID } = params;
     if (confirm('do you want to do this?')) {
-      // TODO: fix delete lesson action
       dispatch(lessonActions.deleteLesson(lessonID));
     }
   };

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/admin/show.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/admin/show.tsx
@@ -62,6 +62,7 @@ class ShowClassroomLesson extends Component<any, any> {
     if (confirmation) {
       deleteLesson(this.props.match.params.classroomLessonID)
       window.location.href = `${window.location.origin}/lessons/#/admin/classroom-lessons/`
+      window.location.reload()
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/admin/show.tsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/classroomLessons/admin/show.tsx
@@ -62,7 +62,6 @@ class ShowClassroomLesson extends Component<any, any> {
     if (confirmation) {
       deleteLesson(this.props.match.params.classroomLessonID)
       window.location.href = `${window.location.origin}/lessons/#/admin/classroom-lessons/`
-      window.location.reload()
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/locker/organizeLocker.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/locker/organizeLocker.tsx
@@ -116,7 +116,7 @@ export const OrganizeLocker = ({ history, personalLocker, userId }) => {
   }
 
   function handleAddSection() {
-    const updatedLockerPreferences = _.cloneDeep(lockerPreferences) || {};
+    let updatedLockerPreferences = _.cloneDeep(lockerPreferences);
     updatedLockerPreferences[uuid()] = { label: '', lockers: {} };
     setLockerPreferences(updatedLockerPreferences);
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/locker/organizeLocker.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/locker/organizeLocker.tsx
@@ -116,7 +116,7 @@ export const OrganizeLocker = ({ history, personalLocker, userId }) => {
   }
 
   function handleAddSection() {
-    let updatedLockerPreferences = _.cloneDeep(lockerPreferences);
+    const updatedLockerPreferences = _.cloneDeep(lockerPreferences) || {};
     updatedLockerPreferences[uuid()] = { label: '', lockers: {} };
     setLockerPreferences(updatedLockerPreferences);
   }


### PR DESCRIPTION
## WHAT
Accidentally missed this in testing -- the delete lessons functionality doesn't currently reload the Lessons Index page, so it appears like lessons didn't get deleted. Add a manual refresh to get the page update.

## WHY
Staff want visual confirmation that their deletion in fact worked.

## HOW
Add a manual refresh after lesson deletion so that the Lessons Index component reloads after lesson deletion.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Lessons-Fixes-Restoring-Functionality-of-the-Delete-Button-3966d322f5b147038cc2efd87f208de7?pvs=4)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, tested manually
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
