### PR TITLE
add post query transform hook to QuillBigQuery::Query

### DIFF
--- a/services/QuillLMS/app/queries/quill_big_query/query.rb
+++ b/services/QuillLMS/app/queries/quill_big_query/query.rb
@@ -12,8 +12,12 @@ module QuillBigQuery
       raise NotImplementedError
     end
 
+    def post_query_transform(query_result)
+      query_result
+    end
+
     def run_query
-      runner.execute(query)
+      post_query_transform(runner.execute(query))
     end
 
     def query

--- a/services/QuillLMS/app/queries/snapshots/data_export_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/data_export_query.rb
@@ -29,6 +29,15 @@ module Snapshots
       SQL
     end
 
+    def post_query_transform(query_result)
+      return query_result unless user&.time_zone
+      query_result.map do |row|
+        datetime_string_with_timezone = DateTime.parse(row[:completed_at]).in_time_zone(user.time_zone).to_s
+        row.merge(completed_at: datetime_string_with_timezone)
+      end
+
+    end
+
     def from_and_join_clauses
       super + <<-SQL
         JOIN lms.classroom_units

--- a/services/QuillLMS/app/queries/snapshots/data_export_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/data_export_query.rb
@@ -32,7 +32,7 @@ module Snapshots
     def post_query_transform(query_result)
       return query_result unless user&.time_zone
       query_result.map do |row|
-        datetime_string_with_timezone = DateTime.parse(row[:completed_at]).in_time_zone(user.time_zone).to_s
+        datetime_string_with_timezone = row[:completed_at].in_time_zone(user.time_zone)
         row.merge(completed_at: datetime_string_with_timezone)
       end
 

--- a/services/QuillLMS/app/queries/snapshots/period_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/period_query.rb
@@ -2,15 +2,16 @@
 
 module Snapshots
   class PeriodQuery < ::QuillBigQuery::Query
-    attr_reader :timeframe_start, :timeframe_end, :school_ids, :grades, :teacher_ids, :classroom_ids
+    attr_reader :timeframe_start, :timeframe_end, :school_ids, :grades, :teacher_ids, :classroom_ids, :user
 
-    def initialize(timeframe_start:, timeframe_end:, school_ids:, grades: nil, teacher_ids: nil, classroom_ids: nil, **options)
+    def initialize(timeframe_start:, timeframe_end:, school_ids:, grades: nil, teacher_ids: nil, classroom_ids: nil, user: nil, **options)
       @timeframe_start = timeframe_start
       @timeframe_end = timeframe_end
       @school_ids = school_ids
       @grades = grades
       @teacher_ids = teacher_ids
       @classroom_ids = classroom_ids
+      @user = user
 
       super(**options)
     end

--- a/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
@@ -11,7 +11,8 @@ module Snapshots
     }
 
     def perform(cache_key, query, user_id, timeframe, school_ids, filters, previous_timeframe)
-      payload = generate_payload(query, timeframe, school_ids, filters)
+      user = User.find(user_id)
+      payload = generate_payload(query, timeframe, school_ids, user, filters)
       Rails.cache.write(cache_key, payload.to_a, expires_in: cache_expiry)
 
       filter_hash = PayloadHasher.run([
@@ -36,13 +37,14 @@ module Snapshots
       now.end_of_day.to_i - now.to_i
     end
 
-    private def generate_payload(query, timeframe, school_ids, filters)
+    private def generate_payload(query, timeframe, school_ids, user, filters)
       filters_symbolized = filters.symbolize_keys
 
       QUERIES[query].run(**{
         timeframe_start: DateTime.parse(timeframe['timeframe_start']),
         timeframe_end: DateTime.parse(timeframe['timeframe_end']),
-        school_ids: school_ids
+        school_ids: school_ids,
+        user:
       }.merge(filters_symbolized))
     end
   end

--- a/services/QuillLMS/app/workers/snapshots/premium_download_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/premium_download_reports_worker.rb
@@ -12,9 +12,10 @@ module Snapshots
     TEMPFILE_NAME = 'temp.csv'
 
     def perform(query, user_id, timeframe, school_ids, headers_to_display, filters)
-      payload = generate_payload(query, timeframe, school_ids, filters)
-      uploader = AdminReportCsvUploader.new(admin_id: user_id)
       user = User.find(user_id)
+      payload = generate_payload(query, timeframe, school_ids, user, filters)
+      uploader = AdminReportCsvUploader.new(admin_id: user_id)
+
 
       csv_tempfile = Tempfile.new(TEMPFILE_NAME)
       csv_tempfile << Adapters::Csv::AdminPremiumDataExport.to_csv_string(payload, headers_to_display)
@@ -31,7 +32,7 @@ module Snapshots
       PremiumHubUserMailer.admin_premium_download_report_email(user.first_name, uploaded_file_url, email).deliver_now!
     end
 
-    private def generate_payload(query, timeframe, school_ids, filters)
+    private def generate_payload(query, timeframe, school_ids, user, filters)
       timeframe_start = parse_datetime_string(timeframe['timeframe_start'])
       timeframe_end = parse_datetime_string(timeframe['timeframe_end'])
       filters_symbolized = filters.symbolize_keys
@@ -39,7 +40,8 @@ module Snapshots
       QUERIES[query].run(**{
         timeframe_start:,
         timeframe_end:,
-        school_ids:
+        school_ids:,
+        user:
       }.merge(filters_symbolized))
     end
 

--- a/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
@@ -7,7 +7,7 @@ module Snapshots
     include_context 'Snapshots Period CTE'
 
     context 'post query transforms' do
-      let(:stubbed_query_result) { [{completed_at: DateTime.new(2020, 1, 1, 1).to_s}]}
+      let(:stubbed_query_result) { [{completed_at: DateTime.new(2020, 1, 1, 1)}]}
 
       context 'user timezone exists' do
         let(:user) { create(:user, time_zone: 'America/Chicago' )}
@@ -15,7 +15,7 @@ module Snapshots
         it 'should adjust the completed_at DateTime string for the given timezone' do
           query = DataExportQuery.new(**query_args.merge(user: user))
           transformed_query = query.post_query_transform(stubbed_query_result)
-          expect(transformed_query.first[:completed_at][..9]).to eq "2019-12-31"
+          expect(transformed_query.first[:completed_at].strftime("%F")).to eq "2019-12-31"
         end
       end
 
@@ -23,7 +23,7 @@ module Snapshots
         it 'should return the untransformed DateTime string' do
           query = DataExportQuery.new(**query_args)
           transformed_query = query.post_query_transform(stubbed_query_result)
-          expect(transformed_query.first[:completed_at][..9]).to eq "2020-01-01"
+          expect(transformed_query.first[:completed_at].strftime("%F")).to eq "2020-01-01"
         end
       end
     end

--- a/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/snapshots/cache_premium_reports_worker_spec.rb
@@ -8,7 +8,8 @@ module Snapshots
 
     let(:cache_key) { 'CACHE_KEY' }
     let(:query) { 'data-export' }
-    let(:user_id) { 123 }
+    let(:user) { create(:user) }
+    let(:user_id) { user.id }
     let(:timeframe_name) { 'last-30-days' }
     let(:school_ids) { [1,2,3] }
     let(:grades) { ['Kindergarten',1,2,3,4] }
@@ -51,7 +52,9 @@ module Snapshots
           school_ids: school_ids,
           grades: grades,
           teacher_ids: teacher_ids,
-          classroom_ids: classroom_ids
+          classroom_ids: classroom_ids,
+          user:
+
         }
       }
       let(:hashed_payload) do


### PR DESCRIPTION
## WHAT / HOW
1. Adds insertion point for post query transforms to the base QuillBigQuery::Query class
2. Adds a particular DateTime transform to DateExportQuery 

## WHY
1. So that there's a standard way to add post query transforms in the future
2. To satisfy the specification of this user story 

## DISCUSSION

An alternative is to keep transforms completely separate from queries, like this:
```
result = DataExportQuery.run(...)
transformed_result = DataExportQueryTransformer.run(result)
``` 

I opted to add an insertion point into ::Query because:

1. It keeps transforms and queries together, conceptually and file-wise 
2. It allows unit testing of transforms, avoiding BigQuery data setup and network calls
3. It's extensible for future transforms, and 
4. You don't have to remember to call a transform; it's there by default. (It follows that transforms following this pattern should apply to every instance of the given query. One-off transforms should live elsewhere).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Take-an-admin-s-time-zone-setting-into-account-when-populating-the-Completed-date-value-in-the-adm-1d3785111c4b4e748b47bf77ff8d5d43

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
