### PR TITLE
stop switching chevron direction on toggle

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
@@ -435,23 +435,15 @@
       box-shadow: none;
     }
   }
+  .user-dropdown-button::after {
+    margin-left: 10px;
+    content: "\f078";
+    font-family: "Font Awesome 5 Pro";  /* updated font-family */
+    font-weight: 900; /* regular style/weight */
+  }
   &.dropdown-closed {
-    .user-dropdown-button::after {
-      margin-left: 10px;
-      content: "\f078";
-      font-family: "Font Awesome 5 Pro";  /* updated font-family */
-      font-weight: 900; /* regular style/weight */
-    }
     div {
       display: none;
-    }
-  }
-  &.dropdown-open {
-    .user-dropdown-button::after {
-      margin-left: 10px;
-      content: "\f077";
-      font-family: "Font Awesome 5 Pro";  /* updated font-family */
-      font-weight: 900; /* regular style/weight */
     }
   }
 }


### PR DESCRIPTION
## WHAT
Stop switching the direction of the chevron when you open and close the navbar dropdown.

## WHY
Nobody can ever remember which way it's supposed to go, and this is simpler.

## HOW
Just removed the CSS that changes its direction.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Standardize-Pull-Down-Menu-Arrow-in-Global-Nav-8bcf9f4b15134dae937f4239e22a7aae?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES