### PR TITLE
Remove google logo on button

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/link_provider_account_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/link_provider_account_modal.tsx
@@ -21,7 +21,7 @@ const LinkProviderAccountModal = ({ link, close, provider, user }: LinkProviderA
     let buttonClass = 'quill-button contained primary medium';
 
     if (termsAccepted) {
-      if (provider === 'Google') { return <AuthGoogleAccessForm buttonClass={buttonClass} offlineAccess={true} text={buttonText} /> }
+      if (provider === 'Google') { return <AuthGoogleAccessForm buttonClass={buttonClass} offlineAccess={true} showIcon={false} text={buttonText} /> }
 
       return <a className={buttonClass} href={link}>{buttonText}</a>
     } else {


### PR DESCRIPTION
## WHAT
Remove the google icon on this button entirely.

## WHY
We decided that the icon isn't necessary and looks too cluttered given the context of this modal window.

## HOW
Pass in props to hide this icon when displayed.

### Screenshots
<img width="621" alt="Screenshot 2023-12-04 at 11 23 29 AM" src="https://github.com/empirical-org/Empirical-Core/assets/57366100/4025f3a0-60a7-4c10-925f-cd8e5b341867">


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Fix-styling-of-the-Link-Account-button-in-the-Google-Classroom-workflow-abb2bb71608948ceb2b651d091fab6f2?pvs=4)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, tested manually
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes