### PR TITLE
Fix scrolling to highlight bug in Evidence

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -97,6 +97,13 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
   })
 
   React.useEffect(() => {
+    const { activeStep } = session;
+    if (Object.keys(session.submittedResponses).length && getStrippedPassageHighlights({ activities, session, activeStep })) {
+      scrollToHighlight()
+    }
+  }, [session.submittedResponses])
+
+  React.useEffect(() => {
     if(hasStartedReadPassageStep || session.previewSessionStep === READ_AND_HIGHLIGHT) {
       const el = document.getElementById('end-of-passage')
       const observer = new IntersectionObserver(([entry]) => { entry.isIntersecting ? setScrolledToEndOfPassage(entry.isIntersecting) : null; });
@@ -581,7 +588,6 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
 
   function submitResponseCallback() {
     callSaveActiveActivitySession()
-    scrollToHighlight()
   }
 
   function scrollToStepOnMobile(ref: string) {


### PR DESCRIPTION
## WHAT
Fix a bug where the scroll to highlight functionality isn't working properly.

## WHY
When a user submits a second attempt to a prompt, `scrollToHighlight` is called, which looks for a node containing a class `passage-highlights`.   However, the `transformMarkTags`, which is responsible for adding `passage-highlights` tag to the relevant passage nodes, has not iterated through all the nodes by the time scrollToHighlight is called.  Therefore, scrollToHighlight does not work properly.

## HOW
Move the `scrollToHighlight` call to a `useEffect` hook that monitors `session.submittedResponses` for requisite values.  This will get the sequence of commands in the correct order.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Highlighting-feedback-in-Evidence-not-moving-page-to-correct-position-36768c25f07c47e096026d505c18a4fe?pvs=4

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Manual check on a few activities, some with stripped passage highlights and some without.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
Spec Review: Have you reviewed the spec and ensured this meets requirements and/or matches design mockups? | N/A