### PR TITLE
Add "turn off auto-renewal" button to Staff Edit Subscription page.

### DIFF
--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_renewals_controller.rb
@@ -7,27 +7,16 @@ module StripeIntegration
     def create
       raise UpdatingCanceledSubscriptionError if stripe_subscription_canceled?
 
-      Stripe::Subscription.update(stripe_subscription_id, cancel_at_period_end: cancel_at_period_end)
+      Stripe::Subscription.update(stripe_subscription_id, cancel_at_period_end:)
       render json: {}, status: 200
     rescue UpdatingCanceledSubscriptionError, Stripe::InvalidRequestError => e
-      ErrorNotifier.report(e, stripe_subscription_id: stripe_subscription_id)
+      ErrorNotifier.report(e, stripe_subscription_id:)
       render json: {}, status: 500
     end
 
-    private def cancel_at_period_end
-      params[:cancel_at_period_end]
-    end
-
-    private def stripe_subscription_id
-      params[:stripe_subscription_id]
-    end
-
-    private def stripe_subscription
-      @stripe_subscription ||= Stripe::Subscription.retrieve(stripe_subscription_id)
-    end
-
-    private def stripe_subscription_canceled?
-      stripe_subscription.status == StripeIntegration::Subscription::CANCELED
-    end
+    private def cancel_at_period_end = params[:cancel_at_period_end]
+    private def stripe_subscription = @stripe_subscription ||= Stripe::Subscription.retrieve(stripe_subscription_id)
+    private def stripe_subscription_id = params[:stripe_subscription_id]
+    private def stripe_subscription_canceled? = stripe_subscription.status == StripeIntegration::Subscription::CANCELED
   end
 end

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
@@ -13,7 +13,7 @@ export default class SubscriptionHistory extends React.Component {
     const subscriptionHistoryRows = this.subscriptionHistoryRows();
     if (subscriptionHistoryRows.length > 0) {
       return (
-        <table style={{ borderCollapse: 'separate', borderSpacing: '10px' }}>
+        <table>
           <tbody>
             <tr>
               {this.tableHeaders()}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import pluralize from 'pluralize';
 import React from 'react';
+import { requestPost } from '../../../../modules/request';
 
 import { ACCOUNT_TYPE_TO_SUBSCRIPTION_TYPES } from './constants';
 
@@ -12,7 +13,7 @@ export default class SubscriptionHistory extends React.Component {
     const subscriptionHistoryRows = this.subscriptionHistoryRows();
     if (subscriptionHistoryRows.length > 0) {
       return (
-        <table>
+        <table style={{ borderCollapse: 'separate', borderSpacing: '10px' }}>
           <tbody>
             <tr>
               {this.tableHeaders()}
@@ -89,6 +90,19 @@ export default class SubscriptionHistory extends React.Component {
 
         if (sub.stripe_invoice_id) {
           tds.push(<td key={key}><a href={href} rel='noopener noreferrer' target='_blank'>View in Stripe</a></td>)
+
+          if (sub.recurring && sub.stripe_subscription_id && sub.de_activated_date === null && !this.isExpired(sub)) {
+            const href = `${process.env.DEFAULT_URL}/stripe_integration/subscription_renewals`
+            const params = { cancel_at_period_end: true, stripe_subscription_id: sub.stripe_subscription_id }
+
+            tds.push(
+              <td key={`${sub.id}-7-row`}>
+                <button className="quill-button secondary outlined small-button" onClick={() => requestPost(href, params)} >
+                  Turn off auto-renewal
+                </button>
+              </td>
+            )
+          }
         } else {
           tds.push(<td key={key}><a href={href}>Edit Subscription</a></td>)
         }
@@ -98,6 +112,12 @@ export default class SubscriptionHistory extends React.Component {
     return rows;
   }
 
+  isExpired(subscription) {
+    const expiration = moment(subscription.expiration);
+    const now = moment();
+    return expiration.isBefore(now);
+  }
+
   tableHeaders() {
     const { view, } = this.props
 
@@ -105,6 +125,7 @@ export default class SubscriptionHistory extends React.Component {
     if (view === 'subscriptionHistory') {
       tableHeaders.push('Link');
     }
+
     return tableHeaders.map((content, i) => <th key={`${i}-table-header`}>{content}</th>);
   }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/subscription_history.jsx
@@ -94,10 +94,15 @@ export default class SubscriptionHistory extends React.Component {
           if (sub.recurring && sub.stripe_subscription_id && sub.de_activated_date === null && !this.isExpired(sub)) {
             const href = `${process.env.DEFAULT_URL}/stripe_integration/subscription_renewals`
             const params = { cancel_at_period_end: true, stripe_subscription_id: sub.stripe_subscription_id }
+            const onSuccess = () => { window.location.reload(); alert('Auto-renewal has been turned off.') }
+            const onFailure = () => { alert('Something went wrong. Please contact engineering.') }
 
             tds.push(
               <td key={`${sub.id}-7-row`}>
-                <button className="quill-button secondary outlined small-button" onClick={() => requestPost(href, params)} >
+                <button
+                  className="quill-button secondary outlined small-button"
+                  onClick={() => requestPost(href, params, onSuccess, onFailure)}
+                >
                   Turn off auto-renewal
                 </button>
               </td>

--- a/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/stripe_integration/subscription_renewals_controller_spec.rb
@@ -5,20 +5,29 @@ require 'rails_helper'
 RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request do
   include_context 'Stripe Subscription'
 
-  let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}" }
-  let(:cancel_at_period_end) { true }
-  let(:options) { { cancel_at_period_end: cancel_at_period_end } }
-  let(:update_stripe_subscription) { allow(Stripe::Subscription).to receive(:update).with(stripe_subscription_id, **options) }
-  let(:url) { '/stripe_integration/subscription_renewals' }
-  let(:params) { { stripe_subscription_id: stripe_subscription_id, cancel_at_period_end: cancel_at_period_end } }
+  subject { post url, params: { stripe_subscription_id:, cancel_at_period_end: }, as: :json }
 
-  before { allow(Stripe::Subscription).to receive(:retrieve).with(stripe_subscription_id).and_return(stripe_subscription) }
+  let(:cancel_at_period_end) { true }
+  let(:stripe_subscription_id) { "sub_#{SecureRandom.hex}" }
+  let(:url) { '/stripe_integration/subscription_renewals' }
+
+  before do
+    allow(Stripe::Subscription)
+      .to receive(:retrieve)
+      .with(stripe_subscription_id)
+      .and_return(stripe_subscription)
+  end
 
   context 'Stripe Subscription exists' do
-    before { update_stripe_subscription.and_return({}) }
+    before do
+      allow(Stripe::Subscription)
+        .to receive(:update)
+        .with(stripe_subscription_id, { cancel_at_period_end: })
+        .and_return({})
+    end
 
     it 'returns 200 if the request to Stripe is successful' do
-      post url, params: params, as: :json
+      subject
 
       expect(response.media_type).to eq 'application/json'
       expect(response).to have_http_status :ok
@@ -27,13 +36,12 @@ RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request
 
   context 'Stripe Subscription exists but was canceled' do
     let(:stripe_subscription_status) { StripeIntegration::Subscription::CANCELED }
+    let(:error_class) { described_class::UpdatingCanceledSubscriptionError }
 
     it 'returns 500 since updates are not allowed on canceled subscriptions' do
-      expect(ErrorNotifier)
-        .to receive(:report)
-        .with(described_class::UpdatingCanceledSubscriptionError, stripe_subscription_id: stripe_subscription_id)
+      expect(ErrorNotifier).to receive(:report).with(error_class, stripe_subscription_id:)
 
-      post url, params: params, as: :json
+      subject
 
       expect(response.media_type).to eq 'application/json'
       expect(response).to have_http_status :internal_server_error
@@ -42,15 +50,19 @@ RSpec.describe StripeIntegration::SubscriptionRenewalsController, type: :request
 
   context 'Stripe Subscription does not exist' do
     let(:error_msg) { "No such subscription: '#{stripe_subscription_id}'" }
+    let(:error_class) { Stripe::InvalidRequestError }
 
-    before { update_stripe_subscription.and_raise(Stripe::InvalidRequestError.new(error_msg, :id)) }
+    before do
+      allow(Stripe::Subscription)
+        .to receive(:update)
+        .with(stripe_subscription_id, { cancel_at_period_end: })
+        .and_raise(error_class.new(error_msg, :id))
+    end
 
     it 'returns 500 if there are errors with the request to Stripe' do
-      expect(ErrorNotifier)
-        .to receive(:report)
-        .with(Stripe::InvalidRequestError, stripe_subscription_id: stripe_subscription_id)
+      expect(ErrorNotifier).to receive(:report).with(error_class, stripe_subscription_id:)
 
-      post url, params: params, as: :json
+      subject
 
       expect(response.media_type).to eq 'application/json'
       expect(response).to have_http_status :internal_server_error


### PR DESCRIPTION
## WHAT
Add functionality that allows staff members to turn off auto-renewal subscriptions for users.

Also there is a diff on a SubscriptionRenewalsController and it's test file that is just refactoring to make the code more compact.

## WHY
Some users who have auto-renewing subscriptions aren’t able to turn them off, generally because their subscription is associated with a different purchaser email or none at all in some cases. 

## HOW
For each subscription in subscription history check if the following are true:
1) `recurring` flag set to true
2) `stripe_subscription_id` existence
3) `de_activated_date` is null
4)  `expiration` date has not passed

and if so, add a button "Turn off auto-renewal" that sends a post request to `StripeIntegration::SubscriptionRenewalsController` that sets `cancel_at_period_end` to true.

### Screenshots

![Screenshot 2024-01-25 at 5 00 11 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/05ee9922-525c-4368-b91a-84e2fbf4947e)



### Notion Card Links
https://www.notion.so/quill/Scope-Update-CMS-to-allow-directly-editing-Stripe-subscriptions-b37365caa68442369809c81a42543809?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Manual check
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
