### PR TITLE
bug fix for timespent

### DIFF
--- a/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
+++ b/services/QuillLMS/app/queries/adapters/csv/admin_premium_data_export.rb
@@ -47,6 +47,7 @@ module Adapters
       end
 
       def self.format_timespent(timespent)
+        return '' unless timespent.is_a?(Numeric)
         return '< 1' if timespent < 60
         (timespent / 60)
       end

--- a/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
+++ b/services/QuillLMS/spec/queries/adapters/csv/admin_premium_data_export_spec.rb
@@ -12,6 +12,7 @@ describe Adapters::Csv::AdminPremiumDataExport do
 
     it { expect(described_class.format_cell(:timespent, 61)).to eq(1)}
     it { expect(described_class.format_cell(:timespent, 59)).to eq('< 1')}
+    it { expect(described_class.format_cell(:timespent, nil)).to eq('')}
 
     it { expect(described_class.format_cell(:score, 0.66777)).to eq('67%')}
     it { expect(described_class.format_cell(:score, -1)).to eq('Completed')}


### PR DESCRIPTION
## WHAT
Handle the case where DataExportQuery returns null values for timespent. 

## WHY
So that the query postprocessing for CSV downloads won't throw an exception 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
n/a

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
