### PR TITLE
Copy update/ legacy reports and remove "Admin Dashboard" reference

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub-header.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub-header.scss
@@ -1,6 +1,5 @@
 #premium-hub-header {
-  background-color: white;
-  border-bottom: 10px solid #00c2a2;
+  background-color: $quill-white;
   .admin-nav-bar {
     max-width: $sitewidepagewidth;
     margin: 0 auto;
@@ -13,10 +12,6 @@
   }
   i, svg {
     margin: 0px 15px;
-    color: $lightgray
-  }
-  hr {
-    border-top-color: $gray;
-    margin: 0px;
+    color: $quill-grey-15
   }
 }

--- a/services/QuillLMS/app/views/application/_premium_hub_header.html.erb
+++ b/services/QuillLMS/app/views/application/_premium_hub_header.html.erb
@@ -2,11 +2,10 @@
   <div class="teacher-dashboard" id="premium-hub-header">
     <div class="admin-nav-bar">
       <h4>
-        <%= link_to("Administrator Dashboard", "/session") %>
+        <%= link_to("Premium Hub", "/session") %>
         <i class="fa fa-chevron-right"></i>
         <%= "#{current_user.name} Account" %>
       </h4>
     </div>
-    <hr>
   </div>
 <% end %>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/activity_scores.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/activity_scores.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`ActivityScores it should render 1`] = `
         class="header-and-tooltip"
       >
         <h1>
-          Activity Scores
+          Activity Scores Report
         </h1>
         <span
           aria-hidden="false"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/concept_reports.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/concept_reports.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`ConceptReports it should render 1`] = `
         class="header-and-tooltip"
       >
         <h1>
-          School Concept Reports
+          Concepts Report
         </h1>
         <span
           aria-hidden="false"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/standardsReports.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/standardsReports.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`StandardsReports component should match snapshot 1`] = `
   <ReportHeader
     className="admin-standards-report"
     csvData={Array []}
-    headerText="School Standards Reports"
+    headerText="Standards Report"
     tooltipText="Each activity on Quill is aligned to a Common Core standard. This report shows the school’s overall progress on each of the standards. You can print this report by downloading a PDF file or export this data by downloading a CSV file. The data you see below is capturing historical activity data for your school. <br/><br/> These reports are updated nightly."
   />
   <StandardsReportsTable

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/activity_scores.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/activity_scores.tsx
@@ -41,7 +41,7 @@ const ActivityScores: React.SFC<ActivityScoresProps> = ({
     <div className="admin-report-container">
       <ReportHeader
         csvData={csvData}
-        headerText="Activity Scores"
+        headerText="Activity Scores Report"
         tooltipText="Each activity takes about 10-20 minutes to complete, and students receive a score out of 100 points based on their performance. Click on a student’s name to see a report and print it as a PDF. You can print this report by downloading a PDF file or export this data by downloading a CSV file. <br/><br/> These reports are updated nightly."
       />
       <div className="dropdowns-container">

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/concept_reports.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/concept_reports.tsx
@@ -21,7 +21,7 @@ export const ConceptReports = ({
   <div className="admin-report-container">
     <ReportHeader
       csvData={csvData}
-      headerText="School Concept Reports"
+      headerText="Concepts Report"
       tooltipText="Each question on Quill targets a specific writing concept. This report shows the number of times the student correctly or incorrectly used the targeted concept to answer the question. You can print this report by downloading a PDF file or export this data by downloading a CSV file. <br/><br/> These reports are updated nightly."
     />
     <div className="dropdowns-container">

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/standardsReports.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/standardsReports.tsx
@@ -8,7 +8,7 @@ export const StandardsReports = ({
   isFreemiumView
 }) => {
   const freemiumClass = isFreemiumView ? 'freemium-view' : ''
-  const header = isFreemiumView ? 'Premium Preview: Standards Report' : 'School Standards Reports'
+  const header = isFreemiumView ? 'Premium Preview: Standards Report' : 'Standards Report'
   const tooltipText = isFreemiumView ? 'Subscribe to School or District Premium to unlock this report and more.' : "Each activity on Quill is aligned to a Common Core standard. This report shows the school’s overall progress on each of the standards. You can print this report by downloading a PDF file or export this data by downloading a CSV file. The data you see below is capturing historical activity data for your school. <br/><br/> These reports are updated nightly."
 
   return(


### PR DESCRIPTION
## WHAT
update the report names for the legacy reports for admins as well as remove a lingering reference to the "Admin Dashboard"

## WHY
we want the naming to reflect current standards

## HOW
just update copy and tweak some CSS

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1333" alt="Screen Shot 2024-01-31 at 12 58 47 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/a14a2379-9aaf-4d1a-96d0-48ba0c0a7bed">
<img width="1309" alt="Screen Shot 2024-01-31 at 1 01 11 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/838ca8b2-32c0-4501-8a55-db9dd0b70266">
<img width="1300" alt="Screen Shot 2024-01-31 at 1 01 45 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/9e860420-bce6-4ba2-9242-688e0898f4c7">
<img width="1274" alt="Screen Shot 2024-01-31 at 1 02 15 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/026d8084-b727-4cce-9ca1-1980b1acb2db">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Minor-copy-changes-to-the-legacy-admin-reports-for-consistency-44d551c06b4c4569babe4a1eb588a3dc?pvs=4
https://www.notion.so/quill/Updates-to-the-header-when-you-log-in-as-a-teacher-from-the-Premium-Hub-5c9a67edb3a54442b05456a420a743fb?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
