### PR TITLE
lms/fix-detailed-student-activity-score-reports

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview.jsx
@@ -6,7 +6,7 @@ import _ from 'underscore';
 import CSVDownloadForProgressReport from './csv_download_for_progress_report.jsx';
 import StudentOveriewTable from './student_overview_table.jsx';
 
-import notLessonsOrDiagnostic from '../../../../modules/activity_classifications.js';
+import shouldCountForScoring from '../../../../modules/activity_classifications.js';
 import { requestGet, } from '../../../../modules/request/index';
 import { getTimeSpent } from '../../helpers/studentReports';
 import getParameterByName from '../modules/get_parameter_by_name';
@@ -50,12 +50,10 @@ export default class extends React.Component {
     let countForAverage = 0;
     let average;
     reportData.forEach((row) => {
-      if (row.percentage || row.percentage === 0) {
-        count += 1;
-        if (notLessonsOrDiagnostic(row.activity_classification_id)) {
-          cumulativeScore += parseFloat(row.percentage);
-          countForAverage += 1;
-        }
+      count += 1;
+      if (shouldCountForScoring(row.activity_classification_id)) {
+        cumulativeScore += parseFloat(row.percentage);
+        countForAverage += 1;
       }
     });
     if (countForAverage > 0) {
@@ -123,7 +121,7 @@ export default class extends React.Component {
       const csvReportData = [];
       reportData.forEach((row) => {
         const newRow = _.omit(row, keysToOmit);
-        if (notLessonsOrDiagnostic(row.activity_classification_id) && row.percentage) {
+        if (shouldCountForScoring(row.activity_classification_id) && row.percentage) {
           newRow.percentage = `${(newRow.percentage * 100).toString()}%`;
         } else if ((row.activity_classification_id === 6 && row.is_a_completed_lesson) || row.percentage) {
           newRow.percentage = 'Completed';

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview.jsx
@@ -50,7 +50,7 @@ export default class extends React.Component {
     let countForAverage = 0;
     let average;
     reportData.forEach((row) => {
-      if (row.percentage) {
+      if (row.percentage || row.percentage === 0) {
         count += 1;
         if (notLessonsOrDiagnostic(row.activity_classification_id)) {
           cumulativeScore += parseFloat(row.percentage);


### PR DESCRIPTION
## WHAT
Remove `if (row.percentage)` guard statement

Also rename `notLessonsOrDiagnostic` to match the name of the function where it is exported from (since it also makes sure an activity is not Evidence in addition to Lessons or Diagnostic).

Note: I'd discussed an alternative solution with Emilia, but further investigation suggested that this even simpler option was better.
## WHY
This guard statement was presumably introduced to prevent trying to build averages on `NULL` values, which would error, but this also excludes cases where students get a `0` score on an activity which means that this report excludes those activities in the rollup at the top.  We also already have a guard statement for `shouldCountForScoring` that should prevent that.

NOTE: I checked our database for legacy data that might still need this guard clause, but the last case of a non Lessons/Diagnostic/Evidence activity that was completed with a `NULL` score was at the end of the 2019-2020 school year, so I think we should be safe to skip it.
## HOW
Remove the guard clause.  Everything else operates exactly the way it always has before.

### Screenshots
Overview row for a student with some `0` score activities
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/d027729e-614d-4180-abf9-590d52d57f17)
Current PROD detailed summary
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/3a54b617-ce18-4abe-b880-e5300ff6a590)
Staging detailed summary:
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/92efa1c5-89be-4efa-a46a-e8c93900369d)

### Notion Card Links
https://www.notion.so/quill/Average-score-discrepancy-on-Activity-Scores-report-b4fc5d31127443d6834e82297f8b90d5

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on this file
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
