### PR TITLE
Fix backgroud color for Premium Q&A (logged out user)

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
@@ -581,7 +581,7 @@ li.premium-tab > a:hover {
 
 #q-and-a {
   padding: 80px 0px;
-  background-color: white;
+  background-color: white !important;
   text-align: center;
   .q-and-a-inner-wrapper {
     padding: 0px 10px;


### PR DESCRIPTION
## WHAT
fix backgroud color for Premium Q&A (logged out user)

## WHY
this shouldn't be showing as blue

## HOW
add an `!important` override 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Purchase-page-FAQ-questions-don-t-expand-into-answers-for-logged-in-users-fb6c712e3b774e2c853fe2784f847f8f?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | css change-- manually verified
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
