### PR TITLE
Move scout gem to staging/production group

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -66,7 +66,6 @@ gem 'pdf-core'
 gem 'grover'
 gem 'pdf-inspector'
 gem 'ttfunk'
-gem 'scout_apm'
 gem 'rubyzip', '~> 1.3.0'
 gem 'httparty', '~> 0.16'
 gem 'intercom', '~> 3.5.23'
@@ -171,6 +170,7 @@ group :production, :staging do
   gem 'rails-autoscale-sidekiq'
   gem 'lograge'
   gem "matrix", '~> 0.4.2'
+  gem 'scout_apm'
 end
 
 group :development do


### PR DESCRIPTION
## WHAT
Move scout gem to staging/production group

## WHY
![Screenshot 2024-01-11 at 10 13 16 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/ff14406a-c159-4756-869e-d37f6899092c)

When running rails commands, my local environment is now reporting scout noise.
I don't think scout needs to be running locally.

## HOW
Move the gem declaration to the appropriate group.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
