### PR TITLE
fix bug with import in diagnostic

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
@@ -8,7 +8,7 @@ import {
   ResponseToggleFields,
   hashToCollection
 } from '../../../Shared/index';
-import filterActions from '../../actions/filters';
+import * as filterActions from '../../actions/filters';
 import massEdit from '../../actions/massEdit';
 import questionActions from '../../actions/questions';
 import { submitResponseEdit } from '../../actions/responses';


### PR DESCRIPTION
## WHAT
Fix bug with `filters` import in Diagnostic.

## WHY
The diagnostic version of the `responseComponent` file was importing the `filterActions` differently than Connect.

## HOW
Just change import type.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | No - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A