### PR TITLE
don't generate student usernames with spaces in them (replace with hyphens)

### DIFF
--- a/services/QuillLMS/app/services/generate_username.rb
+++ b/services/QuillLMS/app/services/generate_username.rb
@@ -4,8 +4,8 @@ class GenerateUsername < ApplicationService
   MAX_LOOPS = 1_000
 
   def initialize(first_name, last_name, classcode = nil)
-    @first_name = first_name.gsub(' ', '-')
-    @last_name = last_name.gsub(' ', '-')
+    @first_name = first_name&.gsub(' ', '-')
+    @last_name = last_name&.gsub(' ', '-')
     @classcode = classcode
   end
 

--- a/services/QuillLMS/app/services/generate_username.rb
+++ b/services/QuillLMS/app/services/generate_username.rb
@@ -4,8 +4,8 @@ class GenerateUsername < ApplicationService
   MAX_LOOPS = 1_000
 
   def initialize(first_name, last_name, classcode = nil)
-    @first_name = first_name
-    @last_name = last_name
+    @first_name = first_name.gsub(' ', '-')
+    @last_name = last_name.gsub(' ', '-')
     @classcode = classcode
   end
 

--- a/services/QuillLMS/spec/services/generate_username_spec.rb
+++ b/services/QuillLMS/spec/services/generate_username_spec.rb
@@ -9,6 +9,10 @@ describe GenerateUsername do
     expect(subject).to eq 'john.smith@student'
   end
 
+  it 'replaces any spaces with a hyphen' do
+    expect(described_class.run('John Jacob', 'Jingleheimer Schmitt', 'student')).to eq('john-jacob.jingleheimer-schmitt@student')
+  end
+
   it 'doesnt increment count if a different class code' do
     create(:student, { username: 'john.smith@teacher' })
 


### PR DESCRIPTION
## WHAT
Update our `generate_usernames` file to replace any spaces in the student's name with hyphens.

## WHY
Shannon reported an issue where password reset was resulting in students having spaces in their passwords. I realized that this was actually due to a bug in initial username creation, where the username was being created with spaces and then any further updates to the user model failed to save because the username itself was invalid. This change should make it so that users imported from Google or Clever have valid usernames, so reset password should always work as expected. 

## HOW
Just `gsub` the name values.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Password-Reset-Message-for-Two-Word-Last-Names-Only-Showing-One-Name-ab47dddc31ae498eac32a376934efd82?d=9ac20a832c8747729ce10dce7a88319f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
