### PR TITLE
Add snackbar messaging to PdfSubscription save flow

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/UsageSnapshotsContainer.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
+import { useEffect, useState } from 'react'
 
 import { FULL, restrictedPage, mapItemsIfNotAll } from '../shared';
+import { Snackbar, defaultSnackbarTimeout } from '../../Shared/index'
+import useSnackbarMonitor from '../../Shared/hooks/useSnackbarMonitor'
 import SnapshotSection from '../components/usage_snapshots/snapshotSection'
 import { snapshotSections, TAB_NAMES, ALL, SECTION_NAME_TO_ICON_URL, } from '../components/usage_snapshots/shared'
 import { Spinner, DropdownInput, filterIcon, whiteArrowPointingDownIcon, documentFileIcon, whiteEmailIcon } from '../../Shared/index'
@@ -42,17 +45,26 @@ export const UsageSnapshotsContainer = ({
   openMobileFilterMenu
 }) => {
 
-  const [selectedTab, setSelectedTab] = React.useState(ALL)
-  const [isSubscriptionModalOpen, setIsSubscriptionModalOpen] = React.useState(false)
-  const [currentPdfSubscription, setCurrentPdfSubscription] = React.useState(null)
+  const [selectedTab, setSelectedTab] = useState(ALL)
+  const [isSubscriptionModalOpen, setIsSubscriptionModalOpen] = useState(false)
+  const [currentPdfSubscription, setCurrentPdfSubscription] = useState(null)
+  const [isSnackbarVisible, setIsSnackbarVisible] = useState(false)
+  const [snackbarCopy, setSnackbarCopy] = useState('')
 
-  React.useEffect(() => {
+  useSnackbarMonitor(isSnackbarVisible, setIsSnackbarVisible, defaultSnackbarTimeout)
+
+  useEffect(() => {
     requestGet(`/pdf_subscriptions/current?report=${PDF_REPORT}`, (body) => {
       setCurrentPdfSubscription(body)
     })
   }, [])
 
   const size = useWindowSize()
+
+  const showSnackbar = (snackbarCopy: string) => {
+    setSnackbarCopy(snackbarCopy)
+    setIsSnackbarVisible(true)
+  }
 
   function handleSetSelectedTabFromDropdown(option) { setSelectedTab(option.value) }
 
@@ -73,6 +85,7 @@ export const UsageSnapshotsContainer = ({
     } else if (currentPdfSubscription) {
       deletePdfSubscription(currentPdfSubscription.id)
     }
+    showSnackbar('Subscription settings saved')
   }
 
   function createOrUpdatePdfSubscription(adminReportFilterSelection, frequency) {
@@ -96,6 +109,10 @@ export const UsageSnapshotsContainer = ({
 
   if (loadingFilters) {
     return <Spinner />
+  }
+
+  const renderSnackbar = () => {
+    return <Snackbar text={snackbarCopy} visible={isSnackbarVisible} />
   }
 
   const tabs = TAB_NAMES.map(s => (
@@ -199,6 +216,7 @@ export const UsageSnapshotsContainer = ({
         isOpen={isSubscriptionModalOpen}
         save={handleSubscriptionSave}
       />
+      {renderSnackbar()}
       <div id="bottom-element" />
 
     </main >

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/UsageSnapshotsContainer.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/UsageSnapshotsContainer.test.tsx
@@ -79,5 +79,15 @@ describe('UsageSnapshotsContainer', () => {
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
       expect(cancelButton).toBeInTheDocument();
     });
-  })
+
+    test('snackbar appears with correct message after clicking subscribe', () => {
+      render(<UsageSnapshotsContainer {...props} />);
+      fireEvent.click(screen.getByText('Subscribe'));
+      fireEvent.click(screen.getByLabelText('On'));
+      fireEvent.click(screen.getByText('Save'));
+
+      const snackbar = screen.getByText('Subscription settings saved');
+      expect(snackbar).toBeInTheDocument();
+    });
+  });
 })

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/UsageSnapshotsContainer.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/UsageSnapshotsContainer.test.tsx.snap
@@ -1180,6 +1180,9 @@ exports[`UsageSnapshotsContainer full state it should render 1`] = `
       </section>
     </div>
     <div
+      class="quill-snackbar "
+    />
+    <div
       id="bottom-element"
     />
   </main>


### PR DESCRIPTION
## WHAT
When a user clicks 'Subscribe' button on the Usage Snapshots Report page, a modal will appear allowing the user to manage a PDF subscription.  When the user clicks save in the dialog box, add a snackbar notification that the Subscription settings have been saved.

## WHY
This communicates to the user that the change has been made.  Currently the user is only able to determine this worked indirectly.

## HOW
Add snackbar pattern to the UsageSnapshotContainer.

### Screenshots
![Screenshot 2024-01-25 at 1 21 25 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/31d8e5a0-e936-467c-8f83-4999bbe94598)

### Notion Card Links
https://www.notion.so/quill/Email-subscription-for-Admin-Usage-Snapshot-Report-1d4f8e91d30549d89f89ec5f8ff3ec8a#23d1d0bbf4484d52bf6b029f93f205f7

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
