### PR TITLE
Admin usage snapshot pdf issues

### DIFF
--- a/services/QuillLMS/app/services/pdfs/admin_usage_snapshot_reports/count_data_injector.rb
+++ b/services/QuillLMS/app/services/pdfs/admin_usage_snapshot_reports/count_data_injector.rb
@@ -19,13 +19,13 @@ module Pdfs
       end
 
       private def change
-        return nil if count.nil?
+        return nil if count.nil? || previous.nil?
 
-        rounded_previous = (previous_results[:count] || 0).round
-        (((count - rounded_previous).to_f / (rounded_previous.nonzero? || 1)) * 100).round
+        (((count - previous).to_f / (previous.nonzero? || 1)) * 100).round
       end
 
       private def count = current_results[:count]&.round
+      private def previous = previous_results[:count]&.round
 
       private def current_results
         @current_results ||= ResultsFetcher.run(admin_report_filter_selection:, query_key:, worker: WORKER)

--- a/services/QuillLMS/app/views/pdfs/admin_usage_snapshot_reports/_snapshot_count.html.erb
+++ b/services/QuillLMS/app/views/pdfs/admin_usage_snapshot_reports/_snapshot_count.html.erb
@@ -7,7 +7,7 @@
 <section class="snapshot-item snapshot-count <%= size %> <%= change_direction_class(change) %>">
   <div class="count-and-label">
     <span class="count"><%= number_with_delimiter(count) || '-' %></span>
-    <span class="snapshot-label"><%= count == 1 ? singular_label : label %></span>
+    <span class="snapshot-label"><%= count == 1 && singular_label ? singular_label : label %></span>
   </div>
   <div class="change">
     <% change_icon_src = change_icon_src(change) %>

--- a/services/QuillLMS/spec/services/pdfs/admin_usage_snapshot_reports/count_data_injector_spec.rb
+++ b/services/QuillLMS/spec/services/pdfs/admin_usage_snapshot_reports/count_data_injector_spec.rb
@@ -65,7 +65,7 @@ module Pdfs
         context 'when previous_count is nil' do
           let(:current_count) { 5 }
           let(:previous_count) { nil }
-          let(:change) { 500 }
+          let(:change) { nil }
 
           it { is_expected.to eq injected_item }
         end


### PR DESCRIPTION
## WHAT
1. Fix handling of nil previous count
2. Fix singular label logic

## WHY
1. `nil` previous count values should make the overall change computation nil.
2. Snapshot sections without a defined singular label were not rendering

## HOW
1. Add previous.nil? to the guard clause
2. Only use singular_label if it exists
 
### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Investigate-issues-with-PDF-version-of-the-Usage-Snapshot-Report-cf6fb6e383f947aab1ba27ee2cad2417?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
