### PR TITLE
lms/remove-job-from-career-page

### DIFF
--- a/services/QuillLMS/config/careers.yml
+++ b/services/QuillLMS/config/careers.yml
@@ -1,8 +1,5 @@
 default:
   open_positions:
-    - category: "Curriculum"
-      title: "Social Studies Curriculum Developer"
-      url: "https://wellfound.com/l/2zzvHp"
     - category: "Marketing"
       title: "Director of Marketing"
       url: "https://wellfound.com/jobs/2869532-director-of-marketing?utm_campaign=startup_share&utm_content=startup_share_module&utm_medium=social&utm_term=quill-org"


### PR DESCRIPTION
## WHAT
Remove the social studies curriculum role from careers page
## WHY
The role has been filled
## HOW
Remove the position from the careers config file

### Screenshots
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/8a19df45-bc3f-4f3b-a2ca-47032dc3423a)

### Notion Card Links
https://www.notion.so/quill/Remove-social-studies-job-posting-from-Quill-s-Careers-page-2f3cf0e106e8418c93ffd338a1b7dafa

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on pure content
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
