### PR TITLE
get css rendering even in non-local env

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/admin_usage_snapshot_report_pdf.scss
+++ b/services/QuillLMS/app/assets/stylesheets/admin_usage_snapshot_report_pdf.scss
@@ -255,6 +255,9 @@
 
       .header-row {
         border-top: 1px solid #aeaeae;
+        display: flex;
+        justify-content: space-between;
+        padding: 12px 0px;
 
         th {
           font-weight: 700;
@@ -296,49 +299,49 @@
   .snapshot-section.classrooms .counts {
     display: grid;
     gap: 16px;
+  }
 
-    /* Specific Grid Template Styles */
-    .highlights .counts {
+  /* Specific Grid Template Styles */
+  .highlights .counts {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .users .snapshot-section-content,
+  .classrooms .snapshot-section-content {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .users .counts,
+  .classrooms .counts {
+    grid-template: repeat(2, 1fr) / repeat(2, 1fr);
+  }
+
+  .practice .snapshot-section-content {
+    display: flex;
+    flex-direction: column;
+
+    .first-row,
+    .second-row,
+    .third-and-fourth-row {
+      margin-bottom: 16px;
+      gap: 16px;
+    }
+
+    .first-row {
+      display: grid;
       grid-template-columns: repeat(2, 1fr);
     }
 
-    .users .snapshot-section-content,
-    .classrooms .snapshot-section-content {
-      grid-template-columns: repeat(2, 1fr);
+    .second-row,
+    .fifth-row {
+      display: grid;
+      grid-template-columns: none;
+      gap: 16px;
     }
 
-    .users .counts,
-    .classrooms .counts {
-      grid-template: repeat(2, 1fr) / repeat(2, 1fr);
-    }
-
-    .practice .snapshot-section-content {
-      display: flex;
-      flex-direction: column;
-
-      .first-row,
-      .second-row,
-      .third-and-fourth-row {
-        margin-bottom: 16px;
-        gap: 16px;
-      }
-
-      .first-row {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-      }
-
-      .second-row,
-      .fifth-row {
-        display: grid;
-        grid-template-columns: none;
-        gap: 16px;
-      }
-
-      .third-and-fourth-row {
-        display: grid;
-        grid-template: repeat(3, 1fr)/repeat(2, 1fr);
-      }
+    .third-and-fourth-row {
+      display: grid;
+      grid-template: repeat(3, 1fr)/repeat(2, 1fr);
     }
   }
 
@@ -346,5 +349,6 @@
   .snapshot-section.classrooms .snapshot-section-content {
     display: flex;
     flex-direction: column;
+    gap: 16px;
   }
 }

--- a/services/QuillLMS/app/services/pdf_file_builder.rb
+++ b/services/QuillLMS/app/services/pdf_file_builder.rb
@@ -18,9 +18,11 @@ class PdfFileBuilder < ApplicationService
   end
 
   private def html
-    ApplicationController
-      .renderer
-      .render(locals: { data: data }, template: template, layout: 'pdf')
+    body_html = ApplicationController
+      .new
+      .render_to_string(locals: { data: data }, template: template, layout: 'pdf')
+      
+    Grover::HTMLPreprocessor.process(body_html, "#{ENV['DEFAULT_URL']}/", 'https')
   end
 
   private def pdf

--- a/services/QuillLMS/app/views/layouts/pdf.html.erb
+++ b/services/QuillLMS/app/views/layouts/pdf.html.erb
@@ -3,8 +3,8 @@
   <head>
     <title>Quill</title>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
-    <link rel="stylesheet" href=<%= "#{ENV['DEFAULT_URL']}/assets/admin_usage_snapshot_report_pdf.scss" %>>
     <link rel="stylesheet" href="https://use.typekit.net/zyx1nqp.css">
+    <%= stylesheet_link_tag "admin_usage_snapshot_report_pdf", :media => "all" %>
   </head>
   <body>
     <div id='header'>

--- a/services/QuillLMS/config/initializers/grover.rb
+++ b/services/QuillLMS/config/initializers/grover.rb
@@ -3,8 +3,8 @@ Grover.configure do |config|
     print_background: true,
     format: 'Letter',
     margin: {
-      top: '50px',
-      bottom: '50px'
+      top: '54px',
+      bottom: '54px'
     },
   }
 end


### PR DESCRIPTION
## WHAT
Get the (slightly corrected) CSS rendering for the PDFs in non-local environments.

## WHY
Having them look good locally doesn't do us a whole lot of good really.

## HOW
Set up some preprocessing. Also make some minor CSS adjustments.

### Screenshots
https://admin-report-fog-directory-staging.s3.amazonaws.com/uploads/ADMIN_SNAPSHOT_REPORT__1_12-06-23_f626a0.pdf?response-content-disposition=attachment%3B&X-Amz-Expires=604800&X-Amz-Date=20231206T204641Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIGN6VTRT3M4545YQ%2F20231206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=68dc252069eb9b56cfd0c02b3f2704421f067be4ba1e9ded2aedd674bb8062f0

### Notion Card Links

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES