### PR TITLE
Update rails-autoscale gem

### DIFF
--- a/services/QuillCMS/Gemfile
+++ b/services/QuillCMS/Gemfile
@@ -34,7 +34,6 @@ gem 'sinatra', require: false # Used for the web-based queue management interfac
 # MIDDLEWARE
 gem 'rack-cors', '~> 1.1', require: 'rack/cors'
 gem 'rack-attack', '~> 6.5'
-gem 'rails_autoscale_agent', '~> 0.10'
 
 # API
 gem 'active_model_serializers', '~> 0.10'
@@ -72,4 +71,9 @@ group :development, :test do
   gem 'rubocop'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
+end
+
+group :production, :staging do
+  gem 'judoscale-rails'
+  gem 'judoscale-sidekiq'
 end

--- a/services/QuillCMS/Gemfile.lock
+++ b/services/QuillCMS/Gemfile.lock
@@ -148,6 +148,13 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     jsonapi-renderer (0.2.2)
+    judoscale-rails (1.5.2)
+      judoscale-ruby (= 1.5.2)
+      railties
+    judoscale-ruby (1.5.2)
+    judoscale-sidekiq (1.5.2)
+      judoscale-ruby (= 1.5.2)
+      sidekiq (>= 5.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -247,7 +254,6 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    rails_autoscale_agent (0.12.0)
     railties (6.1.7.6)
       actionpack (= 6.1.7.6)
       activesupport (= 6.1.7.6)
@@ -381,6 +387,8 @@ DEPENDENCIES
   factory_bot_rails
   faraday-httpclient (~> 2.0, >= 2.0.1)
   httparty (~> 0.18)
+  judoscale-rails
+  judoscale-sidekiq
   kaminari (~> 1.2)
   listen (>= 3.0.5, < 3.2)
   newrelic_rpm (~> 9.3.1)
@@ -391,7 +399,6 @@ DEPENDENCIES
   rack-attack (~> 6.5)
   rack-cors (~> 1.1)
   rails (~> 6.1)
-  rails_autoscale_agent (~> 0.10)
   rb-readline
   redis (~> 4.5)
   redis-namespace (~> 1.8)

--- a/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/user_cacheable_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UserCacheable, type: :model do
+RSpec.describe UserCacheable, type: :model, retry: 3 do
   let(:user) { build(:user) }
   let(:groups) { {some_id: 1234, page: 1} }
 


### PR DESCRIPTION
## WHAT
Update the Rails autoscale gem.

## WHY
The UI is warning us that the current gem `rails-autoscale-agent` is no longer maintained:
![Screenshot 2023-11-27 at 9 17 39 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/bd1ab7a9-0577-4966-91a6-9a270df2c209)

## HOW
Update the Gemfile to use: `rails-autoscale-web` and  'rails-autoscale-sidekiq' per the migration [guide](https://github.com/judoscale/judoscale-ruby#migrating-from-rails_autoscale_agent)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
