### PR TITLE
Link "Rule Analysis" to Because Rule in Evidence CMS

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/navigation.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/navigation.tsx
@@ -120,7 +120,7 @@ const Navigation = ({ location, match }) => {
         <NavLink activeClassName="is-active" to={`/activities/${activityId}/activity-sessions`}>
           View Sessions
         </NavLink>
-        <NavLink activeClassName="is-active" to={`/activities/${activityId}/rules-analysis`}>
+        <NavLink activeClassName="is-active" to={`/activities/${activityId}/rules-analysis/because`}>
           Rules Analysis
         </NavLink>
         {rulesAnalysisSubLinks}


### PR DESCRIPTION
## WHAT
Change the redirect link to "Because" rule in the CMS.

## WHY
Admin want to get automatically redirected to this default rule instead of getting blank rules that they then have to select "Because" from.

## HOW
Change the constant link for redirect.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Make-the-Default-Prompt-Because-for-Rules-Analysis-Page-in-the-Evidence-CMS-d0f8e902f354441e9d27760de61d18f0?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, small change
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
