### PR TITLE
render 0 instead of not available in diagnostic reports

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
@@ -261,7 +261,7 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
   function renderPreSkillsProficient({ total_correct_questions_count, total_pre_correct_questions_count, skill_groups, total_correct_skill_groups_count, correct_skill_groups_text }) {
     if(total_correct_questions_count === undefined) { return null }
 
-    if(!total_correct_questions_count) { return NOT_AVAILABLE }
+    if(!total_correct_questions_count && total_correct_questions_count !== 0) { return NOT_AVAILABLE }
 
     if (total_pre_correct_questions_count) {
       const countOfPreSkillsProficienct = skill_groups.filter(skillGroup => skillGroup.pre_test_proficiency === PROFICIENCY).length
@@ -288,7 +288,7 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
 
     if (total_correct_questions_count === undefined) { return diagnosticNotCompletedElement }
 
-    if (!total_correct_questions_count) { return NOT_AVAILABLE }
+    if (!total_correct_questions_count && total_correct_questions_count !== 0) { return NOT_AVAILABLE }
 
     return(
       <div className="skills-correct-element">


### PR DESCRIPTION
## WHAT
Fix bug where diagnostic student responses page rendered "Not available" instead of "0 of x questions" and "0 of x skills".

## WHY
The data is available, it's just 0.

## HOW
Just update the logic.

### Screenshots
<img width="686" alt="Screenshot 2024-01-19 at 10 40 46 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/24c0cd2c-548a-4ed5-a4fa-d0aedf6e0a1f">

### Notion Card Links
https://www.notion.so/quill/Not-available-showing-for-some-students-on-Student-responses-report-cb92d9a844d44becb32c89b22ee2ab7f?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES