### PR TITLE
Add PdfSubscription model

### DIFF
--- a/services/QuillLMS/app/models/admin_report_filter_selection.rb
+++ b/services/QuillLMS/app/models/admin_report_filter_selection.rb
@@ -16,10 +16,6 @@
 #  index_admin_report_filter_selections_on_report   (report)
 #  index_admin_report_filter_selections_on_user_id  (user_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (user_id => users.id)
-#
 class AdminReportFilterSelection < ApplicationRecord
   REPORTS = [
     DATA_EXPORT = 'data_export',

--- a/services/QuillLMS/app/models/admin_report_filter_selection.rb
+++ b/services/QuillLMS/app/models/admin_report_filter_selection.rb
@@ -5,7 +5,7 @@
 # Table name: admin_report_filter_selections
 #
 #  id                :bigint           not null, primary key
-#  filter_selections :jsonb
+#  filter_selections :jsonb            not null
 #  report            :string           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
@@ -21,15 +21,16 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class AdminReportFilterSelection < ApplicationRecord
-  belongs_to :user
-
-  validates :user_id, presence: true
-
   REPORTS = [
     DATA_EXPORT = 'data_export',
+    DIAGNOSTIC_GROWTH_REPORT = 'diagnostic_growth_report',
     USAGE_SNAPSHOT_REPORT = 'usage_snapshot_report',
-    DIAGNOSTIC_GROWTH_REPORT = 'diagnostic_growth_report'
+    USAGE_SNAPSHOT_REPORT_PDF = 'usage_snapshot_report_pdf'
   ]
 
-  validates :report, :inclusion=> { :in => REPORTS }
+  belongs_to :user
+
+  validates :filter_selections, presence: true
+  validates :report, inclusion: { in: REPORTS }
+  validates :user_id, presence: true
 end

--- a/services/QuillLMS/app/models/pdf_subscription.rb
+++ b/services/QuillLMS/app/models/pdf_subscription.rb
@@ -4,22 +4,22 @@
 #
 # Table name: pdf_subscriptions
 #
-#  id                :bigint           not null, primary key
-#  filter_selections :jsonb
-#  frequency         :string           not null
-#  title             :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  user_id           :bigint           not null
+#  id                               :bigint           not null, primary key
+#  frequency                        :string           not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  admin_report_filter_selection_id :bigint           not null
+#  user_id                          :bigint           not null
 #
 # Indexes
 #
-#  index_pdf_subscriptions_on_frequency  (frequency)
-#  index_pdf_subscriptions_on_title      (title)
-#  index_pdf_subscriptions_on_user_id    (user_id)
+#  index_pdf_subscriptions_on_admin_report_filter_selection_id  (admin_report_filter_selection_id)
+#  index_pdf_subscriptions_on_frequency                         (frequency)
+#  index_pdf_subscriptions_on_user_id                           (user_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (admin_report_filter_selection_id => admin_report_filter_selections.id)
 #  fk_rails_...  (user_id => users.id)
 #
 class PdfSubscription < ApplicationRecord
@@ -28,13 +28,8 @@ class PdfSubscription < ApplicationRecord
     MONTHLY = 'monthly'
   ]
 
-  TITLES = [
-    ADMIN_USAGE_SNAPSHOT_REPORT = 'admin_usage_snapshot_report'
-  ]
-
   belongs_to :user
+  belongs_to :admin_report_filter_selection
 
   validates :frequency, presence: true, inclusion: { in: FREQUENCIES }
-  validates :title, presence: true, inclusion: { in: TITLES }
-  validates :user_id, presence: true
 end

--- a/services/QuillLMS/app/models/pdf_subscription.rb
+++ b/services/QuillLMS/app/models/pdf_subscription.rb
@@ -9,18 +9,11 @@
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  admin_report_filter_selection_id :bigint           not null
-#  user_id                          :bigint           not null
 #
 # Indexes
 #
 #  index_pdf_subscriptions_on_admin_report_filter_selection_id  (admin_report_filter_selection_id)
 #  index_pdf_subscriptions_on_frequency                         (frequency)
-#  index_pdf_subscriptions_on_user_id                           (user_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (admin_report_filter_selection_id => admin_report_filter_selections.id)
-#  fk_rails_...  (user_id => users.id)
 #
 class PdfSubscription < ApplicationRecord
   FREQUENCIES = [

--- a/services/QuillLMS/app/models/pdf_subscription.rb
+++ b/services/QuillLMS/app/models/pdf_subscription.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: pdf_subscriptions
+#
+#  id                :bigint           not null, primary key
+#  filter_selections :jsonb
+#  frequency         :string           not null
+#  title             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint           not null
+#
+# Indexes
+#
+#  index_pdf_subscriptions_on_frequency  (frequency)
+#  index_pdf_subscriptions_on_title      (title)
+#  index_pdf_subscriptions_on_user_id    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class PdfSubscription < ApplicationRecord
+  FREQUENCIES = [
+    WEEKLY = 'weekly',
+    MONTHLY = 'monthly'
+  ]
+
+  TITLES = [
+    ADMIN_USAGE_SNAPSHOT_REPORT = 'admin_usage_snapshot_report'
+  ]
+
+  belongs_to :user
+
+  validates :frequency, presence: true, inclusion: { in: FREQUENCIES }
+  validates :title, presence: true, inclusion: { in: TITLES }
+  validates :user_id, presence: true
+end

--- a/services/QuillLMS/db/migrate/20231206143410_create_pdf_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20231206143410_create_pdf_subscriptions.rb
@@ -4,8 +4,7 @@ class CreatePdfSubscriptions < ActiveRecord::Migration[7.0]
   def change
     create_table :pdf_subscriptions do |t|
       t.string :frequency, index: true, null: false
-      t.references :admin_report_filter_selection, index: true, foreign_key: true, null: false
-      t.references :user, index: true, foreign_key: true, null: false
+      t.references :admin_report_filter_selection, index: true, null: false
 
       t.timestamps
     end

--- a/services/QuillLMS/db/migrate/20231206143410_create_pdf_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20231206143410_create_pdf_subscriptions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreatePdfSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :pdf_subscriptions do |t|
+      t.string :title, index: true, null: false
+      t.string :frequency, index: true, null: false
+      t.jsonb :filter_selections
+      t.references :user, index: true, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20231206143410_create_pdf_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20231206143410_create_pdf_subscriptions.rb
@@ -3,9 +3,8 @@
 class CreatePdfSubscriptions < ActiveRecord::Migration[7.0]
   def change
     create_table :pdf_subscriptions do |t|
-      t.string :title, index: true, null: false
       t.string :frequency, index: true, null: false
-      t.jsonb :filter_selections
+      t.references :admin_report_filter_selection, index: true, foreign_key: true, null: false
       t.references :user, index: true, foreign_key: true, null: false
 
       t.timestamps

--- a/services/QuillLMS/db/migrate/20231207135455_change_filter_selections_to_not_null_in_admin_report_filter_selections.rb
+++ b/services/QuillLMS/db/migrate/20231207135455_change_filter_selections_to_not_null_in_admin_report_filter_selections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeFilterSelectionsToNotNullInAdminReportFilterSelections < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :admin_report_filter_selections, :filter_selections, false
+  end
+end

--- a/services/QuillLMS/db/migrate/20231207151344_remove_user_foreign_key_from_admin_report_filter_selections.rb
+++ b/services/QuillLMS/db/migrate/20231207151344_remove_user_foreign_key_from_admin_report_filter_selections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveUserForeignKeyFromAdminReportFilterSelections < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :admin_report_filter_selections, :users
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3606,7 +3606,6 @@ CREATE TABLE public.pdf_subscriptions (
     id bigint NOT NULL,
     frequency character varying NOT NULL,
     admin_report_filter_selection_id bigint NOT NULL,
-    user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
@@ -8654,13 +8653,6 @@ CREATE INDEX index_pdf_subscriptions_on_frequency ON public.pdf_subscriptions US
 
 
 --
--- Name: index_pdf_subscriptions_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pdf_subscriptions_on_user_id ON public.pdf_subscriptions USING btree (user_id);
-
-
---
 -- Name: index_plans_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9796,14 +9788,6 @@ ALTER TABLE ONLY public.learn_worlds_accounts
 
 
 --
--- Name: pdf_subscriptions fk_rails_9bbfb9971e; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pdf_subscriptions
-    ADD CONSTRAINT fk_rails_9bbfb9971e FOREIGN KEY (user_id) REFERENCES public.users(id);
-
-
---
 -- Name: provider_classrooms fk_rails_9c61f34d66; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10065,22 +10049,6 @@ ALTER TABLE ONLY public.sales_stages
 
 ALTER TABLE ONLY public.activity_survey_responses
     ADD CONSTRAINT fk_rails_e65c2d2818 FOREIGN KEY (activity_session_id) REFERENCES public.activity_sessions(id);
-
-
---
--- Name: pdf_subscriptions fk_rails_e92807a6ef; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pdf_subscriptions
-    ADD CONSTRAINT fk_rails_e92807a6ef FOREIGN KEY (admin_report_filter_selection_id) REFERENCES public.admin_report_filter_selections(id);
-
-
---
--- Name: admin_report_filter_selections fk_rails_f3c9548131; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.admin_report_filter_selections
-    ADD CONSTRAINT fk_rails_f3c9548131 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -10655,6 +10623,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230929135017'),
 ('20231018141022'),
 ('20231206143410'),
-('20231207135455');
+('20231207135455'),
+('20231207151344');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -768,7 +768,7 @@ ALTER SEQUENCE public.admin_infos_id_seq OWNED BY public.admin_infos.id;
 CREATE TABLE public.admin_report_filter_selections (
     id bigint NOT NULL,
     report character varying NOT NULL,
-    filter_selections jsonb,
+    filter_selections jsonb NOT NULL,
     user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -3604,9 +3604,8 @@ ALTER SEQUENCE public.partner_contents_id_seq OWNED BY public.partner_contents.i
 
 CREATE TABLE public.pdf_subscriptions (
     id bigint NOT NULL,
-    title character varying NOT NULL,
     frequency character varying NOT NULL,
-    filter_selections jsonb,
+    admin_report_filter_selection_id bigint NOT NULL,
     user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -8641,17 +8640,17 @@ CREATE INDEX index_partner_contents_on_partner ON public.partner_contents USING 
 
 
 --
+-- Name: index_pdf_subscriptions_on_admin_report_filter_selection_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pdf_subscriptions_on_admin_report_filter_selection_id ON public.pdf_subscriptions USING btree (admin_report_filter_selection_id);
+
+
+--
 -- Name: index_pdf_subscriptions_on_frequency; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_pdf_subscriptions_on_frequency ON public.pdf_subscriptions USING btree (frequency);
-
-
---
--- Name: index_pdf_subscriptions_on_title; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pdf_subscriptions_on_title ON public.pdf_subscriptions USING btree (title);
 
 
 --
@@ -10069,6 +10068,14 @@ ALTER TABLE ONLY public.activity_survey_responses
 
 
 --
+-- Name: pdf_subscriptions fk_rails_e92807a6ef; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pdf_subscriptions
+    ADD CONSTRAINT fk_rails_e92807a6ef FOREIGN KEY (admin_report_filter_selection_id) REFERENCES public.admin_report_filter_selections(id);
+
+
+--
 -- Name: admin_report_filter_selections fk_rails_f3c9548131; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10647,6 +10654,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230912150456'),
 ('20230929135017'),
 ('20231018141022'),
-('20231206143410');
+('20231206143410'),
+('20231207135455');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3599,6 +3599,40 @@ ALTER SEQUENCE public.partner_contents_id_seq OWNED BY public.partner_contents.i
 
 
 --
+-- Name: pdf_subscriptions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.pdf_subscriptions (
+    id bigint NOT NULL,
+    title character varying NOT NULL,
+    frequency character varying NOT NULL,
+    filter_selections jsonb,
+    user_id bigint NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: pdf_subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.pdf_subscriptions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: pdf_subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.pdf_subscriptions_id_seq OWNED BY public.pdf_subscriptions.id;
+
+
+--
 -- Name: plans; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6064,6 +6098,13 @@ ALTER TABLE ONLY public.partner_contents ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: pdf_subscriptions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pdf_subscriptions ALTER COLUMN id SET DEFAULT nextval('public.pdf_subscriptions_id_seq'::regclass);
+
+
+--
 -- Name: plans id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7186,6 +7227,14 @@ ALTER TABLE ONLY public.page_areas
 
 ALTER TABLE ONLY public.partner_contents
     ADD CONSTRAINT partner_contents_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pdf_subscriptions pdf_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pdf_subscriptions
+    ADD CONSTRAINT pdf_subscriptions_pkey PRIMARY KEY (id);
 
 
 --
@@ -8592,6 +8641,27 @@ CREATE INDEX index_partner_contents_on_partner ON public.partner_contents USING 
 
 
 --
+-- Name: index_pdf_subscriptions_on_frequency; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pdf_subscriptions_on_frequency ON public.pdf_subscriptions USING btree (frequency);
+
+
+--
+-- Name: index_pdf_subscriptions_on_title; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pdf_subscriptions_on_title ON public.pdf_subscriptions USING btree (title);
+
+
+--
+-- Name: index_pdf_subscriptions_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pdf_subscriptions_on_user_id ON public.pdf_subscriptions USING btree (user_id);
+
+
+--
 -- Name: index_plans_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9727,6 +9797,14 @@ ALTER TABLE ONLY public.learn_worlds_accounts
 
 
 --
+-- Name: pdf_subscriptions fk_rails_9bbfb9971e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pdf_subscriptions
+    ADD CONSTRAINT fk_rails_9bbfb9971e FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: provider_classrooms fk_rails_9c61f34d66; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10568,6 +10646,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230801140522'),
 ('20230912150456'),
 ('20230929135017'),
-('20231018141022');
+('20231018141022'),
+('20231206143410');
 
 

--- a/services/QuillLMS/spec/controllers/admin_report_filter_selections_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/admin_report_filter_selections_controller_spec.rb
@@ -2,9 +2,25 @@
 
 require 'rails_helper'
 
-describe AdminReportFilterSelectionsController, type: :controller do
+RSpec.describe AdminReportFilterSelectionsController, type: :controller do
   let(:user) { create(:user) }
-  let(:valid_params) { { report: AdminReportFilterSelection::DATA_EXPORT, user_id: user.id } }
+
+  let(:valid_params) do
+    {
+      filter_selections: {
+        classrooms: nil,
+        custom_end_date: nil,
+        custom_start_date: nil,
+        grades: [],
+        schools: [],
+        teachers: [],
+        timeframe: {}
+      },
+      report: AdminReportFilterSelection::DATA_EXPORT,
+      user_id: user.id
+    }
+  end
+
   let(:invalid_params) { { report: 'invalid_report' } }
   let(:valid_model_attributes) { valid_params.merge({ user_id: user.id }) }
 

--- a/services/QuillLMS/spec/factories/admin_report_filter_selections.rb
+++ b/services/QuillLMS/spec/factories/admin_report_filter_selections.rb
@@ -16,10 +16,6 @@
 #  index_admin_report_filter_selections_on_report   (report)
 #  index_admin_report_filter_selections_on_user_id  (user_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (user_id => users.id)
-#
 FactoryBot.define do
   factory :admin_report_filter_selection do
     report { AdminReportFilterSelection::REPORTS.sample }

--- a/services/QuillLMS/spec/factories/admin_report_filter_selections.rb
+++ b/services/QuillLMS/spec/factories/admin_report_filter_selections.rb
@@ -5,7 +5,7 @@
 # Table name: admin_report_filter_selections
 #
 #  id                :bigint           not null, primary key
-#  filter_selections :jsonb
+#  filter_selections :jsonb            not null
 #  report            :string           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
@@ -22,7 +22,12 @@
 #
 FactoryBot.define do
   factory :admin_report_filter_selection do
-    association :user, factory: :user
     report { AdminReportFilterSelection::REPORTS.sample }
+    filter_selections { '{}' }
+    user
+
+    factory :usage_snapshot_report_pdf_filter_selection do
+      report { AdminReportFilterSelection::USAGE_SNAPSHOT_REPORT_PDF }
+    end
   end
 end

--- a/services/QuillLMS/spec/factories/pdf_subscriptions.rb
+++ b/services/QuillLMS/spec/factories/pdf_subscriptions.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: pdf_subscriptions
+#
+#  id                :bigint           not null, primary key
+#  filter_selections :jsonb
+#  frequency         :string           not null
+#  title             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint           not null
+#
+# Indexes
+#
+#  index_pdf_subscriptions_on_frequency  (frequency)
+#  index_pdf_subscriptions_on_title      (title)
+#  index_pdf_subscriptions_on_user_id    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :pdf_subscription do
+    frequency { PdfSubscription::FREQUENCIES.sample }
+    title { PdfSubscription::TITLES.sample }
+    user
+  end
+end

--- a/services/QuillLMS/spec/factories/pdf_subscriptions.rb
+++ b/services/QuillLMS/spec/factories/pdf_subscriptions.rb
@@ -2,28 +2,27 @@
 #
 # Table name: pdf_subscriptions
 #
-#  id                :bigint           not null, primary key
-#  filter_selections :jsonb
-#  frequency         :string           not null
-#  title             :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  user_id           :bigint           not null
+#  id                               :bigint           not null, primary key
+#  frequency                        :string           not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  admin_report_filter_selection_id :bigint           not null
+#  user_id                          :bigint           not null
 #
 # Indexes
 #
-#  index_pdf_subscriptions_on_frequency  (frequency)
-#  index_pdf_subscriptions_on_title      (title)
-#  index_pdf_subscriptions_on_user_id    (user_id)
+#  index_pdf_subscriptions_on_admin_report_filter_selection_id  (admin_report_filter_selection_id)
+#  index_pdf_subscriptions_on_frequency                         (frequency)
+#  index_pdf_subscriptions_on_user_id                           (user_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (admin_report_filter_selection_id => admin_report_filter_selections.id)
 #  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
   factory :pdf_subscription do
     frequency { PdfSubscription::FREQUENCIES.sample }
-    title { PdfSubscription::TITLES.sample }
-    user
+    association :admin_report_filter_selection, factory: :usage_snapshot_report_pdf_filter_selection
   end
 end

--- a/services/QuillLMS/spec/factories/pdf_subscriptions.rb
+++ b/services/QuillLMS/spec/factories/pdf_subscriptions.rb
@@ -7,18 +7,11 @@
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  admin_report_filter_selection_id :bigint           not null
-#  user_id                          :bigint           not null
 #
 # Indexes
 #
 #  index_pdf_subscriptions_on_admin_report_filter_selection_id  (admin_report_filter_selection_id)
 #  index_pdf_subscriptions_on_frequency                         (frequency)
-#  index_pdf_subscriptions_on_user_id                           (user_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (admin_report_filter_selection_id => admin_report_filter_selections.id)
-#  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
   factory :pdf_subscription do

--- a/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
+++ b/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
@@ -5,7 +5,7 @@
 # Table name: admin_report_filter_selections
 #
 #  id                :bigint           not null, primary key
-#  filter_selections :jsonb
+#  filter_selections :jsonb            not null
 #  report            :string           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
@@ -22,28 +22,12 @@
 #
 require 'rails_helper'
 
-describe AdminReportFilterSelection, type: :model, redis: true do
+RSpec.describe AdminReportFilterSelection, type: :model, redis: true do
+  it { expect(build(:admin_report_filter_selection)).to be_valid }
+
   it { should belong_to(:user) }
 
   it { should validate_presence_of(:user_id) }
-
-  let(:admin_report_filter_selection) { create(:admin_report_filter_selection) }
-
-  describe '#report' do
-    it "should allow valid values" do
-      AdminReportFilterSelection::REPORTS.each do |v|
-        admin_report_filter_selection.report = v
-        expect(admin_report_filter_selection).to be_valid
-      end
-    end
-
-    it "should not allow invalid values" do
-      admin_report_filter_selection.report = nil
-      expect(admin_report_filter_selection).not_to be_valid
-
-      admin_report_filter_selection.report = 'other'
-      expect(admin_report_filter_selection).not_to be_valid
-    end
-  end
-
+  it { should validate_presence_of(:filter_selections) }
+  it { should validate_inclusion_of(:report).in_array(described_class::REPORTS)}
 end

--- a/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
+++ b/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
@@ -16,10 +16,6 @@
 #  index_admin_report_filter_selections_on_report   (report)
 #  index_admin_report_filter_selections_on_user_id  (user_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (user_id => users.id)
-#
 require 'rails_helper'
 
 RSpec.describe AdminReportFilterSelection, type: :model, redis: true do

--- a/services/QuillLMS/spec/models/pdf_subscription_spec.rb
+++ b/services/QuillLMS/spec/models/pdf_subscription_spec.rb
@@ -2,22 +2,22 @@
 #
 # Table name: pdf_subscriptions
 #
-#  id                :bigint           not null, primary key
-#  filter_selections :jsonb
-#  frequency         :string           not null
-#  title             :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  user_id           :bigint           not null
+#  id                               :bigint           not null, primary key
+#  frequency                        :string           not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  admin_report_filter_selection_id :bigint           not null
+#  user_id                          :bigint           not null
 #
 # Indexes
 #
-#  index_pdf_subscriptions_on_frequency  (frequency)
-#  index_pdf_subscriptions_on_title      (title)
-#  index_pdf_subscriptions_on_user_id    (user_id)
+#  index_pdf_subscriptions_on_admin_report_filter_selection_id  (admin_report_filter_selection_id)
+#  index_pdf_subscriptions_on_frequency                         (frequency)
+#  index_pdf_subscriptions_on_user_id                           (user_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (admin_report_filter_selection_id => admin_report_filter_selections.id)
 #  fk_rails_...  (user_id => users.id)
 #
 require 'rails_helper'
@@ -25,11 +25,8 @@ require 'rails_helper'
 RSpec.describe PdfSubscription, type: :model do
   it { expect(build(:pdf_subscription)).to be_valid }
 
-  it { should belong_to(:user) }
+  it { should belong_to(:admin_report_filter_selection) }
 
   it { should validate_presence_of(:frequency) }
   it { should validate_inclusion_of(:frequency).in_array(described_class::FREQUENCIES) }
-  it { should validate_inclusion_of(:title).in_array(described_class::TITLES) }
-  it { should validate_presence_of(:title) }
-  it { should validate_presence_of(:user_id) }
 end

--- a/services/QuillLMS/spec/models/pdf_subscription_spec.rb
+++ b/services/QuillLMS/spec/models/pdf_subscription_spec.rb
@@ -7,18 +7,11 @@
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  admin_report_filter_selection_id :bigint           not null
-#  user_id                          :bigint           not null
 #
 # Indexes
 #
 #  index_pdf_subscriptions_on_admin_report_filter_selection_id  (admin_report_filter_selection_id)
 #  index_pdf_subscriptions_on_frequency                         (frequency)
-#  index_pdf_subscriptions_on_user_id                           (user_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (admin_report_filter_selection_id => admin_report_filter_selections.id)
-#  fk_rails_...  (user_id => users.id)
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/pdf_subscription_spec.rb
+++ b/services/QuillLMS/spec/models/pdf_subscription_spec.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: pdf_subscriptions
+#
+#  id                :bigint           not null, primary key
+#  filter_selections :jsonb
+#  frequency         :string           not null
+#  title             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint           not null
+#
+# Indexes
+#
+#  index_pdf_subscriptions_on_frequency  (frequency)
+#  index_pdf_subscriptions_on_title      (title)
+#  index_pdf_subscriptions_on_user_id    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe PdfSubscription, type: :model do
+  it { expect(build(:pdf_subscription)).to be_valid }
+
+  it { should belong_to(:user) }
+
+  it { should validate_presence_of(:frequency) }
+  it { should validate_inclusion_of(:frequency).in_array(described_class::FREQUENCIES) }
+  it { should validate_inclusion_of(:title).in_array(described_class::TITLES) }
+  it { should validate_presence_of(:title) }
+  it { should validate_presence_of(:user_id) }
+end


### PR DESCRIPTION
## WHAT
Create a model `PdfSubscription`
title: name of pdf
frequency: 'weekly', 'monthly'
filter_selections: same as AdminReportFilterSelection model

## WHY
This will store user preferences related to periodic email of a particular PDF.

## HOW
rails generate model PdfSubscription

NB: Initially, I thought about adding a foreign key to `AdminReportFilterSelection` records but that particular record gets overwritten every time a user updates filter selections in the UI.  The specs for this require that we persist the filters with the PDF file itself.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/UI-Report-Subscription-Email-subscription-for-Admin-Usage-Snapshot-Report-b0b949a1f69744ed9ba2a6fc3a1faad6?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
