### PR TITLE
Lms/tweak admin diagnostic query

### DIFF
--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_recommendations_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_recommendations_query.rb
@@ -14,6 +14,7 @@ module AdminDiagnosticReports
       super + <<-SQL
         JOIN lms.activity_sessions
           ON classroom_units.id = activity_sessions.classroom_unit_id
+            AND activity_sessions.visible = true
         JOIN lms.units
           ON classroom_units.unit_id = units.id
         JOIN lms.recommendations

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_completed_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_completed_query.rb
@@ -29,6 +29,7 @@ module AdminDiagnosticReports
       super + <<-SQL
         JOIN lms.activity_sessions
           ON classroom_units.id = activity_sessions.classroom_unit_id
+            AND activity_sessions.visible = true
         JOIN special.concept_results
           ON activity_sessions.id = concept_results.activity_session_id
         JOIN lms.activities AS post_activities

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_completed_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_completed_query.rb
@@ -29,6 +29,7 @@ module AdminDiagnosticReports
       super + <<-SQL
         JOIN lms.activity_sessions
           ON classroom_units.id = activity_sessions.classroom_unit_id
+            AND activity_sessions.visible = true
         JOIN special.concept_results
           ON activity_sessions.id = concept_results.activity_session_id
         JOIN lms.activities

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/diagnosticGrowthReportsHelpers.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/diagnosticGrowthReportsHelpers.test.tsx
@@ -165,7 +165,7 @@ const mockRecommendationsData = [{
 const mockCombinedData = [{
   aggregate_rows: [
     {
-      averageActivitiesAndTimeSpent: "22 Activities (26:56)",
+      averageActivitiesAndTimeSpent: "22 Activities (206:56)",
       id: "5",
       name: "Grade 5",
       overallSkillGrowth: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>+29%</button>,
@@ -174,7 +174,7 @@ const mockCombinedData = [{
       studentsCompletedPractice: "113 Students"
     },
     {
-      averageActivitiesAndTimeSpent: "12 Activities (25:57)",
+      averageActivitiesAndTimeSpent: "12 Activities (85:57)",
       id: "7",
       name: "Grade 7",
       overallSkillGrowth: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>+19%</button>,
@@ -183,7 +183,7 @@ const mockCombinedData = [{
       studentsCompletedPractice: "46 Students"
     }
   ],
-  averageActivitiesAndTimeSpent: "19 Activities (51:56)",
+  averageActivitiesAndTimeSpent: "19 Activities (171:56)",
   id: 1663,
   name: "Starter Baseline Diagnostic (Pre)",
   overallSkillGrowth: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>+24%</button>,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/shared.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/shared.tsx
@@ -78,11 +78,8 @@ export function hashPayload(payloadArray: Array<any>) {
 export function getTimeInMinutesAndSeconds(seconds) {
   if(!seconds) return NOT_APPLICABLE
 
-  const oneHourInSeconds = 3600
-  const oneDayInSeconds = 86400
-  const oneYearInSeconds = 31536000
-  let numminutes = Math.floor((((seconds % oneYearInSeconds) % oneDayInSeconds) % oneHourInSeconds) / 60).toString();
-  let numseconds = Math.floor((((seconds % oneYearInSeconds) % oneDayInSeconds) % oneHourInSeconds) % 60).toString();
+  let numminutes = Math.floor(seconds / 60).toString();
+  let numseconds = Math.floor(seconds % 60).toString();
 
   if (numminutes.length === 1) numminutes = "0" + numminutes
   if (numseconds.length === 1) numseconds = "0" + numseconds

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_recommendations_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_recommendations_query_spec.rb
@@ -70,6 +70,12 @@ module AdminDiagnosticReports
         it { expect(results).to eq([]) }
       end
 
+      context 'no visible activity sessions' do
+        let(:activity_sessions) { classroom_units.map { |classroom_unit| create(:activity_session, :finished, classroom_unit: classroom_unit, activity: recommended_activity, visible: false) } }
+
+        it { expect(results).to eq([]) }
+      end
+
       context 'a mix of completed and incomplete recommendations' do
         let(:complete_activity_sessions) { [create(:activity_session, :finished, classroom_unit: classroom_units.first, activity: recommended_activity, timespent: timespent)] }
         let(:incomplete_activity_sessions) { [create(:activity_session, :unstarted, classroom_unit: classroom_units.first, activity: recommended_activity, timespent: timespent)] }

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_completed_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_completed_query_spec.rb
@@ -42,6 +42,12 @@ module AdminDiagnosticReports
         it { expect(results).to eq([]) }
       end
 
+      context 'no visible activity sessions' do
+        let(:activity_sessions) { classroom_units.map { |classroom_unit| create(:activity_session, :finished, classroom_unit: classroom_unit, activity: post_diagnostic, visible: false) } }
+
+        it { expect(results).to eq([]) }
+      end
+
       context 'a mix of finished and unfinished activity sessions' do
         let(:unfinished_activity_session) { create(:activity_session, :unstarted, classroom_unit: classroom_units.first, activity: post_diagnostic) }
         let(:finished_activity_session) { create(:activity_session, :finished, classroom_unit: classroom_units.last, activity: post_diagnostic) }

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/pre_diagnostic_completed_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/pre_diagnostic_completed_query_spec.rb
@@ -43,6 +43,12 @@ module AdminDiagnosticReports
         it { expect(results).to eq([]) }
       end
 
+      context 'no visible activity sessions' do
+        let(:activity_sessions) { classroom_units.map { |classroom_unit| create(:activity_session, :finished, classroom_unit: classroom_unit, activity: pre_diagnostic, visible: false) } }
+
+        it { expect(results).to eq([]) }
+      end
+
       context 'a mix of finished and unfinished activity sessions' do
         let(:unfinished_activity_session) { create(:activity_session, :unstarted, classroom_unit: classroom_units.first, activity: pre_diagnostic) }
         let(:finished_activity_session) { create(:activity_session, :finished, classroom_unit: classroom_units.last, activity: pre_diagnostic) }


### PR DESCRIPTION
## WHAT
- Fix a bug that was over-counting diagnostic assignments and completions, causing the numbers in the admin report to not match the teacher-level report numbers by one or two in a couple of cases
- Fix a bug in the logic that converts "time spent" values from pure seconds to "minutes:seconds" format.  The existing code was throwing away any values over one hour and displaying only what was left.  So 1 hour, 1 minute, 1 second was displaying as "01:01" instead of "61:01"
## WHY
- We want the numbers we're showing teachers and the numbers we're showing admins to match so that we don't create confusion in cases where they compare
- We want to see the full values for time spent as a number of teachers are doing enough practice on Quill that their students are legitimately spending multiple hours on practice activities
## HOW
- Make sure to exclude `ActivitySession` records that have been deleted (had `visible` set to `false`) when doing admin roll-ups
- Skip the process of modulo-ing off the units larger than an hour in the process that calculates how to display time in our Admin report tables

### Screenshots
Average time spent numbers can go over `59:59` now
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/027d41bc-b84d-4fb2-9e30-28c4a178073e)

### Notion Card Links
https://www.notion.so/quill/Admin-Diagnostic-Growth-Report-QA-Overview-Tab-December-7-0524fc96c41f424a9532228535b11553#e67342bc03694ef0ba3c94b4f044addd

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes, the query specs have been updated to reflect the new `visible` expectations, and front-end jest expectations have been updated.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
