### PR TITLE
Admin Data Export/ add guide link

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/dataExportTableAndFields.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/dataExportTableAndFields.test.tsx.snap
@@ -10,7 +10,22 @@ exports[`DataExportTableAndFields component should match snapshot 1`] = `
       visible={false}
     />
     <h1>
-      Data Export
+      <span>
+        Data Export
+      </span>
+      <a
+        href="https://support.quill.org/en/articles/8672493-how-do-i-use-the-admin-data-export"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <img
+          alt="Document file with folded corner and two horizontal lines"
+          src="undefined/images/icons/file-document.svg"
+        />
+        <span>
+          Guide
+        </span>
+      </a>
     </h1>
     <button
       className="quill-button download-report-button contained primary medium focus-on-light"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -2,7 +2,7 @@ import * as moment from 'moment';
 import * as React from 'react';
 
 import { requestPost, } from '../../../modules/request';
-import { DataTable, Snackbar, Spinner, LightButtonLoadingSpinner, defaultSnackbarTimeout, filterIcon, informationIcon, noResultsMessage, smallWhiteCheckIcon, whiteArrowPointingDownIcon, Tooltip, helpIcon, NOT_APPLICABLE, } from '../../Shared';
+import { DataTable, Snackbar, Spinner, LightButtonLoadingSpinner, defaultSnackbarTimeout, filterIcon, informationIcon, noResultsMessage, smallWhiteCheckIcon, whiteArrowPointingDownIcon, Tooltip, helpIcon, NOT_APPLICABLE, documentFileIcon, } from '../../Shared';
 import useSnackbarMonitor from '../../Shared/hooks/useSnackbarMonitor';
 import { hashPayload, } from '../shared'
 
@@ -309,7 +309,13 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
     <React.Fragment>
       <div className="header">
         <Snackbar text="You will receive an email with a download link shortly." visible={showSnackbar} />
-        <h1>Data Export</h1>
+        <h1>
+          <span>Data Export</span>
+          <a href="https://support.quill.org/en/articles/8672493-how-do-i-use-the-admin-data-export" rel="noopener noreferrer" target="_blank">
+            <img alt={documentFileIcon.alt} src={documentFileIcon.src} />
+            <span>Guide</span>
+          </a>
+        </h1>
         <button className="quill-button download-report-button contained primary medium focus-on-light" onClick={createCsvReportDownload} type="button">
           {downloadButtonBusy ? <LightButtonLoadingSpinner /> : <img alt={whiteArrowPointingDownIcon.alt} src={whiteArrowPointingDownIcon.src} />}
           <span>Download</span>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DataExportContainer.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DataExportContainer.test.tsx.snap
@@ -12,7 +12,22 @@ exports[`DataExportContainer full state it should render 1`] = `
         You will receive an email with a download link shortly.
       </div>
       <h1>
-        Data Export
+        <span>
+          Data Export
+        </span>
+        <a
+          href="https://support.quill.org/en/articles/8672493-how-do-i-use-the-admin-data-export"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <img
+            alt="Document file with folded corner and two horizontal lines"
+            src="undefined/images/icons/file-document.svg"
+          />
+          <span>
+            Guide
+          </span>
+        </a>
       </h1>
       <button
         class="quill-button download-report-button contained primary medium focus-on-light"


### PR DESCRIPTION
## WHAT
add link for guide on how to use the Admin Data Export page

## WHY
we want to provide support to teachers for this feature
 
## HOW
just add an icon with link similar to the Usage Snapshot report

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-Guide-link-to-the-Admin-Data-Export-feature-b97618b64702443d86cb7eec55bd3df9

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
