### PR TITLE
Extend staff session to 12 hours; fix typo

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ApplicationRecord
   include UserFlagset
 
   CHAR_FIELD_MAX_LENGTH = 255
-  STAFF_SESSION_DURATION= 4.hours
+  STAFF_SESSION_DURATION= 12.hours
   USER_INACTIVITY_DURATION = 30.days
   USER_SESSION_DURATION = 30.days
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -42,7 +42,7 @@ module Evidence
     DEFAULT_BECAUSE_RULE_NAME = "Match with \"because of\" responses"
     DEFAULT_BECAUSE_RULE_CONCEPT = "6gQZPREURQQAaSzpIt_EEw"
     DEFAULT_BECAUSE_RULE_FEEDBACK = "Revise your work. Instead of starting your response with the word <i>of</i>, start with a person, place or thing."
-    DEFAULT_BECAUSE_RULE_REGEX = "^of"
+    DEFAULT_BECAUSE_RULE_REGEX = "^of "
 
     DEFAULT_SO_RULE_NAME = "Match with \"so that\" responses"
     DEFAULT_SO_RULE_CONCEPT = "R3sBcYAvoXP2_oNVXiA98g"


### PR DESCRIPTION
## WHAT
Extend the maximum staff session duration to 12 hours.
Also, fix a small typo in the default because rule (it should have a space after "of").

## WHY
Staff finds the four hour session too short to be able to complete some types of work before being forced to log off.

## HOW
Change the constants in the code.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Make-changes-to-automatic-logout-for-the-CMS-to-reduce-lost-work-105ac8fd17eb4830a38e13f557d1550b?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | Yes
