### PR TITLE
Handle archived classrooms in AssignRecommendationsWorker

### DIFF
--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -39,7 +39,7 @@ describe AssignRecommendationsWorker do
   context 'when no classroom is found' do
     before { classroom.update(visible: false) }
 
-    it do
+    it 'does not assign units to the class' do
       expect(Units::AssignmentHelpers).not_to receive(:assign_unit_to_one_class)
       subject
     end

--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -36,6 +36,17 @@ describe AssignRecommendationsWorker do
     allow(PusherRecommendationCompleted).to receive(:run)
   end
 
+  context 'when no classroom is found' do
+    before { classroom.update(visible: false) }
+
+    it do
+      expect(Units::AssignmentHelpers).not_to receive(:assign_unit_to_one_class)
+      subject
+    end
+
+    it { expect { subject }.not_to raise_error }
+  end
+
   context 'when no units is found' do
     context 'when unit was not found with the unit template name' do
       it { should_track_that_all_recommendations_are_being_assigned }
@@ -174,4 +185,3 @@ describe AssignRecommendationsWorker do
     subject
   end
 end
-

--- a/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/assign_recommendations_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AssignRecommendationsWorker do
+RSpec.describe AssignRecommendationsWorker do
   subject { described_class.new.perform(args) }
 
   let(:unit_template) { create(:unit_template) }


### PR DESCRIPTION
## WHAT
Fix the handling of archived classrooms in `AssignRecommendationsWorker`.

Also had to do some refactoring to keep Cyclomatic Complexity down.

## WHY
When AssignRecommendationsWorker is kicked off, a classroom could be subsequently archived effectively making that classroom not visible to `Classroom.find(id)`.  We'd like to handle this case gracefully so that the worker doesn't get retried for no chance of completion.

## HOW
Add a guard clause that finds the classroom using `find_by` instead of `find` which raises an exception when none are found.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YE
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
