### PR TITLE
fix capitalization issue and styling bug

### DIFF
--- a/services/QuillLMS/app/controllers/cms/school_admins_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/school_admins_controller.rb
@@ -4,7 +4,7 @@ class Cms::SchoolAdminsController < Cms::CmsController
   before_action :set_school, only: [:create]
 
   def create
-    user = User.find_by(email: params[:email])
+    user = User.find_by(email: params[:email].downcase)
     if user
       create_admin_user_for_existing_user(user)
     else

--- a/services/QuillLMS/client/app/bundles/Staff/styles/new_admin_user.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/new_admin_user.scss
@@ -1,11 +1,15 @@
 .new-admin-user-container {
   margin-top: 24px;
+  section {
+    border-bottom: none;
+  }
   .instructions {
     max-width: 700px;
     margin: 24px 0;
   }
   .cms-form {
     max-width: 700px;
+    flex-direction: column;
     .name-inputs-container, .buttons-container {
       display: flex;
       .user-details-input {
@@ -26,6 +30,10 @@
           height: 24px;
         }
       }
+    }
+    input {
+      margin-left: 0px;
+      width: 100%
     }
     table {
       overflow: visible;

--- a/services/QuillLMS/spec/controllers/cms/school_admins_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/school_admins_controller_spec.rb
@@ -59,6 +59,15 @@ describe Cms::SchoolAdminsController do
         end
       end
 
+      describe 'when the email is submitted in uppercase' do
+        it 'creates the admin info record as staff approved' do
+          post :create, params: { school_id: school1.id, email: admin1.email.upcase}
+
+          expect(admin1.admin_info.approver_role).to eq(User::STAFF)
+          expect(admin1.admin_info.approval_status).to eq(AdminInfo::APPROVED)
+        end
+      end
+
       it 'creates a new school admin with no linked school and sends the expected email' do
         Sidekiq::Testing.inline! do
           post :create, params: { school_id: school1.id, email: admin1.email}


### PR DESCRIPTION
## WHAT
Fix bug with making a new admin from the CMS where a) the styling for the page was all messed up and b) submitting an admin with capital letters in their email did not work.

## WHY
We want this page to a) look good and b) work.

## HOW
Just add a `downcase` to the email submission, and adjust the styling (can't tell when it broke, maybe Vite?)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Trouble-adding-admin-to-a-school-in-the-CMS-40728ba16a5b4d42ac201b3815b2b34f

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES