### PR TITLE
Allow staff to enable more than ten labels on evidence activity

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/modals.scss
@@ -497,7 +497,8 @@
 .school-and-district-premium-modal,
 .admin-verification-modal,
 .already-has-premium-modal,
-.manage-report-subscription-modal {
+.manage-report-subscription-modal,
+.enable-more-than-ten-labels-modal {
   width: 560px;
   overflow: visible;
   top: 50%;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/__tests__/__snapshots__/enableMoreThanTenLabelsModal.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/__tests__/__snapshots__/enableMoreThanTenLabelsModal.test.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EnableMoreThanLabelsModal matches the snapshot when modal is open 1`] = `
+<DocumentFragment>
+  <div
+    class="modal-container"
+  >
+    <div
+      class="enable-more-than-ten-labels-modal quill-modal modal-body"
+    >
+      <div>
+        <div
+          class="title-and-description"
+        >
+          <h2>
+            Vertex AI: Enable more than 10 labels
+          </h2>
+          <p
+            class="description"
+          >
+            When adding a vertex AI model through the Google Cloud UI, it will only allow us to pull 10 labels in automatically. This modal will allow you to manually specify the additional labels you want enabled on our platform.
+          </p>
+        </div>
+        <div
+          class="input-container  inactive  undefined "
+          role="button"
+          tabindex="-1"
+        >
+          <label
+            for="additionalLabels"
+          >
+            Additional labels (separated by commas)
+          </label>
+          <input
+            autocomplete="on"
+            id="additionalLabels"
+            maxlength="10000"
+            value=""
+          />
+        </div>
+        <div
+          class="save-and-cancel-buttons"
+        >
+          <button
+            class="quill-button medium secondary outlined focus-on-light"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="quill-button medium primary contained focus-on-light"
+            type="button"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/__tests__/enableMoreThanTenLabelsModal.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/__tests__/enableMoreThanTenLabelsModal.test.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event'
 import EnableMoreThanLabelsModal from '../enableMoreThanTenLabelsModal';
 
 describe('EnableMoreThanLabelsModal', () => {
   const mockSave = jest.fn();
   const mockCancel = jest.fn();
 
-  const setup = (isOpen = true) => render(
-    <EnableMoreThanLabelsModal cancel={mockCancel} isOpen={isOpen} save={mockSave} />
-  );
+  function setup(isOpen = true) {
+    return {
+      user: userEvent.setup(),
+      ...render(
+        <EnableMoreThanLabelsModal cancel={mockCancel} isOpen={isOpen} save={mockSave} />
+      )
+    }
+  }
 
   beforeEach(() => {
     mockSave.mockClear();
@@ -32,24 +38,24 @@ describe('EnableMoreThanLabelsModal', () => {
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
   });
 
-  it('updates input value on change', () => {
-    setup();
+  it('updates input value on change', async () => {
+    const { user } = setup();
     const input = screen.getByLabelText(/additional labels/i) as HTMLInputElement;
-    fireEvent.change(input, { target: { value: 'label1, label2' } });
+    await user.type(input, 'label1, label2');
     expect(input.value).toBe('label1, label2');
   });
 
-  it('calls save function with input value on save button click', () => {
-    setup();
+  it('calls save function with input value on save button click', async () => {
+    const { user } = setup();
     const input = screen.getByLabelText(/additional labels/i);
-    fireEvent.change(input, { target: { value: 'label1, label2' } });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await user.type(input, 'label1, label2');
+    await user.click(screen.getByRole('button', { name: /save/i }));
     expect(mockSave).toHaveBeenCalledWith('label1, label2');
   });
 
-  it('calls cancel function on cancel button click', () => {
-    setup();
-    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+  it('calls cancel function on cancel button click', async () => {
+    const { user } = setup();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
     expect(mockCancel).toHaveBeenCalled();
   });
 });

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/__tests__/enableMoreThanTenLabelsModal.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/__tests__/enableMoreThanTenLabelsModal.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import EnableMoreThanLabelsModal from '../enableMoreThanTenLabelsModal';
+
+describe('EnableMoreThanLabelsModal', () => {
+  const mockSave = jest.fn();
+  const mockCancel = jest.fn();
+
+  const setup = (isOpen = true) => render(
+    <EnableMoreThanLabelsModal cancel={mockCancel} isOpen={isOpen} save={mockSave} />
+  );
+
+  beforeEach(() => {
+    mockSave.mockClear();
+    mockCancel.mockClear();
+  });
+
+  it('matches the snapshot when modal is open', () => {
+    const { asFragment } = setup()
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('does not render when isOpen is false', () => {
+    setup(false);
+    expect(screen.queryByText(/enable more than 10 labels/i)).not.toBeInTheDocument();
+  });
+
+  it('renders correctly when isOpen is true', () => {
+    setup();
+    expect(screen.getByText(/enable more than 10 labels/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+
+  it('updates input value on change', () => {
+    setup();
+    const input = screen.getByLabelText(/additional labels/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'label1, label2' } });
+    expect(input.value).toBe('label1, label2');
+  });
+
+  it('calls save function with input value on save button click', () => {
+    setup();
+    const input = screen.getByLabelText(/additional labels/i);
+    fireEvent.change(input, { target: { value: 'label1, label2' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(mockSave).toHaveBeenCalledWith('label1, label2');
+  });
+
+  it('calls cancel function on cancel button click', () => {
+    setup();
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(mockCancel).toHaveBeenCalled();
+  });
+});
+

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/enableMoreThanTenLabelsModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/enableMoreThanTenLabelsModal.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react'
+
+import { Input, } from '../../../../Shared/index'
+
+const EnableMoreThanLabelsModal = ({ cancel, isOpen, save }) => {
+  if (!isOpen) return null;
+
+  const [additionalLabels, setAdditionalLabels] = React.useState('')
+
+  function handleSaveClick() { save(additionalLabels) }
+
+  function renderAdditionalLabels() {
+    return (
+      <Input
+        handleChange={e => setAdditionalLabels(e.target.value)}
+        label="Additional labels (separated by commas)"
+        value={additionalLabels}
+      />
+    )
+  }
+
+  function renderSaveAndCancelButtons() {
+    return (
+      <div className="save-and-cancel-buttons">
+        <button
+          className="quill-button medium secondary outlined focus-on-light"
+          onClick={cancel}
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          className="quill-button medium primary contained focus-on-light"
+          onClick={handleSaveClick}
+          type="button"
+        >
+          Save
+        </button>
+      </div>
+    )
+  }
+
+  function renderTitleAndDescription() {
+    return (
+      <div className="title-and-description">
+        <h2>Vertex AI: Enable more than 10 labels</h2>
+        <p className="description">
+          When adding a vertex AI model through the Google Cloud UI, it will only allow us to pull 10 labels in
+          automatically. This modal will allow you to manually specify the additional labels you want enabled on our
+          platform.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="modal-container">
+      <div className="enable-more-than-ten-labels-modal quill-modal modal-body">
+        <div>
+          {renderTitleAndDescription()}
+          {renderAdditionalLabels()}
+          {renderSaveAndCancelButtons()}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default EnableMoreThanLabelsModal;

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/enableMoreThanTenLabelsModal.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/enableMoreThanTenLabelsModal.tsx
@@ -13,6 +13,7 @@ const EnableMoreThanLabelsModal = ({ cancel, isOpen, save }) => {
     return (
       <Input
         handleChange={e => setAdditionalLabels(e.target.value)}
+        id="additionalLabels"
         label="Additional labels (separated by commas)"
         value={additionalLabels}
       />

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/modelsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/modelsTable.tsx
@@ -27,7 +27,7 @@ const ModelsTable = ({ activityId, prompt }) => {
   const [isEnableMoreThanTenLabelsModalOpen, setIsEnableMoreThanTenLabelsModalOpen] = useState(false)
 
   function getFormattedRows() {
-    if (modelsData && modelsData.models && modelsData.models.length) {
+    if (modelsData?.models?.length) {
       const formattedRows = modelsData.models.map(model => {
         const { id, created_at, name, older_models, labels, state } = model;
         const viewLink = (

--- a/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/semantic_labels.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/evidence_manager/semantic_labels.scss
@@ -74,4 +74,42 @@
       }
     }
   }
+
+  .enable-more-than-ten-labels-modal {
+    min-height: 500px;
+    max-width: 600px;
+    background: $quill-white;
+    border-radius: 6px;
+    border: 1px solid $quill-grey-5;
+    display: inline-flex;
+    padding: 40px 32px;
+
+    .title-and-description {
+      align-items: flex-start;
+      flex-direction: column;
+      display: flex;
+      gap: 8px;
+      justify-content: flex-start;
+
+      .title {
+        color: $quill-black;
+        font-size: 24px;
+        font-weight: 700;
+        line-height: 32px;
+      }
+      .description {
+        color: $quill-grey-50;
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 22px;
+      }
+    }
+
+    .save-and-cancel-buttons {
+      display: flex;
+      gap: 16px;
+      justify-content: flex-end;
+      margin-top: 40px;
+    }
+  }
 }

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/modelAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/modelAPIs.ts
@@ -52,3 +52,10 @@ export const fetchDeployedModelNames = async () => {
   return { error: handleApiError('Failed to fetch deployed model names, please try again.', response), names: names };
 };
 
+export const enableMoreThanTenLabels = async (promptId: string, additionalLabels: string) => {
+  const response = await apiFetch(`automl_models/${promptId}/enable_more_than_ten_labels`, {
+    method: 'PUT',
+    body: JSON.stringify({ additional_labels: additionalLabels })
+  });
+  return { error: handleApiError('Failed to enable additional labels, please try again.', response) };
+}

--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -78,11 +78,7 @@ module Evidence
     def classify_text(text) = VertexAI::TextClassifier.run(endpoint_external_id, text)
 
     def older_models
-      @older_models ||=
-        AutomlModel
-          .where(prompt_id: prompt_id)
-          .where("created_at < ?", created_at)
-          .count
+      @older_models ||= AutomlModel.where(prompt_id: prompt_id).where("created_at < ?", created_at).count
     end
 
     def change_log_name = "AutoML Model"

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -19,6 +19,8 @@ Evidence::Engine.routes.draw do
     collection { get :deployed_model_names }
   end
 
+  put 'automl_models/:prompt_id/enable_more_than_ten_labels' => 'automl_models#enable_more_than_ten_labels'
+
   resource :feedback, only: [:create], controller: :feedback
 
   resources :hints, only: [:index, :show, :create, :update, :destroy]

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/labels.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/labels.rb
@@ -12,7 +12,7 @@
 #
 FactoryBot.define do
   factory :evidence_label, class: 'Evidence::Label' do
-    name { "some label name" }
+    sequence(:name) { |n| "label_#{n}" }
     association :rule, factory: :evidence_rule
   end
 end


### PR DESCRIPTION
## WHAT
There is a limitation where we are unable to pull more than ten labels from a deployed model on Vertex AI.  Instead, I have to manually enter them in via a script.  This adds a modal so that staff can enter the additional labels.

## WHY
The script should be automated so that engineering need not be involved.

## HOW
The user enters in additional labels to the modal which are parsed and then added to the existing AutomlModel located via prompt id.

### Screenshots
https://github.com/empirical-org/Empirical-Core/assets/2057805/5353ba00-52c7-48d4-a647-799d032fdafc

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YE
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
