### PR TITLE
Two small visual bugfixes

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/dataExportTableAndFields.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/dataExportTableAndFields.test.tsx.snap
@@ -27,19 +27,23 @@ exports[`DataExportTableAndFields component should match snapshot 1`] = `
         </span>
       </a>
     </h1>
-    <button
-      className="quill-button download-report-button contained primary medium focus-on-light"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="header-buttons"
     >
-      <img
-        alt="White arrow pointing down icon"
-        src="undefined/images/icons/downward-arrow-icon-white.svg"
-      />
-      <span>
-        Download
-      </span>
-    </button>
+      <button
+        className="quill-button download-report-button contained primary medium focus-on-light"
+        onClick={[Function]}
+        type="button"
+      >
+        <img
+          alt="White arrow pointing down icon"
+          src="undefined/images/icons/downward-arrow-icon-white.svg"
+        />
+        <span>
+          Download
+        </span>
+      </button>
+    </div>
   </div>
   <div
     className="filter-button-container"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/dataExportTableAndFields.tsx
@@ -316,10 +316,12 @@ export const DataExportTableAndFields = ({ queryKey, searchCount, selectedGrades
             <span>Guide</span>
           </a>
         </h1>
-        <button className="quill-button download-report-button contained primary medium focus-on-light" onClick={createCsvReportDownload} type="button">
-          {downloadButtonBusy ? <LightButtonLoadingSpinner /> : <img alt={whiteArrowPointingDownIcon.alt} src={whiteArrowPointingDownIcon.src} />}
-          <span>Download</span>
-        </button>
+        <div className="header-buttons">
+          <button className="quill-button download-report-button contained primary medium focus-on-light" onClick={createCsvReportDownload} type="button">
+            {downloadButtonBusy ? <LightButtonLoadingSpinner /> : <img alt={whiteArrowPointingDownIcon.alt} src={whiteArrowPointingDownIcon.src} />}
+            <span>Download</span>
+          </button>
+        </div>
       </div>
       <div className="filter-button-container">
         <button className="interactive-wrapper focus-on-light" onClick={openMobileFilterMenu} type="button">

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DataExportContainer.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DataExportContainer.test.tsx.snap
@@ -29,18 +29,22 @@ exports[`DataExportContainer full state it should render 1`] = `
           </span>
         </a>
       </h1>
-      <button
-        class="quill-button download-report-button contained primary medium focus-on-light"
-        type="button"
+      <div
+        class="header-buttons"
       >
-        <img
-          alt="White arrow pointing down icon"
-          src="undefined/images/icons/downward-arrow-icon-white.svg"
-        />
-        <span>
-          Download
-        </span>
-      </button>
+        <button
+          class="quill-button download-report-button contained primary medium focus-on-light"
+          type="button"
+        >
+          <img
+            alt="White arrow pointing down icon"
+            src="undefined/images/icons/downward-arrow-icon-white.svg"
+          />
+          <span>
+            Download
+          </span>
+        </button>
+      </div>
     </div>
     <div
       class="filter-button-container"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/key_metrics.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/key_metrics.tsx
@@ -13,7 +13,7 @@ const KeyMetric = ({ number, label, }) => (
     tooltipText={tooltipCopy}
     tooltipTriggerText={(
       <div className="key-metric">
-        <h4>{addCommasToThousands(number)}</h4>
+        <h4>{number?.toLocaleString()}</h4>
         <span>{label}</span>
       </div>
     )}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/key_metrics.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/key_metrics.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { DropdownInput, Tooltip, helpIcon, } from '../../../Shared/index'
+import { addCommasToThousands } from '../../../Staff/helpers/evidence/miscHelpers'
 
 const KEY_METRICS_TIMEFRAME = 'keyMetricsTimeframe'
 const YEARLY = 'yearly'
@@ -12,7 +13,7 @@ const KeyMetric = ({ number, label, }) => (
     tooltipText={tooltipCopy}
     tooltipTriggerText={(
       <div className="key-metric">
-        <h4>{number}</h4>
+        <h4>{addCommasToThousands(number)}</h4>
         <span>{label}</span>
       </div>
     )}


### PR DESCRIPTION
## WHAT
1. Add thousand-delineater commas to the metrics displayed to teachers on their home page (# of activities assigned and completed).
2. Add a missing class to buttons on "Admin Data Export" page to make sure that button gets the styling applied to all buttons on these pages.

## WHY
To make numbers more legible for teachers, and to fix visual inconsistency on that admin page with buttons.

## HOW
For the teacher metrics, just use the utility function we already defined to display numbers in this component.
For the button visual bug, wrap it in a div with "button-headers" class to make sure the css for buttons gets applied there.

### Screenshots
![Screenshot 2024-02-19 at 5 04 40 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/536e36c2-6d37-4762-9d74-30ca3ff3a8a5)
![Screenshot 2024-02-19 at 6 18 47 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/f8b62633-d6e2-4dd6-b10a-78a2652ac898)


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Add-commas-to-the-key-metrics-on-the-teacher-home-page-84ab5d74290d41e08340edb7a151685b?pvs=4)
https://www.notion.so/quill/Improve-button-styling-for-Download-button-on-the-admin-Data-Export-558bc0e607d941309aa7b521d92e32f0?pvs=4



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | yes
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | yes
