### PR TITLE
Update sales renewal form links

### DIFF
--- a/services/QuillLMS/app/controllers/sales_form_submission_controller.rb
+++ b/services/QuillLMS/app/controllers/sales_form_submission_controller.rb
@@ -3,14 +3,9 @@
 class SalesFormSubmissionController < ApplicationController
   skip_before_action :verify_authenticity_token
 
-  RENEWAL_REQUEST = 'renewal request'
   QUOTE_REQUEST = 'quote request'
   SCHOOL = 'school'
   DISTRICT = 'district'
-
-  def request_renewal
-    @type = RENEWAL_REQUEST
-  end
 
   def request_quote
     redirect_to '/premium/request-school-quote'

--- a/services/QuillLMS/app/views/sales_form_submission/request_renewal.html.erb
+++ b/services/QuillLMS/app/views/sales_form_submission/request_renewal.html.erb
@@ -1,1 +1,0 @@
-<%= react_component('SalesFormApp', props: { type: @type }) %>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/SubscriptionStatus.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import {
   DISTRICT_PREMIUM,
+  SALESMATE_RENEWAL_FORM_URL,
   SCHOOL_PREMIUM,
   SCHOOL_PREMIUM_SCHOLARSHIP,
   TEACHER_PREMIUM,
@@ -171,7 +172,9 @@ const SubscriptionStatus = ({
         content.buttonOrDate = (
           <a
             className={CTA_BUTTON_CLASSNAME}
-            href="mailto:sales@quill.org"
+            href={SALESMATE_RENEWAL_FORM_URL}
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Contact us to renew
           </a>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/constants.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/constants.jsx
@@ -1,3 +1,5 @@
+export const SALESMATE_RENEWAL_FORM_URL = "https://webforms.salesmate.io/webforms/#/cdc44d13-84f9-45e9-84c4-2136e1bdb5ca"
+
 // subscription types (for display)
 export const TEACHER_PREMIUM_TRIAL = "Teacher Premium Trial"
 export const TEACHER_PREMIUM_CREDIT = "Teacher Premium Credit"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/current_subscription.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {
   CREDIT_CARD,
+  SALESMATE_RENEWAL_FORM_URL,
   SCHOOL_PREMIUM_SCHOLARSHIP,
   TEACHER_PREMIUM_CREDIT,
   TEACHER_PREMIUM_SCHOLARSHIP,
@@ -37,7 +38,7 @@ export default class CurrentSubscription extends React.Component {
       return <span>{baseText} To prevent your subscription from expiring, contact the purchaser at <a href={`mailto:${purchaser_email}`}>{purchaser_email}</a> and ask them to turn on automatic renewal.</span>
     }
     if (payment_method !== CREDIT_CARD && (authorityLevel || !purchaser_email)) {
-      return <span>{baseText} To renew your subscription for next year, <a href="https://quill.org/request_renewal" rel="noopener noreferrer">contact us</a>.</span>
+      return <span>{baseText} To renew your subscription for next year, <a href={SALESMATE_RENEWAL_FORM_URL} rel="noopener noreferrer" target="_blank">contact us</a>.</span>
     }
     if (payment_method !== CREDIT_CARD && !authorityLevel) {
       return <span>{baseText} To renew your subscription for next year, contact the purchaser at <a href={`mailto:${purchaser_email}`}>{purchaser_email}</a> or <a href="mailto:sales@quill.org">the Quill team</a>.</span>
@@ -69,7 +70,7 @@ export default class CurrentSubscription extends React.Component {
     return (
       <span>
         To renew your subscription for next year,
-        <a href="https://quill.org/request_renewal" rel="noopener noreferrer">contact us now</a>.
+        <a href={SALESMATE_RENEWAL_FORM_URL} rel="noopener noreferrer" target="_blank">contact us now</a>.
       </span>
     )
   }
@@ -95,7 +96,7 @@ export default class CurrentSubscription extends React.Component {
           <span className="content-wrapper">
             Off
             <Tooltip
-              tooltipText="To renew your subscription for next year, contact us at https://quill.org/request_renewal."
+              tooltipText={`To renew your subscription for next year, contact us at ${SALESMATE_RENEWAL_FORM_URL}.`}
               tooltipTriggerText={<span><img alt={helpIcon.alt} className="subscription-tooltip" src={helpIcon.src} /></span>}
             />
           </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
@@ -796,7 +796,9 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           </div>
           <a
             className="quill-button medium contained primary focus-on-light"
-            href="mailto:sales@quill.org"
+            href="https://webforms.salesmate.io/webforms/#/cdc44d13-84f9-45e9-84c4-2136e1bdb5ca"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Contact us to renew
           </a>
@@ -1434,7 +1436,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                           Off
                           <Tooltip
                             isTabbable={true}
-                            tooltipText="To renew your subscription for next year, contact us at https://quill.org/request_renewal."
+                            tooltipText="To renew your subscription for next year, contact us at https://webforms.salesmate.io/webforms/#/cdc44d13-84f9-45e9-84c4-2136e1bdb5ca."
                             tooltipTriggerText={
                               <span>
                                 <img
@@ -1462,7 +1464,7 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                             Off
                             <Tooltip
                               isTabbable={true}
-                              tooltipText="To renew your subscription for next year, contact us at https://quill.org/request_renewal."
+                              tooltipText="To renew your subscription for next year, contact us at https://webforms.salesmate.io/webforms/#/cdc44d13-84f9-45e9-84c4-2136e1bdb5ca."
                               tooltipTriggerText={
                                 <span>
                                   <img
@@ -1598,8 +1600,9 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                       Once your current District Premium subscription expires, you will be downgraded to Quill Basic.
                        To renew your subscription for next year, 
                       <a
-                        href="https://quill.org/request_renewal"
+                        href="https://webforms.salesmate.io/webforms/#/cdc44d13-84f9-45e9-84c4-2136e1bdb5ca"
                         rel="noopener noreferrer"
+                        target="_blank"
                       >
                         contact us
                       </a>
@@ -1990,7 +1993,9 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
           </div>
           <a
             className="quill-button medium contained primary focus-on-light"
-            href="mailto:sales@quill.org"
+            href="https://webforms.salesmate.io/webforms/#/cdc44d13-84f9-45e9-84c4-2136e1bdb5ca"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Contact us to renew
           </a>
@@ -5983,7 +5988,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                           Off
                           <Tooltip
                             isTabbable={true}
-                            tooltipText="To renew your subscription for next year, contact us at https://quill.org/request_renewal."
+                            tooltipText="To renew your subscription for next year, contact us at https://webforms.salesmate.io/webforms/#/cdc44d13-84f9-45e9-84c4-2136e1bdb5ca."
                             tooltipTriggerText={
                               <span>
                                 <img
@@ -6011,7 +6016,7 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                             Off
                             <Tooltip
                               isTabbable={true}
-                              tooltipText="To renew your subscription for next year, contact us at https://quill.org/request_renewal."
+                              tooltipText="To renew your subscription for next year, contact us at https://webforms.salesmate.io/webforms/#/cdc44d13-84f9-45e9-84c4-2136e1bdb5ca."
                               tooltipTriggerText={
                                 <span>
                                   <img
@@ -6147,8 +6152,9 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                       Once your current School Premium subscription expires, you will be downgraded to Quill Basic.
                        To renew your subscription for next year, 
                       <a
-                        href="https://quill.org/request_renewal"
+                        href="https://webforms.salesmate.io/webforms/#/cdc44d13-84f9-45e9-84c4-2136e1bdb5ca"
                         rel="noopener noreferrer"
+                        target="_blank"
                       >
                         contact us
                       </a>

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -942,7 +942,6 @@ EmpiricalGrammar::Application.routes.draw do
   get 'AP', to: redirect('/ap')
   get 'springboard' => 'pages#springboard'
   get 'request_quote' => 'sales_form_submission#request_quote'
-  get 'request_renewal' => 'sales_form_submission#request_renewal'
 
   get '/404' => 'errors#error404'
   get '/500' => 'errors#error500'

--- a/services/QuillLMS/spec/controllers/sales_form_submission_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sales_form_submission_controller_spec.rb
@@ -31,13 +31,6 @@ describe SalesFormSubmissionController, type: :controller do
     end
   end
 
-  describe '#request_renewal' do
-    it 'should set type variable to "renewal request"' do
-      get :request_renewal
-      expect(assigns(:type)).to eq(SalesFormSubmissionController::RENEWAL_REQUEST)
-    end
-  end
-
   describe '#request_quote' do
     it 'should redirect to school quote request' do
       get :request_quote


### PR DESCRIPTION
## WHAT
Replace the request_renewal endpoint with salesmate link

## WHY
The request_renewal endpoint is no longer used.

## HOW
Update appropriate hrefs and remove the request_renewal route, controller action, and template.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-sales-renewal-form-links-04fedeb5bbc3405d8adfc3090ab0667e?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
