### PR TITLE
fix moment off-by-one-day bug

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -2,9 +2,9 @@ import * as moment from 'moment';
 import * as React from 'react';
 
 import { requestPost, } from '../../../modules/request';
-import { DataTable, Snackbar, Spinner, LightButtonLoadingSpinner, defaultSnackbarTimeout, filterIcon, informationIcon, noResultsMessage, smallWhiteCheckIcon, whiteArrowPointingDownIcon, Tooltip, helpIcon, NOT_APPLICABLE, documentFileIcon, } from '../../Shared';
+import { DataTable, LightButtonLoadingSpinner, NOT_APPLICABLE, Snackbar, Spinner, Tooltip, defaultSnackbarTimeout, documentFileIcon, filterIcon, helpIcon, noResultsMessage, smallWhiteCheckIcon, whiteArrowPointingDownIcon } from '../../Shared';
 import useSnackbarMonitor from '../../Shared/hooks/useSnackbarMonitor';
-import { hashPayload, } from '../shared'
+import { hashPayload, } from '../shared';
 
 const STANDARD_WIDTH = "152px";
 const STUDENT_NAME = "Student Name";
@@ -257,7 +257,7 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
       }
 
       formattedEntry.id = index
-      formattedEntry.completed_at = moment(entry.completed_at).format("MM/DD/YYYY");
+      formattedEntry.completed_at = moment(entry.completed_at.substring(0,10)).format("MM/DD/YYYY");
       formattedEntry.timespent = getTimeSpentInMinutes(entry.timespent)
       formattedEntry.score = percentage
       return formattedEntry


### PR DESCRIPTION
## WHAT
For the Admin DateExport Preview, only send the Year, month, and day to moment for formatting 

## WHY
Because `entry.completed_at` is a full ISO Date string, and moment is adding it's own UTC offset, such that

`moment("2023-11-18T00:42:20.515+00:00").format("MM/DD/YYYY")`

yields

`11/17/2023` 

I'm open to other (more universal?) suggestions, but this is quick patch that Peter Sharkey would like to deploy ASAP. 


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manual
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
