### PR TITLE
fix gap to be 16px, not 32px

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/overview.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/overview.scss
@@ -50,7 +50,7 @@
   .integrations, .premium-reports, .account-management {
     .overview-section-content {
       display: grid;
-      gap: 32px;
+      gap: 16px;
       grid-template-columns: repeat(3, 1fr);
     }
   }


### PR DESCRIPTION
## WHAT
Adjust spacing of admin dashboard tiles.

## WHY
We want them to be 16px, not 32px.

## HOW
Just update one CSS rule.

### Screenshots
<img width="838" alt="Screenshot 2024-01-11 at 4 10 44 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/457390e0-a341-4fdf-9dab-0ab61e8cc258">

### Notion Card Links
https://www.notion.so/quill/Admin-Overview-Page-Fix-spacing-between-tiles-aa60e7fca15c4554ad783d041ae0ca56?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | N/A - CSS
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES