### PR TITLE
Stop raising error on nil user in ResetLessonsCache

### DIFF
--- a/services/QuillLMS/app/workers/reset_lesson_cache_worker.rb
+++ b/services/QuillLMS/app/workers/reset_lesson_cache_worker.rb
@@ -12,7 +12,7 @@ class ResetLessonCacheWorker
     $redis.del("user_id:#{user_id}_lessons_array")
     user = User.find_by(id: user_id)
 
-    return ErrorNotifier.report(UserNotFoundError.new, user_id: user_id) if user.nil?
+    return if user.nil?
 
     user.set_lessons_cache
   end

--- a/services/QuillLMS/spec/workers/reset_lesson_cache_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/reset_lesson_cache_worker_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe ResetLessonCacheWorker do
 
     context 'when user is not present' do
       it do
-        expect(ErrorNotifier).to receive(:report).with(described_class::UserNotFoundError, user_id: user_id)
-        subject
+        expect { subject }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
## WHAT
Stop raising error in this worker when user is nil or already deleted.

## WHY
We frequently delete Demo Teacher accounts to recreate fresh ones, so this error is being raised too much in Sentry. We don't need to be notified every time a user is nil on resetting lessons cache, as long as the lessons cache is properly cleared. It's okay to silently return out of the function when the user is deleted.

## HOW
Silently return when user is nil instead of raising an error.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-ResetLessonCacheWorker-UserNotFoundError-5a236541674d4327a9bf3f17516912ee?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes