### PR TITLE
fix lifecycle method console errors

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/draftJSRichButtonsPlugin/BlockButton.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/draftJSRichButtonsPlugin/BlockButton.tsx
@@ -4,12 +4,12 @@ class BlockButton extends React.Component {
 
   constructor(props) {
     super(props);
-    this.componentWillMount = this.componentWillMount.bind(this);
+    this.UNSAFE_componentWillMount = this.UNSAFE_componentWillMount.bind(this);
     this.componentWillUnmount = this.componentWillUnmount.bind(this);
   }
 
   // register with store updates to ensure rerender
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.bindToState(this);
   }
 

--- a/services/QuillLMS/client/app/bundles/Shared/components/draftJSRichButtonsPlugin/StyleButton.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/draftJSRichButtonsPlugin/StyleButton.tsx
@@ -13,12 +13,12 @@ class StyleButton extends React.Component {
 
   constructor(props) {
     super(props);
-    this.componentWillMount = this.componentWillMount.bind(this);
+    this.UNSAFE_componentWillMount = this.UNSAFE_componentWillMount.bind(this);
     this.componentWillUnmount = this.componentWillUnmount.bind(this);
   }
 
   // register with store updates to ensure rerender
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.bindToState(this);
   }
 

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dropdownInput.tsx
@@ -92,7 +92,7 @@ export class DropdownInput extends React.Component<DropdownInputProps, DropdownI
     this.setOptionFocus()
   }
 
-  componentWillReceiveProps(nextProps: any) {
+  UNSAFE_componentWillReceiveProps(nextProps: any) {
     const { error, timesSubmitted, options } = this.props
     const { errorAcknowledged, } = this.state
     if (nextProps.error !== error && errorAcknowledged) {

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/input.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/input.tsx
@@ -47,7 +47,7 @@ export class Input extends React.Component<InputProps, InputState> {
     document.addEventListener(MOUSEDOWN, this.handleClick, false)
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { error, timesSubmitted, } = this.props
     const { errorAcknowledged, } = this.state
 

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/smartSpinner.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/smartSpinner.tsx
@@ -7,7 +7,7 @@ class SmartSpinner extends React.Component<any, any> {
     super(props);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.onMount) {
       this.props.onMount();
     }

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textArea.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textArea.tsx
@@ -40,11 +40,11 @@ export class TextArea extends React.Component<InputProps, InputState> {
     this.deactivateInput = this.deactivateInput.bind(this)
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     document.addEventListener('mousedown', this.handleClick, false)
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.error !== this.props.error && this.state.errorAcknowledged) {
       this.setState({ errorAcknowledged: false, })
     } else if (nextProps.timesSubmitted !== this.props.timesSubmitted && nextProps.error && this.state.errorAcknowledged) {

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -48,7 +48,7 @@ class TextEditor extends React.Component <any, any> {
     }
   }
 
-  componentWillReceiveProps(nextProps: any) {
+  UNSAFE_componentWillReceiveProps(nextProps: any) {
     const { boilerplate, EditorState, handleTextChange, ContentState, } = this.props
     if (nextProps.boilerplate !== boilerplate) {
       this.setState({text: EditorState.createWithContent(ContentState.createFromBlockArray(this.contentState(nextProps.boilerplate)))},


### PR DESCRIPTION
## WHAT
Update names of deprecated lifecycle methods to their UNSAFE counterparts.

## WHY
So we stop getting these console warnings (and also so that these components will work when we are actually running React 18).

## HOW
Find and replace.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Console-log-cleanup-componentWillMount-renamed-5-e542d5c45aec40f08024ad1150715c56?pvs=4

https://www.notion.so/quill/Console-log-cleanup-componentWillReceiveProps-has-been-renamed-46-0a5e3d1a098e4ba19e496d7c14176beb?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | NO