### PR TITLE
fix usage snapshot report bugs

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -56,6 +56,9 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
   React.useEffect(() => {
     resetToDefault()
 
+    clearTimeout(currentRetryTimeout)
+    clearTimeout(previousRetryTimeout)
+
     getCurrentData()
     getPreviousData()
   }, [searchCount])

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/snapshotCount.tsx
@@ -103,6 +103,7 @@ const SnapshotCount = ({ label, size, queryKey, searchCount, selectedGrades, sel
 
   function resetToDefault() {
     setCount(passedCount || null)
+    setPrevious(passedPrevious || null)
     setChangeDirection(passedChangeDirection || null)
     setChange(passedChange || 0)
   }


### PR DESCRIPTION
## WHAT
Fix two usage snapshot report bugs: one where going from a report with previous values to "All time" keeps showing arrows indicating change, and one where switching quickly between time frames results in the switched-away from report loading after the switched-to report is already in place. 

## WHY
We want these numbers to accurately reflect the filter.

## HOW
Make sure to clear the `previousCount` when `searchCount` is changed, and also clear any existing timeouts so that 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Don-t-show-the-percentage-change-values-on-the-Usage-Snapshot-Report-on-the-All-time-timeframe-7203bfcf82ae4e68bc3276e97740a07e?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A