### PR TITLE
Updates to Evidence Activity form for Staff

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -5,6 +5,7 @@ import {
   EditorState,
   RichUtils,
 } from 'draft-js';
+import { decode } from 'html-entities';
 import * as Immutable from 'immutable';
 import * as React from 'react';
 
@@ -69,7 +70,7 @@ class TextEditor extends React.Component <any, any> {
       },
       entityToHTML: (entity, originalText) => {
         if (entity.type === LINK) {
-          return <a href={entity.data.url}>{originalText}</a>;
+          return <a href={entity.data.url}>{decode(originalText)}</a>;
         }
         return originalText;
       }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -159,25 +159,46 @@ exports[`Activity Form component should render Activities 1`] = `
           "component": <ToggleComponentSection
             components={
               Array [
-                <ImageSection
-                  activityPassages={
-                    Array [
-                      Object {
-                        "text": "...",
-                      },
-                    ]
+                <PromptsForm
+                  activityBecausePrompt={
+                    Object {
+                      "conjunction": "because",
+                      "first_strong_example": "",
+                      "id": 7,
+                      "max_attempts": 5,
+                      "max_attempts_feedback": "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.",
+                      "second_strong_example": "",
+                      "text": "1",
+                    }
+                  }
+                  activityButPrompt={
+                    Object {
+                      "conjunction": "but",
+                      "first_strong_example": "",
+                      "id": 8,
+                      "max_attempts": 5,
+                      "max_attempts_feedback": "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.",
+                      "second_strong_example": "",
+                      "text": "2",
+                    }
+                  }
+                  activitySoPrompt={
+                    Object {
+                      "conjunction": "so",
+                      "first_strong_example": "",
+                      "id": 9,
+                      "max_attempts": 5,
+                      "max_attempts_feedback": "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.",
+                      "second_strong_example": "",
+                      "text": "3",
+                    }
                   }
                   errors={Object {}}
-                  handleSetImageAltText={[Function]}
-                  handleSetImageAttribution={[Function]}
-                  handleSetImageCaption={[Function]}
-                  handleSetImageLink={[Function]}
-                  imageAttributionGuideLink="https://www.notion.so/quill/Activity-Images-9bc3993400da46a6af445a8a0d2d9d3f#11e9a01b071e41bc954e1182d56e93e8"
-                  imageAttributionStyle=""
+                  handleSetPrompt={[Function]}
                 />,
               ]
             }
-            label="Image"
+            label="Prompts"
           />,
           "id": 1,
         },
@@ -210,22 +231,25 @@ exports[`Activity Form component should render Activities 1`] = `
           "component": <ToggleComponentSection
             components={
               Array [
-                <React.Fragment>
-                  <p
-                    className="text-editor-label "
-                  >
-                    Building Essential Knowledge Text
-                  </p>
-                  <TextEditor
-                    ContentState={[Function]}
-                    EditorState={[Function]}
-                    handleTextChange={[Function]}
-                    shouldCheckSpelling={true}
-                  />
-                </React.Fragment>,
+                <ImageSection
+                  activityPassages={
+                    Array [
+                      Object {
+                        "text": "...",
+                      },
+                    ]
+                  }
+                  errors={Object {}}
+                  handleSetImageAltText={[Function]}
+                  handleSetImageAttribution={[Function]}
+                  handleSetImageCaption={[Function]}
+                  handleSetImageLink={[Function]}
+                  imageAttributionGuideLink="https://www.notion.so/quill/Activity-Images-9bc3993400da46a6af445a8a0d2d9d3f#11e9a01b071e41bc954e1182d56e93e8"
+                  imageAttributionStyle=""
+                />,
               ]
             }
-            label="Building Essential Knowledge"
+            label="Image"
           />,
           "id": 3,
         },
@@ -296,46 +320,22 @@ exports[`Activity Form component should render Activities 1`] = `
           "component": <ToggleComponentSection
             components={
               Array [
-                <PromptsForm
-                  activityBecausePrompt={
-                    Object {
-                      "conjunction": "because",
-                      "first_strong_example": "",
-                      "id": 7,
-                      "max_attempts": 5,
-                      "max_attempts_feedback": "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.",
-                      "second_strong_example": "",
-                      "text": "1",
-                    }
-                  }
-                  activityButPrompt={
-                    Object {
-                      "conjunction": "but",
-                      "first_strong_example": "",
-                      "id": 8,
-                      "max_attempts": 5,
-                      "max_attempts_feedback": "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.",
-                      "second_strong_example": "",
-                      "text": "2",
-                    }
-                  }
-                  activitySoPrompt={
-                    Object {
-                      "conjunction": "so",
-                      "first_strong_example": "",
-                      "id": 9,
-                      "max_attempts": 5,
-                      "max_attempts_feedback": "At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. I award you no points, and may God have mercy on your soul.",
-                      "second_strong_example": "",
-                      "text": "3",
-                    }
-                  }
-                  errors={Object {}}
-                  handleSetPrompt={[Function]}
-                />,
+                <React.Fragment>
+                  <p
+                    className="text-editor-label "
+                  >
+                    Building Essential Knowledge Text
+                  </p>
+                  <TextEditor
+                    ContentState={[Function]}
+                    EditorState={[Function]}
+                    handleTextChange={[Function]}
+                    shouldCheckSpelling={true}
+                  />
+                </React.Fragment>,
               ]
             }
-            label="Prompts"
+            label="Building Essential Knowledge"
           />,
           "id": 5,
         },

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/imageSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/imageSection.test.tsx.snap
@@ -2,6 +2,20 @@
 
 exports[`ImageSection component should render ImageSection 1`] = `
 <Fragment>
+  <div
+    className="media-upload-container"
+  >
+    <label>
+      Click the square below or drag an image into it to upload an image or video:
+    </label>
+    <div
+      className="dropzone-container"
+    >
+      <Component
+        onDrop={[Function]}
+      />
+    </div>
+  </div>
   <Input
     autoComplete="on"
     className="image-link-input"
@@ -38,10 +52,12 @@ exports[`ImageSection component should render ImageSection 1`] = `
     >
       Image Attribution Guide
     </a>
-    <textarea
-      aria-labelledby="image-attribution-label"
-      className="image-attribution-text-area"
-      onChange={[MockFunction]}
+    <TextEditor
+      ContentState={[Function]}
+      EditorState={[Function]}
+      handleTextChange={[MockFunction]}
+      key="image-attribution"
+      shouldCheckSpelling={true}
     />
   </div>
 </Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/imageSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/imageSection.test.tsx.snap
@@ -5,7 +5,9 @@ exports[`ImageSection component should render ImageSection 1`] = `
   <div
     className="media-upload-container"
   >
-    <label>
+    <label
+      htmlFor="dropzone-container"
+    >
       Click the square below or drag an image into it to upload an image or video:
     </label>
     <div
@@ -19,7 +21,7 @@ exports[`ImageSection component should render ImageSection 1`] = `
   <Input
     autoComplete="on"
     className="image-link-input"
-    handleChange={[MockFunction]}
+    handleChange={[Function]}
     label="Image Link"
     value=""
   />

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activities.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activities.tsx
@@ -21,6 +21,7 @@ const Activities = ({ location, match }) => {
 
   const formattedRows = filteredActivities.map((activity: ActivityInterface) => {
     const { id, title, parent_activity_id, notes } = activity;
+    const activityInternalNameLink = (<Link to={`/activities/${id}`}>{notes}</Link>);
     const activityLink = (<Link to={`/activities/${id}`}>{title}</Link>);
     const highlightLabel = (
       <ActivityInvalidHighlights activityId={id} />
@@ -29,7 +30,7 @@ const Activities = ({ location, match }) => {
       id,
       parent_activity_id,
       title: activityLink,
-      notes,
+      notes: activityInternalNameLink,
       valid_highlights: highlightLabel
     }
   });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -43,7 +43,11 @@ const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormP
   function handleSetActivityTitle(e: InputEvent){ setActivityTitle(e.target.value) };
   function handleSetActivityNotes(e: InputEvent){ setActivityNotes(e.target.value) };
   function handleSetHighlightPrompt(e: InputEvent){ handleSetActivityPassages('highlight_prompt', e.target.value) };
-  function handleSetImageLink(e: InputEvent){ handleSetActivityPassages('image_link', e.target.value) };
+  function handleSetImageLink(text: string){
+    console.log("setting image link");
+    console.log(text);
+    handleSetActivityPassages('image_link', text)
+  };
   function handleSetImageAltText(e: InputEvent){ handleSetActivityPassages('image_alt_text', e.target.value) };
   function handleSetPassageText(text: string) { handleSetActivityPassages('text', text)}
   function handleSetPassageEssentialKnowledgeText(text: string) { handleSetActivityPassages('essential_knowledge_text', text)}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -43,15 +43,11 @@ const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormP
   function handleSetActivityTitle(e: InputEvent){ setActivityTitle(e.target.value) };
   function handleSetActivityNotes(e: InputEvent){ setActivityNotes(e.target.value) };
   function handleSetHighlightPrompt(e: InputEvent){ handleSetActivityPassages('highlight_prompt', e.target.value) };
-  function handleSetImageLink(text: string){
-    console.log("setting image link");
-    console.log(text);
-    handleSetActivityPassages('image_link', text)
-  };
+  function handleSetImageLink(text: string){handleSetActivityPassages('image_link', text) };
   function handleSetImageAltText(e: InputEvent){ handleSetActivityPassages('image_alt_text', e.target.value) };
   function handleSetPassageText(text: string) { handleSetActivityPassages('text', text)}
   function handleSetPassageEssentialKnowledgeText(text: string) { handleSetActivityPassages('essential_knowledge_text', text)}
-  function handleSetImageAttribution(text: string) { handleSetActivityPassages('image_attribution', text)}
+  function handleSetImageAttribution(text: string) {handleSetActivityPassages('image_attribution', text) }
   function handleSetImageCaption(e: InputEvent) { handleSetActivityPassages('image_caption', e.target.value)}
 
   function handleSetActivityPassages(key, value){

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -159,18 +159,15 @@ const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormP
     <ToggleComponentSection components={[passageComponent]} label={titleCase(TEXT)} />,
     <ToggleComponentSection
       components={[
-        <ImageSection
-          activityPassages={activityPassages}
+        <PromptsForm
+          activityBecausePrompt={activityBecausePrompt}
+          activityButPrompt={activityButPrompt}
+          activitySoPrompt={activitySoPrompt}
           errors={errors}
-          handleSetImageAltText={handleSetImageAltText}
-          handleSetImageAttribution={handleSetImageAttribution}
-          handleSetImageCaption={handleSetImageCaption}
-          handleSetImageLink={handleSetImageLink}
-          imageAttributionGuideLink={imageAttributionGuideLink}
-          imageAttributionStyle={imageAttributionStyle}
+          handleSetPrompt={handleSetPrompt}
         />
       ]}
-      label={IMAGE}
+      label={PROMPTS}
     />,
     <ToggleComponentSection
       components={[
@@ -184,20 +181,23 @@ const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormP
       ]}
       label={HIGHLIGHTING_PROMPT}
     />,
-    <ToggleComponentSection components={[buildingEssentialKnowledgeComponent]} label={BUILDING_ESSENTIAL_KNOWLEDGE} />,
-    <ToggleComponentSection components={[getMaxAttemptsFeedbackComponent(BECAUSE, activityBecausePrompt), getMaxAttemptsFeedbackComponent(BUT, activityButPrompt), getMaxAttemptsFeedbackComponent(SO, activitySoPrompt)]} label={MAX_ATTEMPTS_FEEDBACK} />,
     <ToggleComponentSection
       components={[
-        <PromptsForm
-          activityBecausePrompt={activityBecausePrompt}
-          activityButPrompt={activityButPrompt}
-          activitySoPrompt={activitySoPrompt}
+        <ImageSection
+          activityPassages={activityPassages}
           errors={errors}
-          handleSetPrompt={handleSetPrompt}
+          handleSetImageAltText={handleSetImageAltText}
+          handleSetImageAttribution={handleSetImageAttribution}
+          handleSetImageCaption={handleSetImageCaption}
+          handleSetImageLink={handleSetImageLink}
+          imageAttributionGuideLink={imageAttributionGuideLink}
+          imageAttributionStyle={imageAttributionStyle}
         />
       ]}
-      label={PROMPTS}
-    />
+      label={IMAGE}
+    />,
+    <ToggleComponentSection components={[getMaxAttemptsFeedbackComponent(BECAUSE, activityBecausePrompt), getMaxAttemptsFeedbackComponent(BUT, activityButPrompt), getMaxAttemptsFeedbackComponent(SO, activitySoPrompt)]} label={MAX_ATTEMPTS_FEEDBACK} />,
+    <ToggleComponentSection components={[buildingEssentialKnowledgeComponent]} label={BUILDING_ESSENTIAL_KNOWLEDGE} />,
   ];
 
   const formattedRows = formComponents.map((component, i) => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -47,7 +47,7 @@ const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormP
   function handleSetImageAltText(e: InputEvent){ handleSetActivityPassages('image_alt_text', e.target.value) };
   function handleSetPassageText(text: string) { handleSetActivityPassages('text', text)}
   function handleSetPassageEssentialKnowledgeText(text: string) { handleSetActivityPassages('essential_knowledge_text', text)}
-  function handleSetImageAttribution(e: TextAreaEvent) { handleSetActivityPassages('image_attribution', e.target.value)}
+  function handleSetImageAttribution(text: string) { handleSetActivityPassages('image_attribution', text)}
   function handleSetImageCaption(e: InputEvent) { handleSetActivityPassages('image_caption', e.target.value)}
 
   function handleSetActivityPassages(key, value){

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
@@ -32,20 +32,23 @@ export const ImageSection = ({
         body: data
       })
         .then(response => response.json()) // if the response is a JSON object
-        .then(response => setUploadedMediaLink(response.url)); // Handle the success response object
+        .then(response => {
+          setUploadedMediaLink(response.url)
+          handleSetImageLink(response.url)
+        }); // Handle the success response object
     });
   }
 
   return(
     <React.Fragment>
       <div className="media-upload-container">
-        <label>Click the square below or drag an image into it to upload an image or video:</label>
+        <label htmlFor="dropzone-container">Click the square below or drag an image into it to upload an image or video:</label>
         <div className="dropzone-container"><Dropzone onDrop={handleDrop} /></div>
       </div>
       <Input
         className="image-link-input"
         error={errors[IMAGE_LINK]}
-        handleChange={handleSetImageLink}
+        handleChange={(e) => handleSetImageLink(e.target.value)}
         label="Image Link"
         value={uploadedMediaLink}
       />

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
@@ -16,7 +16,6 @@ export const ImageSection = ({
   imageAttributionGuideLink,
   handleSetImageAttribution
 }) => {
-  const [uploadedMediaLink, setUploadedMediaLink] = React.useState<string>(activityPassages[0].image_link);
 
   function handleDrop (acceptedFiles) {
     acceptedFiles.forEach(file => {
@@ -33,7 +32,6 @@ export const ImageSection = ({
       })
         .then(response => response.json()) // if the response is a JSON object
         .then(response => {
-          setUploadedMediaLink(response.url)
           handleSetImageLink(response.url)
         }); // Handle the success response object
     });
@@ -50,7 +48,7 @@ export const ImageSection = ({
         error={errors[IMAGE_LINK]}
         handleChange={(e) => handleSetImageLink(e.target.value)}
         label="Image Link"
-        value={uploadedMediaLink}
+        value={activityPassages[0].image_link}
       />
       <Input
         className="image-alt-text-input"

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import Dropzone from 'react-dropzone';
 
 import { IMAGE_ALT_TEXT, IMAGE_ATTRIBUTION, IMAGE_CAPTION, IMAGE_LINK } from '../../../../../constants/evidence';
 import { Input } from '../../../../Shared';
+import getAuthToken from '../../../../Teacher/components/modules/get_auth_token';
 
 export const ImageSection = ({
   activityPassages,
@@ -13,14 +15,38 @@ export const ImageSection = ({
   imageAttributionGuideLink,
   handleSetImageAttribution
 }) => {
+  const [uploadedMediaLink, setUploadedMediaLink] = React.useState<string>(activityPassages[0].image_link);
+
+  function handleDrop (acceptedFiles) {
+    acceptedFiles.forEach(file => {
+      const data = new FormData()
+      data.append('file', file)
+      fetch(`${process.env.DEFAULT_URL}/cms/images`, {
+        method: 'POST',
+        mode: 'cors',
+        credentials: 'include',
+        headers: {
+          'X-CSRF-Token': getAuthToken()
+        },
+        body: data
+      })
+        .then(response => response.json()) // if the response is a JSON object
+        .then(response => setUploadedMediaLink(response.url)); // Handle the success response object
+    });
+  }
+
   return(
     <React.Fragment>
+      <div className="media-upload-container">
+        <label>Click the square below or drag an image into it to upload an image or video:</label>
+        <div className="dropzone-container"><Dropzone onDrop={handleDrop} /></div>
+      </div>
       <Input
         className="image-link-input"
         error={errors[IMAGE_LINK]}
         handleChange={handleSetImageLink}
         label="Image Link"
-        value={activityPassages[0].image_link}
+        value={uploadedMediaLink}
       />
       <Input
         className="image-alt-text-input"

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import { ContentState, EditorState } from 'draft-js';
 import Dropzone from 'react-dropzone';
 
 import { IMAGE_ALT_TEXT, IMAGE_ATTRIBUTION, IMAGE_CAPTION, IMAGE_LINK } from '../../../../../constants/evidence';
-import { Input } from '../../../../Shared';
+import { Input, TextEditor } from '../../../../Shared';
 import getAuthToken from '../../../../Teacher/components/modules/get_auth_token';
 
 export const ImageSection = ({
@@ -66,11 +67,13 @@ export const ImageSection = ({
       <div className="image-attribution-container">
         <p className={`text-editor-label ${imageAttributionStyle}`} id="image-attribution-label"> Image Attribution</p>
         <a className="data-link image-attribution-guide-link" href={imageAttributionGuideLink} rel="noopener noreferrer" target="_blank">Image Attribution Guide</a>
-        <textarea
-          aria-labelledby="image-attribution-label"
-          className="image-attribution-text-area"
-          onChange={handleSetImageAttribution}
-          value={activityPassages[0].image_attribution}
+        <TextEditor
+          ContentState={ContentState}
+          EditorState={EditorState}
+          handleTextChange={handleSetImageAttribution}
+          key="image-attribution"
+          shouldCheckSpelling={true}
+          text={activityPassages[0].image_attribution}
         />
       </div>
       {errors[IMAGE_ATTRIBUTION] && <p className="error-message">{errors[IMAGE_ATTRIBUTION]}</p>}

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/miscHelpers.tsx
@@ -204,7 +204,7 @@ export function validateFormSection({
         !!activityPassages[0].image_link &&
         !!activityPassages[0].image_alt_text &&
         !!activityPassages[0].image_caption &&
-        !!activityPassages[0].image_attribution
+        activityPassages[0].image_attribution !== BREAK_TAG
       );
       return getCheckIcon(imageDetailsPresent);
     case MAX_ATTEMPTS_FEEDBACK:


### PR DESCRIPTION
## WHAT
Series of updates to the Evidence Activity form. 
-Re-ordering elements on the page, adding more convenient links
-adding capability to directly upload an image and obtain the S3 bucket link
-replacing regular input with TextEditor

## WHY
This is part of a series of upgrades to this part of the site to make the Evidence Activity creation flow easier on Quill staff.

## HOW
Mostly straightforward copying of React Elements we've already made into this form.

### Screenshots
![Screenshot 2023-12-11 at 9 35 27 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/9b68335a-ecd8-4ec4-a534-ce2e436aef0c)


### Notion Card Links
https://www.notion.so/quill/View-Activities-Page-Ability-to-Click-Internal-Name-to-Open-Activity-66a983f23f7f4f1a9a72f2d10873b819?pvs=4
https://www.notion.so/quill/Update-Activity-Settings-Page-in-Evidence-CMS-to-Better-Reflect-Curriculum-Team-Workflow-83f98cdfabe6490f90b5368065d16035?pvs=4
https://www.notion.so/quill/Add-functionality-to-generate-an-image-link-within-the-Evidence-CMS-bda3837a70464f61a08649c669e9e591?pvs=4
https://www.notion.so/quill/Not-having-to-use-markdown-in-Image-Attribution-305861229c8a44c98b68222577d02442?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
