### PR TITLE
vite frontend bug fixes

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/application.scss
+++ b/services/QuillLMS/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @import '_mixins';
 @import 'shared/icons';
 @import "bootstrap";
+@import "../../../client/app/assets/styles/home.scss";
 @import "custom";
 @import "pages/index";
 @import "cms/index";

--- a/services/QuillLMS/app/assets/stylesheets/pages/index.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/index.scss
@@ -80,5 +80,6 @@
 @import 'teacher_premium.scss';
 @import 'team.scss';
 @import 'tutorials.scss';
+@import 'update-assigned-students.scss';
 @import 'unit_templates';
 @import 'user-select-role.scss';

--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/index.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/index.scss
@@ -11,3 +11,4 @@
 @import './evidence_promotion_card.scss';
 @import './onboarding_checklist.scss';
 @import './daily_tiny_tip.scss';
+@import './scoring_updates_card.scss';

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -5,7 +5,7 @@ class PagesController < ApplicationController
   include PagesHelper
   before_action :determine_js_file, :determine_flag
   before_action :set_defer_js, except: [
-    :play, :locker, :preap_units, :springboard_units, :evidence,
+    :play, :preap_units, :springboard_units, :evidence,
     :connect, :grammar, :diagnostic, :proofreader, :lessons
   ]
   before_action :set_root_url
@@ -532,7 +532,7 @@ class PagesController < ApplicationController
       @js_file = 'home'
     when 'premium'
       @js_file = current_user ? 'app' : 'public'
-    when 'backpack' || 'locker'
+    when 'backpack', 'locker'
       @js_file = 'staff'
     when ApplicationController::EVIDENCE
       @js_file = ApplicationController::EVIDENCE

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/style.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/style.scss
@@ -17,12 +17,44 @@
 @import './shared.scss';
 @import '../../../../../app/assets/stylesheets/shared/teacher-preview-menu.scss';
 
+* {
+  box-sizing: border-box;
+}
+
 html {
   overscroll-behavior: none;
 }
 
 body {
   background-color: white;
+}
+
+// this rule duplicates one from minireset, which was getting pulled in somewhere in the webpack version of this file but not in vite
+html,
+body,
+p,
+ol,
+ul,
+li,
+dl,
+dt,
+dd,
+blockquote,
+figure,
+fieldset,
+legend,
+textarea,
+pre,
+iframe,
+hr,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  padding: 0
 }
 
 body, button, input, select, textarea {

--- a/services/QuillLMS/client/app/bundles/Lessons/components/customize/slides/slideComponents/multipleTextEditor.jsx
+++ b/services/QuillLMS/client/app/bundles/Lessons/components/customize/slides/slideComponents/multipleTextEditor.jsx
@@ -1,7 +1,7 @@
 import Editor from '@draft-js-plugins/editor';
 import { EditorState } from 'draft-js';
 import React from 'react';
-const {convertFromHTML, convertToHTML} = require('draft-convert')
+import { convertFromHTML, convertToHTML } from 'draft-convert';
 
 import { richButtonsPlugin, } from '../../../../../Shared/index';
 

--- a/services/QuillLMS/client/app/bundles/Proofreader/styles/style.scss
+++ b/services/QuillLMS/client/app/bundles/Proofreader/styles/style.scss
@@ -7,7 +7,7 @@
 @import './admin.scss';
 @import './headerStyling.scss';
 @import './welcomePage.scss';
-@import "~bulma/bulma.sass";
+@import "bulma/bulma.sass";
 
 body, button, input, select, textarea, {
   font-family: adelle-sans,Arial,sans-serif;

--- a/services/QuillLMS/client/app/bundles/Staff/startup/clientRegistration.js
+++ b/services/QuillLMS/client/app/bundles/Staff/startup/clientRegistration.js
@@ -2,14 +2,18 @@ import 'lazysizes';
 import 'lazysizes/plugins/parent-fit/ls.parent-fit';
 import ReactOnRails from 'react-on-rails';
 
-import BackpackIndex from '../containers/BackpackIndex.tsx';
-import '../styles/styles.scss';
 import ActivityFormIndex from './ActivityFormIndex';
 import AdminVerificationApp from './AdminVerificationApp';
 import AttributesManagerIndex from './AttributesManagerIndex';
 import ConceptsIndex from './ConceptsIndex.tsx';
 import EvidenceIndex from './EvidenceIndex.tsx';
 import NewAdminOrDistrictUserApp from './NewAdminOrDistrictUserApp';
+import LockerApp from './lockerAppClient';
+
+import BackpackIndex from '../containers/BackpackIndex.tsx';
+
+import '../styles/styles.scss';
+
 
 ReactOnRails.register({
   ConceptsIndex,
@@ -19,4 +23,5 @@ ReactOnRails.register({
   ActivityFormIndex,
   NewAdminOrDistrictUserApp,
   AdminVerificationApp,
+  LockerApp,
 });

--- a/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
@@ -49,6 +49,9 @@
         font-size: 12px;
       }
     }
+    h1, h2, h3 {
+      margin: 20px 0px 10px;
+    }
   }
   .card-with-img-container {
     .quill-card {

--- a/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
@@ -49,9 +49,6 @@
         font-size: 12px;
       }
     }
-    h1, h2, h3 {
-      margin: 20px 0px 10px;
-    }
   }
   .card-with-img-container {
     .quill-card {

--- a/services/QuillLMS/client/app/bundles/Staff/styles/styles.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/styles.scss
@@ -48,3 +48,8 @@
 @import './locker/personalLocker.scss';
 @import './locker/organizeLocker.scss';
 @import './locker/lockerTile.scss';
+
+h1, .h1, h2, .h2, h3, .h3 {
+  margin-top: 20px;
+  margin-bottom: 10px;
+}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/grade_level_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/grade_level_filters.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`gradeLevelFilters component should render 1`] = `
   >
     <Tooltip
       isTabbable={false}
-      tooltipText="The grade level range helps you see which activities are accessible to your students, considering things like readability and the topic of the activity. Students never see the grade level range of the activities they’re assigned.<br/><br/>We recommend filtering by the grade you teach, and then using the readability and the concepts filters to narrow down which activities are right for your students. Grades are always presented as a range, rather than as a level, because students in later grades can also benefit from more basic activities.<br/><br/>Click the “?” icon to learn more about how we determine grade ranges and for helpful filtering tips."
+      tooltipText="The grade level range helps you see which activities are accessible to your students, considering things like readability and the topic of the activity. Students never see the grade level range of the activities they’re assigned.<br/><br/>We recommend filtering by the grade you teach, and then using the readability and the concepts filters to narrow down which activities are right for your students. Grades are always presented as a range, rather than as a level, because students in later grades can also benefit from more basic activities.<br/><br/>Click the “?” icon to learn more about how we determine grade ranges and for helpful filtering tips."
       tooltipTriggerText={
         <div
           className="tooltip-trigger-filter-section-content"
@@ -72,7 +72,6 @@ exports[`gradeLevelFilters component should render 1`] = `
                 maxValue={3}
                 minValue={0}
                 step={1}
-                value="4-5"
               />
             </div>
           </div>
@@ -155,10 +154,9 @@ exports[`gradeLevelFilters component should render 1`] = `
                   maxValue={3}
                   minValue={0}
                   step={1}
-                  value="4-5"
                 >
                   <Slider
-                    className="slider-container one-thumb-slider-container"
+                    className="slider-container one-thumb-slider-container display-as-disabled"
                     handleChange={[Function]}
                     id="grade-level-slider"
                     markLabels={
@@ -175,17 +173,17 @@ exports[`gradeLevelFilters component should render 1`] = `
                     trackColors={
                       Array [
                         "#dbdbdb",
-                        "#06806b",
+                        "#dbdbdb",
                       ]
                     }
                     values={
                       Array [
-                        "4-5",
+                        2,
                       ]
                     }
                   >
                     <div
-                      className="slider-container one-thumb-slider-container"
+                      className="slider-container one-thumb-slider-container display-as-disabled"
                       id="grade-level-slider"
                       style={
                         Object {
@@ -211,7 +209,7 @@ exports[`gradeLevelFilters component should render 1`] = `
                         step={1}
                         values={
                           Array [
-                            "4-5",
+                            2,
                           ]
                         }
                       >
@@ -219,7 +217,7 @@ exports[`gradeLevelFilters component should render 1`] = `
                           colors={
                             Array [
                               "#dbdbdb",
-                              "#06806b",
+                              "#dbdbdb",
                             ]
                           }
                           innerRef={
@@ -254,7 +252,7 @@ exports[`gradeLevelFilters component should render 1`] = `
                                 <div
                                   aria-valuemax="3"
                                   aria-valuemin="0"
-                                  aria-valuenow="4-5"
+                                  aria-valuenow="2"
                                   class="thumb"
                                   draggable="false"
                                   role="slider"
@@ -277,7 +275,7 @@ exports[`gradeLevelFilters component should render 1`] = `
                           }
                           values={
                             Array [
-                              "4-5",
+                              2,
                             ]
                           }
                         >
@@ -296,7 +294,7 @@ exports[`gradeLevelFilters component should render 1`] = `
                               className="track"
                               style={
                                 Object {
-                                  "background": "linear-gradient(to right, #dbdbdb 0%, #dbdbdb NaN%, #06806b NaN%, #06806b 100%)",
+                                  "background": "linear-gradient(to right, #dbdbdb 0%, #dbdbdb 66.66666666666666%, #dbdbdb 66.66666666666666%, #dbdbdb 100%)",
                                 }
                               }
                             >
@@ -431,7 +429,7 @@ exports[`gradeLevelFilters component should render 1`] = `
                               <ForwardRef
                                 aria-valuemax={3}
                                 aria-valuemin={0}
-                                aria-valuenow="4-5"
+                                aria-valuenow={2}
                                 draggable={false}
                                 key="0"
                                 onKeyDown={[Function]}
@@ -454,7 +452,7 @@ exports[`gradeLevelFilters component should render 1`] = `
                                 <div
                                   aria-valuemax={3}
                                   aria-valuemin={0}
-                                  aria-valuenow="4-5"
+                                  aria-valuenow={2}
                                   className="thumb"
                                   draggable={false}
                                   onKeyDown={[Function]}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/index.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/index.test.tsx.snap
@@ -14759,7 +14759,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             >
               <Tooltip
                 isTabbable={false}
-                tooltipText="The grade level range helps you see which activities are accessible to your students, considering things like readability and the topic of the activity. Students never see the grade level range of the activities they’re assigned.<br/><br/>We recommend filtering by the grade you teach, and then using the readability and the concepts filters to narrow down which activities are right for your students. Grades are always presented as a range, rather than as a level, because students in later grades can also benefit from more basic activities.<br/><br/>Click the “?” icon to learn more about how we determine grade ranges and for helpful filtering tips."
+                tooltipText="The grade level range helps you see which activities are accessible to your students, considering things like readability and the topic of the activity. Students never see the grade level range of the activities they’re assigned.<br/><br/>We recommend filtering by the grade you teach, and then using the readability and the concepts filters to narrow down which activities are right for your students. Grades are always presented as a range, rather than as a level, because students in later grades can also benefit from more basic activities.<br/><br/>Click the “?” icon to learn more about how we determine grade ranges and for helpful filtering tips."
                 tooltipTriggerText={
                   <div
                     className="tooltip-trigger-filter-section-content"
@@ -14821,7 +14821,6 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                           maxValue={3}
                           minValue={0}
                           step={1}
-                          value="4-5"
                         />
                       </div>
                     </div>
@@ -14904,10 +14903,9 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                             maxValue={3}
                             minValue={0}
                             step={1}
-                            value="4-5"
                           >
                             <Slider
-                              className="slider-container one-thumb-slider-container"
+                              className="slider-container one-thumb-slider-container display-as-disabled"
                               handleChange={[Function]}
                               id="grade-level-slider"
                               markLabels={
@@ -14924,17 +14922,17 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                               trackColors={
                                 Array [
                                   "#dbdbdb",
-                                  "#06806b",
+                                  "#dbdbdb",
                                 ]
                               }
                               values={
                                 Array [
-                                  "4-5",
+                                  2,
                                 ]
                               }
                             >
                               <div
-                                className="slider-container one-thumb-slider-container"
+                                className="slider-container one-thumb-slider-container display-as-disabled"
                                 id="grade-level-slider"
                                 style={
                                   Object {
@@ -14960,7 +14958,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                   step={1}
                                   values={
                                     Array [
-                                      "4-5",
+                                      2,
                                     ]
                                   }
                                 >
@@ -14968,7 +14966,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                     colors={
                                       Array [
                                         "#dbdbdb",
-                                        "#06806b",
+                                        "#dbdbdb",
                                       ]
                                     }
                                     innerRef={
@@ -15003,7 +15001,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                           <div
                                             aria-valuemax="3"
                                             aria-valuemin="0"
-                                            aria-valuenow="4-5"
+                                            aria-valuenow="2"
                                             class="thumb"
                                             draggable="false"
                                             role="slider"
@@ -15026,7 +15024,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                     }
                                     values={
                                       Array [
-                                        "4-5",
+                                        2,
                                       ]
                                     }
                                   >
@@ -15045,7 +15043,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                         className="track"
                                         style={
                                           Object {
-                                            "background": "linear-gradient(to right, #dbdbdb 0%, #dbdbdb NaN%, #06806b NaN%, #06806b 100%)",
+                                            "background": "linear-gradient(to right, #dbdbdb 0%, #dbdbdb 66.66666666666666%, #dbdbdb 66.66666666666666%, #dbdbdb 100%)",
                                           }
                                         }
                                       >
@@ -15180,7 +15178,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                         <ForwardRef
                                           aria-valuemax={3}
                                           aria-valuemin={0}
-                                          aria-valuenow="4-5"
+                                          aria-valuenow={2}
                                           draggable={false}
                                           key="0"
                                           onKeyDown={[Function]}
@@ -15203,7 +15201,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                           <div
                                             aria-valuemax={3}
                                             aria-valuemin={0}
-                                            aria-valuenow="4-5"
+                                            aria-valuenow={2}
                                             className="thumb"
                                             draggable={false}
                                             onKeyDown={[Function]}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
@@ -16867,7 +16867,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             >
               <Tooltip
                 isTabbable={false}
-                tooltipText="The grade level range helps you see which activities are accessible to your students, considering things like readability and the topic of the activity. Students never see the grade level range of the activities they’re assigned.<br/><br/>We recommend filtering by the grade you teach, and then using the readability and the concepts filters to narrow down which activities are right for your students. Grades are always presented as a range, rather than as a level, because students in later grades can also benefit from more basic activities.<br/><br/>Click the “?” icon to learn more about how we determine grade ranges and for helpful filtering tips."
+                tooltipText="The grade level range helps you see which activities are accessible to your students, considering things like readability and the topic of the activity. Students never see the grade level range of the activities they’re assigned.<br/><br/>We recommend filtering by the grade you teach, and then using the readability and the concepts filters to narrow down which activities are right for your students. Grades are always presented as a range, rather than as a level, because students in later grades can also benefit from more basic activities.<br/><br/>Click the “?” icon to learn more about how we determine grade ranges and for helpful filtering tips."
                 tooltipTriggerText={
                   <div
                     className="tooltip-trigger-filter-section-content"
@@ -16929,7 +16929,6 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                           maxValue={3}
                           minValue={0}
                           step={1}
-                          value="4-5"
                         />
                       </div>
                     </div>
@@ -17012,10 +17011,9 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                             maxValue={3}
                             minValue={0}
                             step={1}
-                            value="4-5"
                           >
                             <Slider
-                              className="slider-container one-thumb-slider-container"
+                              className="slider-container one-thumb-slider-container display-as-disabled"
                               handleChange={[Function]}
                               id="grade-level-slider"
                               markLabels={
@@ -17032,17 +17030,17 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                               trackColors={
                                 Array [
                                   "#dbdbdb",
-                                  "#06806b",
+                                  "#dbdbdb",
                                 ]
                               }
                               values={
                                 Array [
-                                  "4-5",
+                                  2,
                                 ]
                               }
                             >
                               <div
-                                className="slider-container one-thumb-slider-container"
+                                className="slider-container one-thumb-slider-container display-as-disabled"
                                 id="grade-level-slider"
                                 style={
                                   Object {
@@ -17068,7 +17066,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                   step={1}
                                   values={
                                     Array [
-                                      "4-5",
+                                      2,
                                     ]
                                   }
                                 >
@@ -17076,7 +17074,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                     colors={
                                       Array [
                                         "#dbdbdb",
-                                        "#06806b",
+                                        "#dbdbdb",
                                       ]
                                     }
                                     innerRef={
@@ -17111,7 +17109,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                           <div
                                             aria-valuemax="3"
                                             aria-valuemin="0"
-                                            aria-valuenow="4-5"
+                                            aria-valuenow="2"
                                             class="thumb"
                                             draggable="false"
                                             role="slider"
@@ -17134,7 +17132,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                     }
                                     values={
                                       Array [
-                                        "4-5",
+                                        2,
                                       ]
                                     }
                                   >
@@ -17153,7 +17151,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                         className="track"
                                         style={
                                           Object {
-                                            "background": "linear-gradient(to right, #dbdbdb 0%, #dbdbdb NaN%, #06806b NaN%, #06806b 100%)",
+                                            "background": "linear-gradient(to right, #dbdbdb 0%, #dbdbdb 66.66666666666666%, #dbdbdb 66.66666666666666%, #dbdbdb 100%)",
                                           }
                                         }
                                       >
@@ -17288,7 +17286,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                         <ForwardRef
                                           aria-valuemax={3}
                                           aria-valuemin={0}
-                                          aria-valuenow="4-5"
+                                          aria-valuenow={2}
                                           draggable={false}
                                           key="0"
                                           onKeyDown={[Function]}
@@ -17311,7 +17309,7 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                                           <div
                                             aria-valuemax={3}
                                             aria-valuemin={0}
-                                            aria-valuenow="4-5"
+                                            aria-valuenow={2}
                                             className="thumb"
                                             draggable={false}
                                             onKeyDown={[Function]}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/grade_level_filters.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/grade_level_filters.tsx
@@ -14,7 +14,7 @@ const MIN_LEVEL = 0
 const MAX_LEVEL = GRADE_LEVEL_LABELS.length - 1
 const DEFAULT_VALUE = 2 // corresponds to '8-9'
 
-const tooltipText = "The grade level range helps you see which activities are accessible to your students, considering things like readability and the topic of the activity. Students never see the grade level range of the activities they’re assigned.<br/><br/>We recommend filtering by the grade you teach, and then using the readability and the concepts filters to narrow down which activities are right for your students. Grades are always presented as a range, rather than as a level, because students in later grades can also benefit from more basic activities.<br/><br/>Click the “?” icon to learn more about how we determine grade ranges and for helpful filtering tips."
+const tooltipText = "The grade level range helps you see which activities are accessible to your students, considering things like readability and the topic of the activity. Students never see the grade level range of the activities they’re assigned.<br/><br/>We recommend filtering by the grade you teach, and then using the readability and the concepts filters to narrow down which activities are right for your students. Grades are always presented as a range, rather than as a level, because students in later grades can also benefit from more basic activities.<br/><br/>Click the “?” icon to learn more about how we determine grade ranges and for helpful filtering tips."
 
 const GradeLevelFilters = ({ gradeLevelFilters, handleGradeLevelFilterChange, }: GradeLevelFiltersProps) => {
   const [defaultValue, setDefaultValue] = React.useState(DEFAULT_VALUE)
@@ -36,7 +36,8 @@ const GradeLevelFilters = ({ gradeLevelFilters, handleGradeLevelFilterChange, }:
 
   let gradeLevelRangeText = 'All Grades'
   let checkbox = <button aria-label="Enable Grade Level Range filters" className="focus-on-light quill-checkbox unselected" onClick={handleEnableGradeLevelFilters} type="button" />
-  let lowerValue = GRADE_LEVEL_LABELS[0]
+
+  let lowerValue
 
   if (gradeLevelFilters.length) {
     checkbox = (<button aria-label="Disable GradeLevel Range filters" className="focus-on-light quill-checkbox selected" onClick={clearAllGradeLevelFilters} type="button">

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/activity_packs.jsx
@@ -97,7 +97,6 @@ export default class ActivityPacks extends React.Component {
       `${process.env.DEFAULT_URL}/teachers/units?report=true`,
       (body) => {
         this.setAllUnits(body);
-        this.populateCompletionAndAverageScore(body);
       }
     )
   }
@@ -114,7 +113,10 @@ export default class ActivityPacks extends React.Component {
   }
 
   setAllUnits = (data) => {
-    this.setState({ allUnits: this.parseUnits(data), }, this.getUnitsForCurrentClass);
+    this.setState({ allUnits: this.parseUnits(data), }, () => {
+      this.getUnitsForCurrentClass()
+      this.populateCompletionAndAverageScore(data);
+    });
   }
 
   addMissingInfo = (data) => {
@@ -196,6 +198,7 @@ export default class ActivityPacks extends React.Component {
         // otherwise, add the activity info if it doesn't already exist
         let completedCount,
           cumulativeScore;
+
         if (caUnit.classroomActivities.has(u.activity_id)) {
           completedCount = Number(caUnit.classroomActivities.get(u.activity_id).completedCount) + Number(u.completed_count || 0);
           cumulativeScore = Number(caUnit.classroomActivities.get(u.activity_id).cumulativeScore) + Number(u.classroom_cumulative_score || 0);

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/clientRegistration.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/clientRegistration.jsx
@@ -42,7 +42,6 @@ import TutorialsApp from './TutorialsAppClient';
 import UnitTemplateCategoriesApp from './UnitTemplateCategoriesAppClient';
 
 import UploadRostersApp from '../../Staff/startup/UploadRostersAppClient';
-import LockerApp from '../../Staff/startup/lockerAppClient';
 import StudentFeedbackModal from '../../Student/startup/StudentFeedbackModalAppClient';
 import StudentNavbarItems from '../../Student/startup/StudentNavbarItemsAppClient';
 
@@ -90,7 +89,6 @@ ReactOnRails.register({
   SpringBoardApp,
   StudentFeedbackModal,
   UploadRostersApp,
-  LockerApp,
   SalesFormApp,
   DemoAccountBanner,
   AdminAccessApp

--- a/services/QuillLMS/client/app/bundles/Teacher/startup/clientRegistration.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/startup/clientRegistration.jsx
@@ -48,7 +48,6 @@ import StudentNavbarItems from '../../Student/startup/StudentNavbarItemsAppClien
 
 import '../styles/styles.scss';
 
-import '../../../assets/styles/home.scss';
 
 // This is how react_on_rails can see the TeacherApp in the browser.
 

--- a/services/QuillLMS/client/app/entrypoints/proofreader.scss
+++ b/services/QuillLMS/client/app/entrypoints/proofreader.scss
@@ -1,0 +1,1 @@
+@import '../bundles/Proofreader/styles/style.scss';


### PR DESCRIPTION
## WHAT
Fix the following bugs:
- bootstrap css taking precedence over custom css (fixed by removing `home.scss` import from `Teacher/startup/clientRegistration` and adding it to the `application.scss`)
- scoring update card on dashboard not showing css (fixed by adding that file to the dashboard css index)
- fix bug where completed counts aren't showing up on activity scores page (fixed by forcing the function that handles that to wait until `allUnits` is set)
- add back header margins to staff scss (this is probably a consequence of the first change, above, hopefully this is the only place that needs fixing/we'll surface the rest).
- adjust grade level filters file to work the way it does in production
- edit students page under "my open activity packs" not showing css (fixed by adding that file to the pages css index)
- locker pages showing wonky css (fixed by moving locker to the staff bundle, where it should have been all along)
- fix wonky evidence css (just added necessary rules to evidence index file -- looks like they were getting some from a npm package I couldn't identify so I just added them back in manually)
- fix missing Proofreader css (added proofreader scss entrypoint we were missing)
- fix tests

## WHY
We want everything to work the way it does now.

## HOW
See "What"

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Vite-QA-once-PK-does-full-site-crawl-de17d43c68d54c50bb93c04c28c72d5c?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
