### PR TITLE
don't try to highlight nonexistent text in evidence

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/promptStep.tsx
@@ -152,7 +152,7 @@ export class PromptStep extends React.Component<PromptStepProps, PromptStepState
 
     if (!lastSubmittedResponse || !lastSubmittedResponse.highlight || !lastSubmittedResponse.entry || submittedResponses.length === prompt.max_attempts) { return str }
 
-    const thereAreResponseHighlights = lastSubmittedResponse.highlight.filter(hl => hl.type === RESPONSE).length
+    const thereAreResponseHighlights = lastSubmittedResponse.highlight.filter(hl => hl.type === RESPONSE && hl.text.length).length
 
     if (!thereAreResponseHighlights) { return str }
 


### PR DESCRIPTION
## WHAT
Fix bug where we were attempting to highlight an empty string, resulting in whatever text appeared at that location being highlighted. Specifically, this came up in the context of a missing period. 

## WHY
We don't want to highlight random characters.

## HOW
Update the highlight check to make sure text is actually present.

### Screenshots
<img width="438" alt="Screenshot 2024-02-21 at 4 52 48 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/0e852854-ca29-4fe6-b285-4bb573261ffb">

### Notion Card Links
https://www.notion.so/quill/correct-evidence-inputs-without-periods-result-in-incorrect-bolding-aa864256b7d14aa8a585f9a56f005f6d

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A
