### PR TITLE
fix getParameterByName typeError

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/Header.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/Header.test.tsx
@@ -12,9 +12,8 @@ const MockActivityID = 1
 const mockGetParameterByName = jest.fn()
   .mockReturnValueOnce(MockSessionID)
   .mockReturnValue(MockActivityID)
-jest.mock('../../helpers/getParameterByName', () => ({
-  default: mockGetParameterByName
-}))
+
+jest.mock('../../helpers/getParameterByName', () => mockGetParameterByName)
 
 import { Header } from '../../components/Header';
 import { Events } from '../../modules/analytics';


### PR DESCRIPTION
## WHAT
Fix `TypeError: (0 , getParameterByName_1.default) is not a function`

## WHY
We want all the tests to pass.

## HOW
Just update the syntax for the default export mock.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-TypeError-0-getParameterByName_1-default-is-not-a-function-in-Vite-41f1814164794f788743b84c5227dbcd?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES