### PR TITLE
CMS - Update ES as requests come in rather than overnight (#11486)

### DIFF
--- a/services/QuillCMS/app/models/cron.rb
+++ b/services/QuillCMS/app/models/cron.rb
@@ -5,11 +5,6 @@ class Cron
 
     return unless current_time.hour == 3
 
-    beginning_of_yesterday = current_time.yesterday.beginning_of_day
-    end_of_yesterday = current_time.yesterday.end_of_day
-
-    UpdateElasticsearchWorker.perform_async(beginning_of_yesterday, end_of_yesterday)
-    UpdateElasticsearchWorker.perform_async(current_time.beginning_of_day, current_time)
     RefreshAllResponsesViewsWorker.perform_async
   end
 end

--- a/services/QuillCMS/app/models/response.rb
+++ b/services/QuillCMS/app/models/response.rb
@@ -4,6 +4,8 @@ class Response < ApplicationRecord
   include Elasticsearch::Model
   include ResponseScopes
   after_create_commit :create_index_in_elastic_search
+  # NB: response.increment!(:count, 1, touch: true) does not call callbacks
+  # so this after_update is rarely called
   after_update_commit :update_index_in_elastic_search
   after_commit :conditional_wipe_question_cache, on: [:create, :update]
   before_destroy :destroy_index_in_elastic_search, :wipe_question_cache

--- a/services/QuillCMS/app/workers/rematch_responses_for_question_worker.rb
+++ b/services/QuillCMS/app/workers/rematch_responses_for_question_worker.rb
@@ -3,7 +3,7 @@ require 'net/http'
 
 class RematchResponsesForQuestionWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 3, queue: SidekiqQueue::LOW
+  sidekiq_options retry: 3, queue: SidekiqQueue::DEFAULT
 
   def perform(question_uid, question_type)
     ActiveRecord::Base.connected_to(role: :reading) do

--- a/services/QuillCMS/app/workers/update_individual_response_worker.rb
+++ b/services/QuillCMS/app/workers/update_individual_response_worker.rb
@@ -1,6 +1,6 @@
 class UpdateIndividualResponseWorker
   include Sidekiq::Worker
-  sidekiq_options queue: SidekiqQueue::DEFAULT
+  sidekiq_options queue: SidekiqQueue::LOW
 
   def perform(response_id)
     Response.find(response_id).update_index_in_elastic_search

--- a/services/QuillCMS/spec/models/cron_spec.rb
+++ b/services/QuillCMS/spec/models/cron_spec.rb
@@ -2,23 +2,13 @@ require "rails_helper"
 
 RSpec.describe Cron do
   describe "kicks off appropriate jobs at the appropriate time" do
-
-    context 'UpdateElasticsearchWorker' do
+    context 'RefreshAllResponsesViewsWorker' do
       it "should not kick off jobs if the hour is not 3AM" do
         allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day)
-        expect(UpdateIndividualResponseWorker).to_not receive(:perform_async)
+        expect(RefreshAllResponsesViewsWorker).to_not receive(:perform_async)
         Cron.run
       end
 
-      it "should kick off job if the hour is 3AM" do
-        allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day + 3.hour)
-        expect(UpdateElasticsearchWorker).to receive(:perform_async).with(Time.zone.now.yesterday.beginning_of_day, Time.zone.now.yesterday.end_of_day)
-        expect(UpdateElasticsearchWorker).to receive(:perform_async).with(Time.zone.now.beginning_of_day, Time.zone.now.beginning_of_day + 3.hour)
-        Cron.run
-      end
-    end
-
-    context 'RefreshAllResponsesViewsWorker' do
       it "should run a refresh response view job if the hour is 3AM" do
         allow(Time).to receive(:now).and_return(Time.zone.now.beginning_of_day + 3.hour)
         expect(RefreshAllResponsesViewsWorker).to receive(:perform_async)

--- a/services/QuillCMS/spec/workers/create_or_increment_response_worker_spec.rb
+++ b/services/QuillCMS/spec/workers/create_or_increment_response_worker_spec.rb
@@ -13,6 +13,9 @@ describe CreateOrIncrementResponseWorker do
   describe '#perform' do
     context 'if the response already exists' do
       it 'should increment the count of the response and set updated at timestamp' do
+        expect(UpdateIndividualResponseWorker).to receive(:perform_async).once.with(response.id)
+        expect(UpdateIndividualResponseWorker).to receive(:perform_async).once.with(response.parent_id)
+
         original_count = response.count
         original_updated_at = response.updated_at
         subject.perform({ text: response.text, question_uid: response.question_uid })
@@ -41,6 +44,8 @@ describe CreateOrIncrementResponseWorker do
 
     context 'if the response does not already exist' do
       it 'should create a new response' do
+        expect(UpdateIndividualResponseWorker).not_to receive(:perform_async)
+
         text = 'Totally different text'
         subject.perform({ text: text })
         expect(Response.find_by(text: 'Totally different text').id).to be


### PR DESCRIPTION
* Remove overnight ES syncing since this is redundant.

* Queue ES jobs in low queue from increment job.

* Lint

* Move rematch workers to default queue.

* Lint.

* Lint.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A or Yes)
