### PR TITLE
Fix bug with quill_staff_demo assigning recommendations

### DIFF
--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -25,7 +25,7 @@ class StudentsController < ApplicationController
   def student_demo
     @user = User.find_by_email 'angie_thomas_demo@quill.org'
     if @user.nil?
-      Demo::ReportDemoCreator.create_demo(nil, teacher_demo: true)
+      Demo::ReportDemoCreator.create_demo(nil, is_teacher_demo: true)
       redirect_to "/student_demo"
     else
       sign_in @user

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -65,7 +65,7 @@ class Demo::CreateAdminReport
       all_classrooms.push(classroom)
       ClassroomsTeacher.create(classroom: classroom, user: teacher, role: ClassroomsTeacher::ROLE_TYPES[:owner])
       student_names = (1..5).to_a.map { |i| "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
-      Demo::ReportDemoCreator.create_demo_classroom_data(teacher, teacher_demo: false, classroom: classroom, student_names: student_names)
+      Demo::ReportDemoCreator.create_demo_classroom_data(teacher, is_teacher_demo: false, classroom: classroom, student_names: student_names)
     end
 
     # delete some activity sessions to make data more varied

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -305,7 +305,7 @@ module Demo::ReportDemoCreator
   end
 
   def self.unit_name(name, is_teacher_demo)
-    is_teacher_demo ? name : "#{name} (Staff Demo)"
+    is_teacher_demo ? name : "#{name} (Demo)"
   end
 
   def self.activity_ids_for_config(template_hash)

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -170,42 +170,40 @@ module Demo::ReportDemoCreator
   STUDENT_COUNT = STUDENT_TEMPLATES.count
   UNITS_COUNT = ACTIVITY_PACKS_TEMPLATES.count
 
-  def self.create_demo(email = nil, teacher_demo: false)
+  def self.create_demo(email = nil, is_teacher_demo: false)
     ActiveRecord::Base.transaction do
       teacher = create_teacher(email)
       create_teacher_info(teacher)
       create_subscription(teacher)
-      create_demo_classroom_data(teacher, teacher_demo: teacher_demo)
+      create_demo_classroom_data(teacher, is_teacher_demo:)
     end
   rescue ActiveRecord::RecordInvalid
     # ignore invalid records
   end
 
-  def self.create_demo_classroom_data(teacher, teacher_demo: false, classroom: nil, student_names: nil)
-    units = reset_units(teacher, student_names.nil?)
+  def self.create_demo_classroom_data(teacher, is_teacher_demo: false, classroom: nil, student_names: nil)
+    units = reset_units(teacher, student_names.nil?, is_teacher_demo)
 
     classroom ||= create_classroom(teacher)
 
     student_templates = student_names ? student_names.map { |name| StudentTemplate.new(name: name, email_eligible: false) } : STUDENT_TEMPLATES
 
-    students = create_students(classroom, teacher_demo, student_templates)
+    students = create_students(classroom, is_teacher_demo, student_templates)
 
     classroom_units = create_classroom_units(classroom, units)
 
     session_data = Demo::SessionData.new
 
-    create_activity_sessions(students, classroom, session_data)
+    create_activity_sessions(students, classroom, session_data, is_teacher_demo)
     create_replayed_activity_session(students.first, classroom_units.first, session_data)
 
     TeacherActivityFeedRefillWorker.perform_async(teacher.id)
   end
 
-  def self.reset_units(teacher, destroy_existing_units)
-    if destroy_existing_units
-      teacher.units&.destroy_all
-    end
+  def self.reset_units(teacher, destroy_existing_units, is_teacher_demo)
+    teacher.units&.destroy_all if destroy_existing_units
 
-    create_units(teacher)
+    create_units(teacher, is_teacher_demo)
   end
 
   def self.reset_account(teacher_id)
@@ -229,7 +227,7 @@ module Demo::ReportDemoCreator
       if teacher && demo_classroom_modified?(teacher)
         # mark as invisible and reset class code (since the demo logic uses a specific class code)
         demo_classroom(teacher)&.update(visible: false, code: nil)
-        create_demo_classroom_data(teacher, teacher_demo: true)
+        create_demo_classroom_data(teacher, is_teacher_demo: true)
       end
     end
   rescue ActiveRecord::RecordInvalid
@@ -292,17 +290,22 @@ module Demo::ReportDemoCreator
     teacher.unscoped_classrooms_i_teach.reject {|c| c.code == classcode(teacher.id) }
   end
 
-  def self.create_units(teacher)
-    ACTIVITY_PACKS_TEMPLATES.map do |ap|
+  def self.create_units(teacher, is_teacher_demo)
+    ACTIVITY_PACKS_TEMPLATES.map do |activity_pack_template|
       # the following line sets the unit template id to nil for the quill_staff_demo account by request of the partnerships team, because they want to be able to assign the starter baseline recommendations
       # and it ensures the unit template actually exists in our database
-      unit_template_id = teacher.email == STAFF_DEMO_EMAIL ? nil : UnitTemplate.find_by_id(ap[:unit_template_id])&.id
-      unit = Unit.find_or_create_by(name: ap[:name], user: teacher, unit_template_id: unit_template_id)
-      activity_ids = activity_ids_for_config(ap)
-      activity_ids.each { |act_id| UnitActivity.find_or_create_by(activity_id: act_id, unit: unit) }
+      unit_template_id = is_teacher_demo ? UnitTemplate.find_by_id(activity_pack_template[:unit_template_id])&.id : nil
+      name = unit_name(activity_pack_template[:name], is_teacher_demo)
+      unit = Unit.find_or_create_by(name:, user: teacher, unit_template_id:)
+      activity_ids = activity_ids_for_config(activity_pack_template)
+      activity_ids.each { |activity_id| UnitActivity.find_or_create_by(activity_id:, unit:) }
 
       unit
     end
+  end
+
+  def self.unit_name(name, is_teacher_demo)
+    is_teacher_demo ? name : "#{name} (Staff Demo)"
   end
 
   def self.activity_ids_for_config(template_hash)
@@ -320,15 +323,15 @@ module Demo::ReportDemoCreator
     Subscription.create_and_attach_subscriber(attributes, teacher)
   end
 
-  def self.create_students(classroom, is_teacher_facing, student_templates)
-    delete_student_email_accounts if is_teacher_facing
+  def self.create_students(classroom, is_teacher_demo, student_templates)
+    delete_student_email_accounts if is_teacher_demo
 
     student_templates.map do |template|
       student = User.create!(
         name: template.name,
         username: template.username(classroom.id),
         role: User::STUDENT,
-        email: is_teacher_facing ? template.email : nil,
+        email: is_teacher_demo ? template.email : nil,
         password: PASSWORD,
         password_confirmation: PASSWORD
       )
@@ -380,10 +383,11 @@ module Demo::ReportDemoCreator
     end
   end
 
-  def self.create_activity_sessions(students, classroom, session_data)
+  def self.create_activity_sessions(students, classroom, session_data, is_teacher_demo)
     students.each_with_index do |student, num|
       ACTIVITY_PACKS_TEMPLATES.each do |activity_pack|
-        unit = Unit.where(name: activity_pack[:name]).last
+        name = unit_name(activity_pack[:name], is_teacher_demo)
+        unit = Unit.where(name:).last
         classroom_unit = ClassroomUnit.find_by(classroom: classroom, unit: unit)
         activity_sessions = activity_pack[:activity_sessions]
         activity_sessions[num].each do |clone_activity_id, clone_user_id|

--- a/services/QuillLMS/app/workers/demo/recreate_account_worker.rb
+++ b/services/QuillLMS/app/workers/demo/recreate_account_worker.rb
@@ -8,8 +8,7 @@ class Demo::RecreateAccountWorker
   STAFF_DEMO_EMAIL = "hello+demoteacher+staff@quill.org"
 
   def perform
-    Demo::ReportDemoCreator.create_demo(nil, teacher_demo: true)
+    Demo::ReportDemoCreator.create_demo(nil, is_teacher_demo: true)
     Demo::ReportDemoCreator.create_demo(STAFF_DEMO_EMAIL)
   end
 end
-

--- a/services/QuillLMS/spec/controllers/students_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/students_controller_spec.rb
@@ -2,8 +2,7 @@
 
 require 'rails_helper'
 
-
-describe StudentsController do
+RSpec.describe StudentsController do
   let(:user) { create(:student) }
 
   before do
@@ -79,7 +78,7 @@ describe StudentsController do
 
     context 'when angie thomas does not exist' do
       it 'should destroy recreate the demo and redirect to student demo' do
-        expect(Demo::ReportDemoCreator).to receive(:create_demo).with(nil, {:teacher_demo=>true})
+        expect(Demo::ReportDemoCreator).to receive(:create_demo).with(nil, is_teacher_demo: true)
         get :student_demo
         expect(response).to redirect_to "/student_demo"
       end

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe Demo::ReportDemoCreator do
       ]
     end
 
+    let(:is_teacher_demo) { true }
+
     before do
       stub_const("Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES", demo_config)
       stub_const("Demo::ReportDemoCreator::REPLAYED_ACTIVITY_ID", activity_id)
@@ -99,7 +101,7 @@ RSpec.describe Demo::ReportDemoCreator do
     end
 
     it 'creates units' do
-      Demo::ReportDemoCreator.create_units(teacher)
+      Demo::ReportDemoCreator.create_units(teacher, is_teacher_demo)
       Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.each do |unit_obj|
         unit = Unit.find_by(name: unit_obj[:name])
         activity_ids = Demo::ReportDemoCreator.activity_ids_for_config(unit_obj)
@@ -117,7 +119,7 @@ RSpec.describe Demo::ReportDemoCreator do
     it 'create classroom units' do
       student = create(:student)
       students = [student]
-      units = Demo::ReportDemoCreator.create_units(teacher)
+      units = Demo::ReportDemoCreator.create_units(teacher, is_teacher_demo)
       classroom = create(:classroom)
       create(:students_classrooms, student: student, classroom: classroom)
       create(:classrooms_teacher, classroom: classroom, user: teacher)
@@ -163,7 +165,7 @@ RSpec.describe Demo::ReportDemoCreator do
       user = build(:user, id: Demo::ReportDemoCreator::REPLAYED_SAMPLE_USER_ID)
       user.save
       sample_session = create(:activity_session, activity_id: Demo::ReportDemoCreator::REPLAYED_ACTIVITY_ID, user_id: Demo::ReportDemoCreator::REPLAYED_SAMPLE_USER_ID, is_final_score: true)
-      units = Demo::ReportDemoCreator.create_units(teacher)
+      units = Demo::ReportDemoCreator.create_units(teacher, is_teacher_demo)
       classroom_unit = Demo::ReportDemoCreator.create_classroom_units(classroom, units).first
       expect {Demo::ReportDemoCreator.create_replayed_activity_session(student, classroom_unit, session_data)}.to change {ActivitySession.count}.by(1)
     end
@@ -176,11 +178,15 @@ RSpec.describe Demo::ReportDemoCreator do
         student = create(:student)
         classroom = create(:classroom)
         create(:students_classrooms, student: student, classroom: classroom)
-        units = Demo::ReportDemoCreator.create_units(teacher)
+        units = Demo::ReportDemoCreator.create_units(teacher, is_teacher_demo)
 
         Demo::ReportDemoCreator.create_classroom_units(classroom, units)
         total_act_sesh_count = Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.map {|ap| ap[:activity_sessions][0].keys.count}.sum
-        expect {Demo::ReportDemoCreator.create_activity_sessions([student], classroom, session_data)}.to change {ActivitySession.count}.by(total_act_sesh_count)
+
+        expect {Demo::ReportDemoCreator.create_activity_sessions([student], classroom, session_data, is_teacher_demo)}
+          .to change {ActivitySession.count}
+          .by(total_act_sesh_count)
+
         activity_session = ActivitySession.last
 
         last_template = Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES.last
@@ -199,7 +205,7 @@ RSpec.describe Demo::ReportDemoCreator do
       before do
         stub_const("Demo::ReportDemoCreator::UNITS_COUNT", 1)
 
-        Demo::ReportDemoCreator.create_demo_classroom_data(teacher, teacher_demo: true)
+        Demo::ReportDemoCreator.create_demo_classroom_data(teacher, is_teacher_demo: true)
       end
 
       subject { Demo::ReportDemoCreator.reset_account(teacher.id) }

--- a/services/QuillLMS/spec/workers/demo/recreate_account_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/demo/recreate_account_worker_spec.rb
@@ -2,12 +2,12 @@
 
 require 'rails_helper'
 
-describe Demo::RecreateAccountWorker, type: :worker do
+RSpec.describe Demo::RecreateAccountWorker, type: :worker do
   let(:worker) { described_class.new }
 
   describe "#perform" do
     it "should destroy and then create a new demo" do
-      expect(Demo::ReportDemoCreator).to receive(:create_demo).with(nil, {:teacher_demo=>true})
+      expect(Demo::ReportDemoCreator).to receive(:create_demo).with(nil, is_teacher_demo: true)
       expect(Demo::ReportDemoCreator).to receive(:create_demo).with(described_class::STAFF_DEMO_EMAIL)
 
       worker.perform


### PR DESCRIPTION
## WHAT
Fix a bug where the staff account is unable to assign recommendations

## WHY
When a staff demo account currently attempts to [assign](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/services/independent_practice_packs_assigner.rb#L71) recommendations, a Unit name validation error occurs because the a unit with that name was already created in the `DemoReportCreator.create_demo(STAFF_DEMO_EMAIL)` daily cron job.

## HOW
Update the `DemoReportCreator.create_demo(STAFF_DEMO_EMAIL)` to create units with names that append "(STAFF DEMO)" so that there is no conflict during the assign recommendations flow.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Cannot-assign-Practice-recommendation-activities-from-quill-org-quill_staff_demo-account-fb35eb78ba734155a6f2753c5f0e638b?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Manual check
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
