### PR TITLE
Update pusher configuration key

### DIFF
--- a/services/QuillLMS/app/pusher_modules/pusher_admin_users_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_admin_users_completed.rb
@@ -7,7 +7,7 @@ module PusherAdminUsersCompleted
         app_id: ENV["PUSHER_APP_ID"],
         key: ENV["PUSHER_KEY"],
         secret: ENV["PUSHER_SECRET"],
-        encrypted: true
+        use_tls: true
     )
     pusher_client.trigger(
       admin_id.to_s,

--- a/services/QuillLMS/app/pusher_modules/pusher_csv_export_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_csv_export_completed.rb
@@ -7,7 +7,7 @@ module PusherCSVExportCompleted
         app_id: ENV['PUSHER_APP_ID'],
         key: ENV['PUSHER_KEY'],
         secret: ENV['PUSHER_SECRET'],
-        encrypted: true
+        use_tls: true
     )
     pusher_client.trigger(current_user_id.to_s, 'csv-export-completed', message: csv_url)
   end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_activity_scores_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_activity_scores_completed.rb
@@ -7,7 +7,7 @@ module PusherDistrictActivityScoresCompleted
         app_id: ENV["PUSHER_APP_ID"],
         key: ENV["PUSHER_KEY"],
         secret: ENV["PUSHER_SECRET"],
-        encrypted: true
+        use_tls: true
     )
     pusher_client.trigger(
       admin_id.to_s,

--- a/services/QuillLMS/app/pusher_modules/pusher_district_concept_reports_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_concept_reports_completed.rb
@@ -7,7 +7,7 @@ module PusherDistrictConceptReportsCompleted
         app_id: ENV["PUSHER_APP_ID"],
         key: ENV["PUSHER_KEY"],
         secret: ENV["PUSHER_SECRET"],
-        encrypted: true
+        use_tls: true
     )
     pusher_client.trigger(
       admin_id.to_s,

--- a/services/QuillLMS/app/pusher_modules/pusher_district_standards_reports_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_standards_reports_completed.rb
@@ -7,7 +7,7 @@ module PusherDistrictStandardsReportsCompleted
         app_id: ENV["PUSHER_APP_ID"],
         key: ENV["PUSHER_KEY"],
         secret: ENV["PUSHER_SECRET"],
-        encrypted: true
+        use_tls: true
     )
     pusher_client.trigger(
       admin_id.to_s,

--- a/services/QuillLMS/app/pusher_modules/pusher_lesson_launched.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_lesson_launched.rb
@@ -7,7 +7,7 @@ module PusherLessonLaunched
         app_id: ENV["PUSHER_APP_ID"],
         key: ENV["PUSHER_KEY"],
         secret: ENV["PUSHER_SECRET"],
-        encrypted: true
+        use_tls: true
     )
     pusher_client.trigger(classroom.id.to_s, 'lesson-launched', message: "Lesson launched for #{classroom.name}.")
   end

--- a/services/QuillLMS/app/pusher_modules/pusher_recommendation_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_recommendation_completed.rb
@@ -7,7 +7,7 @@ module PusherRecommendationCompleted
         app_id: ENV["PUSHER_APP_ID"],
         key: ENV["PUSHER_KEY"],
         secret: ENV["PUSHER_SECRET"],
-        encrypted: true
+        use_tls: true
     )
     if lesson
       pusher_client.trigger(

--- a/services/QuillLMS/app/pusher_modules/pusher_trigger.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_trigger.rb
@@ -7,7 +7,7 @@ module PusherTrigger
       app_id: ENV["PUSHER_APP_ID"],
       key: ENV["PUSHER_KEY"],
       secret: ENV["PUSHER_SECRET"],
-      encrypted: true
+      use_tls: true
     )
 
     pusher_client.trigger(

--- a/services/QuillLMS/client/app/actions/district_activity_scores.js
+++ b/services/QuillLMS/client/app/actions/district_activity_scores.js
@@ -23,7 +23,7 @@ export const initializePusherForDistrictActivityScores = (adminId) => {
     if (process.env.RAILS_ENV === 'development') {
       Pusher.logToConsole = true;
     }
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channel = pusher.subscribe(adminId);
     channel.bind('district-activity-scores-found', () => {
       dispatch(getDistrictActivityScores())

--- a/services/QuillLMS/client/app/actions/district_concept_reports.js
+++ b/services/QuillLMS/client/app/actions/district_concept_reports.js
@@ -23,7 +23,7 @@ export const initializePusherForDistrictConceptReports = (adminId) => {
     if (process.env.RAILS_ENV === 'development') {
       Pusher.logToConsole = true;
     }
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channel = pusher.subscribe(adminId);
     channel.bind('district-concept-reports-found', () => {
       dispatch(getDistrictConceptReports())

--- a/services/QuillLMS/client/app/actions/district_standards_reports.js
+++ b/services/QuillLMS/client/app/actions/district_standards_reports.js
@@ -23,7 +23,7 @@ export const initializePusherForDistrictStandardsReports = (adminId) => {
     if (process.env.RAILS_ENV === 'development') {
       Pusher.logToConsole = true;
     }
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channel = pusher.subscribe(adminId);
     channel.bind('district-standards-reports-found', () => {
       dispatch(getDistrictStandardsReports())

--- a/services/QuillLMS/client/app/bundles/Connect/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/questions.ts
@@ -258,7 +258,7 @@ function initializeSubscription(qid) {
       Pusher.logToConsole = true;
     }
     if (!window.pusher) {
-      window.pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+      window.pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     }
     const channel = window.pusher.subscribe(`admin-${qid}`);
     channel.bind('new-response', (data) => {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/questions.ts
@@ -251,7 +251,7 @@ function initializeSubscription(qid) {
       Pusher.logToConsole = true;
     }
     if (!window.pusher) {
-      window.pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+      window.pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     }
     const channel = window.pusher.subscribe(`admin-${qid}`);
     channel.bind('new-response', (data) => {

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -126,7 +126,7 @@ export const initializeSubscription = (qid: string) => {
       Pusher.logToConsole = true;
     }
     if (!window.pusher) {
-      window.pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+      window.pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     }
     const channel = window.pusher.subscribe(`admin-${qid}`);
     channel.bind('new-response', (data) => {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/AccountManagement.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/AccountManagement.tsx
@@ -93,7 +93,7 @@ export const AccountManagement: React.SFC<AccountManagementProps> = ({
     if (process.env.RAILS_ENV === 'development') {
       Pusher.logToConsole = true;
     }
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channel = pusher.subscribe(String(adminId));
     channel.bind('admin-users-found', () => {
       getData(skipLoading)
@@ -292,7 +292,7 @@ export const AccountManagement: React.SFC<AccountManagementProps> = ({
   }
 
 
-  const schoolOptions = model.schools.map(school => ({ value: school.id, label: school.name}))
+  const schoolOptions = model.schools.map(school => ({ value: school.id, label: school.name }))
 
   const filteredData = model.teachers.filter((d: { school: string }) => d.schools.find(s => s.id === selectedSchoolId)).map(user => {
     const relevantSchool = user.schools.find(s => s.id === selectedSchoolId)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/Overview.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/Overview.tsx
@@ -23,7 +23,7 @@ const Overview = ({ adminId, accessType, passedModel, adminInfo, }) => {
   useSnackbarMonitor(showSnackbar, setShowSnackbar, defaultSnackbarTimeout)
 
   React.useEffect(() => {
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channel = pusher.subscribe(String(adminId));
     setPusherChannel(channel)
   }, [])

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -74,7 +74,7 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
   useHideFooter()
 
   React.useEffect(() => {
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channel = pusher.subscribe(String(adminInfo.id));
     setPusherChannel(channel)
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/SchoolSubscriptionsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/SchoolSubscriptionsContainer.tsx
@@ -39,7 +39,7 @@ const SchoolSubscriptionsContainer = ({ location, accessType, adminInfo, }) => {
     setSelectedSchoolId(selectedSchoolOption.value)
   }
 
-  function getSubscriptionData(callback=null) {
+  function getSubscriptionData(callback = null) {
     requestGet('/subscriptions/school_admin_subscriptions', (body) => {
       setSchools(body.schools)
       setStripeInvoiceId(body.stripe_invoice_id)
@@ -94,7 +94,7 @@ const SchoolSubscriptionsContainer = ({ location, accessType, adminInfo, }) => {
   }
 
   function initializePusherForStripePurchaseConfirmation() {
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channelName = String(stripeInvoiceId)
     const channel = pusher.subscribe(channelName);
 
@@ -107,7 +107,7 @@ const SchoolSubscriptionsContainer = ({ location, accessType, adminInfo, }) => {
   function initializePusherForStripeSubscriptionPaymentMethodUpdating() {
     const { stripe_subscription_id } = selectedSchool.subscription_status
 
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channelName = String(stripe_subscription_id)
     const channel = pusher.subscribe(channelName);
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendations.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendations.tsx
@@ -84,7 +84,7 @@ const LessonRecommendation = ({ previouslyAssignedRecommendations, selections, s
   })
 
   return (
-    <section className={`lessons-recommendation ${isExpanded? 'is-expanded' : ''} ${isRecommended && !isAssigned ? 'is-recommended-and-not-assigned' : ''}`}>
+    <section className={`lessons-recommendation ${isExpanded ? 'is-expanded' : ''} ${isRecommended && !isAssigned ? 'is-recommended-and-not-assigned' : ''}`}>
       <div className="top-row">
         <div>
           {isRecommended ? recommendedGlyph : <span className="recommended-glyph-placeholder" />}
@@ -158,7 +158,7 @@ const RecommendationsButtons = ({ className, parentClassName, numberSelected, as
   )
 }
 
-const PostTestAssignmentButton = ({ assigningPostTest, assignedPostTest, assignPostTest, numberSelectedForPostTest, releaseMethod}) => {
+const PostTestAssignmentButton = ({ assigningPostTest, assignedPostTest, assignPostTest, numberSelectedForPostTest, releaseMethod }) => {
   let assignDivClass
   if (releaseMethod) {
     assignDivClass = "larger-assign"
@@ -181,7 +181,7 @@ const PostTestAssignmentButton = ({ assigningPostTest, assignedPostTest, assignP
   )
 }
 
-const IndependentRecommendationsButtons = ({ handleClickAssignActivityPacks, independentSelections, setIndependentSelections, recommendations, students, assigned, assigning, previouslyAssignedRecommendations, releaseMethod, setShowReleaseMethodModal,}) => {
+const IndependentRecommendationsButtons = ({ handleClickAssignActivityPacks, independentSelections, setIndependentSelections, recommendations, students, assigned, assigning, previouslyAssignedRecommendations, releaseMethod, setShowReleaseMethodModal, }) => {
   function handleClickEditReleaseMethod() { setShowReleaseMethodModal(true) }
 
   function handleSelectAllClick() {
@@ -388,11 +388,11 @@ export const Recommendations = ({ passedPreviouslyAssignedRecommendations, passe
     }));
   }
 
-  function initializePusher(isLessons=false) {
+  function initializePusher(isLessons = false) {
     if (process.env.RAILS_ENV === 'development') {
       Pusher.logToConsole = true;
     }
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channel = pusher.subscribe(classroomId);
     if (isLessons) {
       channel.bind('lessons-recommendations-assigned', (data) => {
@@ -425,7 +425,7 @@ export const Recommendations = ({ passedPreviouslyAssignedRecommendations, passe
 
   function assignLessonsActivityPacks() {
     initializePusher(true)
-    requestPost('/teachers/progress_reports/assign_whole_class_instruction_packs/', { unit_template_ids: lessonsSelections, classroom_id: params.classroomId }, (data) => {}, (data) => {
+    requestPost('/teachers/progress_reports/assign_whole_class_instruction_packs/', { unit_template_ids: lessonsSelections, classroom_id: params.classroomId }, (data) => { }, (data) => {
       alert(TROUBLE_PROCESSING_MESSAGE);
     })
   }
@@ -444,7 +444,7 @@ export const Recommendations = ({ passedPreviouslyAssignedRecommendations, passe
         ]
       }
     });
-    return { selections: independentSelectionsArr ,};
+    return { selections: independentSelectionsArr, };
   }
 
   function assignIndependentActivityPacks() {
@@ -458,7 +458,7 @@ export const Recommendations = ({ passedPreviouslyAssignedRecommendations, passe
     }
     setIndependentAssigning(true)
     initializePusher()
-    requestPost('/teachers/progress_reports/assign_independent_practice_packs/', dataToPass, (data) => {}, (data) => {
+    requestPost('/teachers/progress_reports/assign_independent_practice_packs/', dataToPass, (data) => { }, (data) => {
       alert(TROUBLE_PROCESSING_MESSAGE);
       setIndependentAssigning(false)
     })

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/export_csv.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/export_csv.jsx
@@ -45,7 +45,7 @@ export default class ExportCSV extends React.Component {
     if (process.env.RAILS_ENV === 'development') {
       Pusher.logToConsole = true;
     }
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     let teacherId = this.props.teacher.id
     const channel = pusher.subscribe(teacherId.toString());
     const that = this;

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -92,7 +92,7 @@ class StudentProfile extends React.Component {
       if (process.env.RAILS_ENV === 'development') {
         Pusher.logToConsole = true;
       }
-      const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+      const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
       const channel = pusher.subscribe(classroomId.toString());
       channel.bind('lesson-launched', () => {
         fetchStudentProfile(classroomId);

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/Subscriptions.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/Subscriptions.jsx
@@ -85,7 +85,7 @@ export default class Subscriptions extends React.Component {
 
   initializePusherForStripePurchaseConfirmation() {
     const { stripeInvoiceId } = this.props
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channelName = String(stripeInvoiceId)
     const channel = pusher.subscribe(channelName);
 
@@ -99,7 +99,7 @@ export default class Subscriptions extends React.Component {
     const { subscriptionStatus } = this.props
     const { stripe_subscription_id } = subscriptionStatus
 
-    const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+    const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     const channelName = String(stripe_subscription_id)
     const channel = pusher.subscribe(channelName);
 

--- a/services/QuillLMS/client/app/modules/pusherInitializer.ts
+++ b/services/QuillLMS/client/app/modules/pusherInitializer.ts
@@ -3,7 +3,7 @@ import Pusher from 'pusher-js';
 const pusherInitializer = (id: number, channelEvent: string, callback?: () => void) => {
   if (process.env.RAILS_ENV === 'development') { Pusher.logToConsole = true; }
 
-  const pusher = new Pusher(process.env.PUSHER_KEY, { encrypted: true, cluster: process.env.PUSHER_CLUSTER });
+  const pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
   const channelName = String(id)
   const channel = pusher.subscribe(channelName);
 

--- a/services/QuillLMS/spec/pusher_modules/pusher_csv_export_completed_spec.rb
+++ b/services/QuillLMS/spec/pusher_modules/pusher_csv_export_completed_spec.rb
@@ -15,7 +15,7 @@ describe PusherCSVExportCompleted do
         app_id: ENV['PUSHER_APP_ID'],
         key: ENV['PUSHER_KEY'],
         secret: ENV['PUSHER_SECRET'],
-        encrypted: true
+        use_tls: true
       )
       expect(client).to receive(:trigger).with("1", "csv-export-completed", message: "some_url")
       described_class.run(1, "some_url")

--- a/services/QuillLMS/spec/pusher_modules/pusher_recommendation_completed_spec.rb
+++ b/services/QuillLMS/spec/pusher_modules/pusher_recommendation_completed_spec.rb
@@ -17,7 +17,7 @@ describe PusherRecommendationCompleted do
           app_id: ENV["PUSHER_APP_ID"],
           key: ENV["PUSHER_KEY"],
           secret: ENV["PUSHER_SECRET"],
-          encrypted: true
+          use_tls: true
         )
         expect(client).to receive(:trigger).with(
           "some_id",
@@ -34,7 +34,7 @@ describe PusherRecommendationCompleted do
           app_id: ENV["PUSHER_APP_ID"],
           key: ENV["PUSHER_KEY"],
           secret: ENV["PUSHER_SECRET"],
-          encrypted: true
+          use_tls: true
         )
         expect(client).to receive(:trigger).with(
           "some_id",


### PR DESCRIPTION
## WHAT
While investigating a bug with admin account management I noticed that `encrypted` configuration for frontend/backend is need of updating.

## WHY
1.  The `encrypted: true` will be deprecated soon.
![Screenshot 2024-02-23 at 7 25 25 AM](https://github.com/empirical-org/Empirical-Core/assets/2057805/d9ba8462-47f7-4f91-83e7-93f09751f803)

2.  The `encrypted: true` key is deprecated in pusher-js.
Fortunately, the new key `forceTLS` is enabled by [default](https://github.com/pusher/pusher-js?tab=readme-ov-file#forcetls-boolean)

## HOW
1. Update pusher backend configuration by changing `encrypted: true` entries to `use_tls: true`
2. Update pusher frontend configuration by removing `encrypted: true` entries

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
After pushing this to staging, I tried some user flow that rely on pusher notifications (e.g. import a google classroom and making unlink a teacher through admin account management).


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No new functionality, just configuration change.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
