### PR TITLE
fix css bug for usage snapshot tables

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/admin_usage_snapshot_report_pdf.scss
+++ b/services/QuillLMS/app/assets/stylesheets/admin_usage_snapshot_report_pdf.scss
@@ -275,6 +275,11 @@
         font-size: 14px;
         border-top: 1px solid #e0e0e0;
 
+        td {
+          border-top: none;
+          padding: 0px;
+        }
+
         td:first-of-type {
           font-weight: 400;
           line-height: 16px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/snapshots.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/snapshots.scss
@@ -146,6 +146,10 @@
       }
       .data-row {
         border-top: 1px solid $quill-grey-5;
+        td {
+          border-top: none;
+          padding: 0px;
+        }
         td:first-of-type {
           font-weight: 400;
           line-height: 16px;


### PR DESCRIPTION
## WHAT
Fix CSS bug for usage snapshot tables.

## WHY
Some extra CSS was getting applied that we don't want.

## HOW
Just overwrite that CSS.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Styling-bug-on-Usage-Snapshot-Report-0e68130c33f34727862363f34b141611?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - CSS change only
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES