### PR TITLE
lms/homepage-copy-update

### DIFF
--- a/services/QuillLMS/app/views/pages/home_new.html.erb
+++ b/services/QuillLMS/app/views/pages/home_new.html.erb
@@ -17,7 +17,7 @@
     <a class="q-button cta-button cta-home  bg-white" href="/sign-up/teacher">Teacher</a>
     <a class="q-button cta-button cta-home  bg-white" href="/administrator">Administrator</a>
     <a class="q-button cta-button cta-home  bg-white" href="/sign-up/teacher">Guardian</a>
-    <p class="text-white" id="mission"><strong><u>New</u> for 2022-2023 School Year:</strong> Quill's nonprofit mission is to now build both ﻿reading and writing skills through free, OER content across the curriculum.  Over the coming years, we will be building a library of free ELA, social studies, and science activities that engage students in deeper thinking through writing prompts that provide immediate feedback.</p>
+    <p class="text-white" id="mission"><strong>Writing Across the Curriculum:</strong> Quill's nonprofit mission is to now build both ﻿reading and writing skills through free, OER content across the curriculum.  Over the coming years, we will be building a library of free ELA, social studies, and science activities that engage students in deeper thinking through writing prompts that provide immediate feedback.</p>
   </div>
   <div class="q-hero-footer">
     <p class="text-white">


### PR DESCRIPTION
## WHAT
Update homepage copy to avoid referencing a specific school year
## WHY
We don't want people to think we don't keep our homepage up to date
## HOW
Tweak the copy that is specific about a school year to be more generic

### Screenshots
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/7671f78c-32b2-4d58-9b6c-6143fa5f3bc6)
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/88795902-db21-4d1c-b39e-40271b8f6e34)


### Notion Card Links
https://www.notion.so/quill/Remove-text-about-2022-2023-school-year-from-homepage-b8c3f53a8dc64422933bbfb44e9f9334

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on pure copy
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A