### PR TITLE
fix bug with premium page scroll

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
@@ -656,7 +656,7 @@ li.premium-tab > a:hover {
   .premium-page {
 
     .overview {
-      height: 2087px;
+      height: min-content;
       width: 950px;
 
       .header {


### PR DESCRIPTION
## WHAT
Fix bug where sections on premium page overlapped.

## WHY
This looks bad.

## HOW
Change from a hard-coded height (so often a bad idea!) to just a `min-content`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/UI-Errors-on-the-Premium-Pricing-page-b71303998ade4238b0d5dd1722148e36

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO - CSS change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | YES