### PR TITLE
Change bigquery builds to parallelism 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
           path: /home/circleci/Empirical-Core/services/QuillLMS/tmp/screenshots
   lms_big_query_build:
     working_directory: ~/Empirical-Core
-    parallelism: 1
+    parallelism: 2
     docker:
       - image: cimg/ruby:3.1.4
         environment:


### PR DESCRIPTION
## WHAT
Change big query circle ci builds to use `parallelism: 2`

## WHY
![Screenshot 2023-12-08 at 9 24 21 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/1788d99c-6f24-4236-b93b-37121a48877f)

This particular jobs is taking longer than the others.

## HOW
Update circleci config.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
