### PR TITLE
fix window.scrollTo test error

### DIFF
--- a/services/QuillLMS/client/setupTests.ts
+++ b/services/QuillLMS/client/setupTests.ts
@@ -40,3 +40,5 @@ global.IntersectionObserver = class IntersectionObserver {
 };
 
 window.process.env = processEnvMock.env
+
+window.scrollTo = jest.fn();


### PR DESCRIPTION
## WHAT
Fix window.scrollTo error in Jest tests

## WHY
This is one of the console errors we were trying to address, but is actually just a Jest thing, and intersects with work PK is doing with Vite (where it looks like this error causes actual failures, not just warnings).

## HOW
Just mock this behavior.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Console-log-cleanup-Not-implemented-window-scrollTo-15-7c17b5ad74b6465e897e6e458fe32669?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Updated setupTests
Have you deployed to Staging? |  NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A