### PR TITLE
fix bug with how feedback renders

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/__tests__/__snapshots__/student_report.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/__tests__/__snapshots__/student_report.test.jsx.snap
@@ -5074,6 +5074,7 @@ exports[`StudentReport should render 1`] = `
                 <tbody>
                   <tr
                     className="Directions"
+                    key=""
                   >
                     <td>
                       Directions
@@ -5161,21 +5162,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-1"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-1"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="1-concepts"
                   >
@@ -5280,21 +5278,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-2"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-2"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="2-concepts"
                   >
@@ -5399,21 +5394,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-3"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-3"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="3-concepts"
                   >
@@ -5518,21 +5510,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-4"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-4"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="4-concepts"
                   >
@@ -5637,9 +5626,6 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="false-5"
-                  />
                   <tr
                     key="5-concepts"
                   >
@@ -5856,6 +5842,7 @@ exports[`StudentReport should render 1`] = `
                 <tbody>
                   <tr
                     className="Directions"
+                    key=""
                   >
                     <td>
                       Directions
@@ -5943,21 +5930,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-1"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-1"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="1-concepts"
                   >
@@ -6062,21 +6046,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-2"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-2"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="2-concepts"
                   >
@@ -6181,21 +6162,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-3"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-3"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="3-concepts"
                   >
@@ -6300,21 +6278,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-4"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-4"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="4-concepts"
                   >
@@ -6419,9 +6394,6 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="false-5"
-                  />
                   <tr
                     key="5-concepts"
                   >
@@ -6558,6 +6530,7 @@ exports[`StudentReport should render 1`] = `
                 <tbody>
                   <tr
                     className="Directions"
+                    key=""
                   >
                     <td>
                       Directions
@@ -6645,9 +6618,6 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="false-1"
-                  />
                   <tr
                     key="1-concepts"
                   >
@@ -6804,6 +6774,7 @@ exports[`StudentReport should render 1`] = `
                 <tbody>
                   <tr
                     className="Directions"
+                    key=""
                   >
                     <td>
                       Directions
@@ -6891,21 +6862,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-1"
+                  <tr
+                    className="Feedback"
+                    key="Try again! Unfortunately, that answer is not correct.-1"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Try again! Unfortunately, that answer is not correct.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Try again! Unfortunately, that answer is not correct.
+                    </td>
+                  </tr>
                   <tr
                     key="1-concepts"
                   >
@@ -7010,9 +6978,6 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="false-2"
-                  />
                   <tr
                     key="2-concepts"
                   >
@@ -7189,6 +7154,7 @@ exports[`StudentReport should render 1`] = `
                 <tbody>
                   <tr
                     className="Directions"
+                    key=""
                   >
                     <td>
                       Directions
@@ -7276,21 +7242,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-1"
+                  <tr
+                    className="Feedback"
+                    key="Try again! Unfortunately, that answer is not correct.-1"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Try again! Unfortunately, that answer is not correct.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Try again! Unfortunately, that answer is not correct.
+                    </td>
+                  </tr>
                   <tr
                     key="1-concepts"
                   >
@@ -7395,21 +7358,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-2"
+                  <tr
+                    className="Feedback"
+                    key="Try again! Unfortunately, that answer is not correct.-2"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Try again! Unfortunately, that answer is not correct.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Try again! Unfortunately, that answer is not correct.
+                    </td>
+                  </tr>
                   <tr
                     key="2-concepts"
                   >
@@ -7519,9 +7479,6 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="false-3"
-                  />
                   <tr
                     key="3-concepts"
                   >
@@ -7738,6 +7695,7 @@ exports[`StudentReport should render 1`] = `
                 <tbody>
                   <tr
                     className="Directions"
+                    key=""
                   >
                     <td>
                       Directions
@@ -7825,21 +7783,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-1"
+                  <tr
+                    className="Feedback"
+                    key="Try again! Unfortunately, that answer is not correct.-1"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Try again! Unfortunately, that answer is not correct.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Try again! Unfortunately, that answer is not correct.
+                    </td>
+                  </tr>
                   <tr
                     key="1-concepts"
                   >
@@ -7949,21 +7904,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-2"
+                  <tr
+                    className="Feedback"
+                    key="<p>Revise your sentence. You don't need to have a space before a period.</p>-2"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Revise your sentence. You don't need to have a space before a period.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Revise your sentence. You don't need to have a space before a period.
+                    </td>
+                  </tr>
                   <tr
                     key="2-concepts"
                   >
@@ -8073,21 +8025,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-3"
+                  <tr
+                    className="Feedback"
+                    key="Try again! Unfortunately, that answer is not correct.-3"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Try again! Unfortunately, that answer is not correct.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Try again! Unfortunately, that answer is not correct.
+                    </td>
+                  </tr>
                   <tr
                     key="3-concepts"
                   >
@@ -8192,21 +8141,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-4"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your punctuation.-4"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="4-concepts"
                   >
@@ -8311,9 +8257,6 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="false-5"
-                  />
                   <tr
                     key="5-concepts"
                   >
@@ -8450,6 +8393,7 @@ exports[`StudentReport should render 1`] = `
                 <tbody>
                   <tr
                     className="Directions"
+                    key=""
                   >
                     <td>
                       Directions
@@ -8537,9 +8481,6 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="false-1"
-                  />
                   <tr
                     key="1-concepts"
                   >
@@ -8736,6 +8677,7 @@ exports[`StudentReport should render 1`] = `
                 <tbody>
                   <tr
                     className="Directions"
+                    key=""
                   >
                     <td>
                       Directions
@@ -8823,21 +8765,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-1"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-1"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="1-concepts"
                   >
@@ -8942,21 +8881,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-2"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-2"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="2-concepts"
                   >
@@ -9061,21 +8997,18 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="[object Object]-3"
+                  <tr
+                    className="Feedback"
+                    key="Proofread your work. Check your ending punctuation.-3"
                   >
-                    <tr
-                      className="Feedback"
-                    >
-                      <td>
-                        Feedback
-                      </td>
-                      <td />
-                      <td>
-                        Proofread your work. Check your ending punctuation.
-                      </td>
-                    </tr>
-                  </span>
+                    <td>
+                      Feedback
+                    </td>
+                    <td />
+                    <td>
+                      Proofread your work. Check your ending punctuation.
+                    </td>
+                  </tr>
                   <tr
                     key="3-concepts"
                   >
@@ -9180,9 +9113,6 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="false-4"
-                  />
                   <tr
                     key="4-concepts"
                   >
@@ -9319,6 +9249,7 @@ exports[`StudentReport should render 1`] = `
                 <tbody>
                   <tr
                     className="Directions"
+                    key=""
                   >
                     <td>
                       Directions
@@ -9406,9 +9337,6 @@ exports[`StudentReport should render 1`] = `
                       </span>
                     </td>
                   </tr>
-                  <span
-                    key="false-1"
-                  />
                   <tr
                     key="1-concepts"
                   >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/__tests__/__snapshots__/student_report_box.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/__tests__/__snapshots__/student_report_box.test.jsx.snap
@@ -72,6 +72,7 @@ exports[`StudentReportBox should render 1`] = `
           <tbody>
             <tr
               className="Directions"
+              key=""
             >
               <td>
                 Directions
@@ -159,21 +160,18 @@ exports[`StudentReportBox should render 1`] = `
                 </span>
               </td>
             </tr>
-            <span
-              key="[object Object]-1"
+            <tr
+              className="Feedback"
+              key="<p>Revise your work. Use one of the joining words from the instructions.</p>-1"
             >
-              <tr
-                className="Feedback"
-              >
-                <td>
-                  Feedback
-                </td>
-                <td />
-                <td>
-                  Revise your work. Use one of the joining words from the instructions.
-                </td>
-              </tr>
-            </span>
+              <td>
+                Feedback
+              </td>
+              <td />
+              <td>
+                Revise your work. Use one of the joining words from the instructions.
+              </td>
+            </tr>
             <tr
               key="1-concepts"
             >
@@ -252,9 +250,6 @@ exports[`StudentReportBox should render 1`] = `
                 </span>
               </td>
             </tr>
-            <span
-              key="false-2"
-            />
             <tr
               key="2-concepts"
             >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
@@ -38,10 +38,10 @@ const StudentReportBox = ({ questionData, boxNumber, showScore, showDiff, }) => 
     );
   }
 
-  function feedbackOrDirections(directionsOrFeedback, classNameAndText) {
+  function feedbackOrDirections(directionsOrFeedback, classNameAndText, key) {
     if (directionsOrFeedback) {
       return (
-        <tr className={classNameAndText}>
+        <tr className={classNameAndText} key={key || ''}>
           <td>{classNameAndText}</td>
           <td />
           <td>{formatString(directionsOrFeedback)}</td>
@@ -74,10 +74,10 @@ const StudentReportBox = ({ questionData, boxNumber, showScore, showDiff, }) => 
     }
     // sometimes feedback is coming through as a react variable, I've been unable to find the source of it
     if (feedback && typeof feedback === 'string') {
-      feedback = feedbackOrDirections(feedback, 'Feedback')
+      feedback = feedbackOrDirections(feedback, 'Feedback', `${String(feedback)}-${attemptNum}`)
     }
 
-    return <span key={`${String(feedback)}-${attemptNum}`}>{feedback}</span>
+    return feedback
   }
 
   function conceptsByAttempt() {


### PR DESCRIPTION
## WHAT
Fix bug where feedback was getting squished in the activity analysis student reports.

## WHY
We want this to render correctly!

## HOW
Update this so the row doesn't render inside of a span and instead just passes a key to the row itself.

### Screenshots
<img width="1241" alt="Screenshot 2023-12-08 at 2 45 48 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/4813c8ed-236d-4806-9f4b-fba22e022156">

### Notion Card Links
https://www.notion.so/quill/b417e5b89fe04af89cba62d4198f7031?v=77f294a5b0df466e98633244de7ebfef

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES