### PR TITLE
add universal test stub for network requests

### DIFF
--- a/services/QuillLMS/client/setupTests.ts
+++ b/services/QuillLMS/client/setupTests.ts
@@ -3,6 +3,7 @@ import { configure } from 'enzyme';
 import 'whatwg-fetch';
 
 import processEnvMock from './__mocks__/processEnvMock';
+import * as requestsApi from './app/modules/request';
 
 configure({ adapter: new Adapter() });
 
@@ -33,3 +34,8 @@ global.IntersectionObserver = class IntersectionObserver {
 window.process.env = processEnvMock.env
 
 window.scrollTo = jest.fn();
+
+const requestGetSpy = jest.spyOn(requestsApi, 'requestGet').mockImplementation(() =>  new Promise(jest.fn()))
+const requestPutSpy = jest.spyOn(requestsApi, 'requestPut').mockImplementation(() => new Promise(jest.fn()))
+const requestPostSpy = jest.spyOn(requestsApi, 'requestPost').mockImplementation(() => new Promise(jest.fn()))
+const requestDeleteSpy = jest.spyOn(requestsApi, 'requestDelete').mockImplementation(() => new Promise(jest.fn()))


### PR DESCRIPTION
## WHAT
Add universal test stub for network requests.

## WHY
We are having intermittent test failures from `UnhandledPromiseRejectionWarning: TypeError: Network request failed`, and I don't want to have to stub it in every test file for every component that makes a request. 

## HOW
Just add this mock to the `setupTests` file.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Console-log-cleanup-UnhandledPromiseRejectionWarning-TypeError-95-1c2a466052004a4db3a578d909a41c91?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Kind of?
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A