### PR TITLE
Pin webmock

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -220,5 +220,5 @@ group :test do
   gem 'shoulda-callback-matchers', '~> 1.1.1'
   gem 'super_diff', require: false
   gem 'vcr', '~> 6.2.0'
-  gem 'webmock'
+  gem 'webmock', '~> 3.19'
 end

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -809,10 +809,10 @@ GEM
       dry-cli (>= 0.7, < 2)
       rack-proxy (~> 0.6, >= 0.6.1)
       zeitwerk (~> 2.2)
-    webmock (3.5.1)
-      addressable (>= 2.3.6)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket (1.2.9)
     websocket-driver (0.6.5)
@@ -969,7 +969,7 @@ DEPENDENCIES
   validates_email_format_of
   vcr (~> 6.2.0)
   vite_rails (~> 3.0.14)
-  webmock
+  webmock (~> 3.19)
   websocket-driver (= 0.6.5)
   wicked_pdf
   wkhtmltopdf-binary


### PR DESCRIPTION
## WHAT
Pin webmock version so that it's current with [develop](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/Gemfile.lock#L801) at 3.19.1

## WHY
It's causing an error with testing bigquery LTE

## HOW
I ran into a similar [error](https://www.notion.so/quill/Engineering-Meeting-187fbbd0975c415a8d40804ab17bb870?pvs=4#67d401710fb54a32b5c40ecf38b03da1) when upgrading to Ruby3.  Unfortunately the error messages are a red herring and have nothing to do with Google Signet.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
