### PR TITLE
fix closure for subnav dropdown

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
@@ -108,7 +108,7 @@ const PremiumReportsDropdown = ({ activeTab }) => {
       document.removeEventListener(MOUSEDOWN, handleClickOutside);
       document.removeEventListener(KEYDOWN, handleKeyDown);
     };
-  }, [dropdownRef]);
+  }, [dropdownRef, isOpen]);
 
   const activeClass = activeTab === PREMIUM_REPORTS ? 'active' : '';
   const openClass = isOpen ? 'open' : '';
@@ -129,7 +129,7 @@ const PremiumReportsDropdown = ({ activeTab }) => {
 
   function closeDropdown() {
     if (!isOpen) { return }
-    
+
     setIsOpen(false);
     // Return focus to the button when dropdown closes
     buttonRef.current.focus();


### PR DESCRIPTION
## WHAT
Fix subnav dropdown so that clicking outside the dropdown or pressing escape closes the document.

## WHY
We want this functionality to work.

## HOW
Add `isOpen` to the useEffect hook so that it gets called again when that value changes, so that the `closeDropdown` function can accurately read the `isOpen` value.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, but this change should fix tests broken on develop
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES