### PR TITLE
add data export to nav dropdown

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
@@ -101,6 +101,17 @@ exports[`AdminSubnav it should render 1`] = `
               class="checkmark-icon "
             />
           </li>
+          <li>
+            <a
+              class=""
+              href="/teachers/premium_hub/data_export"
+            >
+              Data Export
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
         </ul>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
@@ -63,11 +63,11 @@ const premiumReportDropdownItems = [
   //   url: '/teachers/premium_hub/diagnostic_growth_report',
   //   new: true
   // },
-  // {
-  //   label: DATA_EXPORT,
-  //   url: '/teachers/premium_hub/data_export',
-  //   new: true
-  // },
+  {
+    label: DATA_EXPORT,
+    url: '/teachers/premium_hub/data_export',
+    new: true
+  },
   {
     label: CONCEPT_REPORTS,
     url: '/teachers/premium_hub/district_concept_reports'
@@ -87,10 +87,6 @@ const tabs = {
   [DIAGNOSTIC_GROWTH_REPORT]: {
     label: DIAGNOSTIC_GROWTH_REPORT,
     url: '/teachers/premium_hub/diagnostic_growth_report'
-  },
-  [DATA_EXPORT]: {
-    label: DATA_EXPORT,
-    url: '/teachers/premium_hub/data_export'
   }
 }
 
@@ -192,7 +188,7 @@ export const AdminSubnav = ({ path }) => {
   function determineActiveTab() {
     const { pathname } = path;
 
-    const reportPaths = ['/district_activity_scores', '/district_concept_reports', '/district_standards_reports', '/usage_snapshot_report']
+    const reportPaths = ['/district_activity_scores', '/district_concept_reports', '/district_standards_reports', '/usage_snapshot_report', '/data_export']
 
     if (reportPaths.find(path => pathname.includes(path))) {
       setActiveTab(PREMIUM_REPORTS)
@@ -200,8 +196,6 @@ export const AdminSubnav = ({ path }) => {
       setActiveTab(SUBSCRIPTIONS)
     } else if (pathname.includes('/diagnostic_growth_report')) {
       setActiveTab(DIAGNOSTIC_GROWTH_REPORT)
-    } else if (pathname.includes('/data_export')) {
-      setActiveTab(DATA_EXPORT)
     } else if (pathname.includes('/integrations')) {
       setActiveTab(INTEGRATIONS)
     } else if (pathname.includes('/premium_hub')) {
@@ -219,7 +213,7 @@ export const AdminSubnav = ({ path }) => {
 
   const dropdownClass = dropdownOpen ? 'open' : '';
 
-  const tabsToShow = window.location.href.includes('data_export') || window.location.href.includes('diagnostic_growth_report') ? tabs : baseTabs
+  const tabsToShow = window.location.href.includes('diagnostic_growth_report') ? tabs : baseTabs
 
   return(
     <React.Fragment>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
@@ -48,6 +48,10 @@ const mobileTabs = {
   [USAGE_SNAPSHOT_REPORT]: {
     label: USAGE_SNAPSHOT_REPORT,
     url: '/teachers/premium_hub/usage_snapshot_report'
+  },
+  [DATA_EXPORT]: {
+    label: DATA_EXPORT,
+    url: '/teachers/premium_hub/data_export'
   }
 }
 


### PR DESCRIPTION
## WHAT
Add the Data Export item to the subnav dropdown so it's accessible for all users.

## WHY
This report is ready to go live!

## HOW
Just uncomment the item and adjust the rest of the file to match.

### Screenshots
<img width="1512" alt="Screenshot 2023-12-13 at 12 56 30 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/484ddf34-45a5-4d3c-a849-ab9b899199a5">


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES