### PR TITLE
add mailer previews

### DIFF
--- a/services/QuillLMS/config/application.rb
+++ b/services/QuillLMS/config/application.rb
@@ -37,8 +37,6 @@ module EmpiricalGrammar
     # config.i18n.default_locale = :de
     config.assets.initialize_on_precompile = false
 
-    config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
-
     # changed config.exceptions_app from what was commented out
     # in order to enable custom controller actions https://mattbrictson.com/dynamic-rails-error-pages
     config.exceptions_app = routes

--- a/services/QuillLMS/spec/mailers/previews/rollup_mailer_preview.rb
+++ b/services/QuillLMS/spec/mailers/previews/rollup_mailer_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+  class RollupMailerPreview < ActionMailer::Preview
+    def rollup
+      teacher = User.find_or_initialize_by(
+        name: 'Teacher MailerPreview',
+        email: 'teacher@rollup_mailer_preview.com',
+        role: 'teacher'
+      )
+
+      teacher_info = TeacherInfo.find_or_initialize_by(user: teacher)
+      teacher_notification = TeacherNotifications::StudentCompletedDiagnostic.find_or_initialize_by(user: teacher).tap{|row| row.student_name = 'John' }
+      TeacherNotifications::RollupMailer.rollup(teacher, [teacher_notification])
+    end
+  end

--- a/services/QuillLMS/spec/mailers/previews/user_mailer_preview.rb
+++ b/services/QuillLMS/spec/mailers/previews/user_mailer_preview.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-module MailerPreviews
   class UserMailerPreview < ActionMailer::Preview
     def welcome_email
+      puts "hello"
       UserMailer.welcome_email(User.find_by(email: 'marcello.sachs@gmail.com')).tap do |email|
         Premailer::Rails::Hook.delivering_email(email)
       end
     end
   end
-end

--- a/services/QuillLMS/spec/mailers/previews/user_mailer_preview.rb
+++ b/services/QuillLMS/spec/mailers/previews/user_mailer_preview.rb
@@ -2,6 +2,6 @@
 
   class UserMailerPreview < ActionMailer::Preview
     def ell_starter_diagnostic_info_email
-      UserMailer.ell_starter_diagnostic_info_email('pk', 'pkong@quill.org')
+      UserMailer.ell_starter_diagnostic_info_email('exmaple_name', 'user@domain.org')
     end
   end

--- a/services/QuillLMS/spec/mailers/previews/user_mailer_preview.rb
+++ b/services/QuillLMS/spec/mailers/previews/user_mailer_preview.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
   class UserMailerPreview < ActionMailer::Preview
-    def welcome_email
-      puts "hello"
-      UserMailer.welcome_email(User.find_by(email: 'marcello.sachs@gmail.com')).tap do |email|
-        Premailer::Rails::Hook.delivering_email(email)
-      end
+    def ell_starter_diagnostic_info_email
+      UserMailer.ell_starter_diagnostic_info_email('pk', 'pkong@quill.org')
     end
   end


### PR DESCRIPTION
## BACKGROUND / WHY
[Mailer Preview is a Rails subsystem](https://guides.rubyonrails.org/action_mailer_basics.html#previewing-emails) that renders emails in-browser, as an email client would. This allows fast email render debugging, since
- You have access to the full dev tool suite of the browser
- You can simply refresh the email display, rather than sending an email to yourself 

We have a stub directory of mailer previews, but it hasn't been touched since 2015, and it wasn't working, likely due to Rails upgrades since 2015. 

## WHAT 
- fix mailer preview configuration, so that it works
- move the mailer previews from `app/lib` (not standard) to `spec/` (standard)
- add email previews for `rollup` and  `ell_starter_diagnostic_info_email` email templates 


### Screenshots
<img width="757" alt="Screenshot 2023-12-21 at 12 23 39 PM" src="https://github.com/empirical-org/Empirical-Core/assets/90669/c5b5d419-a160-41a9-bef3-4521a3dc7387">
<img width="1063" alt="Screenshot 2023-12-21 at 12 23 33 PM" src="https://github.com/empirical-org/Empirical-Core/assets/90669/370059e6-b1dc-4d93-88b4-011d7802ee5b">


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - spec code only
Have you deployed to Staging? | no
Self-Review: Have you done an initial self-review of the code below on Github? | 
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A 
