### PR TITLE
Add token to pdf_subscriptions

### DIFF
--- a/services/QuillLMS/app/models/pdf_subscription.rb
+++ b/services/QuillLMS/app/models/pdf_subscription.rb
@@ -6,6 +6,7 @@
 #
 #  id                               :bigint           not null, primary key
 #  frequency                        :string           not null
+#  token                            :string           not null
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  admin_report_filter_selection_id :bigint           not null
@@ -21,8 +22,13 @@ class PdfSubscription < ApplicationRecord
     MONTHLY = 'monthly'
   ]
 
-  belongs_to :user
+  before_create :generate_token
+
   belongs_to :admin_report_filter_selection
 
   validates :frequency, presence: true, inclusion: { in: FREQUENCIES }
+
+  def generate_token
+    self.token = SecureRandom.hex
+  end
 end

--- a/services/QuillLMS/db/migrate/20240111143245_add_token_to_pdf_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20240111143245_add_token_to_pdf_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddTokenToPdfSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :pdf_subscriptions, :token, :string, null: false
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3608,7 +3608,8 @@ CREATE TABLE public.pdf_subscriptions (
     frequency character varying NOT NULL,
     admin_report_filter_selection_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    token character varying NOT NULL
 );
 
 
@@ -10626,6 +10627,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231206143410'),
 ('20231207135455'),
 ('20231207151344'),
-('20231214182438');
+('20231214182438'),
+('20240111143245');
 
 

--- a/services/QuillLMS/spec/factories/pdf_subscriptions.rb
+++ b/services/QuillLMS/spec/factories/pdf_subscriptions.rb
@@ -4,6 +4,7 @@
 #
 #  id                               :bigint           not null, primary key
 #  frequency                        :string           not null
+#  token                            :string           not null
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  admin_report_filter_selection_id :bigint           not null

--- a/services/QuillLMS/spec/models/pdf_subscription_spec.rb
+++ b/services/QuillLMS/spec/models/pdf_subscription_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                               :bigint           not null, primary key
 #  frequency                        :string           not null
+#  token                            :string           not null
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  admin_report_filter_selection_id :bigint           not null
@@ -22,4 +23,9 @@ RSpec.describe PdfSubscription, type: :model do
 
   it { should validate_presence_of(:frequency) }
   it { should validate_inclusion_of(:frequency).in_array(described_class::FREQUENCIES) }
+
+  it 'generates a token before creating a subscription' do
+    pdf_subscription = build(:pdf_subscription)
+    expect { pdf_subscription.save }.to change(pdf_subscription, :token).from(nil).to(String)
+  end
 end


### PR DESCRIPTION
## WHAT
Add a token field to the pdf_subscriptions table

## WHY
When unsubscribing from a Pdf Subscription (e.g. admin usage snapshot report pdf), we'd like to allow the user to unsubscribe from the email without logging in.  This token will allow for a secure way to do this. 

## HOW
Add a migration and then use a before_create callback that ensures the token is set.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Email-subscription-for-Admin-Usage-Snapshot-Report-1d4f8e91d30549d89f89ec5f8ff3ec8a?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
