### PR TITLE
fix inline editing for incorrect sequences and focus points

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
@@ -64,7 +64,7 @@ export class FocusPointsContainer extends Component {
     const { fpOrderedIds, focusPoints } = this.state
     if (fpOrderedIds) {
       const focusPointsCollection = hashToCollection(focusPoints)
-      return fpOrderedIds.map(id => focusPointsCollection.find(fp => fp.text === id))
+      return fpOrderedIds.map(id => focusPointsCollection.find(fp => fp.key === id))
     } else {
       return hashToCollection(focusPoints).sort((a, b) => a.order - b.order);
     }
@@ -113,7 +113,7 @@ export class FocusPointsContainer extends Component {
       const newFp = {};
       const focusPointsArray = hashToCollection(focusPoints)
       fpOrderedIds.forEach((id, index) => {
-        const fp = Object.assign({}, focusPointsArray.find(fp => fp.text === id));
+        const fp = Object.assign({}, focusPointsArray.find(fp => fp.key === id));
         fp.order = index + 1;
         newFp[id] = fp;
       });
@@ -178,7 +178,7 @@ export class FocusPointsContainer extends Component {
     const { questionID } = params
     const components = this.fPsortedByOrder().map((fp) => {
       return (
-        <div className="card is-fullwidth has-bottom-margin" id={fp.text} key={fp.text}>
+        <div className="card is-fullwidth has-bottom-margin" id={fp.key} key={fp.key}>
           <header className="card-header">
             <input className="regex-name" onChange={(e) => this.handleNameChange(e, fp.key)} placeholder="Name" type="text" value={fp.name || ''} />
           </header>

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 import _ from 'underscore';
+import { v4 as uuid } from 'uuid';
 
 import { SortableList, TextEditor, hashToCollection, isValidRegex } from '../../../Shared/index';
 import questionActions from '../../actions/questions';
@@ -37,17 +38,15 @@ class IncorrectSequencesContainer extends Component {
     const incorrectSequences = this.getSequences(question)
 
     if (!_.isEqual(previousState.incorrectSequences, incorrectSequences)) {
-      this.setState({ incorrectSequences, });
+      this.setState({ incorrectSequences, orderedIds: null });
     };
   }
 
   getSequences = (question) => {
-    const sequences = question.incorrectSequences;
-    if(sequences && sequences.length) {
-      return sequences.filter(incorrectSequence => incorrectSequence)
-    } else {
-      return sequences
-    }
+    return hashToCollection(question.incorrectSequences).map(is => {
+      is.uid = is.uid || uuid()
+      return is
+    }).filter(incorrectSequence => incorrectSequence);
   }
 
   deleteConceptResult = (conceptResultKey, sequenceKey) => {
@@ -80,7 +79,7 @@ class IncorrectSequencesContainer extends Component {
     const { orderedIds, incorrectSequences } = this.state
     if (orderedIds) {
       const sequencesCollection = hashToCollection(incorrectSequences)
-      return orderedIds.map(id => sequencesCollection.find(sequence => sequence.text === id))
+      return orderedIds.map(id => sequencesCollection.find(sequence => sequence.uid === id))
     } else {
       return hashToCollection(incorrectSequences).sort((a, b) => a.order - b.order);
     }
@@ -184,7 +183,7 @@ class IncorrectSequencesContainer extends Component {
 
     const components = this.sequencesSortedByOrder().map((sequence) => {
       return (
-        <div className="card is-fullwidth has-bottom-margin" id={sequence.text} key={sequence.text} >
+        <div className="card is-fullwidth has-bottom-margin" id={sequence.uid} key={sequence.uid} >
           <header className="card-header">
             <input className="regex-name" onChange={(e) => this.handleNameChange(e, sequence.key)} placeholder="Name" type="text" value={sequence.name || ''} />
           </header>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
@@ -91,7 +91,7 @@ export class FocusPointsContainer extends Component {
     const { fpOrderedIds, focusPoints } = this.state;
     if (fpOrderedIds) {
       const focusPointsCollection = hashToCollection(focusPoints)
-      return fpOrderedIds.map(id => focusPointsCollection.find(fp => fp.text === id))
+      return fpOrderedIds.map(id => focusPointsCollection.find(fp => fp.key === id))
     } else {
       return hashToCollection(focusPoints).sort((a, b) => a.order - b.order);
     }
@@ -144,7 +144,7 @@ export class FocusPointsContainer extends Component {
       const newFp = {};
       const focusPointsArray = hashToCollection(focusPoints)
       fpOrderedIds.forEach((id, index) => {
-        const fp = Object.assign({}, focusPointsArray.find(fp => fp.text === id));
+        const fp = Object.assign({}, focusPointsArray.find(fp => fp.key === id));
         fp.order = index + 1;
         newFp[id] = fp;
       });
@@ -178,7 +178,7 @@ export class FocusPointsContainer extends Component {
     const components = this.fPsortedByOrder().map((fp) => {
       const { conceptResults, feedback, key, order, text } = fp;
       return (
-        <div className="card is-fullwidth has-bottom-margin" id={text} key={text}>
+        <div className="card is-fullwidth has-bottom-margin" id={key} key={key}>
           <header className="card-header">
             <input className="regex-name" onChange={(e) => this.handleNameChange(e, key)} placeholder="Name" type="text" value={fp.name || ''} />
           </header>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -2,6 +2,7 @@ import { ContentState, EditorState } from 'draft-js';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import _ from 'underscore';
+import { v4 as uuid } from 'uuid';
 
 import { hashToCollection, SortableList, TextEditor } from '../../../Shared/index';
 import questionActions from '../../actions/questions';
@@ -41,13 +42,16 @@ class IncorrectSequencesContainer extends Component {
     const question = this.props[this.state.questionType].data[this.props.match.params.questionID]
     const incorrectSequences = this.getSequences(question)
 
-    if (previousState.incorrectSequences === incorrectSequences) return;
+    if (_.isEqual(previousState.incorrectSequences, incorrectSequences)) return;
 
-    this.setState({ incorrectSequences, });
+    this.setState({ incorrectSequences, orderedIds: null, });
   }
 
   getSequences(question) {
-    return question.incorrectSequences;
+    return question.incorrectSequences.map(is => {
+      is.uid = is.uid || uuid()
+      return is
+    });
   }
 
   deleteSequence = sequenceID => {
@@ -143,7 +147,7 @@ class IncorrectSequencesContainer extends Component {
     const { orderedIds, incorrectSequences } = this.state
     if (orderedIds) {
       const sequencesCollection = hashToCollection(incorrectSequences)
-      return orderedIds.map(id => sequencesCollection.find(s => s.text === id))
+      return orderedIds.map(id => sequencesCollection.find(s => s.uid === id))
     } else {
       return hashToCollection(incorrectSequences).sort((a, b) => a.order - b.order);
     }
@@ -185,7 +189,7 @@ class IncorrectSequencesContainer extends Component {
     const path = url.includes('sentence-fragments') ? 'sentence-fragments' : 'questions'
     const components = this.sequencesSortedByOrder().map((seq) => {
       return (
-        <div className="card is-fullwidth has-bottom-margin" id={seq.text} key={seq.text}>
+        <div className="card is-fullwidth has-bottom-margin" id={seq.uid} key={seq.uid}>
           <header className="card-header">
             <input className="regex-name" onChange={(e) => this.handleNameChange(e, seq.key)} placeholder="Name" type="text" value={seq.name || ''} />
           </header>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
@@ -46,7 +46,7 @@ export class FocusPointsContainer extends React.Component {
     const { focusPoints } = this.state
     if (this.state.fpOrderedIds) {
       const focusPointsCollection = hashToCollection(focusPoints)
-      return this.state.fpOrderedIds.map(id => focusPointsCollection.find(fp => fp.text === id))
+      return this.state.fpOrderedIds.map(id => focusPointsCollection.find(fp => fp.key === id))
     } else {
       return hashToCollection(focusPoints).sort((a, b) => a.order - b.order);
     }
@@ -124,7 +124,7 @@ export class FocusPointsContainer extends React.Component {
       const newFp = {};
       const focusPointsArray = hashToCollection(focusPoints)
       fpOrderedIds.forEach((id, index) => {
-        const fp = Object.assign({}, focusPointsArray.find(fp => fp.text === id));
+        const fp = Object.assign({}, focusPointsArray.find(fp => fp.key === id));
         fp.order = index + 1;
         newFp[id] = fp;
       });
@@ -139,7 +139,7 @@ export class FocusPointsContainer extends React.Component {
   renderFocusPointsList() {
     const components = this.fPsortedByOrder().map((fp) => {
       return (
-        <div className="card is-fullwidth has-bottom-margin" id={fp.text} key={fp.text}>
+        <div className="card is-fullwidth has-bottom-margin" id={fp.key} key={fp.key}>
           <header className="card-header">
             <input className="regex-name" onChange={(e) => this.handleNameChange(e, fp.key)} placeholder="Name" type="text" value={fp.name || ''} />
           </header>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -2,6 +2,7 @@ import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import _ from 'underscore';
+import { v4 as uuid } from 'uuid';
 
 import { hashToCollection, SortableList, TextEditor } from '../../../Shared/index';
 import * as questionActions from '../../actions/questions';
@@ -12,7 +13,11 @@ class IncorrectSequencesContainer extends React.Component {
     super(props);
 
     const question = this.props.questions.data[this.props.match.params.questionID]
-    this.state = { orderedIds: null, incorrectSequences: question.incorrectSequences }
+    const incorrectSequencesWithUids = question.incorrectSequences.map(is => {
+      is.uid = is.uid || uuid()
+      return is
+    });
+    this.state = { orderedIds: null, incorrectSequences: incorrectSequencesWithUids, }
   }
 
   UNSAFE_componentWillMount() {
@@ -92,6 +97,7 @@ class IncorrectSequencesContainer extends React.Component {
   handleSequenceChange = (e, key) => {
     const { incorrectSequences } = this.state
     const className = `regex-${key}`
+    debugger;
     const value = `${Array.from(document.getElementsByClassName(className)).map(i => i.value).filter(val => val !== '').join('|||')}`;
     if (value === '') {
       if (!confirm("Deleting this regex will delete the whole incorrect sequence. Are you sure you want that?")) {
@@ -116,7 +122,7 @@ class IncorrectSequencesContainer extends React.Component {
     const { orderedIds, incorrectSequences } = this.state
     if (orderedIds) {
       const sequencesCollection = hashToCollection(incorrectSequences)
-      return orderedIds.map(id => sequencesCollection.find(s => s.text === id))
+      return orderedIds.map(id => sequencesCollection.find(s => s.uid === id))
     } else {
       return hashToCollection(incorrectSequences).sort((a, b) => a.order - b.order);
     }
@@ -160,7 +166,7 @@ class IncorrectSequencesContainer extends React.Component {
     const components = this.sequencesSortedByOrder().map((seq) => {
       const onClickDelete = () => { this.handleDeleteSequence(seq.key) }
       return (
-        <div className="card is-fullwidth has-bottom-margin" id={seq.text} key={seq.text}>
+        <div className="card is-fullwidth has-bottom-margin" id={seq.uid} key={seq.uid}>
           <header className="card-header">
             <input className="regex-name" onChange={(e) => this.handleNameChange(e, seq.key)} placeholder="Name" type="text" value={seq.name || ''} />
           </header>

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/sortableList.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/sortableList.tsx
@@ -5,6 +5,7 @@ import { SortableContext, sortableKeyboardCoordinates, useSortable, verticalList
 import { CSS } from '@dnd-kit/utilities';
 
 import { DragHandleProvider, } from '../../hooks/useDragHandle'
+import { INPUT, TEXTAREA, BUTTON, SELECT, } from '../../utils/tagNames'
 
 const dropAnimationConfig: DropAnimation = {
   sideEffects: defaultDropAnimationSideEffects({
@@ -60,6 +61,28 @@ interface SortableListProps {
   useDragHandle?: boolean,
 }
 
+export class KeyboardSensorThatHandlesElementType extends KeyboardSensor {
+  static activators = [
+    {
+      eventName: 'onKeyDown' as const,
+      handler: ({ nativeEvent: event }: React.KeyboardEvent<Element>) => {
+        return shouldHandleKeyboardEvent(event)
+      }
+    }
+  ]
+}
+
+function shouldHandleKeyboardEvent(event) {
+  const activeElement = document.activeElement;
+  const tagNames = [INPUT, SELECT, TEXTAREA, BUTTON];
+  // Prevent keyboard sensor activation if focused on input, select, textarea, or button
+  if (activeElement && (tagNames.includes(activeElement.tagName) || activeElement.attributes['contenteditable'].value === 'true')) {
+    return false;
+  }
+  return true; // Return true to allow activation in other cases
+}
+
+
 export const SortableList = ({ data, sortCallback, helperClass, useDragHandle, }: SortableListProps) => {
   const [activeId, setActiveId] = React.useState(null)
 
@@ -69,7 +92,7 @@ export const SortableList = ({ data, sortCallback, helperClass, useDragHandle, }
         distance: 8,
       },
     }),
-    useSensor(KeyboardSensor, {
+    useSensor(KeyboardSensorThatHandlesElementType, {
       coordinateGetter: sortableKeyboardCoordinates,
     })
   );

--- a/services/QuillLMS/client/app/bundles/Shared/utils/tagNames.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/tagNames.ts
@@ -1,0 +1,4 @@
+export const INPUT = 'INPUT'
+export const SELECT = 'SELECT'
+export const TEXTAREA = 'TEXTAREA'
+export const BUTTON = 'BUTTON'


### PR DESCRIPTION
## WHAT
Change the values we're using for keys in incorrect sequence and focus point components so that curriculum team members can edit the texts inline while also being able to reorder them.

Also fix bug where entering a space would result in weird behavior, due to dnd-kit using space commands for accessibility purposes.

## WHY
We want the curriculum team members to be able to edit these things inline.

## HOW
This problem was caused by the fact that we were using the incorrect sequence/focus point's text as the element's key, resulting in the whole thing rerendering when the text changed (by editing it) and focus being lost. The fix here is fairly straightforward for focus points, because they already have keys that are actual unique identifiers which we could use instead. It doesn't work well for incorrect sequences, however, because their "keys" in the database are just indices, which don't play well with the drag and drop library. Ultimately, I think it would be best to migrate to using a structure more like the one we have for focus points, but that is a major rewrite, so in order to solve this bug while preserving reorderability I've opted to just use temporary uids in these components. These uids do not actually save to the database due to the code [here](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb#L49-L50). I'm open to other suggestions if we don't like this approach.

See photo of a question's data structure with both focus points and incorrect sequences here:
<img width="981" alt="Screenshot 2024-02-21 at 2 58 13 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/1a402333-ae3d-4534-b288-a357600f7ccb">

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Inline-editing-not-working-in-Connect-CMS-b6c43cf969d440cc81f85610e3728023?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | Tested locally with staging db
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A