### PR TITLE
add ClassroomsTeachers.deleted_at column

### DIFF
--- a/services/QuillLMS/app/models/classrooms_teacher.rb
+++ b/services/QuillLMS/app/models/classrooms_teacher.rb
@@ -24,6 +24,9 @@ class ClassroomsTeacher < ApplicationRecord
   belongs_to :user
   belongs_to :classroom, touch: true
 
+  validates :user_id, uniqueness: { scope: [:classroom_id, :deleted_at], message: "user_id, classroom_id, and deleted_at must be collectively unique"}
+
+
   after_create :delete_classroom_minis_cache_for_each_teacher_of_this_classroom, :reset_lessons_cache_for_teacher
   before_destroy :delete_classroom_minis_cache_for_each_teacher_of_this_classroom, :reset_lessons_cache_for_teacher
 

--- a/services/QuillLMS/app/models/classrooms_teacher.rb
+++ b/services/QuillLMS/app/models/classrooms_teacher.rb
@@ -5,6 +5,7 @@
 # Table name: classrooms_teachers
 #
 #  id           :integer          not null, primary key
+#  deleted_at   :datetime
 #  order        :integer
 #  role         :string           not null
 #  created_at   :datetime
@@ -14,10 +15,10 @@
 #
 # Indexes
 #
-#  index_classrooms_teachers_on_classroom_id             (classroom_id)
-#  index_classrooms_teachers_on_role                     (role)
-#  index_classrooms_teachers_on_user_id                  (user_id)
-#  unique_classroom_and_user_ids_on_classrooms_teachers  (user_id,classroom_id) UNIQUE
+#  index_classrooms_teachers_on_classroom_id            (classroom_id)
+#  index_classrooms_teachers_on_role                    (role)
+#  index_classrooms_teachers_on_user_id                 (user_id)
+#  unique_user_class_deleted_at_on_classrooms_teachers  (user_id,classroom_id,deleted_at) UNIQUE
 #
 class ClassroomsTeacher < ApplicationRecord
   belongs_to :user

--- a/services/QuillLMS/db/migrate/20240122203546_add_deleted_at_to_classrooms_teacher.rb
+++ b/services/QuillLMS/db/migrate/20240122203546_add_deleted_at_to_classrooms_teacher.rb
@@ -1,0 +1,7 @@
+class AddDeletedAtToClassroomsTeacher < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :classrooms_teachers, [:user_id, :classroom_id]
+    add_column :classrooms_teachers, :deleted_at, :timestamp
+    add_index :classrooms_teachers, [:user_id, :classroom_id, :deleted_at], unique: true, name: 'unique_user_class_deleted_at_on_classrooms_teachers'
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -10,13 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
-
---
 -- Name: hstore; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -872,8 +865,8 @@ ALTER SEQUENCE public.app_settings_id_seq OWNED BY public.app_settings.id;
 CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -1228,8 +1221,8 @@ CREATE TABLE public.change_logs (
     id integer NOT NULL,
     explanation text,
     action character varying NOT NULL,
-    changed_record_type character varying NOT NULL,
     changed_record_id integer,
+    changed_record_type character varying NOT NULL,
     user_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -1458,6 +1451,7 @@ CREATE TABLE public.classrooms_teachers (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     "order" integer,
+    deleted_at timestamp without time zone,
     CONSTRAINT check_role_is_valid CHECK ((((role)::text = ANY (ARRAY[('owner'::character varying)::text, ('coteacher'::character varying)::text])) AND (role IS NOT NULL)))
 );
 
@@ -2323,8 +2317,8 @@ CREATE TABLE public.credit_transactions (
     id integer NOT NULL,
     amount integer NOT NULL,
     user_id integer NOT NULL,
-    source_type character varying,
     source_id integer,
+    source_type character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -2835,8 +2829,8 @@ ALTER SEQUENCE public.evidence_text_generations_id_seq OWNED BY public.evidence_
 CREATE TABLE public.feedback_histories (
     id integer NOT NULL,
     feedback_session_uid text,
-    prompt_type character varying,
     prompt_id integer,
+    prompt_type character varying,
     concept_uid text,
     attempt integer NOT NULL,
     entry text NOT NULL,
@@ -7342,14 +7336,6 @@ ALTER TABLE ONLY public.sales_stages
 
 
 --
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.schema_migrations
-    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
-
-
---
 -- Name: school_subscriptions school_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9327,13 +9313,6 @@ CREATE UNIQUE INDEX unique_classroom_and_activity_for_cua_state ON public.classr
 
 
 --
--- Name: unique_classroom_and_user_ids_on_classrooms_teachers; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX unique_classroom_and_user_ids_on_classrooms_teachers ON public.classrooms_teachers USING btree (user_id, classroom_id);
-
-
---
 -- Name: unique_index_schools_on_nces_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9373,6 +9352,20 @@ CREATE UNIQUE INDEX unique_index_users_on_google_id ON public.users USING btree 
 --
 
 CREATE UNIQUE INDEX unique_index_users_on_username ON public.users USING btree (username) WHERE ((id > 1641954) AND (username IS NOT NULL) AND ((username)::text <> ''::text));
+
+
+--
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
+
+
+--
+-- Name: unique_user_class_deleted_at_on_classrooms_teachers; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX unique_user_class_deleted_at_on_classrooms_teachers ON public.classrooms_teachers USING btree (user_id, classroom_id, deleted_at);
 
 
 --
@@ -10628,6 +10621,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231207135455'),
 ('20231207151344'),
 ('20231214182438'),
-('20240111143245');
+('20240111143245'),
+('20240122203546');
 
 

--- a/services/QuillLMS/spec/factories/classrooms_teachers.rb
+++ b/services/QuillLMS/spec/factories/classrooms_teachers.rb
@@ -5,6 +5,7 @@
 # Table name: classrooms_teachers
 #
 #  id           :integer          not null, primary key
+#  deleted_at   :datetime
 #  order        :integer
 #  role         :string           not null
 #  created_at   :datetime
@@ -14,10 +15,10 @@
 #
 # Indexes
 #
-#  index_classrooms_teachers_on_classroom_id             (classroom_id)
-#  index_classrooms_teachers_on_role                     (role)
-#  index_classrooms_teachers_on_user_id                  (user_id)
-#  unique_classroom_and_user_ids_on_classrooms_teachers  (user_id,classroom_id) UNIQUE
+#  index_classrooms_teachers_on_classroom_id            (classroom_id)
+#  index_classrooms_teachers_on_role                    (role)
+#  index_classrooms_teachers_on_user_id                 (user_id)
+#  unique_user_class_deleted_at_on_classrooms_teachers  (user_id,classroom_id,deleted_at) UNIQUE
 #
 FactoryBot.define do
   factory :classrooms_teacher do

--- a/services/QuillLMS/spec/models/classrooms_teacher_spec.rb
+++ b/services/QuillLMS/spec/models/classrooms_teacher_spec.rb
@@ -56,6 +56,28 @@ RSpec.describe ClassroomsTeacher, type: :model, redis: true do
     it 'should require a classroom_id that is not null' do
       expect{classrooms_teacher_with_null_classroom_id.save}.to raise_error ActiveRecord::StatementInvalid
     end
+
+    it 'should invalidate two undeleted records with the same classroom and teacher' do
+      classroom = create(:classroom)
+      teacher = create(:teacher)
+      create(:classrooms_teacher, user: teacher, classroom: classroom)
+
+      expect do
+        create(:classrooms_teacher, user: teacher, classroom: classroom)
+      end.to raise_error ActiveRecord::RecordInvalid
+    end
+
+    it 'should validate two deleted records with the same classroom and teacher' do
+      classroom = create(:classroom)
+      teacher = create(:teacher)
+      create(:classrooms_teacher, user: teacher, classroom: classroom, deleted_at: Time.now)
+
+      expect do
+        create(:classrooms_teacher, user: teacher, classroom: classroom, deleted_at: Time.now - 1.hour)
+      end.to_not raise_error
+    end
+
+
   end
 
   describe 'callbacks' do

--- a/services/QuillLMS/spec/models/classrooms_teacher_spec.rb
+++ b/services/QuillLMS/spec/models/classrooms_teacher_spec.rb
@@ -5,6 +5,7 @@
 # Table name: classrooms_teachers
 #
 #  id           :integer          not null, primary key
+#  deleted_at   :datetime
 #  order        :integer
 #  role         :string           not null
 #  created_at   :datetime
@@ -14,10 +15,10 @@
 #
 # Indexes
 #
-#  index_classrooms_teachers_on_classroom_id             (classroom_id)
-#  index_classrooms_teachers_on_role                     (role)
-#  index_classrooms_teachers_on_user_id                  (user_id)
-#  unique_classroom_and_user_ids_on_classrooms_teachers  (user_id,classroom_id) UNIQUE
+#  index_classrooms_teachers_on_classroom_id            (classroom_id)
+#  index_classrooms_teachers_on_role                    (role)
+#  index_classrooms_teachers_on_user_id                 (user_id)
+#  unique_user_class_deleted_at_on_classrooms_teachers  (user_id,classroom_id,deleted_at) UNIQUE
 #
 require 'rails_helper'
 


### PR DESCRIPTION
## WHAT
- adds `SchoolsTeachers.deleted_at` 
- adds DB level uniqueness constraint
- adds ActiveRecord-level uniqueness constraint

## WHY
- So that we can propagate deletions via Airbyte, without using Change Data Capture
- it's good to push up constraints to the DB level wherever possible
- The ActiveRecord-level constraint actually matters here, because Postgres uniqueness indices treat columns with null values as unique. Example: the two records `(user_id: 1, classroom:1, null)` and `(user_id: 1, classroom:1, null)`  would both be accepted by the Postgres index, but not the validation. Better controls exist once we migrate to Postgres 14 (https://pganalyze.com/blog/5mins-postgres-unique-constraint-null-parallel-distinct#:~:text=In%20Postgres%2014%20and%20older,always%20different%20from%20another%20NULL.)


Note: This PR must be deployed before its sibling: https://github.com/empirical-org/Empirical-Core/pull/11436

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=c356c8cfe98246098a80e5c67c2a382a&pm=s

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
