### PR TITLE
fix vite frontend bugs

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/index.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/index.scss
@@ -12,3 +12,4 @@
 @import './onboarding_checklist.scss';
 @import './daily_tiny_tip.scss';
 @import './scoring_updates_card.scss';
+@import './bulk_archive_classrooms_card.scss';

--- a/services/QuillLMS/client/app/bundles/Connect/actions/filters.js
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/filters.js
@@ -1,28 +1,33 @@
 import C from '../constants';
 
-module.exports = {
-  toggleExpandSingleResponse: function (rkey) {
-    return {type:C.TOGGLE_EXPAND_SINGLE_RESPONSE, rkey, };
-  },
-  collapseAllResponses: function () {
-    return {type:C.COLLAPSE_ALL_RESPONSES, };
-  },
-  expandAllResponses: function (expandedResponses) {
-    return {type:C.EXPAND_ALL_RESPONSES, expandedResponses, };
-  },
-  toggleStatusField: function (status) {
-    return {type:C.TOGGLE_STATUS_FIELD, status, };
-  },
-  toggleResponseSort: function (field) {
-    return {type:C.TOGGLE_RESPONSE_SORT, field, };
-  },
-  toggleExcludeMisspellings: function () {
-    return {type:C.TOGGLE_EXCLUDE_MISSPELLINGS, };
-  },
-  resetAllFields: function () {
-    return {type: C.RESET_ALL_FIELDS, };
-  },
-  deselectAllFields: function() {
-    return {type: C.DESELECT_ALL_FIELDS, };
-  },
-};
+export function toggleExpandSingleResponse(rkey) {
+  return {type:C.TOGGLE_EXPAND_SINGLE_RESPONSE, rkey, };
+}
+
+export function collapseAllResponses() {
+  return {type:C.COLLAPSE_ALL_RESPONSES, };
+}
+
+export function expandAllResponses(expandedResponses) {
+  return {type:C.EXPAND_ALL_RESPONSES, expandedResponses, };
+}
+
+export function toggleStatusField(status) {
+  return {type:C.TOGGLE_STATUS_FIELD, status, };
+}
+
+export function toggleResponseSort(field) {
+  return {type:C.TOGGLE_RESPONSE_SORT, field, };
+}
+
+export function toggleExcludeMisspellings() {
+  return {type:C.TOGGLE_EXCLUDE_MISSPELLINGS, };
+}
+
+export function resetAllFields() {
+  return {type: C.RESET_ALL_FIELDS, };
+}
+
+export function deselectAllFields() {
+  return {type: C.DESELECT_ALL_FIELDS, };
+}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/filters.js
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/filters.js
@@ -1,28 +1,33 @@
 import C from '../constants';
 
-export default {
-  toggleExpandSingleResponse: function (rkey) {
-    return {type:C.TOGGLE_EXPAND_SINGLE_RESPONSE, rkey, };
-  },
-  collapseAllResponses: function () {
-    return {type:C.COLLAPSE_ALL_RESPONSES, };
-  },
-  expandAllResponses: function (expandedResponses) {
-    return {type:C.EXPAND_ALL_RESPONSES, expandedResponses, };
-  },
-  toggleStatusField: function (status) {
-    return {type:C.TOGGLE_STATUS_FIELD, status, };
-  },
-  toggleResponseSort: function (field) {
-    return {type:C.TOGGLE_RESPONSE_SORT, field, };
-  },
-  toggleExcludeMisspellings: function () {
-    return {type:C.TOGGLE_EXCLUDE_MISSPELLINGS, };
-  },
-  resetAllFields: function () {
-    return {type: C.RESET_ALL_FIELDS, };
-  },
-  deselectAllFields: function() {
-    return {type: C.DESELECT_ALL_FIELDS, };
-  },
-};
+export function toggleExpandSingleResponse(rkey) {
+  return {type:C.TOGGLE_EXPAND_SINGLE_RESPONSE, rkey, };
+}
+
+export function collapseAllResponses() {
+  return {type:C.COLLAPSE_ALL_RESPONSES, };
+}
+
+export function expandAllResponses(expandedResponses) {
+  return {type:C.EXPAND_ALL_RESPONSES, expandedResponses, };
+}
+
+export function toggleStatusField(status) {
+  return {type:C.TOGGLE_STATUS_FIELD, status, };
+}
+
+export function toggleResponseSort(field) {
+  return {type:C.TOGGLE_RESPONSE_SORT, field, };
+}
+
+export function toggleExcludeMisspellings() {
+  return {type:C.TOGGLE_EXCLUDE_MISSPELLINGS, };
+}
+
+export function resetAllFields() {
+  return {type: C.RESET_ALL_FIELDS, };
+}
+
+export function deselectAllFields() {
+  return {type: C.DESELECT_ALL_FIELDS, };
+}

--- a/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/styles.scss
@@ -27,6 +27,7 @@
 @import './notification_bar.scss';
 @import './dropdown_input_with_search_tokens.scss';
 @import './internal_tool';
+@import "react-select-search/style.css";
 
 #main-content {
   outline: none;


### PR DESCRIPTION
## WHAT
Fix some vite frontend bugs we missed in QA.

## WHY
We want everything to work as it used to.

## HOW
Update `filters` file to use regular exports instead of `module.exports`, which didn't seem to be working; import two missing style files.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-expand-connect-responses-5ec7ad6c030e49589bcf78a9daa69f9c?pvs=4

https://www.notion.so/quill/Drop-down-turned-into-giant-list-93a7c2a0d1f24f61bc0bd1fe8242ce13?pvs=4

https://www.notion.so/quill/Helpful-Tip-in-teacher-view-is-broken-79cc48ee7f3b45c0bf963cb677ff4888?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | NO - tiny change, tested locally
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A