### PR TITLE
lms/fix-proofreader-spacing

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editInput.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editInput.tsx
@@ -3,7 +3,7 @@ import ContentEditable from 'react-contenteditable';
 
 import { WordObject } from '../../interfaces/proofreaderActivities';
 
-type EditInputProps = WordObject & { onWordChange: Function, numberOfResets: number, isFollowedByPunctuation: boolean, underlineErrors: boolean }
+type EditInputProps = WordObject & { onWordChange: Function, numberOfResets: number, underlineErrors: boolean }
 
 export default class EditInput extends React.Component<EditInputProps, {}> {
   handleWordChange = (e: any) => {
@@ -15,7 +15,7 @@ export default class EditInput extends React.Component<EditInputProps, {}> {
   setEditInputRef = node => this.editInput = node
 
   render() {
-    const { currentText, originalText, underlined, wordIndex, paragraphIndex, numberOfResets, isFollowedByPunctuation, underlineErrors} = this.props
+    const { currentText, originalText, underlined, wordIndex, paragraphIndex, numberOfResets, underlineErrors} = this.props
     const beforeElements = []
     const afterElements = []
     let className = 'edit-input'
@@ -26,9 +26,6 @@ export default class EditInput extends React.Component<EditInputProps, {}> {
       beforeElements.push(<span className="sr-only" tabIndex={0}>(underlined text begins here)</span>)
       afterElements.push(<span className="sr-only" tabIndex={0}>(underlined text ends here)</span>)
       /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
-    }
-    if (isFollowedByPunctuation) {
-      className += ' no-right-margin'
     }
     if (currentText.trim() !== originalText) {
       className += ' bolded'

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/paragraph.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/paragraph.tsx
@@ -36,12 +36,10 @@ export default class Paragraph extends React.Component<ParagraphProps, {}> {
       className += ' no-underline'
     }
     const inputs = words.map((word: WordObject, i: number) => {
-      const isFollowedByPunctuation = words[i + 1] && words[i + 1]['originalText'].match(startsWithPunctuationRegex)
       return (
         <EditInput
           key={word.wordIndex}
           {...word}
-          isFollowedByPunctuation={!!isFollowedByPunctuation}
           numberOfResets={numberOfResets}
           onWordChange={this.handleWordChange}
           underlineErrors={underlineErrors}


### PR DESCRIPTION


## WHAT
Remove isFollowedByPunctuation logic
## WHY
Talking to Emilia, and digging into the code history, it's not clear why we do this, and it's causing issues with things like "reaching -100" which is getting squished into "reaching-11".

NOTE: This is risky per [Chesterton's Fence](https://sproutsschools.com/chesterton-fence-dont-destroy-what-you-dont-understand/).  It's possible that this will give rise to additional bugs that we need to resolve by re-introducing something like this later on.  That said, I've spot-tested a bunch of Proofreader activities with the code change and nothing has jumped out at me as a problem.
## HOW
Remove logic around `isFollowedByPunctuation` as it's not clear what edge case this is trying to solve for.

### Screenshots
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/1f8aa557-16da-4aa1-8467-deedde394ad0)
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/6cb060ba-576c-4e8b-bde3-0f94541c9dbf)

### Notion Card Links
https://www.notion.so/quill/Some-spaces-not-showing-up-in-Proofreader-f4e5c8cbcc8547f48a635c4e5eaeb53c

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage for this behavior
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A