### PR TITLE
[blocked - not sure how to test yet] update admin usage snapshot pdf css file with color variables

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/admin_usage_snapshot_report_pdf.scss
+++ b/services/QuillLMS/app/assets/stylesheets/admin_usage_snapshot_report_pdf.scss
@@ -1,3 +1,5 @@
+@import "variables";
+
 .admin-usage-snapshot-report-pdf {
   font-family: adelle-sans, Arial, sans-serif;
   padding: 0px 64px;
@@ -23,15 +25,15 @@
   .applied-filters {
     padding: 20px;
     border-radius: 8px;
-    border: 1px solid #E8AB88;
-    background-color: #FFF6F1;
+    border: 1px solid $quill-maroon-20;
+    background-color: $quill-maroon-1;
 
     h3 {
-      color: #FFF;
+      color: $quill-white;
       font-size: 9px;
       font-weight: 700;
       text-transform: uppercase;
-      background-color: #C04500;
+      background-color: $quill-maroon;
       width: min-content;
       white-space: nowrap;
       padding: 4px 5px 3px;
@@ -40,7 +42,7 @@
     }
 
     p {
-      color: #5C5C5C;
+      color: $quill-grey-50;
       font-size: 14px;
       margin: 8px 0px 24px;
     }
@@ -54,7 +56,7 @@
     .pill {
       display: block;
       border-radius: 16px;
-      background: #06806b;
+      background: $quill-green;
       padding: 6px 10px;
       color: white;
       margin-bottom: 8px;
@@ -66,13 +68,13 @@
     .filter-section {
       flex: 1;
       border-radius: 8px;
-      border: 1px solid #E8AB88;
-      background: #F6E5DC;
+      border: 1px solid $quill-maroon-20;
+      background: $quill-maroon-5;
       padding: 8px 16px;
 
       .filter-section-title {
         margin-top: 0px;
-        color: #000;
+        color: $quill-black;
         font-size: 14px;
         line-height: 22px;
         margin-bottom: 8px;
@@ -94,7 +96,7 @@
       font-weight: 600;
       font-size: 20px;
       line-height: 32px;
-      color: #373737;
+      color: $quill-grey-90;
       margin-bottom: 16px;
       display: flex;
       align-items: center;
@@ -108,11 +110,11 @@
     .snapshot-section {
       border-radius: 8px;
       padding: 24px;
-      border: 1px solid #e0e0e0;
+      border: 1px solid $quill-grey-5;
 
       .snapshot-item {
-        background-color: #f8f8f8;
-        border: 1px solid #e0e0e0;
+        background-color: $quill-grey-1;
+        border: 1px solid $quill-grey-5;
         border-radius: 8px;
         display: flex;
         justify-content: space-between;
@@ -140,7 +142,7 @@
 
           .snapshot-label {
             font-weight: 600;
-            color: #373737;
+            color: $quill-grey-90;
           }
         }
 
@@ -148,7 +150,7 @@
           font-weight: 700;
           font-size: 20px;
           line-height: 24px;
-          color: #373737;
+          color: $quill-grey-90;
           display: flex;
           align-items: center;
           height: min-content;
@@ -189,7 +191,7 @@
         &.positive,
         &.negative,
         &.no-change {
-          color: #373737;
+          color: $quill-grey-90;
         }
 
         &.positive {
@@ -202,7 +204,7 @@
         }
 
         &.negative .change {
-          color: #c38d33;
+          color: $quill-gold-dark-50;
         }
       }
     }
@@ -226,7 +228,7 @@
       font-weight: 400;
       font-size: 14px;
       line-height: 20px;
-      color: #373737;
+      color: $quill-grey-90;
     }
 
     img {
@@ -254,7 +256,7 @@
       margin-bottom: 0px;
 
       .header-row {
-        border-top: 1px solid #aeaeae;
+        border-top: 1px solid $quill-grey-20;
         display: flex;
         justify-content: space-between;
         padding: 12px 0px;
@@ -263,7 +265,7 @@
           font-weight: 700;
           font-size: 14px;
           line-height: 17px;
-          color: #373737;
+          color: $quill-grey-90;
         }
       }
 
@@ -271,9 +273,9 @@
         padding: 12px 0px;
         display: flex;
         justify-content: space-between;
-        color: #373737;
+        color: $quill-grey-90;
         font-size: 14px;
-        border-top: 1px solid #e0e0e0;
+        border-top: 1px solid $quill-grey-5;
 
         td:first-of-type {
           font-weight: 400;

--- a/services/QuillLMS/app/assets/stylesheets/pages/contact.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/contact.scss
@@ -25,7 +25,7 @@
   }
   span {
     font-weight: 700;
-    color: #06806B;
+    color: $quill-green;
   }
   button {
     height: 33px;
@@ -36,7 +36,7 @@
     font-size: 13px;
     font-weight: 500;
     line-height: 13px;
-    color: #000000;
+    color: $quill-black;
     font-weight: bold;
     margin-top: 20px;
   }

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_student_responses_index.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_student_responses_index.scss
@@ -20,7 +20,7 @@
       }
       .data-table-header {
         font-weight: 700;
-        color: #373737;
+        color: $quill-grey-90;
         margin-right: 8px;
         display: flex;
         justify-content: space-between;
@@ -73,7 +73,7 @@
             }
             &.name-section {
               font-weight: 700;
-              color: #373737;
+              color: $quill-grey-90;
             }
           }
         }

--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/scoring_updates_card.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/scoring_updates_card.scss
@@ -28,7 +28,7 @@
     font-size: 14px;
     font-weight: 700;
     line-height: 20px;
-    color: #5c5c5c;
+    color: $quill-grey-50;
     margin-top: 10px;
     img {
       margin-left: 5px;


### PR DESCRIPTION
## WHAT
Use color variables in this file when possible.

## WHY
We want to consistently use variables from Backpack instead of hex codes.

## HOW
Just globally search each hex code in this file to see if there is a variable assigned to it, then replace. Note: there are three that do not have variables assigned, and I'm going to ask Jack about those when he's back next week.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Convert-colors-in-services-QuillLMS-app-assets-stylesheets-admin_usage_snapshot_report_pdf-scss-to-v-90c5851f358641a3872c47fcd8f8c447?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES