### PR TITLE
2 more custom formattings for admin csv cells

### DIFF
--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -40,14 +40,25 @@ module Adapters
         sym_columns.map{|col| ORDERED_COLUMNS[col] }
       end
 
+      def self.format_score(score)
+        return '' unless score.is_a?(Numeric)
+        return 'Completed' if score == -1
+        "#{(score*100).round(0)}%"
+      end
+
+      def self.format_timespent(timespent)
+        return '< 1' if timespent < 60
+        (timespent / 60)
+      end
+
       def self.format_cell(sym_column, value)
         case sym_column
         when :completed_at
           value&.strftime("%F")
         when :timespent
-          (value / 60)
+          format_timespent(value)
         when :score
-          value.is_a?(Numeric) ? "#{(value*100).round(0)}%" : ''
+          format_score(value)
         else
           value
         end

--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -41,7 +41,7 @@ module Adapters
       end
 
       def self.format_score(score)
-        return '' unless score.is_a?(Numeric)
+        return 'Completed' unless score.is_a?(Numeric)
         return 'Completed' if score == -1
         "#{(score*100).round(0)}%"
       end

--- a/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
+++ b/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
@@ -15,6 +15,8 @@ describe Adapters::Csv::AdminPremiumDataExport do
 
     it { expect(described_class.format_cell(:score, 0.66777)).to eq('67%')}
     it { expect(described_class.format_cell(:score, -1)).to eq('Completed')}
+    it { expect(described_class.format_cell(:score, nil)).to eq('Completed')}
+    it { expect(described_class.format_cell(:score, '')).to eq('Completed')}
 
     it { expect(described_class.format_cell(:not_a_special_case, 1.5)).to eq(1.5)}
   end

--- a/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
+++ b/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
@@ -7,9 +7,15 @@ describe Adapters::Csv::AdminPremiumDataExport do
 
   describe '#format_cell' do
     it { expect(described_class.format_cell(:completed_at, DateTime.new(2020,1,1))).to eq('2020-01-01')}
+
     it { expect(described_class.format_cell(:activity_pack, 'foo')).to eq('foo')}
+
     it { expect(described_class.format_cell(:timespent, 61)).to eq(1)}
+    it { expect(described_class.format_cell(:timespent, 59)).to eq('< 1')}
+
     it { expect(described_class.format_cell(:score, 0.66777)).to eq('67%')}
+    it { expect(described_class.format_cell(:score, -1)).to eq('Completed')}
+
     it { expect(described_class.format_cell(:not_a_special_case, 1.5)).to eq(1.5)}
   end
 


### PR DESCRIPTION
## WHAT
1. When `ActivitySession.percentage` is nil, display `Completed` 
2. When `timespent` is less than a minute, display `< 1`


## WHY
QA change requests.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=f1bfffdb6c7d45a9b2705c6883456e6d&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
