### PR TITLE
Disable overnight caching for admin snapshots

### DIFF
--- a/services/QuillLMS/app/workers/pre_cache_premium_hubs_worker.rb
+++ b/services/QuillLMS/app/workers/pre_cache_premium_hubs_worker.rb
@@ -13,7 +13,6 @@ class PreCachePremiumHubsWorker
 
     active_admin_ids.each do |id|
       FindAdminUsersWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
-      CacheAdminSnapshotsWorker.set(queue: SidekiqQueue::DEFAULT).perform_async(id)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/pre_cache_premium_hub_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/pre_cache_premium_hub_worker_spec.rb
@@ -26,12 +26,6 @@ describe PreCachePremiumHubsWorker, type: :worker do
     worker.perform
   end
 
-  it 'enqueues CacheAdminSnapshotsWorker for all active admins' do
-    expect(mock_snapshot_cache_worker).to receive(:perform_async).with(current_admin1.id).once
-    expect(mock_snapshot_cache_worker).to receive(:perform_async).with(current_admin2.id).once
-    worker.perform
-  end
-
   it 'does not enqueue FindAdminUsersWorker for non-admins' do
     expect(mock_users_worker).not_to receive(:perform_async).with(not_admin.id)
     worker.perform


### PR DESCRIPTION
## WHAT
Disable overnight caching for admin snapshots
## WHY
Running these jobs look like a big contributor to our BigQuery on-demand billing
## HOW
Stop enqueuing jobs to do the overnight cache every night

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, tiny change related to cron jobs
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
