### PR TITLE
lms/fix-intermittent-spec-failure

### DIFF
--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -114,6 +114,11 @@ describe ClassroomUnit, type: :model, redis: true do
   end
 
   describe '#hide_all_activity_sessions' do
+    before do
+      # try making sure that the gap between initialization and update is treated wide enough to register a difference in updated_at
+      allow(DateTime).to receive(:current).and_return(Time.now + 1.minute)
+    end
+
     it { expect { classroom_unit.send(:hide_all_activity_sessions) }.to change { activity_session.reload.visible }.from(true).to(false) }
     it { expect { classroom_unit.send(:hide_all_activity_sessions) }.to change { activity_session.reload.updated_at } }
   end

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -114,8 +114,8 @@ describe ClassroomUnit, type: :model, redis: true do
   end
 
   describe '#hide_all_activity_sessions' do
-    it { expect { classroom_unit.update(visible: false) }.to change { activity_session.reload.visible }.from(true).to(false) }
-    it { expect { classroom_unit.update(visible: false) }.to change { activity_session.reload.updated_at } }
+    it { expect { classroom_unit.send(:hide_all_activity_sessions) }.to change { activity_session.reload.visible }.from(true).to(false) }
+    it { expect { classroom_unit.send(:hide_all_activity_sessions) }.to change { activity_session.reload.updated_at } }
   end
 
   describe '#check_for_assign_on_join_and_update_students_array_if_true callback' do


### PR DESCRIPTION
## WHAT
Explicitly call the callback function in the test case

Should fix intermittent failures reported here: https://quill.slack.com/archives/C05DP57UPAQ/p1704314446026719
## WHY
This should avoid any weird timing issues with the after_save hook
## HOW
Instead of calling `update`, which should trigger the callback via after_save hook, just call the hook directly using `send` (since it's a private method)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | No, spec change only
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
