### PR TITLE
Fix identify stripe invoices with subscriptions bug

### DIFF
--- a/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions_worker.rb
@@ -53,7 +53,7 @@ class IdentifyStripeInvoicesWithoutSubscriptionsWorker
 
   private def relevant_stripe_invoices
     @relevant_stripe_invoices ||= [].tap do |invoices|
-      Stripe::Invoice.list(created: { gte: 1.month.ago.to_i }, limit: 100).auto_paging_each do |invoice|
+      Stripe::Invoice.list(created: { gte: INVOICE_START_EPOCH }, limit: 100).auto_paging_each do |invoice|
         invoices << invoice if relevant_stripe_invoice?(invoice)
       end
     end

--- a/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions_worker.rb
@@ -42,7 +42,7 @@ class IdentifyStripeInvoicesWithoutSubscriptionsWorker
 
   private def linked_quill_subscription?(stripe_invoice_id) = Subscription.exists?(stripe_invoice_id:)
 
-  # The ordering of these conditions is least to most expensive to compute
+  # These conditions are ordered least to most expensive to compute
   private def relevant_stripe_invoice?(invoice)
     invoice.amount_due.positive? &&
     invoice.status.in?(RELEVANT_INVOICE_STATUSES) &&

--- a/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe IdentifyStripeInvoicesWithoutSubscriptionsWorker do
+RSpec.describe IdentifyStripeInvoicesWithoutSubscriptionsWorker do
   include_context 'Stripe Invoice'
 
   subject { described_class.new }
@@ -20,36 +20,20 @@ describe IdentifyStripeInvoicesWithoutSubscriptionsWorker do
     end
 
     it 'should send an email that includes invoices with no associated Quill Subscriptions' do
-      expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([{
+      expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([
         id: stripe_invoice.id,
         created: Time.at(stripe_invoice.created).getlocal.to_datetime,
         total: stripe_invoice.total / 100.0,
         customer_name: stripe_invoice.customer_name,
         customer_email: stripe_invoice.customer_email,
         number: stripe_invoice.number
-      }]).and_return(mailer_double)
-
-      subject.perform
-    end
-
-    it 'should send an email that does not include invoices that are not of status open or paid' do
-      expect(stripe_invoice).to receive(:status).and_return('void')
-
-      expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([]).and_return(mailer_double)
+      ]).and_return(mailer_double)
 
       subject.perform
     end
 
     it 'should send an email that does not include invoices associated with Quill Subscriptions' do
       create(:subscription, stripe_invoice_id: stripe_invoice_id)
-
-      expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([]).and_return(mailer_double)
-
-      subject.perform
-    end
-
-    it 'should send an email that does not include invoices for $0' do
-      expect(stripe_invoice).to receive(:amount_due).and_return(0)
 
       expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([]).and_return(mailer_double)
 

--- a/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_worker_spec.rb
@@ -32,8 +32,24 @@ RSpec.describe IdentifyStripeInvoicesWithoutSubscriptionsWorker do
       subject.perform
     end
 
+    it 'should send an email that does not include invoices that are not of status open or paid' do
+      expect(stripe_invoice).to receive(:status).and_return('void')
+
+      expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([]).and_return(mailer_double)
+
+      subject.perform
+    end
+
     it 'should send an email that does not include invoices associated with Quill Subscriptions' do
       create(:subscription, stripe_invoice_id: stripe_invoice_id)
+
+      expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([]).and_return(mailer_double)
+
+      subject.perform
+    end
+
+    it 'should send an email that does not include invoices for $0' do
+      expect(stripe_invoice).to receive(:amount_due).and_return(0)
 
       expect(StripeIntegration::Mailer).to receive(:invoices_without_subscriptions).with([]).and_return(mailer_double)
 


### PR DESCRIPTION
## WHAT
Fix an error with a worker that finds Stripe Invoices without corresponding subscriptions on Quill

## WHY
I suspect the the `invoice_payloads` calculation fails during the `auto_paging_each` block within `private def stripe_invoices`.  This particular block builds up an array of invoice objects from stripe and then after that array is pulled, attempts to filter those based on certain criteria.

As the number of invoices is increased, the array size required to keep all the `Stripe::Invoice` objects in memory has ballooned.

Long term we probably want to restrict this calculation at 1 year.

## HOW
Instead of building the entire array and then filtering, do the filtering incrementally to keep the size of the array down.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sentry-Error-Blank-Email-Error-Sidekiq-IdentifyStripeInvoicesWithoutSubs-c493a2a357b04343b6563439ac4127e9?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Just moved where filtering is performed.   I've verified on production through the console that this approach succeeds in the calculation of invoice_payloads whereas the existing one seems to crash the console.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
