### PR TITLE
fix bug where clicking anywhere on premium page returns focus to the top

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
@@ -128,6 +128,8 @@ const PremiumReportsDropdown = ({ activeTab }) => {
   }
 
   function closeDropdown() {
+    if (!isOpen) { return }
+    
     setIsOpen(false);
     // Return focus to the button when dropdown closes
     buttonRef.current.focus();


### PR DESCRIPTION
## WHAT
Fix bug where clicking anywhere on a premium page returns focus to the top of the page.

## WHY
This is very annoying behavior when you're scrolled down.

## HOW
Make sure the dropdown is open before changing focus.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A