### PR TITLE
Add punctuation feedback to quill-marking-logic

### DIFF
--- a/packages/quill-marking-logic/package.json
+++ b/packages/quill-marking-logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-marking-logic",
-  "version": "0.15.11",
+  "version": "0.15.13",
   "description": "Shared Quill logic for grading and contextualizing student writing.",
   "main": "./dist/lib",
   "module": "./dist/lib",

--- a/packages/quill-marking-logic/src/libs/constants/error_authors.ts
+++ b/packages/quill-marking-logic/src/libs/constants/error_authors.ts
@@ -14,6 +14,7 @@ export interface ErrorAuthors {
   "Punctuation End Hint": string
   "Punctuation Hint": string
   "Punctuation and Case Hint": string
+  "Quotation Mark Hint": string
   "Required Words Hint": string
   "Spacing After Comma Hint": string
   "Starting Capitalization Hint": string
@@ -39,6 +40,7 @@ const error_authors: ErrorAuthors = {
   "Punctuation End Hint": "Punctuation End Hint",
   "Punctuation Hint": "Punctuation Hint",
   "Punctuation and Case Hint": "Punctuation and Case Hint",
+  "Quotation Mark Hint": "Quotation Mark Hint",
   "Required Words Hint": "Required Words Hint",
   "Spacing After Comma Hint": "Spacing After Comma Hint",
   "Spelling Hint": "Spelling Hint",

--- a/packages/quill-marking-logic/src/libs/constants/feedback_strings.ts
+++ b/packages/quill-marking-logic/src/libs/constants/feedback_strings.ts
@@ -2,6 +2,7 @@ export interface FeedbackStrings {
   punctuationError: string;
   punctuationEndError: string;
   punctuationAndCaseError: string;
+  quotationMarkError: string;
   typingError: string;
   caseError: string;
   minLengthError: string;
@@ -22,6 +23,9 @@ export const feedbackStrings: FeedbackStrings = {
   punctuationError: 'Proofread your work. Check your punctuation.',
   punctuationEndError: 'Proofread your work. Check your ending punctuation.',
   punctuationAndCaseError: 'Proofread your work. Check your punctuation and capitalization.',
+  quotationMarkError: `It looks like you might have used two apostrophes to make a quotation mark. <br/><br/>
+    Instead of hitting the apostrophe key twice to make a quotation mark, hold down the shift key and hit the apostrophe key once. <br/><br/>
+    <img alt="keyboard with double quote highlighted" src="https://quill-cdn.s3.amazonaws.com/images/illustrations/Illustration+-+Keyboard+(Chromebook).svg">`,
   typingError: 'Proofread your work. Check your spelling.',
   caseError: 'Proofread your work. Check your capitalization.',
   minLengthError: 'Revise your work. Do you have all of the information from the prompt?',

--- a/packages/quill-marking-logic/src/libs/graders/grammar.ts
+++ b/packages/quill-marking-logic/src/libs/graders/grammar.ts
@@ -16,6 +16,7 @@ import {whitespaceChecker} from '../matchers/whitespace_match';
 import {rigidChangeObjectChecker, flexibleChangeObjectChecker} from '../matchers/change_object_match';
 import {caseStartChecker} from '../matchers/case_start_match';
 import {punctuationEndChecker} from '../matchers/punctuation_end_match';
+import {quotationMarkChecker} from '../matchers/quotation_mark_match';
 import {spellingFeedbackStrings} from '../constants/feedback_strings';
 
 export function checkGrammarQuestion(
@@ -71,6 +72,7 @@ function* firstPassMatchers(data: GradingObject, spellCorrected=false) {
     yield incorrectSequenceChecker(submission, incorrectSequences, responses);
   }
   yield caseInsensitiveChecker(submission, responses);
+  yield quotationMarkChecker(submission, responses);
   yield punctuationInsensitiveChecker(submission, responses);
   yield punctuationAndCaseInsensitiveChecker(submission, responses);
   yield spacingBeforePunctuationChecker(submission, responses);

--- a/packages/quill-marking-logic/src/libs/graders/sentence_combining.ts
+++ b/packages/quill-marking-logic/src/libs/graders/sentence_combining.ts
@@ -11,6 +11,7 @@ import {incorrectSequenceChecker} from '../matchers/incorrect_sequence_match';
 import {caseInsensitiveChecker} from '../matchers/case_insensitive_match';
 import {punctuationInsensitiveChecker} from '../matchers/punctuation_insensitive_match';
 import {punctuationAndCaseInsensitiveChecker} from '../matchers/punctuation_and_case_insensitive_match';
+import {quotationMarkChecker} from '../matchers/quotation_mark_match';
 import {spacingBeforePunctuationChecker} from '../matchers/spacing_before_punctuation_match';
 import {spacingAfterCommaChecker} from '../matchers/spacing_after_comma_match';
 import {whitespaceChecker} from '../matchers/whitespace_match';
@@ -91,6 +92,7 @@ function* firstPassMatchers(data: GradingObject, spellCorrected=false) {
     yield incorrectSequenceChecker(submission, incorrectSequences, responses);
   }
   yield caseInsensitiveChecker(submission, responses);
+  yield quotationMarkChecker(submission, responses);
   yield punctuationInsensitiveChecker(submission, responses);
   yield punctuationAndCaseInsensitiveChecker(submission, responses);
   yield spacingBeforePunctuationChecker(submission, responses);

--- a/packages/quill-marking-logic/src/libs/graders/sentence_combining_integration.spec.ts
+++ b/packages/quill-marking-logic/src/libs/graders/sentence_combining_integration.spec.ts
@@ -201,6 +201,12 @@ describe('The checking a sentence combining question', () => {
       assert.equal(matchedResponse.feedback, feedbackStrings.wordsOutOfOrderError);
     });
 
+    it('should be able to find a quotation mark match', () => {
+      const questionString = "Bats have wings \'\' so they can fly.";
+      const matchedResponse = checkSentenceCombining(responses[0].question_uid, questionString, responses, focusPoints, incorrectSequences, responses[0].question_uid);
+      assert.equal(matchedResponse.feedback, feedbackStrings.quotationMarkError);
+    });
+
     it('should be able to find a punctuation end match', () => {
       const questionString = "Bats have wings, so they can fly";
       const matchedResponse = checkSentenceCombining(responses[0].question_uid, questionString, responses, focusPoints, incorrectSequences, responses[0].question_uid);

--- a/packages/quill-marking-logic/src/libs/matchers/quotation_mark_match.spec.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/quotation_mark_match.spec.ts
@@ -1,0 +1,55 @@
+import { assert } from 'chai';
+
+import { quotationMarkChecker, quotationMarkMatch } from './quotation_mark_match';
+
+import {Response,PartialResponse} from '../../interfaces'
+import {feedbackStrings} from '../constants/feedback_strings'
+import {conceptResultTemplate} from '../helpers/concept_result_template'
+
+describe('The quotationMarkMatch function', () => {
+
+  const savedResponses: Array<Response> = [
+    {
+      id: 1,
+      text: "My dog took a nap.",
+      feedback: "Good job, that's a sentence!",
+      optimal: true,
+      count: 2,
+      question_uid: "questionOne"
+    },
+    {
+      id: 2,
+      text: "My dog took another nap.",
+      feedback: "Good job, that's a sentence!",
+      optimal: true,
+      count: 1,
+      question_uid: "questionTwo"
+    }
+  ]
+
+  it('Should take a response string and return true if response does not contain two adjacent single quotes', () => {
+    const responseString = "There are adjacent single quotes in \'\' this string.";
+    assert.ok(quotationMarkMatch(responseString, savedResponses));
+  });
+
+  it('Should take a response string and return false if response does not contain two adjacent single quotes', () => {
+    const responseString = "There are only double \" \" quotes in this string.";
+    assert.notOk(quotationMarkMatch(responseString, savedResponses));
+  });
+
+  it('Should take a response string and find top optimal response if the response string contains two adjacent single quotes', () => {
+    const responseString = "There are two adjacent single quotes \'\' in this string.";
+    const partialResponse: PartialResponse =  {
+      feedback: feedbackStrings.quotationMarkError,
+      author: 'Quotation Mark Hint',
+      parent_id: quotationMarkChecker(responseString, savedResponses).id,
+      concept_results: [
+        conceptResultTemplate('TWgxAwCxRjDLPzpZWYmGrw')
+      ]
+    }
+    assert.equal(quotationMarkChecker(responseString, savedResponses).feedback, partialResponse.feedback);
+    assert.equal(quotationMarkChecker(responseString, savedResponses).author, partialResponse.author);
+    assert.equal(quotationMarkChecker(responseString, savedResponses).concept_results.length, partialResponse.concept_results.length);
+  });
+
+});

--- a/packages/quill-marking-logic/src/libs/matchers/quotation_mark_match.ts
+++ b/packages/quill-marking-logic/src/libs/matchers/quotation_mark_match.ts
@@ -1,0 +1,32 @@
+import * as _ from 'underscore'
+
+import {getTopOptimalResponse} from '../sharedResponseFunctions'
+import {feedbackStrings} from '../constants/feedback_strings'
+import {conceptResultTemplate} from '../helpers/concept_result_template'
+import {Response, PartialResponse} from '../../interfaces'
+
+export function quotationMarkMatch(responseString: string, responses:Array<Response>): Boolean {
+  return /''/.test(responseString);
+}
+
+export function quotationMarkChecker(responseString: string, responses:Array<Response>, markOptimalFalse:Boolean=false):PartialResponse|undefined {
+  const match = quotationMarkMatch(responseString, responses);
+  if (match) {
+    return quotationMarkResponseBuilder(responses, markOptimalFalse)
+  }
+}
+
+export function quotationMarkResponseBuilder(responses:Array<Response>, markOptimalFalse:Boolean): PartialResponse {
+  const res:PartialResponse = {
+    feedback: feedbackStrings.quotationMarkError,
+    author: 'Quotation Mark Hint',
+    parent_id: getTopOptimalResponse(responses).id,
+    concept_results: [
+      conceptResultTemplate('TWgxAwCxRjDLPzpZWYmGrw')
+    ],
+  }
+  if (markOptimalFalse) {
+    res.optimal = false
+  }
+  return res
+}


### PR DESCRIPTION
## WHAT
[Duplicate of PR here](https://github.com/empirical-org/Empirical-Core/pull/11400), which I mistakenly merged incompletely to develop. I forgot to merge develop into production after merging these changes, so Thomas reverted my PR to be safe. I'm merging the changes in again now.

## WHY
These changes to quill-marking-logic have been tested and are safe to merge into production. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/P3-Fix-quotation-mark-grading-in-Connect-and-Grammar-751cb7e21e6a44feb5e2a99aa92c2d08?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
