### PR TITLE
Styling bug on Link Google Account button

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/link_provider_account_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/link_provider_account_modal.tsx
@@ -21,7 +21,7 @@ const LinkProviderAccountModal = ({ link, close, provider, user }: LinkProviderA
     let buttonClass = 'quill-button contained primary medium';
 
     if (termsAccepted) {
-      if (provider === 'Google') { return <AuthGoogleAccessForm offlineAccess={true} text={buttonText} /> }
+      if (provider === 'Google') { return <AuthGoogleAccessForm buttonClass={buttonClass} offlineAccess={true} text={buttonText} /> }
 
       return <a className={buttonClass} href={link}>{buttonText}</a>
     } else {


### PR DESCRIPTION
## WHAT
This button was missing styling, because it wasn't getting the buttonClass prop passed in.

## WHY
So the button looks uniform with other styled elements on the page.

## HOW
Just pass the buttonClass button in from the parent element, so it gets the right styling.

### Screenshots
![Screenshot 2023-11-21 at 4 23 37 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/26406c0e-2cc3-46ba-99df-c490c6322bd4)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Fix-styling-of-the-Link-Account-button-in-the-Google-Classroom-workflow-abb2bb71608948ceb2b651d091fab6f2?pvs=4)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Tested manually
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
