### PR TITLE
use correct class name for select search css

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/styles/style.scss
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/styles/style.scss
@@ -436,7 +436,7 @@ textarea.submission {
   }
 }
 
-.select-search__option {
+.select-search__option, .select-search-option {
   height: min-content;
   padding: 8px 16px 8px 16px;
 }


### PR DESCRIPTION
## WHAT
Use correct class name for search-select CSS in Diagnostic.

## WHY
We were running into an issue where the `height` set in the `react-select-search` library's CSS wasn't sufficient for our menu options, resulting in them bleeding over each other.

## HOW
Just make sure we're using the correct class name for this element.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A - CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
