### PR TITLE
lms/update-timestamps-in-teacher-fixes

### DIFF
--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -102,7 +102,7 @@ module Student
 
           ActivitySession
             .where(classroom_unit_id: cu.id, user_id: user_id)
-            .update_all(classroom_unit_id: sibling_cu.id)
+            .update_all(classroom_unit_id: sibling_cu.id, updated_at: DateTime.current)
 
           hide_extra_activity_sessions(cu.id)
           cu.save_user_pack_sequence_items
@@ -122,7 +122,7 @@ module Student
           activity_ids = (activity_sessions.pluck(:activity_id) - unit.unit_activities.pluck(:activity_id)).uniq
           activity_ids.each { |activity_id| UnitActivity.find_or_create_by(unit_id: unit.id, activity_id: activity_id) }
 
-          activity_sessions.update_all(classroom_unit_id: new_cu.id)
+          activity_sessions.update_all(classroom_unit_id: new_cu.id, updated_at: DateTime.current)
 
           hide_extra_activity_sessions(cu.id)
           cu.save_user_pack_sequence_items

--- a/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
@@ -143,6 +143,10 @@ describe 'Student Concern', type: :model do
     it 'should create the necessary UnitActivity records for the new classroom' do
       expect { student1.move_activity_sessions(classroom, classroom2) }.to change(UnitActivity, :count).by(6)
     end
+
+    it 'should update the ActivitySession updated_at value' do
+      expect { student1.move_activity_sessions(classroom, classroom2) }.to change { started.reload.updated_at }
+    end
   end
 
   describe "#move_student_from_one_class_to_another" do


### PR DESCRIPTION
## WHAT
Make sure to change updated_at when using update_all
## WHY
We rely on the `updated_at` field for ensuring that updates are propagated to Bigquery, but `update_all` explicitly bypasses Rails model instantiation, so automatic things like validation and touching `updated_at` don't happen during `update_all`.
## HOW
Make sure that when we make our `update_all` call, we explicitly change the `updated_at` column

### Notion Card Links
https://www.notion.so/quill/Admin-Diagnostic-Growth-Report-QA-Overview-Tab-December-7-0524fc96c41f424a9532228535b11553#3c9299885a674ad390701f30a01039e8

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
