### PR TITLE
fix assignment to nil error and adjust font size

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_questions_analysis.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_questions_analysis.scss
@@ -33,6 +33,7 @@
     overflow: visible;
     border-radius: 8px;
     border: solid 1px $quill-grey-5;
+    font-size: 13px;
     .data-table-headers {
       min-height: 32px;
       border-radius: 8px 8px 0px 0px;
@@ -112,7 +113,6 @@
     .directions-and-prompt {
       div {
         > span:not(.quill-tooltip-trigger) {
-          font-size: 14px;
           line-height: 1.43;
           color: $quill-grey-50;
           width: 80px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/skills_table.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/skills_table.scss
@@ -34,7 +34,7 @@
       border-bottom: none;
       border-right: none;
       border-radius: 0px !important;
-      font-size: 14px;
+      font-size: 13px;
       color: $quill-grey-90;
       &:first-of-type {
         font-weight: 600;

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/skills_table.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/skills_table.scss
@@ -110,7 +110,7 @@
     td {
       padding: 0px;
       &:first-of-type {
-        padding: 16px;
+        padding: 8px 16px;
         vertical-align: top;
       }
     }

--- a/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/growth_results_summary.rb
@@ -91,9 +91,9 @@ module GrowthResultsSummary
     post_test_proficiency_score = correct_skill_number / present_skill_number.to_f
     acquired_skills = post_test_proficiency_score > pre_test_proficiency_score
     proficiency_text = summarize_student_proficiency_for_skill_overall(present_skill_number, correct_skill_number, pre_correct_skill_number, acquired_skills)
+    skill_group_summary_index = @skill_group_summaries&.find_index { |sg| sg[:name] == skill_group.name }
 
-    if @skill_group_summaries
-      skill_group_summary_index = @skill_group_summaries.find_index { |sg| sg[:name] == skill_group.name }
+    if @skill_group_summaries && skill_group_summary_index
       @skill_group_summaries[skill_group_summary_index][:proficiency_scores_by_student][student_name] = { pre: nil, post: nil }
       @skill_group_summaries[skill_group_summary_index][:not_yet_proficient_in_post_test_student_names].push(student_name) unless FULL_OR_MAINTAINED_PROFICIENCY_TEXTS.include?(proficiency_text)
       @skill_group_summaries[skill_group_summary_index][:gained_proficiency_in_post_test_student_names].push(student_name) if GAINED_PROFICIENCY_TEXTS.include?(proficiency_text)

--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -72,8 +72,9 @@ module ResultsSummary
         sum += score
       end / skills.length.to_f
 
-      if @skill_group_summaries
-        skill_group_summary_index = @skill_group_summaries.find_index { |sg| sg[:name] == skill_group.name }
+      skill_group_summary_index = @skill_group_summaries&.find_index { |sg| sg[:name] == skill_group.name }
+
+      if @skill_group_summaries && skill_group_summary_index
         @skill_group_summaries[skill_group_summary_index][:proficiency_scores_by_student][student_name] = average_proficiency_score
         unless proficiency_text == PROFICIENCY
           @skill_group_summaries[skill_group_summary_index][:not_yet_proficient_student_names].push(student_name)

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -87,7 +87,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
           pre: { questions: pre_questions },
           post: { questions: post_questions }
         }
-        skill_group_results = GrowthResultsSummar.skill_groups_for_session(skill_groups, activity_session, pre_test_activity_session, student.name)
+        skill_group_results = GrowthResultsSummary.skill_groups_for_session(skill_groups, activity_session, pre_test_activity_session, student.name)
       else
         concept_results = { questions: format_concept_results(activity_session, activity_session.concept_results.order("question_number::int")) }
         skill_group_results = ResultsSummary.skill_groups_for_session(skill_groups, activity_session.concept_results, student.name)

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -87,10 +87,10 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
           pre: { questions: pre_questions },
           post: { questions: post_questions }
         }
-        skill_group_results = GrowthResultsSummary::skill_groups_for_session(skill_groups, activity_session, pre_test_activity_session, student.name)
+        skill_group_results = GrowthResultsSummar.skill_groups_for_session(skill_groups, activity_session, pre_test_activity_session, student.name)
       else
         concept_results = { questions: format_concept_results(activity_session, activity_session.concept_results.order("question_number::int")) }
-        skill_group_results = ResultsSummary::skill_groups_for_session(skill_groups, activity_session.concept_results, student.name)
+        skill_group_results = ResultsSummary.skill_groups_for_session(skill_groups, activity_session.concept_results, student.name)
       end
       { concept_results: concept_results, skill_group_results: skill_group_results, name: student.name }
     end


### PR DESCRIPTION
## WHAT
Fix this bug on Sentry: https://quillorg-5s.sentry.io/issues/4935272728/?project=11238&referrer=github-pr-bot and also some font sizes I noticed.

## WHY
We don't want any errors occurring for our users.

## HOW
This is a weird one, because it's only happening on the `individual_student_diagnostic_responses` path, for which `@skill_group_summaries` should never be defined, and it's inconsistent -- when I wipe the cache I haven't been able to replicate it for any of these users. However, this safeguard should ensure that the error Sentry is reporting cannot happen. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested that the page loads correctly
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES