### PR TITLE
lms/fix-empty-sentences-written-count

### DIFF
--- a/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/sentences_written_query.rb
@@ -3,7 +3,7 @@
 module Snapshots
   class SentencesWrittenQuery < ActivitySessionCountQuery
     def select_clause
-      "SELECT SUM(activities.question_count) AS count"
+      "SELECT IFNULL(SUM(activities.question_count), 0) AS count"
     end
 
     def from_and_join_clauses

--- a/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/sentences_written_query_spec.rb
@@ -7,10 +7,14 @@ module Snapshots
     context 'external_api', :big_query_snapshot do
       include_context 'Snapshots Activity Session Count CTE'
 
-      let(:concept_results) { activity_sessions.map { |activity_session| create(:concept_result, activity_session: activity_session) } }
-      let(:cte_records) { count_query_cte_records << concept_results }
-
       it { expect(results).to eq(count: activities.sum(&:question_count)) }
+
+      context 'no activity_sessions to count' do
+        # we need a dummy ActivitySession unrelated to the filters so that BigQuery tests can infer the appropriate shape of the data
+        let(:activity_sessions) { [create(:activity_session)] }
+
+        it { expect(results).to eq(count: 0) }
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Update new SentencesWritten query logic to return 0 instead of null by using `IFNULL`
## WHY
The old method used COUNT which returns 0 if there are no relevant rows to count, while the new method uses SUM which returns NULL if there are no relevant rows to sum.  
## HOW
Just wrap the rollup in an IFNULL to deal with this case

### Screenshots
OLD
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/63a25c45-61cd-4cdf-97db-b80e0fb01dc6)
NEW
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/5f98eacc-992d-4404-bd2e-c70e72cd3b61)

### Notion Card Links
https://www.notion.so/quill/On-the-Usage-Snapshot-Report-display-0-for-Sentences-written-if-none-have-been-written-07d8e207913845939448a42b402e103e

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
