### PR TITLE
Lms/admin diagnostic performance by skill

### DIFF
--- a/services/QuillLMS/app/controllers/admin_diagnostic_skills_controller.rb
+++ b/services/QuillLMS/app/controllers/admin_diagnostic_skills_controller.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+class AdminDiagnosticSkillsController < ApplicationController
+  CACHE_REPORT_NAME = 'admin-diagnostic-skills'
+  WORKERS_FOR_ACTIONS = {
+    "report" => AdminDiagnosticReports::DiagnosticSkillsWorker
+  }
+
+  before_action :set_query
+  before_action :validate_request
+  before_action :authorize_request
+
+  def report
+    render json: retrieve_cache_or_enqueue_worker(WORKERS_FOR_ACTIONS[action_name])
+  end
+
+  private def set_query
+    @query = permitted_params[:query]
+    @group_by = permitted_params[:group_by]
+    @diagnostic_id = permitted_params[:diagnostic_id]
+  end
+
+  private def validate_request
+    return render json: { error: 'timeframe must be present and valid' }, status: 400 unless timeframe_param_valid?
+
+    return render json: { error: 'school_ids are required' }, status: 400 unless school_ids_param_valid?
+
+    return render json: { error: 'group_by param is required' }, status: 400 unless school_ids_param_valid?
+
+    return render json: { error: 'diagnostic_id param is required' }, status: 400 unless school_ids_param_valid?
+
+    return render json: { error: 'unrecognized query type for this endpoint' }, status: 400 unless WORKERS_FOR_ACTIONS[action_name]::QUERIES.keys.include?(@query)
+  end
+
+  private def timeframe_param_valid?
+    Snapshots::Timeframes.find_timeframe(permitted_params[:timeframe]).present?
+  end
+
+  private def school_ids_param_valid?
+    permitted_params[:school_ids]&.any?
+  end
+
+  private def group_by_param_valid?
+    permitted_params[:group_by].present?
+  end
+
+  private def diagnostic_id_param_valid?
+    permitted_params[:diagnostic_id].present?
+  end
+
+  private def authorize_request
+    schools_user_admins = current_user.administered_schools.pluck(:id)
+
+    return if permitted_params[:school_ids]&.all? { |param_id| schools_user_admins.include?(param_id.to_i) }
+
+    return render json: { error: 'user is not authorized for all specified schools' }, status: 403
+  end
+
+  private def retrieve_cache_or_enqueue_worker(worker)
+    timeframe_start, timeframe_end = Snapshots::Timeframes.calculate_timeframes(
+      permitted_params[:timeframe],
+      custom_start: permitted_params[:timeframe_custom_start],
+      custom_end: permitted_params[:timeframe_custom_end])
+    cache_key = cache_key_for_timeframe(permitted_params[:timeframe], timeframe_start, timeframe_end)
+    response = Rails.cache.read(cache_key)
+
+    return { results: response } if response
+
+    worker.perform_async(cache_key,
+      @query,
+      @group_by,
+      @diagnostic_id,
+      current_user.id,
+      {
+        name: permitted_params[:timeframe],
+        timeframe_start: timeframe_start,
+        timeframe_end: timeframe_end
+      },
+      permitted_params[:school_ids],
+      {
+        grades: permitted_params[:grades],
+        teacher_ids: permitted_params[:teacher_ids],
+        classroom_ids: permitted_params[:classroom_ids]
+      })
+
+    { message: 'Generating snapshot' }
+  end
+
+  private def cache_key_for_timeframe(timeframe_name, timeframe_start, timeframe_end)
+
+    Snapshots::CacheKeys.generate_key(CACHE_REPORT_NAME,
+      "#{@query}-#{@group_by}-#{@diagnostic_id}",
+      timeframe_name,
+      timeframe_start,
+      timeframe_end,
+      permitted_params.fetch(:school_ids, []),
+      additional_filters: {
+        grades: permitted_params.fetch(:grades, []),
+        teacher_ids: permitted_params.fetch(:teacher_ids, []),
+        classroom_ids: permitted_params.fetch(:classroom_ids, [])
+      })
+  end
+
+  private def permitted_params
+    params.permit(:query,
+      :group_by,
+      :diagnostic_id,
+      :timeframe,
+      :timeframe_custom_start,
+      :timeframe_custom_end,
+      school_ids: [],
+      grades: [],
+      teacher_ids: [],
+      classroom_ids: [])
+  end
+end

--- a/services/QuillLMS/app/controllers/admin_diagnostic_skills_controller.rb
+++ b/services/QuillLMS/app/controllers/admin_diagnostic_skills_controller.rb
@@ -29,7 +29,7 @@ class AdminDiagnosticSkillsController < ApplicationController
 
     return render json: { error: 'diagnostic_id param is required' }, status: 400 unless school_ids_param_valid?
 
-    return render json: { error: 'unrecognized query type for this endpoint' }, status: 400 unless WORKERS_FOR_ACTIONS[action_name]::QUERIES.keys.include?(@query)
+    return render json: { error: 'unrecognized query type for this endpoint' }, status: 400 unless query_param_valid?
   end
 
   private def timeframe_param_valid?
@@ -46,6 +46,10 @@ class AdminDiagnosticSkillsController < ApplicationController
 
   private def diagnostic_id_param_valid?
     permitted_params[:diagnostic_id].present?
+  end
+
+  private def query_param_valid?
+    WORKERS_FOR_ACTIONS[action_name]::QUERIES.keys.include?(@query)
   end
 
   private def authorize_request

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_aggregate_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_aggregate_query.rb
@@ -37,11 +37,7 @@ module AdminDiagnosticReports
       post_process(run_query)
     end
 
-    def run_query
-      runner.execute(union_query)
-    end
-
-    def union_query
+    def query
       <<-SQL
         WITH #{with_sql}
         #{contextual_query}
@@ -56,7 +52,7 @@ module AdminDiagnosticReports
 
     def with_queries
       {
-        aggregate_rows: query
+        aggregate_rows: root_query
       }
     end
 

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_aggregate_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_aggregate_query.rb
@@ -140,8 +140,12 @@ module AdminDiagnosticReports
 
       result.group_by { |row| row[self.class::AGGREGATE_COLUMN] }
         .values
-        .map { |diagnostic_rows| build_diagnostic_aggregates(diagnostic_rows) }
-        .sort_by { |diagnostic| DIAGNOSTIC_ORDER_BY_ID.index(diagnostic[:diagnostic_id]) }
+        .map { |group_rows| build_diagnostic_aggregates(group_rows) }
+        .sort_by { |group| group_sort_by(group) }
+    end
+
+    private def group_sort_by(group)
+      DIAGNOSTIC_ORDER_BY_ID.index(group[:diagnostic_id])
     end
 
     private def build_diagnostic_aggregates(diagnostic_rows)

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query.rb
@@ -9,7 +9,7 @@ module AdminDiagnosticReports
     AGGREGATE_COLUMN = :skill_name
 
     def initialize(diagnostic_id:, **options)
-      raise InvalidDiagnosticIdError, "#{diagnostic_id} is not a valid diagnostic_id value." unless DIAGNOSTIC_ORDER_BY_ID.include?(diagnostic_id)
+      raise InvalidDiagnosticIdError, "#{diagnostic_id} is not a valid diagnostic_id value." unless DIAGNOSTIC_ORDER_BY_ID.include?(diagnostic_id.to_i)
 
       @diagnostic_id = diagnostic_id
 

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+module AdminDiagnosticReports
+  class DiagnosticPerformanceBySkillQuery < DiagnosticAggregateQuery
+    class InvalidDiagnosticIdError < StandardError; end
+
+    attr_reader :diagnostic_id
+
+    AGGREGATE_COLUMN = :skill_name
+
+    def initialize(diagnostic_id:, **options)
+      raise InvalidDiagnosticIdError, "#{diagnostic_id} is not a valid diagnostic_id value." unless DIAGNOSTIC_ORDER_BY_ID.include?(diagnostic_id)
+
+      @diagnostic_id = diagnostic_id
+
+      super(**options)
+    end
+
+    def specific_select_clause
+      <<-SQL
+        students.id AS student_id,
+        MAX(pre_activity_sessions.id) AS pre_activity_session_id,
+        MAX(post_activity_sessions.id) AS post_activity_session_id
+      SQL
+    end
+
+    def from_and_join_clauses
+      super + <<-SQL
+        JOIN lms.activity_sessions AS pre_activity_sessions
+          ON classroom_units.id = pre_activity_sessions.classroom_unit_id
+        JOIN lms.activities
+          ON pre_activity_sessions.activity_id = activities.id
+        JOIN lms.users AS students
+          ON pre_activity_sessions.user_id = students.id
+        LEFT OUTER JOIN lms.activity_sessions AS post_activity_sessions
+          ON activities.follow_up_activity_id = post_activity_sessions.activity_id
+            AND pre_activity_sessions.user_id = post_activity_sessions.user_id
+            AND pre_activity_sessions.completed_at < post_activity_sessions.completed_at
+      SQL
+    end
+
+    def rollup_select_columns
+      "skill_name"
+    end
+
+    def select_clause
+      <<-SQL
+        SELECT
+          #{aggregate_by_clause} AS aggregate_id,
+          #{aggregate_sort_clause} AS name,
+          '#{additional_aggregation}' AS group_by,
+          #{specific_select_clause}
+      SQL
+    end
+
+    def with_queries
+      {
+        most_recent_activity_sessions: query,
+        pre_questions_correct:,
+        pre_skill_scores:,
+        post_questions_correct:,
+        post_skill_scores:,
+        with_improvement:,
+        aggregate_rows: aggregate_query
+      }
+    end
+
+    def pre_questions_correct
+      <<-SQL
+        SELECT
+          student_id,
+          pre_activity_session_id,
+          post_activity_session_id,
+          MAX(STRING(PARSE_JSON(pre_concept_results.extra_metadata).question_uid)) AS pre_question_uid,
+          MAX(CAST(pre_concept_results.correct AS INT64)) AS pre_correct,
+          most_recent_activity_sessions.aggregate_id,
+          most_recent_activity_sessions.name,
+          most_recent_activity_sessions.group_by
+        FROM most_recent_activity_sessions
+        JOIN special.concept_results AS pre_concept_results
+          ON most_recent_activity_sessions.pre_activity_session_id = pre_concept_results.activity_session_id
+        GROUP BY student_id, pre_activity_session_id, post_activity_session_id, pre_concept_results.question_number, aggregate_id, name, group_by
+      SQL
+    end
+
+    def pre_skill_scores
+      <<-SQL
+        SELECT
+          pre_questions_correct.student_id,
+          pre_questions_correct.pre_activity_session_id,
+          pre_questions_correct.post_activity_session_id,
+          pre_skill_groups.name AS skill_name,
+          COUNT(DISTINCT(CASE pre_correct WHEN 1 THEN pre_question_uid ELSE NULL END)) AS pre_correct_total,
+          COUNT(DISTINCT pre_question_uid) AS pre_total_questions,
+          pre_questions_correct.aggregate_id,
+          pre_questions_correct.name,
+          pre_questions_correct.group_by
+        FROM pre_questions_correct
+        JOIN lms.questions AS pre_questions
+          ON pre_questions_correct.pre_question_uid = pre_questions.uid
+        JOIN lms.diagnostic_question_skills AS pre_diagnostic_question_skills
+          ON pre_questions.id = pre_diagnostic_question_skills.question_id
+        JOIN lms.skill_groups AS pre_skill_groups
+          ON pre_diagnostic_question_skills.skill_group_id = pre_skill_groups.id
+        GROUP BY student_id, pre_activity_session_id, post_activity_session_id, pre_skill_groups.name, aggregate_id, name, group_by
+      SQL
+    end
+
+    def post_questions_correct
+      <<-SQL
+        SELECT
+          student_id,
+          pre_activity_session_id,
+          post_activity_session_id,
+          MAX(STRING(PARSE_JSON(post_concept_results.extra_metadata).question_uid)) AS post_question_uid,
+          MAX(CAST(post_concept_results.correct AS INT64)) AS post_correct,
+          most_recent_activity_sessions.aggregate_id,
+          most_recent_activity_sessions.name,
+          most_recent_activity_sessions.group_by
+        FROM most_recent_activity_sessions
+        JOIN special.concept_results AS post_concept_results
+          ON most_recent_activity_sessions.post_activity_session_id = post_concept_results.activity_session_id
+        GROUP BY student_id, pre_activity_session_id, post_activity_session_id, post_concept_results.question_number, aggregate_id, name, group_by
+      SQL
+    end
+
+    def post_skill_scores
+      <<-SQL
+        SELECT
+          post_questions_correct.student_id,
+          post_questions_correct.pre_activity_session_id,
+          post_questions_correct.post_activity_session_id,
+          post_skill_groups.name AS skill_name,
+          COUNT(DISTINCT(CASE post_correct WHEN 1 THEN post_question_uid ELSE NULL END)) AS post_correct_total,
+          COUNT(DISTINCT post_question_uid) AS post_total_questions,
+          post_questions_correct.aggregate_id,
+          post_questions_correct.name,
+          post_questions_correct.group_by
+        FROM post_questions_correct
+        JOIN lms.questions AS post_questions
+          ON post_questions_correct.post_question_uid = post_questions.uid
+        JOIN lms.diagnostic_question_skills AS post_diagnostic_question_skills
+          ON post_questions.id = post_diagnostic_question_skills.question_id
+        JOIN lms.skill_groups AS post_skill_groups
+          ON post_diagnostic_question_skills.skill_group_id = post_skill_groups.id
+        GROUP BY student_id, pre_activity_session_id, post_activity_session_id, post_skill_groups.name, aggregate_id, name, group_by
+      SQL
+    end
+
+    def with_improvement
+      <<-SQL
+        SELECT
+          most_recent_activity_sessions.student_id,
+          most_recent_activity_sessions.pre_activity_session_id,
+          most_recent_activity_sessions.post_activity_session_id,
+          most_recent_activity_sessions.aggregate_id,
+          most_recent_activity_sessions.name,
+          most_recent_activity_sessions.group_by,
+          COUNT(DISTINCT post_skill_scores.student_id) AS total_students,
+          COUNT(DISTINCT CASE WHEN
+            (pre_correct_total = pre_total_questions
+              AND post_correct_total = post_total_questions
+            ) THEN post_skill_scores.student_id ELSE NULL END) AS maintained_proficiency,
+          COUNT(DISTINCT CASE WHEN
+            (pre_correct_total < pre_total_questions
+              AND post_correct_total > pre_correct_total
+            ) THEN post_skill_scores.student_id ELSE NULL END) AS improved_proficiency,
+          COUNT(DISTINCT CASE WHEN
+            (pre_correct_total < pre_total_questions
+              AND post_correct_total <= pre_correct_total
+            ) THEN post_skill_scores.student_id ELSE NULL END) AS recommended_practice
+        FROM most_recent_activity_sessions
+        JOIN pre_skill_scores
+          ON most_recent_activity_sessions.pre_activity_session_id = pre_skill_scores.pre_activity_session_id
+        LEFT OUTER JOIN post_skill_scores
+          ON most_recent_activity_sessions.post_activity_session_id = post_skill_scores.post_activity_session_id
+            AND pre_skill_scores.skill_name = post_skill_scores.skill_name
+        GROUP BY most_recent_activity_sessions.student_id, most_recent_activity_sessions.pre_activity_session_id, most_recent_activity_sessions.post_activity_session_id, aggregate_id, name, group_by
+      SQL
+    end
+
+    def aggregate_query
+      <<-SQL
+        SELECT
+          pre_skill_scores.skill_name,
+          with_improvement.aggregate_id,
+          with_improvement.name,
+          with_improvement.group_by,
+          #{rollup_aggregation_select}
+        FROM most_recent_activity_sessions
+        JOIN pre_skill_scores
+          ON most_recent_activity_sessions.pre_activity_session_id = pre_skill_scores.pre_activity_session_id
+        LEFT OUTER JOIN post_skill_scores
+          ON most_recent_activity_sessions.post_activity_session_id = post_skill_scores.post_activity_session_id
+            AND pre_skill_scores.skill_name = post_skill_scores.skill_name
+        LEFT OUTER JOIN with_improvement
+          ON most_recent_activity_sessions.student_id = with_improvement.student_id
+        GROUP BY aggregate_id, name, skill_name, group_by
+      SQL
+    end
+
+    def relevant_diagnostic_where_clause
+        "AND activities.id = #{diagnostic_id}"
+    end
+
+    def group_by_clause
+      "GROUP BY aggregate_id, #{aggregate_sort_clause}, student_id"
+    end
+
+    def relevant_date_column
+      "pre_activity_sessions.completed_at"
+    end
+
+    private def rollup_aggregation_hash
+      {
+        pre_score: percentage_aggregate(:pre_correct_total, :pre_total_questions),
+        post_score: percentage_aggregate(:post_correct_total, :post_total_questions),
+        pre_correct_total: sum_aggregate,
+        pre_total_questions: sum_aggregate,
+        post_correct_total: sum_aggregate,
+        post_total_questions: sum_aggregate,
+        total_students: sum_aggregate,
+        maintained_proficiency: sum_aggregate,
+        improved_proficiency: sum_aggregate,
+        recommended_practice: sum_aggregate
+      }
+    end
+  end
+end

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query.rb
@@ -55,7 +55,7 @@ module AdminDiagnosticReports
 
     def with_queries
       {
-        most_recent_activity_sessions: query,
+        most_recent_activity_sessions: root_query,
         pre_questions_correct:,
         pre_skill_scores:,
         post_questions_correct:,

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_completed_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_completed_query.rb
@@ -2,7 +2,7 @@
 
 module AdminDiagnosticReports
   class PostDiagnosticCompletedQuery < DiagnosticAggregateQuery
-    def query
+    def root_query
       <<-SQL
         SELECT
             diagnostic_id,

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_completed_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_completed_query.rb
@@ -2,7 +2,7 @@
 
 module AdminDiagnosticReports
   class PreDiagnosticCompletedQuery < DiagnosticAggregateQuery
-    def query
+    def root_query
       <<-SQL
         SELECT
             diagnostic_id,

--- a/services/QuillLMS/app/queries/quill_big_query/query.rb
+++ b/services/QuillLMS/app/queries/quill_big_query/query.rb
@@ -17,6 +17,10 @@ module QuillBigQuery
     end
 
     def query
+      root_query
+    end
+
+    def root_query
       <<-SQL
         #{select_clause}
         #{from_and_join_clauses}

--- a/services/QuillLMS/app/workers/admin_diagnostic_reports/diagnostic_skills_worker.rb
+++ b/services/QuillLMS/app/workers/admin_diagnostic_reports/diagnostic_skills_worker.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module AdminDiagnosticReports
+  class DiagnosticSkillsWorker
+    include Sidekiq::Worker
+
+    PUSHER_EVENT = 'admin-diagnostic-skill-cached'
+    TOO_SLOW_THRESHOLD = 20
+
+    class SlowQueryError < StandardError
+      def message
+        "Diagnostic Skill query took more than #{TOO_SLOW_THRESHOLD}"
+      end
+    end
+
+    QUERIES = {
+      'diagnostic-skills' => DiagnosticPerformanceBySkillQuery
+    }
+
+    def perform(cache_key, query, aggregation, diagnostic_id, user_id, timeframe, school_ids, filters)
+      payload = generate_payload(query, aggregation, diagnostic_id, timeframe, school_ids, filters)
+
+      Rails.cache.write(cache_key, payload, expires_in: cache_expiry)
+
+      filter_hash = PayloadHasher.run([
+        query,
+        aggregation,
+        diagnostic_id,
+        timeframe['name'],
+        school_ids,
+        filters['grades'],
+        filters['teacher_ids'],
+        filters['classroom_ids']
+      ].flatten)
+      SendPusherMessageWorker.perform_async(user_id, PUSHER_EVENT, filter_hash)
+    end
+
+    private def cache_expiry
+      # We need to pass a number of seconds to Redis as a TTL value, and we
+      # want to expire our caches overnight so that each day reports can be
+      # updated, so we want the number of seconds until end of day
+      now = DateTime.current
+      now.end_of_day.to_i - now.to_i
+    end
+
+    private def generate_payload(query, aggregation, diagnostic_id, timeframe, school_ids, filters)
+      timeframe_start = parse_datetime_string(timeframe['timeframe_start'])
+      timeframe_end = parse_datetime_string(timeframe['timeframe_end'])
+      filters_symbolized = filters.symbolize_keys
+
+      long_process_notifier = LongProcessNotifier.new(
+        SlowQueryError.new,
+        TOO_SLOW_THRESHOLD,
+        {
+          query:,
+          aggregation:,
+          diagnostic_id:,
+          timeframe_start:,
+          timeframe_end:,
+          school_ids:
+        }.merge(filters_symbolized)
+      )
+
+      long_process_notifier.run do
+        QUERIES[query].run(**{
+          aggregation:,
+          diagnostic_id:,
+          timeframe_start:,
+          timeframe_end:,
+          school_ids:
+        }.merge(filters_symbolized))
+      end
+    end
+
+    private def parse_datetime_string(value)
+      return nil if value.nil?
+
+      DateTime.parse(value)
+    end
+  end
+end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -751,6 +751,12 @@ EmpiricalGrammar::Application.routes.draw do
     end
   end
 
+  resources :admin_diagnostic_skills, only: [] do
+    collection do
+      post :report
+    end
+  end
+
   other_pages = %w(
     beta
     board

--- a/services/QuillLMS/spec/controllers/admin_diagnostic_skills_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/admin_diagnostic_skills_controller_spec.rb
@@ -21,9 +21,10 @@ describe AdminDiagnosticSkillsController, type: :controller do
     let(:school_ids) { [school.id.to_s] }
     let(:controller_actions) {
       [
-        [:report, 'pre-diagnostic-assigned']
+        [:report, 'diagnostic-skills']
       ]
     }
+    let(:query_name) { 'diagnostic-skills' }
     let(:previous_start) { now - 1.day }
     let(:previous_end) { current_start }
     let(:current_start) { now }
@@ -39,8 +40,7 @@ describe AdminDiagnosticSkillsController, type: :controller do
     end
 
     context 'cache key generation' do
-      let(:query) { 'pre-diagnostic-assigned' }
-      let(:query_group_by) { "#{query}-#{group_by}-#{diagnostic_id}" }
+      let(:query_group_by) { "#{query_name}-#{group_by}-#{diagnostic_id}" }
       let(:grades) { ['Kindergarten', '1'] }
       let(:teacher_ids) { ['4', '5'] }
       let(:classroom_ids) { ['7', '8'] }
@@ -63,7 +63,7 @@ describe AdminDiagnosticSkillsController, type: :controller do
             classroom_ids: classroom_ids
           })
 
-        post :report, params: { query: query, group_by: group_by, diagnostic_id: diagnostic_id, timeframe: timeframe_name, school_ids: school_ids, grades: grades, teacher_ids: teacher_ids, classroom_ids: classroom_ids }
+        post :report, params: { query: query_name, group_by: group_by, diagnostic_id: diagnostic_id, timeframe: timeframe_name, school_ids: school_ids, grades: grades, teacher_ids: teacher_ids, classroom_ids: classroom_ids }
       end
     end
 
@@ -157,8 +157,6 @@ describe AdminDiagnosticSkillsController, type: :controller do
         let(:current_end) { 'TIMEFRAME_END' }
 
         it 'should trigger a job to cache data if the cache is empty for counts' do
-          query_name = 'pre-diagnostic-assigned'
-
           allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
           expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
           expect(AdminDiagnosticReports::DiagnosticSkillsWorker).to receive(:perform_async).with(cache_key,
@@ -186,7 +184,6 @@ describe AdminDiagnosticSkillsController, type: :controller do
         end
 
         it 'should include school_ids and grades in the call to the cache worker if they are in params' do
-          query_name = 'pre-diagnostic-assigned'
           grades = ["Kindergarten", "1", "2"]
           teacher_ids = ['3', '4']
           classroom_ids = ['5', '6', '7']
@@ -214,7 +211,6 @@ describe AdminDiagnosticSkillsController, type: :controller do
         end
 
         it 'should properly calculate custom timeframes' do
-          query_name = 'pre-diagnostic-assigned'
           timeframe_name = 'custom'
           current_end = DateTime.now.change(usec: 0)
           timeframe_length = 3.days

--- a/services/QuillLMS/spec/controllers/admin_diagnostic_skills_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/admin_diagnostic_skills_controller_spec.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AdminDiagnosticSkillsController, type: :controller do
+  let(:school) { create(:school) }
+  let(:user) { create(:user, administered_schools: [school]) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  context "#actions" do
+    let(:cache_key) { 'CACHE_KEY' }
+    let(:timeframe_name) { 'last-30-days' }
+    let(:now) { DateTime.current }
+    let(:current_snapshot_stub) { 'CURRENT' }
+    let(:previous_snapshot_stub) { 'PREVIOUS' }
+    let(:group_by) { 'grade' }
+    let(:diagnostic_id) { '1663' }
+    let(:school_ids) { [school.id.to_s] }
+    let(:controller_actions) {
+      [
+        [:report, 'pre-diagnostic-assigned']
+      ]
+    }
+    let(:previous_start) { now - 1.day }
+    let(:previous_end) { current_start }
+    let(:current_start) { now }
+    let(:current_end) { now + 1.day }
+    let(:previous_timeframe) { [previous_start, previous_end] }
+    let(:current_timeframe) { [current_start, current_end] }
+    let(:timeframes) { current_timeframe }
+
+    let(:json_response) { JSON.parse(response.body) }
+
+    before do
+      allow(DateTime).to receive(:current).and_return(now)
+    end
+
+    context 'cache key generation' do
+      let(:query) { 'pre-diagnostic-assigned' }
+      let(:query_group_by) { "#{query}-#{group_by}-#{diagnostic_id}" }
+      let(:grades) { ['Kindergarten', '1'] }
+      let(:teacher_ids) { ['4', '5'] }
+      let(:classroom_ids) { ['7', '8'] }
+
+      before do
+        allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
+      end
+
+      it do
+        expect(Snapshots::CacheKeys).to receive(:generate_key).with(
+          described_class::CACHE_REPORT_NAME,
+          query_group_by,
+          timeframe_name,
+          current_start,
+          current_end,
+          school_ids,
+          additional_filters: {
+            grades: grades,
+            teacher_ids: teacher_ids,
+            classroom_ids: classroom_ids
+          })
+
+        post :report, params: { query: query, group_by: group_by, diagnostic_id: diagnostic_id, timeframe: timeframe_name, school_ids: school_ids, grades: grades, teacher_ids: teacher_ids, classroom_ids: classroom_ids }
+      end
+    end
+
+    context 'stub caching logic' do
+      before do
+        allow(controller).to receive(:cache_key_for_timeframe).and_return(cache_key)
+      end
+
+      it 'should return the value in the cache assigned to the `results` key if it is available for all actions' do
+        cache_payload = {
+          "current" => "CURRENT",
+          "previous" => "PREVIOUS"
+        }
+        expected_response = { "results" => cache_payload }
+
+        expect(Rails.cache).to receive(:read).exactly(controller_actions.length).times.with(cache_key).and_return(cache_payload)
+
+        controller_actions.each do |action, query_name|
+          post action, params: { query: query_name, timeframe: timeframe_name, school_ids: school_ids }
+
+          json_response = JSON.parse(response.body)
+
+          expect(json_response).to eq(expected_response)
+        end
+      end
+
+      context 'authentication' do
+        it 'should return a 403 if the current_user is not an admin for all of the school_ids provided' do
+          school2 = create(:school)
+          expanded_school_ids = school_ids + [school2.id.to_s]
+
+          controller_actions.each do |action, query_name|
+            post action, params: { query: query_name, timeframe: timeframe_name, school_ids: expanded_school_ids }
+
+            expect(response.status).to eq(403)
+          end
+        end
+      end
+
+      context 'param validation' do
+        it 'should 400 if the timeframe param is not provided' do
+          controller_actions.each do |action, query_name|
+            post action, params: { query: query_name, school_ids: school_ids }
+
+            expect(response.status).to eq(400)
+            expect(json_response['error']).to eq('timeframe must be present and valid')
+          end
+        end
+
+        it 'should 400 if the timeframe param is not from the TIMEFRAME list' do
+          controller_actions.each do |action, query_name|
+            post action, params: { query: query_name, timeframe: 'INVALID_TIMEFRAME', school_ids: school_ids }
+
+            expect(response.status).to eq(400)
+            expect(json_response['error']).to eq('timeframe must be present and valid')
+          end
+        end
+
+        it 'should 400 if the school_ids param is not provided' do
+          controller_actions.each do |action, query_name|
+            post action, params: { query: query_name, timeframe: timeframe_name }
+
+            expect(response.status).to eq(400)
+            expect(json_response['error']).to eq('school_ids are required')
+          end
+        end
+
+        it 'should 400 if the school_ids param is empty' do
+          controller_actions.each do |action, query_name|
+            post action, params: { query: query_name, timeframe: timeframe_name, school_ids: [] }
+
+            expect(response.status).to eq(400)
+            expect(json_response['error']).to eq('school_ids are required')
+          end
+        end
+
+        it 'should 400 if the query name provided is not valid for the endpoint' do
+          controller_actions.each do |action, _|
+            post action, params: { query: 'INVALID_QUERY_NAME', timeframe: timeframe_name, school_ids: [1] }
+
+            expect(response.status).to eq(400)
+            expect(json_response['error']).to eq('unrecognized query type for this endpoint')
+          end
+        end
+      end
+
+      context 'param variation' do
+        let(:previous_start) { 'PREVIOUS_TIMEFRAME' }
+        let(:previous_end) { 'PREVIOUS_END' }
+        let(:current_start) { 'CURRENT_TIMEFRAME' }
+        let(:current_end) { 'TIMEFRAME_END' }
+
+        it 'should trigger a job to cache data if the cache is empty for counts' do
+          query_name = 'pre-diagnostic-assigned'
+
+          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
+          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+          expect(AdminDiagnosticReports::DiagnosticSkillsWorker).to receive(:perform_async).with(cache_key,
+            query_name,
+            group_by,
+            diagnostic_id,
+            user.id,
+            {
+              name: timeframe_name,
+              timeframe_start: current_start,
+              timeframe_end: current_end
+            },
+            school_ids,
+            {
+              grades: nil,
+              teacher_ids: nil,
+              classroom_ids: nil
+            })
+
+          post :report, params: { query: query_name, group_by: group_by, diagnostic_id: diagnostic_id, timeframe: timeframe_name, school_ids: school_ids }
+
+          json_response = JSON.parse(response.body)
+
+          expect(json_response).to eq("message" => "Generating snapshot")
+        end
+
+        it 'should include school_ids and grades in the call to the cache worker if they are in params' do
+          query_name = 'pre-diagnostic-assigned'
+          grades = ["Kindergarten", "1", "2"]
+          teacher_ids = ['3', '4']
+          classroom_ids = ['5', '6', '7']
+
+          allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)
+          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+          expect(AdminDiagnosticReports::DiagnosticSkillsWorker).to receive(:perform_async).with(cache_key,
+            query_name,
+            group_by,
+            diagnostic_id,
+            user.id,
+            {
+              name: timeframe_name,
+              timeframe_start: current_start,
+              timeframe_end: current_end
+            },
+            school_ids,
+            {
+              grades: grades,
+              teacher_ids: teacher_ids,
+              classroom_ids: classroom_ids
+            })
+
+          post :report, params: { query: query_name, group_by: group_by, diagnostic_id: diagnostic_id, timeframe: timeframe_name, school_ids: school_ids, grades: grades, teacher_ids: teacher_ids, classroom_ids: classroom_ids }
+        end
+
+        it 'should properly calculate custom timeframes' do
+          query_name = 'pre-diagnostic-assigned'
+          timeframe_name = 'custom'
+          current_end = DateTime.now.change(usec: 0)
+          timeframe_length = 3.days
+          current_start = current_end - timeframe_length
+
+          expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+          expect(AdminDiagnosticReports::DiagnosticSkillsWorker).to receive(:perform_async).with(cache_key,
+            query_name,
+            group_by,
+            diagnostic_id,
+            user.id,
+            {
+              name: timeframe_name,
+              timeframe_start: current_start,
+              timeframe_end: current_end
+            },
+            school_ids,
+            {
+              grades: nil,
+              teacher_ids: nil,
+              classroom_ids: nil
+            })
+
+          post :report, params: { query: query_name, group_by: group_by, diagnostic_id: diagnostic_id, timeframe: timeframe_name, timeframe_custom_start: current_start.to_s, timeframe_custom_end: current_end.to_s, school_ids: school_ids }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_aggregate_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_aggregate_query_spec.rb
@@ -11,7 +11,8 @@ module AdminDiagnosticReports
         def specific_select_clause
           <<-SQL
             COUNT(classroom_units.id) AS classroom_unit_count,
-            COUNT(users.id) AS teacher_count
+            COUNT(users.id) AS teacher_count,
+            0 AS percentage
           SQL
         end
 
@@ -31,7 +32,8 @@ module AdminDiagnosticReports
         private def rollup_aggregation_hash
           {
             classroom_unit_count: sum_aggregate,
-            teacher_count: average_aggregate(:classroom_unit_count)
+            teacher_count: average_aggregate(:classroom_unit_count),
+            percentage: percentage_aggregate(:classroom_unit_count, :teacher_count)
           }
         end
       end
@@ -79,6 +81,7 @@ module AdminDiagnosticReports
       it { expect(results.first[:diagnostic_name]).to eq(pre_diagnostic.name) }
       it { expect(results.first[:classroom_unit_count]).to eq(classroom_units.length) }
       it { expect(results.first[:teacher_count]).to eq(teachers.length / classroom_units.length) }
+      it { expect(results.first[:percentage]).to eq(classroom_units.length / teachers.length * 100) }
 
       context 'aggregate_rows ordering' do
         it { expect(results.first[:aggregate_rows].first[:name]).to eq('Kindergarten') }

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AdminDiagnosticReports
+  describe DiagnosticPerformanceBySkillQuery do
+    include_context 'Admin Diagnostic Aggregate CTE'
+
+    context 'big_query_snapshot', :big_query_snapshot do
+      subject { results }
+
+      let(:classrooms) { Array.new(num_classrooms) { |i| create(:classroom, grade: i + 1) } }
+      let(:classroom_units) { classrooms.map { |classroom| create(:classroom_unit, classroom: classroom) } }
+      let(:post_classroom_units) { classrooms.map { |classroom| create(:classroom_unit, classroom: classroom) } }
+      let(:pre_activity_sessions) { classroom_units.map { |classroom_unit| create(:activity_session, :finished, classroom_unit: classroom_unit, activity: pre_diagnostic) } }
+      let(:post_activity_sessions) { pre_activity_sessions.map { |pre_activity_session| create(:activity_session, :finished, classroom_unit: pre_activity_session.classroom_unit, activity: post_diagnostic, user: pre_activity_session.user, completed_at: pre_activity_session.completed_at + 1.day) } }
+      let(:students) { pre_activity_sessions.map(&:user) }
+
+      let(:skill_group) { create(:skill_group) }
+      let(:pre_correct_count) { 5 }
+      let(:pre_incorrect_count) { 5 }
+      let(:pre_questions) { Array.new(pre_correct_count + pre_incorrect_count) { create(:question) } }
+      let(:post_correct_count) { 10 }
+      let(:post_incorrect_count) { 0 }
+      let(:post_questions) { Array.new(post_correct_count + post_incorrect_count) { create(:question) } }
+      let(:questions) { pre_questions + post_questions }
+      let(:diagnostic_question_skills) { (questions).map{ |question| create(:diagnostic_question_skill, question: question, skill_group: skill_group) } }
+
+      def concept_results_for_activity_session(activity_session, questions, correct_count)
+        [
+          Array.new(correct_count) { |i| create(:concept_result, activity_session: activity_session, question_number: i + 1, extra_metadata: {question_uid: questions[i].uid}, correct: true) },
+          Array.new(questions.length - correct_count) { |i| create(:concept_result, activity_session: activity_session, question_number: i + 1 + correct_count, extra_metadata: {question_uid: questions[i + correct_count].uid}, correct: false) }
+        ].flatten
+      end
+
+      let(:concept_results) do
+        [
+          pre_activity_sessions.map { |activity_session| concept_results_for_activity_session(activity_session, pre_questions, pre_correct_count) },
+          post_activity_sessions.map { |activity_session| concept_results_for_activity_session(activity_session, post_questions, post_correct_count) }
+        ]
+      end
+
+      let(:diagnostic_id) { pre_diagnostic.id }
+
+      let(:query_args) do
+        {
+          timeframe_start: timeframe_start,
+          timeframe_end: timeframe_end,
+          school_ids: school_ids,
+          grades: grades,
+          teacher_ids: teacher_ids,
+          classroom_ids: classroom_ids,
+          aggregation: aggregation_arg,
+          diagnostic_id: diagnostic_id
+        }
+      end
+
+      # Some of our tests include activity_sessions having NULL in its timestamps so we need a version that has timestamps with datetime data in them so that WITH in the CTE understands the data type expected
+      let(:reference_activity_session) { create(:activity_session, :finished) }
+
+      let(:cte_records) do
+        [
+          classrooms,
+          teachers,
+          students,
+          classrooms_teachers,
+          schools,
+          schools_users,
+          classroom_units,
+          pre_activity_sessions,
+          post_activity_sessions,
+          concept_results,
+          pre_diagnostic,
+          post_diagnostic,
+          reference_activity_session,
+          questions,
+          diagnostic_question_skills,
+          skill_group
+        ]
+      end
+
+      context 'invalid diagnostic id' do
+        let(:diagnostic_id) { 1 }
+
+        it { expect{ subject }.to raise_error(DiagnosticPerformanceBySkillQuery::InvalidDiagnosticIdError) }
+      end
+
+      # Ideally we'd break this up into multiple cases, and also account for more varied inputs, but for some reason this query takes 15-ish seconds to run even with this dummy data, so writing a bunch of separate cases would balloon our run time.  Writing one super-case for now.
+      # TODO: Come back and expand the test cases in this spec once they can be run in reasonable time
+      it 'maximal results test' do
+        result = results.first
+        all_pre_concept_results = pre_activity_sessions.map(&:concept_results).flatten
+        all_post_concept_results = post_activity_sessions.map(&:concept_results).flatten
+
+        expect(result[:aggregate_rows].length).to eq(classrooms.map(&:grade).uniq.length)
+        expect(result[:skill_name]).to eq(skill_group.name)
+        expect(result[:pre_score]).to eq(all_pre_concept_results.select { |cr| cr.correct }.length.to_f / all_pre_concept_results.length * 100)
+        expect(result[:post_score]).to eq(all_post_concept_results.select { |cr| cr.correct }.length.to_f / all_post_concept_results.length * 100)
+        expect(result[:pre_correct_total]).to eq(all_pre_concept_results.select { |cr| cr.correct }.length)
+        expect(result[:pre_total_questions]).to eq(all_pre_concept_results.length)
+        expect(result[:post_correct_total]).to eq(all_post_concept_results.select { |cr| cr.correct }.length)
+        expect(result[:post_total_questions]).to eq(all_post_concept_results.length)
+
+        # The setup for these tests gives users 50% correct rates on their pre-diagnostic, and 100% correct rates on their post-diagnostic, which correspond to "imrpoved proficiency"
+        expect(result[:maintained_proficiency]).to eq(0)
+        expect(result[:improved_proficiency]).to eq(post_activity_sessions.length)
+        expect(result[:recommended_practice]).to eq(0)
+
+        [:pre_correct_total, :pre_total_questions, :post_correct_total, :post_correct_total, :maintained_proficiency, :improved_proficiency, :recommended_practice].each do |column_name|
+          expect(result[column_name]).to eq(result[:aggregate_rows].map { |row| row[column_name] }.sum)
+        end
+      end
+
+      # TODO: Here's a list of edge cases we should consider covering once runtimes are reasonable
+      # no completed activity_sessions
+      # pre activity_sessions only
+      ## count total questions
+      ### with multiple attempts
+      ## count total correct answers
+      ### with multiple attempts
+      # pre and post activity_sessions
+      ## count total questions
+      ### with multiple attempts
+      ## count total correct answers
+      ### with multiple attempts
+      # pre and post activity sessions plus second pre
+      # two sets of pre and post activity_sessions
+      # score calculations
+      ## pre activity_session only
+      ## pre and post activity_sessions
+      # proficiency gain logic
+      ## pre activity_session only
+      ## 0 score for pre
+      ### partial score for post
+      ### full score for post
+      ## partial score for pre
+      ### lower score for post
+      ### equal score for post
+      ### higher score for post
+      ### max score for post
+      ## max score for pre
+      ### lower score for post
+      ### same score for post
+      ### higher score for post
+      ### max score for pre
+
+    end
+  end
+end

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_query_spec.rb
@@ -94,14 +94,14 @@ module AdminDiagnosticReports
 
         expect(result[:aggregate_rows].length).to eq(classrooms.map(&:grade).uniq.length)
         expect(result[:skill_name]).to eq(skill_group.name)
-        expect(result[:pre_score]).to eq(all_pre_concept_results.select { |cr| cr.correct }.length.to_f / all_pre_concept_results.length * 100)
+        expect(result[:pre_score]).to eq(all_pre_concept_results.select(&:correct).length.to_f / all_pre_concept_results.length * 100)
         expect(result[:post_score]).to eq(all_post_concept_results.select { |cr| cr.correct }.length.to_f / all_post_concept_results.length * 100)
         expect(result[:pre_correct_total]).to eq(all_pre_concept_results.select { |cr| cr.correct }.length)
         expect(result[:pre_total_questions]).to eq(all_pre_concept_results.length)
         expect(result[:post_correct_total]).to eq(all_post_concept_results.select { |cr| cr.correct }.length)
         expect(result[:post_total_questions]).to eq(all_post_concept_results.length)
 
-        # The setup for these tests gives users 50% correct rates on their pre-diagnostic, and 100% correct rates on their post-diagnostic, which correspond to "imrpoved proficiency"
+        # The setup for these tests gives users 50% correct rates on their pre-diagnostic, and 100% correct rates on their post-diagnostic, which correspond to "improved proficiency"
         expect(result[:maintained_proficiency]).to eq(0)
         expect(result[:improved_proficiency]).to eq(post_activity_sessions.length)
         expect(result[:recommended_practice]).to eq(0)

--- a/services/QuillLMS/spec/workers/admin_diagnostic_reports/diagnostic_skills_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/admin_diagnostic_reports/diagnostic_skills_worker_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AdminDiagnosticReports
+  describe DiagnosticSkillsWorker, type: :worker do
+    subject { described_class.new }
+
+    let(:cache_key) { 'CACHE_KEY' }
+    let(:query) { 'diagnostic-skills' }
+    let(:aggregation) { 'grade' }
+    let(:diagnostic_id) { '1663' }
+    let(:user_id) { 123 }
+    let(:timeframe_name) { 'last-30-days' }
+    let(:school_ids) { [1,2,3] }
+    let(:grades) { ['Kindergarten',1,2,3,4] }
+    let(:teacher_ids) { [3,4,5] }
+    let(:classroom_ids) { [6,7] }
+    let(:filters) do
+      {
+        grades: grades,
+        teacher_ids: teacher_ids,
+        classroom_ids: classroom_ids
+      }
+    end
+    let(:filters_with_string_keys) { filters.stringify_keys }
+    let(:query_double) { double(run: {}) }
+
+    it { expect { described_class::QUERIES.values }.not_to raise_error }
+
+    context '#perform' do
+      let(:perform) { subject.perform(cache_key, query, aggregation, diagnostic_id, user_id, timeframe, school_ids, filters) }
+      let(:timeframe_end) { DateTime.now }
+      let(:current_timeframe_start) { timeframe_end - 30.days }
+      let(:timeframe) {
+        {
+          'name' => timeframe_name,
+          'timeframe_start' => current_timeframe_start.to_s,
+          'timeframe_end' => timeframe_end.to_s
+        }
+      }
+      let(:expected_query_args) {
+        {
+          aggregation: aggregation,
+          diagnostic_id: diagnostic_id,
+          timeframe_start: current_timeframe_start,
+          timeframe_end: timeframe_end,
+          school_ids: school_ids,
+          grades: grades,
+          teacher_ids: teacher_ids,
+          classroom_ids: classroom_ids
+        }
+      }
+
+      before do
+        stub_const("AdminDiagnosticReports::DiagnosticSkillsWorker::QUERIES", {
+          query => query_double
+        })
+      end
+
+      it 'should execute a query for the timeframe' do
+        expect(query_double).to receive(:run).with(expected_query_args)
+        expect(Rails.cache).to receive(:write)
+        expect(SendPusherMessageWorker).to receive(:perform_async)
+
+        perform
+      end
+
+      context 'serialization/deserialization' do
+        it 'should deserialize timeframes back into DateTimes' do
+          allow(SendPusherMessageWorker).to receive(:perform_async)
+          Sidekiq::Testing.inline! do
+            expect(query_double).to receive(:run).with(expected_query_args)
+
+            described_class.perform_async(cache_key, query, aggregation, diagnostic_id, user_id, timeframe, school_ids, filters)
+          end
+        end
+      end
+
+      context "params with string keys" do
+        it 'should execute a query for the timeframe' do
+          expect(query_double).to receive(:run).with(expected_query_args)
+          expect(Rails.cache).to receive(:write)
+          expect(SendPusherMessageWorker).to receive(:perform_async)
+
+          subject.perform(cache_key, query, aggregation, diagnostic_id, user_id, timeframe, school_ids, filters_with_string_keys)
+        end
+      end
+
+      it 'should write a payload to cache' do
+        cache_ttl = 1
+        payload = [{ value: 'Some Thing', count: 10 }]
+
+        expect(subject).to receive(:cache_expiry).and_return(cache_ttl)
+
+        expect(query_double).to receive(:run).and_return(payload)
+        expect(Rails.cache).to receive(:write).with(cache_key, payload, expires_in: cache_ttl)
+        expect(SendPusherMessageWorker).to receive(:perform_async)
+
+        perform
+      end
+
+      it 'should send a Pusher notification' do
+        hashed_payload = PayloadHasher.run([
+          query,
+          aggregation,
+          diagnostic_id,
+          timeframe_name,
+          school_ids,
+          grades,
+          teacher_ids,
+          classroom_ids
+        ].flatten)
+
+        expect(Rails.cache).to receive(:write)
+        expect(SendPusherMessageWorker).to receive(:perform_async).with(user_id, described_class::PUSHER_EVENT, hashed_payload)
+
+        subject.perform(cache_key, query, aggregation, diagnostic_id, user_id, timeframe, school_ids, filters_with_string_keys)
+      end
+
+      context 'slow query reporting' do
+        let(:start) { 0 }
+        let(:finish) { described_class::TOO_SLOW_THRESHOLD }
+
+        before { allow(LongProcessNotifier).to receive(:current_time).and_return(start, finish) }
+
+        it do
+          allow(PusherTrigger).to receive(:run)
+          expect(ErrorNotifier).to receive(:report)
+          perform
+        end
+
+        context 'query takes less time than threshold' do
+          let(:finish) { start }
+
+          it do
+            allow(PusherTrigger).to receive(:run)
+            expect(ErrorNotifier).not_to receive(:report)
+            perform
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
- Add a new query to aggregate Diagnostic data for admins by skill (instead of by diagnostic)
- Add a worker and controller to cache and fetch the data from this query

NOTE: This query is currently quite time-consuming (~15 seconds regardless of the size of the dataset being analyzed).  We're intent is to address performance concerns with BigQuery in general next.
## WHY
- We need this data for the "By Skill" part of the Admin Diagnostic reports
- We have an established pattern for these workers and controllers, so we're just doing a bunch of copy/paste work here.  We should follow this project up with a refactor to consolidate the shared logic into some sort of shared code rather than doing all of this duplication
## HOW
- The nature of the data calculation we need to do involves multiple steps of aggregation.  In order to facilitate this, I developed a query with a series of `WITH` statements that feed into each other to successively aggregate the necessary data.  This involved a mild refactor of the parent query in order to support an arbitrary number of `WITH` statements
- - This also involved adding support for a new "type" of aggregation in the parent query to handle the calculation of percentages
- Copy and paste from the reference worker and controller (in this case, the one for the Admin Diagnostic Overview), and modify as appropriate

### Notion Card Links
https://www.notion.so/quill/Admin-Diagnostic-Growth-Report-Growth-Per-Skill-1cdc878fb976477ea40089ddef6711ca?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
