### PR TITLE
Snapshot Sentences Written Query - use activity.question_count

### DIFF
--- a/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
@@ -2,26 +2,15 @@
 
 module Snapshots
   class SentencesWrittenQuery < ActivitySessionCountQuery
-    def query
-      <<-SQL
-        SELECT COUNT(*) AS count
-          FROM (#{super})
-      SQL
-    end
-
     def select_clause
-      "SELECT COUNT(*)"
+      "SELECT SUM(activities.question_count) AS count"
     end
 
     def from_and_join_clauses
       super + <<-SQL
-        JOIN special.concept_results
-          ON activity_sessions.id = concept_results.activity_session_id
+        JOIN lms.activities
+          ON activity_sessions.activity_id = activities.id
       SQL
-    end
-
-    def group_by_clause
-      "GROUP BY activity_sessions.id, concept_results.question_number"
     end
   end
 end

--- a/services/QuillLMS/lib/query_examples/snapshots/9874030-2023-08-01-2023-12-01/sentences-written.sql
+++ b/services/QuillLMS/lib/query_examples/snapshots/9874030-2023-08-01-2023-12-01/sentences-written.sql
@@ -1,7 +1,6 @@
-      /* Data Processed By Query: 46.19 GB */
+      /* Data Processed By Query: 0.74 GB */
 
-        SELECT COUNT(*) AS count
-          FROM (        SELECT COUNT(*)
+        SELECT SUM(activities.question_count) AS count
                 FROM lms.schools
         JOIN lms.schools_users
           ON schools.id = schools_users.school_id
@@ -13,8 +12,8 @@
           ON classrooms.id = classroom_units.classroom_id
         JOIN lms.activity_sessions
           ON classroom_units.id = activity_sessions.classroom_unit_id
-        JOIN special.concept_results
-          ON activity_sessions.id = concept_results.activity_session_id
+        JOIN lms.activities
+          ON activity_sessions.activity_id = activities.id
 
                 WHERE
           activity_sessions.completed_at BETWEEN '2023-08-01 00:00:00' AND '2023-12-01 00:00:00'
@@ -24,7 +23,6 @@
           
           AND classrooms_teachers.role = 'owner'
 
-        GROUP BY activity_sessions.id, concept_results.question_number
         
         
-)
+        

--- a/services/QuillLMS/lib/tasks/queries.thor
+++ b/services/QuillLMS/lib/tasks/queries.thor
@@ -45,7 +45,7 @@ class Queries < Thor
 
   # user_id 9874030 is a test user
   # e.g. bundle exec thor queries:print_snapshot_sql 9874030 'sentences-written'
-  desc 'print_snapshot_sql user_id query_key', 'Output .sql fils for all snapshots for a user'
+  desc 'print_snapshot_sql user_id query_key', 'Print the SQL and data usage for a snaphot query to the console'
   def print_snapshot_sql(user_id, query_key, start_time = DEFAULT_START, end_time = DEFAULT_END)
 
     timeframe_start = DateTime.parse(start_time)

--- a/services/QuillLMS/lib/tasks/queries.thor
+++ b/services/QuillLMS/lib/tasks/queries.thor
@@ -43,6 +43,26 @@ class Queries < Thor
     end
   end
 
+  # user_id 9874030 is a test user
+  # e.g. bundle exec thor queries:print_snapshot_sql 9874030 'sentences-written'
+  desc 'print_snapshot_sql user_id query_key', 'Output .sql fils for all snapshots for a user'
+  def print_snapshot_sql(user_id, query_key, start_time = DEFAULT_START, end_time = DEFAULT_END)
+
+    timeframe_start = DateTime.parse(start_time)
+    timeframe_end = DateTime.parse(end_time)
+    school_ids = school_ids_for_user(user_id)
+
+    query = SNAPSHOT_QUERIES_TO_RUN[query_key]
+
+    sql = query
+      .new(**{timeframe_start:,timeframe_end:,school_ids:})
+      .query
+    metadata = query_metadata(sql)
+
+    puts sql
+    puts metadata
+  end
+
   # put helper methods in this block
   no_commands do
     private def make_directory(path)

--- a/services/QuillLMS/spec/factories/activities.rb
+++ b/services/QuillLMS/spec/factories/activities.rb
@@ -53,6 +53,7 @@ FactoryBot.define do
     activity_categories     { create_pair(:activity_category) }
     raw_score               { create(:raw_score) }
     repeatable              { true }
+    question_count          { 10 }
     data                    { { questionType: 'questions', questions: [{ key: 'fake_key' }] } }
 
     factory :diagnostic_activity do

--- a/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
@@ -10,7 +10,7 @@ module Snapshots
       let(:concept_results) { activity_sessions.map { |activity_session| create(:concept_result, activity_session: activity_session) } }
       let(:cte_records) { count_query_cte_records << concept_results }
 
-      it { expect(results).to eq(count: concept_results.count) }
+      it { expect(results).to eq(count: activities.sum(&:question_count)) }
     end
   end
 end

--- a/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_activity_session_count_cte.rb
+++ b/services/QuillLMS/spec/support/shared_contexts/snapshots/snapshots_activity_session_count_cte.rb
@@ -11,6 +11,8 @@ RSpec.shared_context 'Snapshots Activity Session Count CTE' do
     end
   end
 
-  let(:count_query_cte_records) { period_query_cte_records << classroom_units << activity_sessions }
+  let(:activities) {activity_sessions.map(&:activity).uniq}
+
+  let(:count_query_cte_records) { period_query_cte_records << classroom_units << activity_sessions << activities}
   let(:cte_records) { count_query_cte_records }
 end


### PR DESCRIPTION
## WHAT
Use the new activity.question_count for sentences written.
## WHY
It's much more efficient to calculate
## HOW
Update query and tests. Still needs to be QA'd to make sure this metric works well (my initial QA shows the numbers are very close to the previous calculation.

I also added thor task to print out an individual query, since that was helpful for testing.
### Screenshots
![Screenshot 2023-12-18 at 1 18 55 PM](https://github.com/empirical-org/Empirical-Core/assets/1304933/f600fda2-b866-4527-8e3d-ff25dbd5ff3f)


### Notion Card Links
https://www.notion.so/quill/Use-Activity-question_count-for-sentences-writen-f5ae726c8875404ab3e1908de11e97f7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |   'YES'
Have you deployed to Staging? |  YES, this is on my staging env.
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A 
