### PR TITLE
fix bug with grammar cms

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseComponent.tsx
@@ -558,10 +558,10 @@ class ResponseComponent extends React.Component {
     //   array = this.getPOSTagsList()
     // }
 
+    let pageNumbers = [1]
+
     if (this.props.filters.numberOfPages) {
-      const pageNumbers = _.range(1, this.props.filters.numberOfPages + 1);
-    } else {
-      const pageNumbers = [1]
+      pageNumbers = _.range(1, this.props.filters.numberOfPages + 1);
     }
 
     let pageNumberStyle = {};


### PR DESCRIPTION
## WHAT
Fix bug where responses page wasn't loading for Grammar CMS.

## WHY
We need this section to load.

## HOW
This section hadn't been touched in five years, but the code was breaking -- I think it was probably a Vite issue we missed.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Grammar-CMS-Responses-pages-not-working-5bf0cdfadcae44ba8b11186cba349f48?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES