### PR TITLE
Lms/audit update all

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::ClassroomUnitsController < Api::ApiController
       data
     )
 
-    states.update_all(locked: true, pinned: false, completed: true)
+    states.update_all(locked: true, pinned: false, completed: true, updated_at: DateTime.current)
 
     concept_results = concept_result_params[:concept_results].map(&:to_h)
 

--- a/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
+++ b/services/QuillLMS/app/controllers/concerns/teacher_fixes.rb
@@ -129,7 +129,7 @@ module TeacherFixes
     ClassroomUnit.where(classroom_id: source_classroom_id).each do |cu|
       existing_cu = ClassroomUnit.find_by(classroom_id: target_classroom_id, unit_id: cu.unit_id)
       if existing_cu
-        cu.activity_sessions.update_all(classroom_unit_id: existing_cu.id)
+        cu.activity_sessions.update_all(classroom_unit_id: existing_cu.id, updated_at: DateTime.current)
         existing_cu.update(assigned_student_ids: cu.assigned_student_ids.concat(existing_cu.assigned_student_ids).uniq)
         existing_cu.assigned_student_ids.each do |student_id|
           student = User.find(student_id)

--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -26,7 +26,7 @@ class TeacherFixController < ApplicationController
       Unit.unscoped.where(id: id).first.update_attribute('name', name)
     end
     units = Unit.unscoped.where(id: unit_ids)
-    units.update_all(visible: true)
+    units.update_all(visible: true, updated_at: DateTime.current)
     TeacherFixes::recover_unit_activities_for_units(units)
     classroom_units = ClassroomUnit.where(unit_id: unit_ids)
     TeacherFixes::recover_classroom_units_and_associated_activity_sessions(classroom_units)
@@ -101,7 +101,7 @@ class TeacherFixController < ApplicationController
     account2 = User.find_by_username_or_email(params['account2_identifier'])
     if account1 && account2
       if account1.teacher? && account2.teacher?
-        Unit.unscoped.where(user_id: account1.id).update_all(user_id: account2.id)
+        Unit.unscoped.where(user_id: account1.id).update_all(user_id: account2.id, updated_at: DateTime.current)
         ClassroomsTeacher.where(user_id: account1.id).each do |ct|
           if ClassroomsTeacher.find_by(user_id: account2.id, classroom_id: ct.classroom_id)
             ct.destroy

--- a/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_activities_controller.rb
@@ -14,9 +14,9 @@ class Teachers::UnitActivitiesController < ApplicationController
   end
 
   def hide
-    @unit_activities.update_all(visible: false)
+    @unit_activities.update_all(visible: false, updated_at: DateTime.current)
     @unit_activity&.unit&.hide_if_no_visible_unit_activities
-    @activity_sessions.update_all(visible: false)
+    @activity_sessions.update_all(visible: false, updated_at: DateTime.current)
     @unit_activities.each(&:save_user_pack_sequence_items)
     # touch the parent unit in order to clear our caches
     @unit_activity&.unit&.touch

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -151,8 +151,8 @@ class Classroom < ApplicationRecord
   end
 
   def hide_all_classroom_units
-    ActivitySession.where(classroom_unit: classroom_units).update_all(visible: false)
-    classroom_units.update_all(visible: false)
+    ActivitySession.where(classroom_unit: classroom_units).update_all(visible: false, updated_at: DateTime.current)
+    classroom_units.update_all(visible: false, updated_at: DateTime.current)
     classroom_units.each(&:save_user_pack_sequence_items)
     return if owner.nil?
 
@@ -166,7 +166,7 @@ class Classroom < ApplicationRecord
       AND unit.user_id = #{owner.id}")
 
     units = Unit.where(id: ids)
-    units.update_all(visible: false)
+    units.update_all(visible: false, updated_at: DateTime.current)
     units.each(&:save_user_pack_sequence_items)
   end
 

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -119,7 +119,7 @@ class ClassroomUnit < ApplicationRecord
   end
 
   private def hide_all_activity_sessions
-    activity_sessions.update_all(visible: false)
+    activity_sessions.update_all(visible: false, updated_at: DateTime.current)
   end
 
   private def hide_appropriate_activity_sessions

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -137,9 +137,9 @@ module Student
     .where("users.id = ?", id)
     .where("classroom_units.id = ?", classroom_unit_id)
     .where("activity_sessions.visible = true")
-    .order("activity_sessions.is_final_score DESC, activity_sessions.percentage ASC, activity_sessions.started_at")
+    .order("activity_sessions.is_final_score DESC, activity_sessions.percentage DESC, activity_sessions.started_at")
     .offset(1)
-    .update_all(visible: false)
+    .update_all(visible: false, updated_at: DateTime.current)
   end
 
   def merge_student_account(secondary_account, teacher_id=nil)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -944,7 +944,7 @@ class User < ApplicationRecord
   end
 
   private def update_invitee_email_address
-    Invitation.where(invitee_email: email_before_last_save).update_all(invitee_email: email)
+    Invitation.where(invitee_email: email_before_last_save).update_all(invitee_email: email, updated_at: DateTime.current)
   end
 
   private def generate_default_notification_email_frequency

--- a/services/QuillLMS/app/services/provider_classroom_users_updater.rb
+++ b/services/QuillLMS/app/services/provider_classroom_users_updater.rb
@@ -20,7 +20,7 @@ class ProviderClassroomUsersUpdater < ApplicationService
       .deleted
       .where(classroom_external_id: classroom_external_id)
       .where(user_external_id: user_external_ids)
-      .update_all(deleted_at: nil)
+      .update_all(deleted_at: nil, updated_at: Time.current)
   end
 
   private def update_active_to_deleted
@@ -28,7 +28,7 @@ class ProviderClassroomUsersUpdater < ApplicationService
       .active
       .where(classroom_external_id: classroom_external_id)
       .where.not(user_external_id: user_external_ids)
-      .update_all(deleted_at: Time.current)
+      .update_all(deleted_at: Time.current, updated_at: Time.current)
   end
 
   private def create_new_active

--- a/services/QuillLMS/app/workers/clear_user_data_worker.rb
+++ b/services/QuillLMS/app/workers/clear_user_data_worker.rb
@@ -20,7 +20,7 @@ class ClearUserDataWorker
       user.ip_location.destroy! if user.ip_location.present?
       SchoolsUsers.where(user_id: id).destroy_all
       ClassroomUnit.where("? = ANY (assigned_student_ids)", id).each {|cu| cu.update(assigned_student_ids: cu.assigned_student_ids - [id])}
-      ActivitySession.where(user_id: id).update_all(user_id: nil, classroom_unit_id: nil)
+      ActivitySession.where(user_id: id).update_all(user_id: nil, classroom_unit_id: nil, updated_at: DateTime.current)
 
       user.subscriptions.each do |subscription|
         subscription.update!(recurring: false)

--- a/services/QuillLMS/app/workers/teacher_notifications/send_rollup_email_worker.rb
+++ b/services/QuillLMS/app/workers/teacher_notifications/send_rollup_email_worker.rb
@@ -10,7 +10,7 @@ module TeacherNotifications
       return if notifications.empty?
 
       TeacherNotifications::RollupMailer.rollup(user, notifications).deliver_now!
-      notifications.update_all(email_sent: DateTime.current)
+      notifications.update_all(email_sent: DateTime.current, updated_at: DateTime.current)
     end
   end
 end

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -217,6 +217,23 @@ describe Classroom, type: :model do
     end
   end
 
+  describe '#hide_all_classroom_units' do
+    subject { classroom.hide_all_classroom_units }
+
+    let(:owner) { create(:teacher) }
+    let(:classroom) { create(:classroom, classrooms_teachers: [build(:classrooms_teacher, user: owner, role: 'owner')]) }
+    let(:unit) { create(:unit, user: owner) }
+    let(:classroom_unit) { create(:classroom_unit, unit_id: unit.id, classroom_id: classroom.id ) }
+    let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit) }
+
+    it { expect { subject }.to change { classroom_unit.reload.visible }.from(true).to(false) }
+    it { expect { subject }.to change { classroom_unit.reload.updated_at } }
+    it { expect { subject }.to change { activity_session.reload.visible }.from(true).to(false) }
+    it { expect { subject }.to change { activity_session.reload.updated_at } }
+    it { expect { subject }.to change { unit.reload.visible }.from(true).to(false) }
+    it { expect { subject }.to change { unit.reload.updated_at } }
+  end
+
   describe '#with_student_ids' do
     let(:classroom) { create(:classroom) }
 

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -113,6 +113,11 @@ describe ClassroomUnit, type: :model, redis: true do
     end
   end
 
+  describe '#hide_all_activity_sessions' do
+    it { expect { classroom_unit.update(visible: false) }.to change { activity_session.reload.visible }.from(true).to(false) }
+    it { expect { classroom_unit.update(visible: false) }.to change { activity_session.reload.updated_at } }
+  end
+
   describe '#check_for_assign_on_join_and_update_students_array_if_true callback' do
     context 'when assign_on_join is false' do
       let(:classroom_with_two_students) { create(:classroom, students: [student, student2])}

--- a/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
@@ -83,6 +83,10 @@ describe 'Student Concern', type: :model do
   end
 
   describe "#hide_extra_activity_sessions" do
+    it "updates the updated_at value for models that are hidden" do
+        expect { student1.hide_extra_activity_sessions(classroom_unit2.id) }.to change { lower_percentage.reload.updated_at }
+    end
+
     context "there is an activity session with a final score" do
       it "leaves the activity session with a final score" do
         student1.hide_extra_activity_sessions(classroom_unit1.id)
@@ -97,8 +101,10 @@ describe 'Student Concern', type: :model do
 
     context "there are activities with percentages assigned" do
       it "leaves the activity session with the highest percentage" do
-        student1.hide_extra_activity_sessions(classroom_unit2.id)
-        expect(higher_percentage.visible).to be true
+        expect do
+          student1.hide_extra_activity_sessions(classroom_unit2.id)
+        end.to change { lower_percentage.reload.visible }.to(false)
+          .and not_change { higher_percentage.reload.visible }
       end
 
       it "hides all other activity sessions with that user id and classroom unit id" do

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1238,7 +1238,9 @@ RSpec.describe User, type: :model do
 
     it 'should update invitee email address in invitations table if email changed' do
       new_email = "new-email@fake-email.com"
-      User.find_by_email(old_email).update(email: new_email)
+      expect do
+        User.find_by_email(old_email).update(email: new_email)
+      end.to change { invite_two.reload.updated_at }
       expect(Invitation.where(invitee_email: old_email).count).to be(0)
       expect(Invitation.where(invitee_email: new_email).count).to be(2)
     end

--- a/services/QuillLMS/spec/services/provider_classroom_users_updater_spec.rb
+++ b/services/QuillLMS/spec/services/provider_classroom_users_updater_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe ProviderClassroomUsersUpdater do
     { user1: { before: DELETED, now: DELETED }, user2: { before: DELETED, now: DELETED } }
   ]
 
+  context 'setting update_at during update_all calls' do
+    let(:classroom_external_id) { Faker::Number.number}
+    let(:deleted_classroom_user) { create(:google_classroom_user, :deleted, classroom_external_id: classroom_external_id) }
+    let(:active_classroom_user) { create(:google_classroom_user, :active, classroom_external_id: classroom_external_id) }
+
+    it do
+      expect do
+        described_class.run(classroom_external_id, [deleted_classroom_user.user_external_id], GoogleClassroomUser)
+      end.to change { deleted_classroom_user.reload.updated_at }
+        .and change { active_classroom_user.reload.updated_at }
+    end
+  end
+
   context 'canvas' do
     let(:klass) { CanvasClassroomUser }
     let(:classroom_external_id) do

--- a/services/QuillLMS/spec/workers/clear_user_data_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/clear_user_data_worker_spec.rb
@@ -37,6 +37,8 @@ describe ClearUserDataWorker, type: :worker do
     end
   end
 
+  it { expect { subject }.to change { activity_sessions.first.reload.updated_at } }
+
   context 'subscriptions' do
     let!(:subscription) { create(:subscription, :recurring, :stripe) }
     let!(:user_subscription) { create(:user_subscription, subscription: subscription, user: user) }


### PR DESCRIPTION
## WHAT
Audit all places in the code where we use `update_all` and make sure to set `updated_at` when the model supports it
## WHY
We want our `updated_at` to be a reliable indicator of when the row was last modified in the database, and the Rails magic that handles `updated_at` doesn't work for `update_all` calls.  So we need to make sure we explicitly update those values when appropriate.  Specifically, we rely on `activity_sessions.updated_at` to handle syncing updates to that data to BigQuery, and no one thought about the idea that `updated_at` might not actually be up to date, so we should clean this up on any tables we can so that we don't get surprised like this in the future.
## HOW
Just add `updated_at: DateTime.current` to the params of every `update_all` call for models that support `updated_at` (not all do).


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
