### PR TITLE
lms/fix-overnight-admin-caching?

### DIFF
--- a/services/QuillLMS/app/workers/cache_admin_snapshots_worker.rb
+++ b/services/QuillLMS/app/workers/cache_admin_snapshots_worker.rb
@@ -24,7 +24,8 @@ class CacheAdminSnapshotsWorker
   end
 
   private def generate_worker_payload(query, timeframe_start, timeframe_end)
-    cache_key = Snapshots::CacheKeys.generate_key(query,
+    cache_key = Snapshots::CacheKeys.generate_key(SnapshotsController::CACHE_REPORT_NAME,
+      query,
       Snapshots::Timeframes::DEFAULT_TIMEFRAME,
       timeframe_start,
       timeframe_end,

--- a/services/QuillLMS/spec/workers/cache_admin_snapshots_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/cache_admin_snapshots_worker_spec.rb
@@ -47,6 +47,13 @@ describe CacheAdminSnapshotsWorker, type: :worker do
 
       subject
     end
+
+    context 'make actual calls to workers' do
+      # Make sure that the actual calls don't error (the previous test mocks their calls)
+      Sidekiq::Testing.inline! do
+        it { expect { subject }.not_to raise_error }
+      end
+    end
   end
 
   context 'non-existent admin_id' do


### PR DESCRIPTION

## WHAT
Add additional param to function call now that it's changed.

Also add a spec to help avoid this kind of thing happening again in the future.
## WHY
We want this job to successfully run overnight and not get stuck in an endless Sidekiq retry loop because of ArgumentErrors
## HOW
Update the cache key generator function call to use the newly-updated number of params, and then add a small spec to ensure that the full call stack is run so that we don't mask this kind of failure behind all of the stubs we have in place.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
