### PR TITLE
Fix bug with percent change and previous count zero

### DIFF
--- a/services/QuillLMS/app/services/pdfs/admin_usage_snapshot_reports/count_data_injector.rb
+++ b/services/QuillLMS/app/services/pdfs/admin_usage_snapshot_reports/count_data_injector.rb
@@ -19,9 +19,9 @@ module Pdfs
       end
 
       private def change
-        return nil if count.nil? || previous.nil?
+        return nil if count.nil? || previous.nil? || previous.zero?
 
-        (((count - previous).to_f / (previous.nonzero? || 1)) * 100).round
+        (((count - previous).to_f / previous) * 100).round
       end
 
       private def count = current_results[:count]&.round

--- a/services/QuillLMS/spec/services/pdfs/admin_usage_snapshot_reports/count_data_injector_spec.rb
+++ b/services/QuillLMS/spec/services/pdfs/admin_usage_snapshot_reports/count_data_injector_spec.rb
@@ -57,7 +57,7 @@ module Pdfs
         context 'when previous_count is 0' do
           let(:current_count) { 10 }
           let(:previous_count) { 0 }
-          let(:change) { 1000 }
+          let(:change) { nil }
 
           it { is_expected.to eq injected_item }
         end


### PR DESCRIPTION
## WHAT
In the Admin Usage Snapshot Report PDF, update the percent change calculation when the previous count is zero.

## WHY
When previous count is zero, the percent change is undefined.

## HOW
Add a condition to the change calculation that returns nil if the previous count is zero. 

### Screenshots
![Screenshot 2024-02-15 at 10 32 33 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/75622679-2e62-4314-839a-35447ab25d76)

### Notion Card Links
https://www.notion.so/quill/Investigate-issues-with-PDF-version-of-the-Usage-Snapshot-Report-cf6fb6e383f947aab1ba27ee2cad2417?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES
