### PR TITLE
Bugfixes and improvements to Evidence View Sessions

### DIFF
--- a/services/QuillLMS/app/services/serialize_evidence_prompt_health.rb
+++ b/services/QuillLMS/app/services/serialize_evidence_prompt_health.rb
@@ -29,7 +29,7 @@ class SerializeEvidencePromptHealth
       avg_time_spent_per_prompt: nil
     }
 
-    return serialized_data if prompt_feedback_history.empty?
+    return serialized_data if prompt_feedback_history.empty? || prompt_feedback_history[prompt.id].empty?
 
     feedback_history_data = {
       version_responses: prompt_feedback_history[prompt.id]["total_responses"],

--- a/services/QuillLMS/app/services/serialize_evidence_prompt_health.rb
+++ b/services/QuillLMS/app/services/serialize_evidence_prompt_health.rb
@@ -29,7 +29,7 @@ class SerializeEvidencePromptHealth
       avg_time_spent_per_prompt: nil
     }
 
-    return serialized_data if prompt_feedback_history.empty? || prompt_feedback_history[prompt.id].empty?
+    return serialized_data if prompt_feedback_history.empty? || prompt_feedback_history[prompt.id].blank?
 
     feedback_history_data = {
       version_responses: prompt_feedback_history[prompt.id]["total_responses"],

--- a/services/QuillLMS/app/workers/populate_evidence_activity_health_worker.rb
+++ b/services/QuillLMS/app/workers/populate_evidence_activity_health_worker.rb
@@ -6,6 +6,9 @@ class PopulateEvidenceActivityHealthWorker
 
   def perform(id)
     @activity = Evidence::Activity.find(id)
+    # if a record already exists, that means an exception was thrown somewhere and this worker is a retry,
+    # so delete the record that ran into an exception
+    Evidence::ActivityHealth.find_by(activity_id: id)&.destroy
 
     prompt_feedback_history = PromptFeedbackHistory.run(activity_id: @activity.id, activity_version: @activity.version)
     serializer = SerializeEvidenceActivityHealth.new(@activity, prompt_feedback_history)

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
@@ -78,7 +78,8 @@ const SessionsIndex = ({ match }) => {
   }, [versionOption]);
 
   React.useEffect(() => {
-    sessionsData && !pageDropdownOptions && getPageDropdownOptions(sessionsData);
+    console.log("Sessions data changed");
+    sessionsData && getPageDropdownOptions(sessionsData);
   }, [sessionsData]);
 
   React.useEffect(() => {
@@ -112,6 +113,7 @@ const SessionsIndex = ({ match }) => {
   }
 
   function getPageDropdownOptions(sessionsData: { activitySessions: ActivitySessionsInterface }) {
+    console.log("getting dropdonw")
     if(!sessionsData) {
       return null;
     }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
@@ -195,10 +195,10 @@ const SessionsIndex = ({ match }) => {
         <p className="link-info-blurb">Use <a href={metabaseLink}><strong>this Metabase</strong></a> query to display feedback sessions on a single page.</p>
         <p className="link-info-blurb">If you want to look up an individual activity session, plug the activity session ID into this url and it will load: https://www.quill.org/cms/evidence#/activities/<strong>activityID</strong>/<strong>sessionID</strong></p>
         <section className="top-section">
-          <section className="total-container">
+          <div className="total-container">
             <p className="total-label">Total</p>
             <p className="total-value">{total_activity_sessions}</p>
-          </section>
+          </div>
           <DropdownInput
             className="page-number-dropdown"
             handleChange={handlePageChange}
@@ -218,18 +218,18 @@ const SessionsIndex = ({ match }) => {
               options={activitySessionFilterOptions}
               value={filterOption}
             />
-            <section className="responses-for-scoring-container">
-              <section className="label-section">
+            <div className="responses-for-scoring-container">
+              <div className="label-section">
                 <label>Responses for Scoring</label>
                 <Tooltip
                   tooltipText="6+ responses per session OR sessions with 2+ responses for each conjunction"
                   tooltipTriggerText={<img alt={informationIcon.alt} src={informationIcon.src} />}
                 />
-              </section>
+              </div>
               <input checked={responsesForScoring} onChange={handleResponsesForScoringChange} type="checkbox" />
-            </section>
+            </div>
           </section>
-          <section className="bottom-section">
+          <div className="bottom-section">
             <FilterWidget
               endDate={endDate}
               handleFilterClick={handleFilterClick}
@@ -241,7 +241,7 @@ const SessionsIndex = ({ match }) => {
               versionOptions={versionOptions}
             />
             {renderCSVDownloadButton(handleLoadCSVDataClick)}
-          </section>
+          </div>
         </section>
         <ReactTable
           className="activity-sessions-table"

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
@@ -118,9 +118,6 @@ const SessionsIndex = ({ match }) => {
     if(!sessionsData) {
       return null;
     }
-    if(pageDropdownOptions) {
-      return pageDropdownOptions;
-    }
     const { activitySessions } = sessionsData
     const { current_page, total_pages } = activitySessions;
     console.log(total_pages)

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
@@ -78,7 +78,6 @@ const SessionsIndex = ({ match }) => {
   }, [versionOption]);
 
   React.useEffect(() => {
-    console.log("Sessions data changed");
     sessionsData && getPageDropdownOptions(sessionsData);
   }, [sessionsData]);
 
@@ -113,14 +112,11 @@ const SessionsIndex = ({ match }) => {
   }
 
   function getPageDropdownOptions(sessionsData: { activitySessions: ActivitySessionsInterface }) {
-    console.log("getting dropdonw")
-    console.log(sessionsData)
     if(!sessionsData) {
       return null;
     }
     const { activitySessions } = sessionsData
     const { current_page, total_pages } = activitySessions;
-    console.log(total_pages)
     setPageNumber({'value': current_page.toString(), 'label':`Page ${current_page}`})
     const options = [];
     for(let i=1; i <= total_pages; i++) {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
@@ -114,6 +114,7 @@ const SessionsIndex = ({ match }) => {
 
   function getPageDropdownOptions(sessionsData: { activitySessions: ActivitySessionsInterface }) {
     console.log("getting dropdonw")
+    console.log(sessionsData)
     if(!sessionsData) {
       return null;
     }
@@ -122,6 +123,7 @@ const SessionsIndex = ({ match }) => {
     }
     const { activitySessions } = sessionsData
     const { current_page, total_pages } = activitySessions;
+    console.log(total_pages)
     setPageNumber({'value': current_page.toString(), 'label':`Page ${current_page}`})
     const options = [];
     for(let i=1; i <= total_pages; i++) {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
@@ -7,12 +7,11 @@ import { firstBy } from 'thenby';
 
 import { PromptHealthRows } from './promptHealthRow';
 
-import { FlagDropdown, ReactTable, expanderColumn, filterNumbers } from '../../../../Shared/index';
+import { FlagDropdown, ReactTable, expanderColumn, filterNumbers, PRODUCTION_FLAG } from '../../../../Shared/index';
 import { addCommasToThousands, getLinkToActivity, secondsToHumanReadableTime } from "../../../helpers/evidence/miscHelpers";
 import { fetchAggregatedActivityHealths } from '../../../utils/evidence/ruleFeedbackHistoryAPIs';
 
 const ALL_FLAGS = "All Flags"
-const PRODUCTION_FLAG = "production"
 const NAME_COLUMN = "name"
 const POOR_HEALTH_FLAG_COLUMN = "poor_health_flag"
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/healthDashboards/activityHealthDashboard.tsx
@@ -12,6 +12,7 @@ import { addCommasToThousands, getLinkToActivity, secondsToHumanReadableTime } f
 import { fetchAggregatedActivityHealths } from '../../../utils/evidence/ruleFeedbackHistoryAPIs';
 
 const ALL_FLAGS = "All Flags"
+const PRODUCTION_FLAG = "production"
 const NAME_COLUMN = "name"
 const POOR_HEALTH_FLAG_COLUMN = "poor_health_flag"
 
@@ -52,7 +53,7 @@ const TrueFalseFilter = ({ column, setFilter }) => (
 )
 
 export const ActivityHealthDashboard = ({ handleDashboardToggle }) => {
-  const [flag, setFlag] = React.useState<string>(ALL_FLAGS)
+  const [flag, setFlag] = React.useState<string>(PRODUCTION_FLAG)
   const [promptSearchInput, setPromptSearchInput] = React.useState<string>("")
   const [dataToDownload, setDataToDownload] = React.useState<Array<{}>>([])
   const [rows, setRows] = React.useState<Array<{}>>(null)

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/rulesAnalysis/ruleAnalysis.tsx
@@ -411,6 +411,9 @@ const RuleAnalysis = ({ match }) => {
         <button className={massMarkButtonClassName} disabled={massMarkButtonDisabled} onClick={massMarkWeak} type="button">Mark All Selected As Weak</button>
         <button className={massMarkButtonClassName} disabled={massMarkButtonDisabled} onClick={massUnmark} type="button">Unmark All Selected</button>
       </div>
+      <div className="stem">
+        <span>Stem: {prompt && prompt.text && <span className="prompt-text" dangerouslySetInnerHTML={{ __html: prompt.text.replace(prompt.conjunction, `<b>${prompt.conjunction}</b>`)}} />}</span>
+      </div>
       <Input
         handleChange={onSearchChange}
         label='Search by text or regex'

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/shared/filterWidget.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/shared/filterWidget.tsx
@@ -36,7 +36,7 @@ const FilterWidget = ({
           <p className="date-picker-label">End Date:</p>
           <Datetime
             dateFormat='y-MM-D'
-            onChange={onStartDateChange}
+            onChange={onEndDateChange}
             timeFormat='HH:mm'
             value={endDate || new Date()}
           />

--- a/services/QuillLMS/client/app/bundles/Staff/styles/rule_analysis.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/rule_analysis.scss
@@ -52,4 +52,10 @@
       background-color: red;
     }
   }
+
+  .stem {
+    font-size: 20px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
 }

--- a/services/QuillLMS/spec/services/serialize_evidence_prompt_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_evidence_prompt_health_spec.rb
@@ -110,4 +110,29 @@ describe SerializeEvidencePromptHealth do
     data = SerializeEvidencePromptHealth.new(prompt, {}).data
     expect(data).to eq nil_data_object
   end
+
+  it 'will return without erring if prompt_feedback_history hash value for prompt id is empty' do
+    nil_data_object = {
+      prompt_id: @because_prompt1.id,
+      activity_short_name: @activity.notes,
+      text: @because_prompt1.text,
+      current_version: @activity.version,
+      version_responses: 0,
+      first_attempt_optimal: nil,
+      final_attempt_optimal: nil,
+      avg_attempts: nil,
+      confidence: nil,
+      percent_automl_consecutive_repeated: nil,
+      percent_automl: nil,
+      percent_plagiarism: nil,
+      percent_opinion: nil,
+      percent_grammar: nil,
+      percent_spelling: nil,
+      avg_time_spent_per_prompt: nil
+    }
+
+    prompt = @because_prompt1
+    data = SerializeEvidencePromptHealth.new(prompt, {"empty_prompt": "empty"}).data
+    expect(data).to eq nil_data_object
+  end
 end

--- a/services/QuillLMS/spec/workers/populate_evidence_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_evidence_activity_health_worker_spec.rb
@@ -64,5 +64,23 @@ describe PopulateEvidenceActivityHealthWorker do
       expect(activity_health.so_final_optimal).to eq(0)
       expect(activity_health.avg_completion_time).to eq(400)
     end
+
+    it 'should destroy an existing Evidence Activity Health object for the same Evidence Activity' do
+      existing_activity_health = Evidence::ActivityHealth.create(
+        name: @activity.title,
+        flag: @activity.flag.to_s,
+        version: @activity.version,
+        activity_id: @activity.id,
+        version_plays: 0,
+        total_plays: 0
+      )
+      expect { subject.perform(@activity.id) }.to change { Evidence::ActivityHealth.exists?(existing_activity_health.id) }.to(false)
+      expect(Evidence::ActivityHealth.count).to eq(1)
+      new_activity_health = Evidence::ActivityHealth.first
+      expect(new_activity_health.name).to eq(@activity.title)
+      expect(new_activity_health.flag).to eq(@activity.flag.to_s)
+      expect(new_activity_health.version).to eq(@activity.version)
+      expect(new_activity_health.activity_id).to eq(@activity.id)
+    end
   end
 end


### PR DESCRIPTION
## WHAT
A series of bugfixes and improvements to "View Sessions" on Evidence Activities:
-Show "stem" on rule analysis page
-Remove unnecessary borders on HTML elements
-make "production" the default filter on health dashboard
-fix "end date selection" on calendar date filter widget
-fix React state updates on page number and updating page dropdown React component
-prevent duplicate records from being created in Evidence Activity Health table

## WHY
These bugs are making some aspects of Evidence Activity work difficult and time-consuming for admin.

## HOW
Adding appropriate null checks and error catching on back end. On the React front end, add a series of styling tweaks and modifications to React code to get the state to update appropriately.

### Screenshots
![Screenshot 2024-01-10 at 3 19 45 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/163ef069-0840-4687-a864-bcb3d03e9d0b)
![Screenshot 2024-01-10 at 3 19 39 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/b2055ea5-6525-480d-84af-911153bed352)
![Screenshot 2024-01-10 at 3 17 39 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/f3dc87c1-626c-4331-b258-d51bca921ded)
![Screenshot 2024-01-10 at 3 25 58 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/17783e9e-fb90-42cc-a168-62e5deba99f7)

### Notion Card Links
https://www.notion.so/quill/Duplicate-Records-of-Activities-in-Evidence-CMS-Activities-Health-Dashboard-c01067f7a0574ddc8f5bd62c25e1244c?pvs=4
https://www.notion.so/quill/Have-the-stem-visible-on-individual-rules-analysis-pages-in-the-Evidence-CMS-6172329567284d4991a5d43dc9448923?pvs=4
https://www.notion.so/quill/Make-the-default-filter-Production-On-the-Health-Dashboard-within-the-Evidence-CMS-7abc2f827adb49e9b53556ec07ac9ce7?pvs=4
https://www.notion.so/quill/View-Sessions-Filtering-Bugs-bc5846138751494d90271b5133b3a575?pvs=4


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes