### PR TITLE
new premium hub navigation

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
@@ -526,6 +526,7 @@
           top: 36px;
           width: 300px;
           z-index: 1;
+          box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.10);
           a {
             color: $quill-black;
             margin: 8px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
@@ -514,14 +514,14 @@
           &.open:not(.active) {
             background-color: rgba(255, 255, 255, 0.5);
             text-decoration: none;
-            color: #FFF;
+            color: $quill-white;
           }
         }
         .premium-reports-nav-dropdown {
           position: absolute;
           border-radius: 8px;
-          border: 1px solid #CFCFCF;
-          background: #FFF;
+          border: 1px solid $quill-grey-15;
+          background: $quill-white;
           min-height: min-content;
           top: 36px;
           width: 300px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
@@ -508,13 +508,8 @@
           background: transparent;
           span::after {
             margin-left: 8px;
-            content: "\f077";
+            content: "\f078";
             font-family: "Font Awesome 5 Pro";
-          }
-          &.open {
-            span::after {
-              content: "\f078";
-            }
           }
           &.open:not(.active) {
             background-color: rgba(255, 255, 255, 0.5);

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
@@ -469,7 +469,7 @@
     li {
       padding-top: 0 !important;
       padding-bottom: 0 !important;
-      a {
+      a, button {
         display: flex;
         align-items: center;
         .small-diamond-icon {
@@ -501,6 +501,58 @@
       a:hover {
         background-color: rgba(255, 255, 255, 0.50);
         text-decoration: none;
+      }
+      &.premium-reports-tab {
+        position: relative;
+        button {
+          background: transparent;
+          span::after {
+            margin-left: 8px;
+            content: "\f077";
+            font-family: "Font Awesome 5 Pro";
+          }
+          &.open {
+            span::after {
+              content: "\f078";
+            }
+          }
+          &.open:not(.active) {
+            background-color: rgba(255, 255, 255, 0.5);
+            text-decoration: none;
+            color: #FFF;
+          }
+        }
+        .premium-reports-nav-dropdown {
+          position: absolute;
+          border-radius: 8px;
+          border: 1px solid #CFCFCF;
+          background: #FFF;
+          min-height: min-content;
+          top: 36px;
+          width: 300px;
+          z-index: 1;
+          a {
+            color: $quill-black;
+            margin: 8px;
+            display: flex;
+            padding: 20px 8px;
+            justify-content: space-between;
+            .new-tag {
+              color: $quill-white;
+              background-color: $quill-maroon;
+              font-size: 10px;
+              padding: 4px 6px;
+              border-radius: 5px;
+            }
+            &:hover {
+              color: $quill-black;
+              background-color: $quill-green-5;
+            }
+            &:focus, &:hover {
+              text-decoration: none;
+            }
+          }
+        }
       }
     }
   }

--- a/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
@@ -80,7 +80,7 @@
         &:first-of-type {
           padding-left: 0px;
         }
-        a {
+        a, button {
           border-radius: 6px;
           color: $quill-white;
           font-size: 13px;

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
@@ -1,195 +1,167 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AdminSubnav it should render 1`] = `
-Document {
-  "_reactListeningopdqfn5y6gd": true,
-  "location": Location {
-    "assign": [Function],
-    "hash": "",
-    "host": "localhost",
-    "hostname": "localhost",
-    "href": "http://localhost/",
-    "origin": "http://localhost",
-    "pathname": "/",
-    "port": "",
-    "protocol": "http:",
-    "reload": [Function],
-    "replace": [Function],
-    "search": "",
-    "toString": [Function],
-  },
-  Symbol(SameObject caches): Object {
-    "childNodes": NodeList [
-      DocumentType {},
-      <html>
-        <head />
-        <body>
-          <div>
-            <div
-              class="tab-subnavigation-wrapper mobile class-subnav premium-hub-subnav red"
+<DocumentFragment>
+  <div
+    class="tab-subnavigation-wrapper mobile class-subnav premium-hub-subnav red"
+  >
+    <div
+      class="dropdown-container"
+    >
+      <div
+        class=""
+      >
+        <button
+          class="interactive-wrapper"
+          id="mobile-subnav-dropdown"
+          type="button"
+        >
+          <p />
+          <i
+            class="fa fa-thin fa-angle-down"
+          />
+        </button>
+        <ul
+          class="dropdown-menu"
+        >
+          <li>
+            <a
+              class=""
+              href="/teachers/premium_hub"
             >
-              <div
-                class="dropdown-container"
-              >
-                <div
-                  class=""
-                >
-                  <button
-                    class="interactive-wrapper"
-                    id="mobile-subnav-dropdown"
-                    type="button"
-                  >
-                    <p />
-                    <i
-                      class="fa fa-thin fa-angle-down"
-                    />
-                  </button>
-                  <ul
-                    class="dropdown-menu"
-                  >
-                    <li>
-                      <a
-                        class=""
-                        href="/teachers/premium_hub"
-                      >
-                        Overview
-                      </a>
-                      <div
-                        class="checkmark-icon "
-                      />
-                    </li>
-                    <li>
-                      <a
-                        class=""
-                        href="/teachers/premium_hub/school_subscriptions"
-                      >
-                        School Subscriptions
-                      </a>
-                      <div
-                        class="checkmark-icon "
-                      />
-                    </li>
-                    <li>
-                      <a
-                        class=""
-                        href="/teachers/premium_hub/integrations"
-                      >
-                        Integrations
-                      </a>
-                      <div
-                        class="checkmark-icon "
-                      />
-                    </li>
-                    <li>
-                      <a
-                        class=""
-                        href="/teachers/premium_hub/district_activity_scores"
-                      >
-                        Activity Scores
-                      </a>
-                      <div
-                        class="checkmark-icon "
-                      />
-                    </li>
-                    <li>
-                      <a
-                        class=""
-                        href="/teachers/premium_hub/district_concept_reports"
-                      >
-                        Concept Reports
-                      </a>
-                      <div
-                        class="checkmark-icon "
-                      />
-                    </li>
-                    <li>
-                      <a
-                        class=""
-                        href="/teachers/premium_hub/district_standards_reports"
-                      >
-                        Standards Reports
-                      </a>
-                      <div
-                        class="checkmark-icon "
-                      />
-                    </li>
-                    <li>
-                      <a
-                        class=""
-                        href="/teachers/premium_hub/usage_snapshot_report"
-                      >
-                        Usage Snapshot Report
-                      </a>
-                      <div
-                        class="checkmark-icon "
-                      />
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
+              Overview
+            </a>
             <div
-              class="tab-subnavigation-wrapper desktop class-subnav premium-hub-subnav"
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=""
+              href="/teachers/premium_hub/school_subscriptions"
             >
-              <div
-                class="container"
-              >
-                <ul>
-                  <li>
-                    <a
-                      class=""
-                      href="/teachers/premium_hub"
-                    >
-                      Overview
-                    </a>
-                    <div
-                      class="checkmark-icon "
-                    />
-                  </li>
-                  <li>
-                    <a
-                      class=""
-                      href="/teachers/premium_hub/school_subscriptions"
-                    >
-                      School Subscriptions
-                    </a>
-                    <div
-                      class="checkmark-icon "
-                    />
-                  </li>
-                  <li>
-                    <a
-                      class=""
-                      href="/teachers/premium_hub/integrations"
-                    >
-                      Integrations
-                    </a>
-                    <div
-                      class="checkmark-icon "
-                    />
-                  </li>
-                  <li
-                    class="premium-reports-tab"
-                  >
-                    <button
-                      aria-controls="premium-reports-nav-dropdown"
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      class="premium-reports-button focus-on-dark  "
-                      type="button"
-                    >
-                      <span>
-                        Premium Reports
-                      </span>
-                    </button>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </body>
-      </html>,
-    ],
-  },
-}
+              School Subscriptions
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=""
+              href="/teachers/premium_hub/integrations"
+            >
+              Integrations
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=""
+              href="/teachers/premium_hub/district_activity_scores"
+            >
+              Activity Scores
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=""
+              href="/teachers/premium_hub/district_concept_reports"
+            >
+              Concept Reports
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=""
+              href="/teachers/premium_hub/district_standards_reports"
+            >
+              Standards Reports
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=""
+              href="/teachers/premium_hub/usage_snapshot_report"
+            >
+              Usage Snapshot Report
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="tab-subnavigation-wrapper desktop class-subnav premium-hub-subnav"
+  >
+    <div
+      class="container"
+    >
+      <ul>
+        <li>
+          <a
+            class=""
+            href="/teachers/premium_hub"
+          >
+            Overview
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li>
+          <a
+            class=""
+            href="/teachers/premium_hub/school_subscriptions"
+          >
+            School Subscriptions
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li>
+          <a
+            class=""
+            href="/teachers/premium_hub/integrations"
+          >
+            Integrations
+          </a>
+          <div
+            class="checkmark-icon "
+          />
+        </li>
+        <li
+          class="premium-reports-tab"
+        >
+          <button
+            aria-controls="premium-reports-nav-dropdown"
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="premium-reports-button focus-on-dark  "
+            type="button"
+          >
+            <span>
+              Premium Reports
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
 `;

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AdminSubnav it should render 1`] = `
 Document {
-  "_reactListeningw8412lbbic": true,
+  "_reactListeningopdqfn5y6gd": true,
   "location": Location {
     "assign": [Function],
     "hash": "",

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
@@ -1,196 +1,195 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AdminSubnav it should render 1`] = `
-<DocumentFragment>
-  <div
-    class="tab-subnavigation-wrapper mobile class-subnav premium-hub-subnav red"
-  >
-    <div
-      class="dropdown-container"
-    >
-      <div
-        class=""
-      >
-        <button
-          class="interactive-wrapper"
-          id="mobile-subnav-dropdown"
-          type="button"
-        >
-          <p />
-          <i
-            class="fa fa-thin fa-angle-down"
-          />
-        </button>
-        <ul
-          class="dropdown-menu"
-        >
-          <li>
-            <a
-              class=""
-              href="/teachers/premium_hub"
-            >
-              Overview
-            </a>
+Document {
+  "_reactListeningw8412lbbic": true,
+  "location": Location {
+    "assign": [Function],
+    "hash": "",
+    "host": "localhost",
+    "hostname": "localhost",
+    "href": "http://localhost/",
+    "origin": "http://localhost",
+    "pathname": "/",
+    "port": "",
+    "protocol": "http:",
+    "reload": [Function],
+    "replace": [Function],
+    "search": "",
+    "toString": [Function],
+  },
+  Symbol(SameObject caches): Object {
+    "childNodes": NodeList [
+      DocumentType {},
+      <html>
+        <head />
+        <body>
+          <div>
             <div
-              class="checkmark-icon "
-            />
-          </li>
-          <li>
-            <a
-              class=""
-              href="/teachers/premium_hub/school_subscriptions"
+              class="tab-subnavigation-wrapper mobile class-subnav premium-hub-subnav red"
             >
-              School Subscriptions
-            </a>
+              <div
+                class="dropdown-container"
+              >
+                <div
+                  class=""
+                >
+                  <button
+                    class="interactive-wrapper"
+                    id="mobile-subnav-dropdown"
+                    type="button"
+                  >
+                    <p />
+                    <i
+                      class="fa fa-thin fa-angle-down"
+                    />
+                  </button>
+                  <ul
+                    class="dropdown-menu"
+                  >
+                    <li>
+                      <a
+                        class=""
+                        href="/teachers/premium_hub"
+                      >
+                        Overview
+                      </a>
+                      <div
+                        class="checkmark-icon "
+                      />
+                    </li>
+                    <li>
+                      <a
+                        class=""
+                        href="/teachers/premium_hub/school_subscriptions"
+                      >
+                        School Subscriptions
+                      </a>
+                      <div
+                        class="checkmark-icon "
+                      />
+                    </li>
+                    <li>
+                      <a
+                        class=""
+                        href="/teachers/premium_hub/integrations"
+                      >
+                        Integrations
+                      </a>
+                      <div
+                        class="checkmark-icon "
+                      />
+                    </li>
+                    <li>
+                      <a
+                        class=""
+                        href="/teachers/premium_hub/district_activity_scores"
+                      >
+                        Activity Scores
+                      </a>
+                      <div
+                        class="checkmark-icon "
+                      />
+                    </li>
+                    <li>
+                      <a
+                        class=""
+                        href="/teachers/premium_hub/district_concept_reports"
+                      >
+                        Concept Reports
+                      </a>
+                      <div
+                        class="checkmark-icon "
+                      />
+                    </li>
+                    <li>
+                      <a
+                        class=""
+                        href="/teachers/premium_hub/district_standards_reports"
+                      >
+                        Standards Reports
+                      </a>
+                      <div
+                        class="checkmark-icon "
+                      />
+                    </li>
+                    <li>
+                      <a
+                        class=""
+                        href="/teachers/premium_hub/usage_snapshot_report"
+                      >
+                        Usage Snapshot Report
+                      </a>
+                      <div
+                        class="checkmark-icon "
+                      />
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
             <div
-              class="checkmark-icon "
-            />
-          </li>
-          <li>
-            <a
-              class=""
-              href="/teachers/premium_hub/district_activity_scores"
+              class="tab-subnavigation-wrapper desktop class-subnav premium-hub-subnav"
             >
-              Activity Scores
-            </a>
-            <div
-              class="checkmark-icon "
-            />
-          </li>
-          <li>
-            <a
-              class=""
-              href="/teachers/premium_hub/district_concept_reports"
-            >
-              Concept Reports
-            </a>
-            <div
-              class="checkmark-icon "
-            />
-          </li>
-          <li>
-            <a
-              class=""
-              href="/teachers/premium_hub/district_standards_reports"
-            >
-              Standards Reports
-            </a>
-            <div
-              class="checkmark-icon "
-            />
-          </li>
-          <li>
-            <a
-              class=""
-              href="/teachers/premium_hub/integrations"
-            >
-              Integrations
-            </a>
-            <div
-              class="checkmark-icon "
-            />
-          </li>
-          <li>
-            <a
-              class=""
-              href="/teachers/premium_hub/usage_snapshot_report"
-            >
-              Usage Snapshot Report
-            </a>
-            <div
-              class="checkmark-icon "
-            />
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  <div
-    class="tab-subnavigation-wrapper desktop class-subnav premium-hub-subnav"
-  >
-    <div
-      class="container"
-    >
-      <ul>
-        <li>
-          <a
-            class=""
-            href="/teachers/premium_hub"
-          >
-            Overview
-          </a>
-          <div
-            class="checkmark-icon "
-          />
-        </li>
-        <li>
-          <a
-            class=""
-            href="/teachers/premium_hub/school_subscriptions"
-          >
-            School Subscriptions
-          </a>
-          <div
-            class="checkmark-icon "
-          />
-        </li>
-        <li>
-          <a
-            class=""
-            href="/teachers/premium_hub/district_activity_scores"
-          >
-            Activity Scores
-          </a>
-          <div
-            class="checkmark-icon "
-          />
-        </li>
-        <li>
-          <a
-            class=""
-            href="/teachers/premium_hub/district_concept_reports"
-          >
-            Concept Reports
-          </a>
-          <div
-            class="checkmark-icon "
-          />
-        </li>
-        <li>
-          <a
-            class=""
-            href="/teachers/premium_hub/district_standards_reports"
-          >
-            Standards Reports
-          </a>
-          <div
-            class="checkmark-icon "
-          />
-        </li>
-        <li>
-          <a
-            class=""
-            href="/teachers/premium_hub/integrations"
-          >
-            Integrations
-          </a>
-          <div
-            class="checkmark-icon "
-          />
-        </li>
-        <li>
-          <a
-            class=""
-            href="/teachers/premium_hub/usage_snapshot_report"
-          >
-            Usage Snapshot Report
-          </a>
-          <div
-            class="checkmark-icon "
-          />
-        </li>
-      </ul>
-    </div>
-  </div>
-</DocumentFragment>
+              <div
+                class="container"
+              >
+                <ul>
+                  <li>
+                    <a
+                      class=""
+                      href="/teachers/premium_hub"
+                    >
+                      Overview
+                    </a>
+                    <div
+                      class="checkmark-icon "
+                    />
+                  </li>
+                  <li>
+                    <a
+                      class=""
+                      href="/teachers/premium_hub/school_subscriptions"
+                    >
+                      School Subscriptions
+                    </a>
+                    <div
+                      class="checkmark-icon "
+                    />
+                  </li>
+                  <li>
+                    <a
+                      class=""
+                      href="/teachers/premium_hub/integrations"
+                    >
+                      Integrations
+                    </a>
+                    <div
+                      class="checkmark-icon "
+                    />
+                  </li>
+                  <li
+                    class="premium-reports-tab"
+                  >
+                    <button
+                      aria-controls="premium-reports-nav-dropdown"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      class="premium-reports-button focus-on-dark  "
+                      type="button"
+                    >
+                      <span>
+                        Premium Reports
+                      </span>
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </body>
+      </html>,
+    ],
+  },
+}
 `;

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`AdminSubnav it should render 1`] = `
               class=""
               href="/teachers/premium_hub/school_subscriptions"
             >
-              School Subscriptions
+              Subscriptions
             </a>
             <div
               class="checkmark-icon "
@@ -62,7 +62,7 @@ exports[`AdminSubnav it should render 1`] = `
               class=""
               href="/teachers/premium_hub/district_activity_scores"
             >
-              Activity Scores
+              Activity Scores Report
             </a>
             <div
               class="checkmark-icon "
@@ -73,7 +73,7 @@ exports[`AdminSubnav it should render 1`] = `
               class=""
               href="/teachers/premium_hub/district_concept_reports"
             >
-              Concept Reports
+              Concepts Report
             </a>
             <div
               class="checkmark-icon "
@@ -84,7 +84,7 @@ exports[`AdminSubnav it should render 1`] = `
               class=""
               href="/teachers/premium_hub/district_standards_reports"
             >
-              Standards Reports
+              Standards Report
             </a>
             <div
               class="checkmark-icon "
@@ -128,7 +128,7 @@ exports[`AdminSubnav it should render 1`] = `
             class=""
             href="/teachers/premium_hub/school_subscriptions"
           >
-            School Subscriptions
+            Subscriptions
           </a>
           <div
             class="checkmark-icon "

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/subnav_tabs.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/subnav_tabs.test.tsx
@@ -23,9 +23,8 @@ const setup = async (openMenu = false) => {
 
 describe('AdminSubnav', () => {
   test('it should render', () => {
-    setup();
-    const asFragment = screen.getByText('Premium Reports').ownerDocument;
-    expect(asFragment).toMatchSnapshot();
+    const { asFragment } = render(<MemoryRouter><AdminSubnav path={mockPath} /></MemoryRouter>);
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('clicking on premium-reports-button opens the menu', async () => {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/subnav_tabs.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/subnav_tabs.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { MemoryRouter } from 'react-router';
-import { render } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from '@testing-library/user-event';
 
 import { AdminSubnav } from '../subnav_tabs'
 
@@ -8,10 +9,42 @@ const mockPath = {
   path: {
     pathname: ''
   }
+};
+
+// Common setup function
+const setup = async (openMenu = false) => {
+  render(<MemoryRouter><AdminSubnav path={mockPath} /></MemoryRouter>);
+  if (openMenu) {
+    const button = screen.getByText('Premium Reports');
+    userEvent.click(button);
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+  }
 }
+
 describe('AdminSubnav', () => {
   test('it should render', () => {
-    const { asFragment } = render(<MemoryRouter><AdminSubnav path={mockPath} /></MemoryRouter>);
-    expect(asFragment()).toMatchSnapshot();
-  })
-})
+    setup();
+    const asFragment = screen.getByText('Premium Reports').ownerDocument;
+    expect(asFragment).toMatchSnapshot();
+  });
+
+  test('clicking on premium-reports-button opens the menu', async () => {
+    await setup();
+    const button = screen.getByText('Premium Reports');
+    userEvent.click(button);
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+  });
+
+  test('clicking outside premium-reports-button closes the menu', async () => {
+    await setup(true);
+    userEvent.click(document.body);
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+
+  test('pressing Escape key closes the menu', async () => {
+    await setup(true);
+    userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+
+});

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
+
 import { renderNavList } from '../../Shared';
+import { MOUSEDOWN, KEYDOWN, } from '../../Shared/utils/eventNames'
+import { ESCAPE, } from '../../Shared/utils/keyNames'
 
 const ACTIVITY_SCORES = 'Activity Scores';
 const CONCEPT_REPORTS = 'Concept Reports';
@@ -10,8 +14,9 @@ const STANDARDS_REPORTS = 'Standards Reports';
 const USAGE_SNAPSHOT_REPORT = 'Usage Snapshot Report'
 const DATA_EXPORT = 'Data Export'
 const DIAGNOSTIC_GROWTH_REPORT = 'Diagnostic Growth Report'
+const PREMIUM_REPORTS = 'Premium Reports'
 
-const tabsWithoutHiddenTabs = {
+const baseTabs = {
   [OVERVIEW]: {
     label: OVERVIEW,
     url: '/teachers/premium_hub'
@@ -20,6 +25,14 @@ const tabsWithoutHiddenTabs = {
     label: SCHOOL_SUBSCRIPTIONS,
     url: '/teachers/premium_hub/school_subscriptions'
   },
+  [INTEGRATIONS]: {
+    label: INTEGRATIONS,
+    url: '/teachers/premium_hub/integrations'
+  },
+}
+
+const mobileTabs = {
+  ...baseTabs,
   [ACTIVITY_SCORES]: {
     label: ACTIVITY_SCORES,
     url: '/teachers/premium_hub/district_activity_scores'
@@ -32,18 +45,45 @@ const tabsWithoutHiddenTabs = {
     label: STANDARDS_REPORTS,
     url: '/teachers/premium_hub/district_standards_reports'
   },
-  [INTEGRATIONS]: {
-    label: INTEGRATIONS,
-    url: '/teachers/premium_hub/integrations'
-  },
   [USAGE_SNAPSHOT_REPORT]: {
     label: USAGE_SNAPSHOT_REPORT,
     url: '/teachers/premium_hub/usage_snapshot_report'
   }
 }
 
+const premiumReportDropdownItems = [
+  {
+    label: USAGE_SNAPSHOT_REPORT,
+    url: '/teachers/premium_hub/usage_snapshot_report',
+    new: true
+  },
+  // TODO: uncomment the following two when the reports are ready for public access
+  // {
+  //   label: DIAGNOSTIC_GROWTH_REPORT,
+  //   url: '/teachers/premium_hub/diagnostic_growth_report',
+  //   new: true
+  // },
+  // {
+  //   label: DATA_EXPORT,
+  //   url: '/teachers/premium_hub/data_export',
+  //   new: true
+  // },
+  {
+    label: ACTIVITY_SCORES,
+    url: '/teachers/premium_hub/district_activity_scores'
+  },
+  {
+    label: CONCEPT_REPORTS,
+    url: '/teachers/premium_hub/district_concept_reports'
+  },
+  {
+    label: STANDARDS_REPORTS,
+    url: '/teachers/premium_hub/district_standards_reports'
+  },
+]
+
 const tabs = {
-  ...tabsWithoutHiddenTabs,
+  ...baseTabs,
   [DIAGNOSTIC_GROWTH_REPORT]: {
     label: DIAGNOSTIC_GROWTH_REPORT,
     url: '/teachers/premium_hub/diagnostic_growth_report'
@@ -53,6 +93,85 @@ const tabs = {
     url: '/teachers/premium_hub/data_export'
   }
 }
+
+const PremiumReportsDropdown = ({ activeTab }) => {
+  const dropdownId = "premium-reports-nav-dropdown"
+  const [isOpen, setIsOpen] = React.useState(false);
+  const dropdownRef = React.useRef(null);
+  const buttonRef = React.useRef(null);
+
+  React.useEffect(() => {
+    document.addEventListener(MOUSEDOWN, handleClickOutside);
+    document.addEventListener(KEYDOWN, handleKeyDown);
+    return () => {
+      document.removeEventListener(MOUSEDOWN, handleClickOutside);
+      document.removeEventListener(KEYDOWN, handleKeyDown);
+    };
+  }, [dropdownRef]);
+
+  const activeClass = activeTab === PREMIUM_REPORTS ? 'active' : '';
+  const openClass = isOpen ? 'open' : '';
+
+  function toggleDropdown() {
+    setIsOpen(!isOpen);
+    if (!isOpen) {
+
+      // setTimeout here is a workaround to make sure that the dropdownRef is actually available in the DOM by the time this executes (it pushes execution to the end of the event queue, after the rerender)
+      setTimeout(() => {
+        const firstItem = dropdownRef.current.querySelector('a');
+        if (firstItem) firstItem.focus();
+      }, 0);
+    }
+  }
+
+  function closeDropdown() {
+    setIsOpen(false);
+    // Return focus to the button when dropdown closes
+    buttonRef.current.focus();
+  }
+
+  function handleClickOutside(event) {
+    if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+      closeDropdown();
+    }
+  }
+
+  function handleKeyDown(event) {
+    if (event.key === ESCAPE) {
+      closeDropdown();
+    }
+  }
+
+  function renderDropdown() {
+    return (
+      <div className={dropdownId} id={dropdownId} ref={dropdownRef} role="menu">
+        {premiumReportDropdownItems.map((item) => (
+          <Link className="focus-on-light" key={item.label} onClick={closeDropdown} role="menuitem" to={item.url}>
+            {item.label}
+            {item.new ? <span className="new-tag">NEW</span> : null}
+          </Link>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <li className="premium-reports-tab">
+      <button
+        aria-controls={dropdownId}
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+        className={`premium-reports-button focus-on-dark ${activeClass} ${openClass}`}
+        onClick={toggleDropdown}
+        ref={buttonRef}
+        type="button"
+      >
+        <span>Premium Reports</span>
+      </button>
+      {isOpen ? renderDropdown() : null}
+    </li>
+  );
+};
 
 export const AdminSubnav = ({ path }) => {
 
@@ -67,16 +186,13 @@ export const AdminSubnav = ({ path }) => {
 
   function determineActiveTab() {
     const { pathname } = path;
-    if (pathname.includes('/district_activity_scores')) {
-      setActiveTab(ACTIVITY_SCORES)
-    } else if (pathname.includes('/district_concept_reports')) {
-      setActiveTab(CONCEPT_REPORTS)
-    } else if (pathname.includes('/district_standards_reports')) {
-      setActiveTab(STANDARDS_REPORTS)
+
+    const reportPaths = ['/district_activity_scores', '/district_concept_reports', '/district_standards_reports', '/usage_snapshot_report']
+
+    if (reportPaths.find(path => pathname.includes(path))) {
+      setActiveTab(PREMIUM_REPORTS)
     } else if (pathname.includes('/school_subscriptions')) {
       setActiveTab(SCHOOL_SUBSCRIPTIONS)
-    } else if (pathname.includes('/usage_snapshot_report')) {
-      setActiveTab(USAGE_SNAPSHOT_REPORT)
     } else if (pathname.includes('/diagnostic_growth_report')) {
       setActiveTab(DIAGNOSTIC_GROWTH_REPORT)
     } else if (pathname.includes('/data_export')) {
@@ -98,7 +214,7 @@ export const AdminSubnav = ({ path }) => {
 
   const dropdownClass = dropdownOpen ? 'open' : '';
 
-  const tabsToShow = window.location.href.includes('data_export') || window.location.href.includes('diagnostic_growth_report') ? tabs : tabsWithoutHiddenTabs
+  const tabsToShow = window.location.href.includes('data_export') || window.location.href.includes('diagnostic_growth_report') ? tabs : baseTabs
 
   return(
     <React.Fragment>
@@ -109,13 +225,13 @@ export const AdminSubnav = ({ path }) => {
               <p>{activeTab}</p>
               <i className="fa fa-thin fa-angle-down" />
             </button>
-            {renderNavList({ tabs: tabsToShow, handleLinkClick: handleLinkClick, activeTab, listClass: 'dropdown-menu' })}
+            {renderNavList({ tabs: mobileTabs, handleLinkClick: handleLinkClick, activeTab, listClass: 'dropdown-menu' })}
           </div>
         </div>
       </div >
       <div className="tab-subnavigation-wrapper desktop class-subnav premium-hub-subnav">
         <div className="container">
-          {renderNavList({ tabs: tabsToShow, handleLinkClick: handleLinkClick, activeTab })}
+          {renderNavList({ tabs: tabsToShow, handleLinkClick: handleLinkClick, activeTab, childElement: <PremiumReportsDropdown activeTab={activeTab} /> })}
         </div>
       </div>
     </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
@@ -5,12 +5,12 @@ import { renderNavList } from '../../Shared';
 import { MOUSEDOWN, KEYDOWN, } from '../../Shared/utils/eventNames'
 import { ESCAPE, } from '../../Shared/utils/keyNames'
 
-const ACTIVITY_SCORES = 'Activity Scores';
-const CONCEPT_REPORTS = 'Concept Reports';
+const ACTIVITY_SCORES = 'Activity Scores Report';
+const CONCEPT_REPORTS = 'Concepts Report';
 const INTEGRATIONS = 'Integrations';
 const OVERVIEW = 'Overview';
-const SCHOOL_SUBSCRIPTIONS = 'School Subscriptions';
-const STANDARDS_REPORTS = 'Standards Reports';
+const SUBSCRIPTIONS = 'Subscriptions';
+const STANDARDS_REPORTS = 'Standards Report';
 const USAGE_SNAPSHOT_REPORT = 'Usage Snapshot Report'
 const DATA_EXPORT = 'Data Export'
 const DIAGNOSTIC_GROWTH_REPORT = 'Diagnostic Growth Report'
@@ -21,8 +21,8 @@ const baseTabs = {
     label: OVERVIEW,
     url: '/teachers/premium_hub'
   },
-  [SCHOOL_SUBSCRIPTIONS]: {
-    label: SCHOOL_SUBSCRIPTIONS,
+  [SUBSCRIPTIONS]: {
+    label: SUBSCRIPTIONS,
     url: '/teachers/premium_hub/school_subscriptions'
   },
   [INTEGRATIONS]: {
@@ -69,12 +69,12 @@ const premiumReportDropdownItems = [
   //   new: true
   // },
   {
-    label: ACTIVITY_SCORES,
-    url: '/teachers/premium_hub/district_activity_scores'
-  },
-  {
     label: CONCEPT_REPORTS,
     url: '/teachers/premium_hub/district_concept_reports'
+  },
+  {
+    label: ACTIVITY_SCORES,
+    url: '/teachers/premium_hub/district_activity_scores'
   },
   {
     label: STANDARDS_REPORTS,
@@ -97,6 +97,7 @@ const tabs = {
 const PremiumReportsDropdown = ({ activeTab }) => {
   const dropdownId = "premium-reports-nav-dropdown"
   const [isOpen, setIsOpen] = React.useState(false);
+  const containerRef = React.useRef(null)
   const dropdownRef = React.useRef(null);
   const buttonRef = React.useRef(null);
 
@@ -113,8 +114,10 @@ const PremiumReportsDropdown = ({ activeTab }) => {
   const openClass = isOpen ? 'open' : '';
 
   function toggleDropdown() {
-    setIsOpen(!isOpen);
-    if (!isOpen) {
+    if (isOpen) {
+      closeDropdown()
+    } else {
+      setIsOpen(true);
 
       // setTimeout here is a workaround to make sure that the dropdownRef is actually available in the DOM by the time this executes (it pushes execution to the end of the event queue, after the rerender)
       setTimeout(() => {
@@ -131,7 +134,7 @@ const PremiumReportsDropdown = ({ activeTab }) => {
   }
 
   function handleClickOutside(event) {
-    if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+    if (containerRef.current && !containerRef.current.contains(event.target)) {
       closeDropdown();
     }
   }
@@ -156,7 +159,7 @@ const PremiumReportsDropdown = ({ activeTab }) => {
   }
 
   return (
-    <li className="premium-reports-tab">
+    <li className="premium-reports-tab" ref={containerRef}>
       <button
         aria-controls={dropdownId}
         aria-expanded={isOpen}
@@ -192,7 +195,7 @@ export const AdminSubnav = ({ path }) => {
     if (reportPaths.find(path => pathname.includes(path))) {
       setActiveTab(PREMIUM_REPORTS)
     } else if (pathname.includes('/school_subscriptions')) {
-      setActiveTab(SCHOOL_SUBSCRIPTIONS)
+      setActiveTab(SUBSCRIPTIONS)
     } else if (pathname.includes('/diagnostic_growth_report')) {
       setActiveTab(DIAGNOSTIC_GROWTH_REPORT)
     } else if (pathname.includes('/data_export')) {

--- a/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/navbarHelpers.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+
 import { MAX_VIEW_WIDTH_FOR_MOBILE_NAVBAR } from '../utils/constants';
 
 interface renderNavListProps {
@@ -11,7 +12,8 @@ interface renderNavListProps {
   },
   activeTab: string,
   handleLinkClick: () => void,
-  listClass?: string
+  listClass?: string,
+  childElement?: JSX.Element
 }
 
 function renderListItem({ tabs, handleLinkClick, tabLabel, activeTab, i }) {
@@ -37,12 +39,13 @@ function renderListItem({ tabs, handleLinkClick, tabLabel, activeTab, i }) {
   )
 }
 
-export function renderNavList({ tabs, handleLinkClick, listClass, activeTab }: renderNavListProps) {
+export function renderNavList({ tabs, handleLinkClick, listClass, activeTab, childElement }: renderNavListProps) {
   return (
     <ul className={listClass}>
       {Object.keys(tabs).map((tabLabel, i) => {
         return renderListItem({ tabs, handleLinkClick, tabLabel, activeTab, i })
       })}
+      {childElement}
     </ul>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Shared/utils/keyNames.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/keyNames.ts
@@ -1,0 +1,1 @@
+export const ESCAPE = 'Escape'


### PR DESCRIPTION
## WHAT
Condense premium reports into a new dropdown in the premium tertiary navigation.

## WHY
We need a solution to fit all of the premium reports.

## HOW
Add a new component that renders the premium reports dropdown to the premium subnav tabs, using accessibility best practices to make sure this menu is easily usable for screenreader users. 

### Screenshots
<img width="335" alt="Screenshot 2023-12-08 at 2 35 22 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/af4ec2e8-5f98-485e-9472-d1ef354b3514">
<img width="715" alt="Screenshot 2023-12-08 at 2 35 14 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/ab39eb44-60db-422c-8069-c916d1c4b0f6">

### Notion Card Links
https://www.notion.so/quill/P2-Admin-Tertiary-Level-Navigation-for-Reports-ac40f8a7c2cb4549b768b1e32bd89285?pvs=4

https://www.notion.so/quill/Implement-the-new-Premium-Hub-navigation-7f50c5484d0d4a29bf3655f6a8100445?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES 
