### PR TITLE
Convert an array parameter for segment to a comma-separated string

### DIFF
--- a/services/QuillLMS/app/models/admin_report_filter_selection.rb
+++ b/services/QuillLMS/app/models/admin_report_filter_selection.rb
@@ -44,6 +44,7 @@ class AdminReportFilterSelection < ApplicationRecord
       .uniq
       .map { |report| SEGMENT_MAPPING[report] }
       .compact
+      .join(", ")
   end
 
   def classrooms = filter_selections['classrooms']&.pluck('name')

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -2,6 +2,7 @@
 
 module SegmentIntegration
   class User < SimpleDelegator
+    # NOTE: Remember to convert array args to comma separated strings for Ortto (Segment can handle arrays)
     def identify_params
       {
         user_id: id,

--- a/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
+++ b/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe AdminReportFilterSelection, type: :model, redis: true do
   describe '.segment_admin_report_subscriptions' do
     subject { described_class.segment_admin_report_subscriptions }
 
-    it { is_expected.to match_array [] }
+    it { is_expected.to eq '' }
 
     context 'when there are pdf subscriptions' do
       let(:usage_snapshot) { described_class::SEGMENT_MAPPING[described_class::USAGE_SNAPSHOT_REPORT_PDF] }
 
       before { create(:pdf_subscription) }
 
-      it { is_expected.to match_array [usage_snapshot] }
+      it { is_expected.to eq usage_snapshot }
 
       context 'when the report type is not mapped to segment' do
         let(:report) { described_class::USAGE_SNAPSHOT_REPORT }
@@ -46,13 +46,13 @@ RSpec.describe AdminReportFilterSelection, type: :model, redis: true do
 
         before { create(:pdf_subscription, admin_report_filter_selection:) }
 
-        it { is_expected.to match_array [usage_snapshot] }
+        it { is_expected.to eq usage_snapshot }
       end
 
       context 'when there are multiple pdf subscriptions' do
         before { create(:pdf_subscription) }
 
-        it { is_expected.to match_array [usage_snapshot] }
+        it { is_expected.to eq usage_snapshot }
       end
     end
   end

--- a/services/QuillLMS/spec/models/segment_integration/user_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/user_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe SegmentIntegration::User do
       context 'when the admin is a premium admin' do
         before { allow(admin).to receive(:premium_admin?).and_return(true) }
 
-        it { is_expected.to eq common_params.merge(admin_report_subscriptions: []) }
+        it { is_expected.to eq common_params.merge(admin_report_subscriptions: '') }
       end
     end
 


### PR DESCRIPTION
## WHAT
Change the `admin_report_subscription` parameter sent to Segment from an array to a comma-separated string. 

## WHY
The info is sent from Segment to Ortto which does not handle array types.

## HOW
Add a `.join(', ')` to `def self.segment_admin_report_subscriptions` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
