### PR TITLE
add some additional data to the admin demo generation script

### DIFF
--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -68,9 +68,10 @@ class Demo::CreateAdminReport
 
       # create teacher data
       teacher = find_or_create_teacher_data(row['Teacher'], school, subscription)
+      teacher.record_login # necessary to populate the active teachers count for the usage snapshot report
 
       # create classroom data
-      classroom = Classroom.create(name: row['Classroom'])
+      classroom = Classroom.create(name: row['Classroom'], grade: (5..12).to_a.sample.to_s)
       all_classrooms.push(classroom)
       ClassroomsTeacher.create(classroom: classroom, user: teacher, role: ClassroomsTeacher::ROLE_TYPES[:owner])
       student_names = (1..NUMBER_OF_STUDENTS_PER_CLASSROOM).to_a.map { |i| "#{Faker::Name.first_name} #{Faker::Name.last_name}" }

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -6,8 +6,13 @@ class Demo::CreateAdminReport
   RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY = 14..28 # 10-20% of 140
   BATCH_DELAY = 1.minute
   NUMBER_OF_STUDENTS_PER_CLASSROOM = 25
+
   GRADE_MIN = 5
   GRADE_MAX = 12
+
+  GRADES = (GRADE_MIN..GRADE_MAX).to_a
+
+  OWNER_ROLE = ClassroomsTeacher::ROLE_TYPES[:owner]
 
   attr_reader :data, :delay, :teacher_email
 
@@ -73,10 +78,10 @@ class Demo::CreateAdminReport
       teacher = find_or_create_teacher_data(row['Teacher'], school, subscription)
 
       # create classroom data
-      classroom = Classroom.create(name: row['Classroom'], grade: (GRADE_MIN..GRADE_MAX).to_a.sample.to_s)
+      classroom = Classroom.create(name: row['Classroom'], grade: sample_grade)
       all_classrooms.push(classroom)
-      ClassroomsTeacher.create(classroom: classroom, user: teacher, role: ClassroomsTeacher::ROLE_TYPES[:owner])
-      student_names = (1..NUMBER_OF_STUDENTS_PER_CLASSROOM).to_a.map { |i| "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
+      ClassroomsTeacher.create(classroom: classroom, user: teacher, role: OWNER_ROLE)
+      student_names = NUMBER_OF_STUDENTS_PER_CLASSROOM.times.map { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
       Demo::ReportDemoCreator.create_demo_classroom_data(teacher, is_teacher_demo: false, classroom: classroom, student_names: student_names)
       sleep @delay
     end
@@ -88,4 +93,7 @@ class Demo::CreateAdminReport
       activity_sessions_for_classroom.sample(number_of_sessions_to_destroy).each { |as| as.destroy }
     end
   end
+
+  private def sample_grade = GRADES.sample.to_s
+
 end

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -6,6 +6,8 @@ class Demo::CreateAdminReport
   RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY = 14..28 # 10-20% of 140
   BATCH_DELAY = 1.minute
   NUMBER_OF_STUDENTS_PER_CLASSROOM = 25
+  GRADE_MIN = 5
+  GRADE_MAX = 12
 
   attr_reader :data, :delay, :teacher_email
 
@@ -43,6 +45,7 @@ class Demo::CreateAdminReport
 
     SchoolsUsers.find_or_create_by(school: school, user: user)
     UserSubscription.create!(user_id: user.id, subscription: subscription)
+    user.record_login # necessary to populate the active teachers count for the usage snapshot report
 
     user
   end
@@ -68,10 +71,9 @@ class Demo::CreateAdminReport
 
       # create teacher data
       teacher = find_or_create_teacher_data(row['Teacher'], school, subscription)
-      teacher.record_login # necessary to populate the active teachers count for the usage snapshot report
 
       # create classroom data
-      classroom = Classroom.create(name: row['Classroom'], grade: (5..12).to_a.sample.to_s)
+      classroom = Classroom.create(name: row['Classroom'], grade: (GRADE_MIN..GRADE_MAX).to_a.sample.to_s)
       all_classrooms.push(classroom)
       ClassroomsTeacher.create(classroom: classroom, user: teacher, role: ClassroomsTeacher::ROLE_TYPES[:owner])
       student_names = (1..NUMBER_OF_STUDENTS_PER_CLASSROOM).to_a.map { |i| "#{Faker::Name.first_name} #{Faker::Name.last_name}" }

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -14,6 +14,8 @@ module Demo::ReportDemoCreator
   TAHEREH_ID = 14862323
   KEN_ID = 14862324
 
+  DEFAULT_TIMESPENT = 600 # 10 minutes in seconds
+
   # Use report_demo:generate_new_data to generate new data
   ACTIVITY_PACKS_TEMPLATES = [
     {
@@ -370,7 +372,7 @@ module Demo::ReportDemoCreator
 
     return unless session_to_clone
 
-    act_session = ActivitySession.create!(activity_id: clone_activity_id, classroom_unit_id: classroom_unit_id, user_id: student_id, state: 'finished', percentage: session_to_clone.percentage)
+    act_session = ActivitySession.create!(activity_id: clone_activity_id, classroom_unit_id: classroom_unit_id, user_id: student_id, state: 'finished', percentage: session_to_clone.percentage, timespent: session_to_clone.timespent || DEFAULT_TIMESPENT)
     concept_results = session_data.concept_results.select {|cr| cr.activity_session_id == session_to_clone.id }
     concept_results.each do |cr|
       question_type = session_data.concept_result_question_types.first {|qt| qt.id == cr.concept_result_question_type_id}

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -372,7 +372,7 @@ module Demo::ReportDemoCreator
 
     return unless session_to_clone
 
-    act_session = ActivitySession.create!(activity_id: clone_activity_id, classroom_unit_id: classroom_unit_id, user_id: student_id, state: 'finished', percentage: session_to_clone.percentage, timespent: session_to_clone.timespent || DEFAULT_TIMESPENT)
+    act_session = create_activity_session(student_id, classroom_unit_id, clone_activity_id, session_to_clone)
     concept_results = session_data.concept_results.select {|cr| cr.activity_session_id == session_to_clone.id }
     concept_results.each do |cr|
       question_type = session_data.concept_result_question_types.first {|qt| qt.id == cr.concept_result_question_type_id}
@@ -383,6 +383,17 @@ module Demo::ReportDemoCreator
         question_type: question_type&.text
       })
     end
+  end
+
+  def self.create_activity_session(student_id, classroom_unit_id, clone_activity_id, session_to_clone)
+    ActivitySession.create!(
+      activity_id: clone_activity_id,
+      classroom_unit_id: classroom_unit_id,
+      user_id: student_id,
+      state: 'finished',
+      percentage: session_to_clone.percentage,
+      timespent: session_to_clone.timespent || DEFAULT_TIMESPENT
+    )
   end
 
   def self.create_activity_sessions(students, classroom, session_data, is_teacher_demo)

--- a/services/QuillLMS/app/services/demo/report_demo_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_creator.rb
@@ -14,7 +14,7 @@ module Demo::ReportDemoCreator
   TAHEREH_ID = 14862323
   KEN_ID = 14862324
 
-  DEFAULT_TIMESPENT = 600 # 10 minutes in seconds
+  DEFAULT_TIMESPENT = 10.minutes.to_i
 
   # Use report_demo:generate_new_data to generate new data
   ACTIVITY_PACKS_TEMPLATES = [

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -47,13 +47,14 @@ RSpec.describe Demo::CreateAdminReport do
     end
   end
 
-  it 'should create every teacher account from the data hash, associated with the correct school' do
+  it 'should create every teacher account from the data hash, associated with the correct school and with a login record' do
     schools_and_teachers = subject.data.map { |d| { 'School' => d['School'], 'Teacher' => d['Teacher'] } }.uniq
     schools_and_teachers.each do |row|
       teacher = User.find_by_name(row['Teacher'])
       school = School.find_by_name(row['School'])
       expect(SchoolsUsers.find_by(school: school, user: teacher)).to be
       expect(UserSubscription.find_by(user: teacher, subscription: subscription)).to be
+      expect(UserLogin.find_by(user: teacher)).to be
     end
   end
 
@@ -68,6 +69,7 @@ RSpec.describe Demo::CreateAdminReport do
         classroom = Classroom.find_by_name(row['Classroom'])
         teacher = User.find_by_name(row['Teacher'])
         expect(classroom).to be
+        expect(classroom.grade.to_i).to be_between(described_class::GRADE_MIN, described_class::GRADE_MAX)
         expect(classroom.owner).to eq(teacher)
         expect(classroom.students.count).to eq(described_class::NUMBER_OF_STUDENTS_PER_CLASSROOM)
         expect(classroom.activity_sessions.count).to be_between(min, max)

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Demo::CreateAdminReport do
       school = School.find_by_name(row['School'])
       expect(SchoolsUsers.find_by(school: school, user: teacher)).to be
       expect(UserSubscription.find_by(user: teacher, subscription: subscription)).to be
-      expect(UserLogin.find_by(user: teacher)).to be
+      expect(UserLogin.exists?(user: teacher)).to be true
     end
   end
 

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -197,6 +197,7 @@ RSpec.describe Demo::ReportDemoCreator do
         expect(activity_session.state).to eq('finished')
 
         expect(activity_session.percentage).to eq(session_clone.percentage)
+        expect(activity_session.timespent).to eq(session_clone.timespent || Demo::ReportDemoCreator::DEFAULT_TIMESPENT)
         expect(activity_session.concept_results.first.extra_metadata.keys).to match_array ['question_uid', 'question_concept_uid']
         # Taken from actual concept_result
         expect(activity_session.concept_results.first.answer).to eq('Traveling is easier with a guide than without one.')


### PR DESCRIPTION
## WHAT
Add some additional data to the admin demo/regular demo generation script.

## WHY
So it looks good in the usage snapshot report.

## HOW
Add classroom grades, teacher login records, and activity session timespent values, so that we don't have 0s for queries that use these values in the usage snapshot report.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-Admin-Demo-Account-For-Partnerships-Team-Sales-Demos-f07a9fe1074e4901adc55c53b960f1a7?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - I can't test the usage snapshot report in staging, so I'm just using tests and will run it on a private account in prod to test
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | (N/A