### PR TITLE
persist the selected school in the account management file

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/AccountManagement.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/AccountManagement.tsx
@@ -62,13 +62,20 @@ export const AccountManagement: React.SFC<AccountManagementProps> = ({
   const [showModal, setShowModal] = React.useState(null)
   const [error, setError] = React.useState('')
   const [selectedSchoolId, setSelectedSchoolId] = React.useState(null)
+  const selectedSchoolIdRef = React.useRef(selectedSchoolId);
 
-  React.useEffect(getData, [])
+  React.useEffect(() => {
+    initializePusher(false)
+    getData()
+  }, [])
+
+  React.useEffect(() => {
+    selectedSchoolIdRef.current = selectedSchoolId;
+  }, [selectedSchoolId]);
 
   useSnackbarMonitor(showSnackbar, setShowSnackbar, defaultSnackbarTimeout)
 
   function getData(skipLoading = false) {
-    initializePusher(skipLoading);
     requestGet(
       `${process.env.DEFAULT_URL}/admins/${adminId}`,
       (body) => {
@@ -80,8 +87,10 @@ export const AccountManagement: React.SFC<AccountManagementProps> = ({
   function receiveData(data, skipLoading) {
     if (Object.keys(data).length > 1) {
       setModel(data)
-      const defaultSchool = data.schools.find(s => s.id === data.associated_school?.id) || data.schools[0]
-      setSelectedSchoolId(defaultSchool?.id)
+      if (!selectedSchoolIdRef.current) {
+        const defaultSchool = data.schools.find(s => s.id === data.associated_school?.id) || data.schools[0]
+        setSelectedSchoolId(defaultSchool?.id)
+      }
       setLoading(false)
     } else if (!skipLoading) {
       setModel(data)
@@ -131,7 +140,6 @@ export const AccountManagement: React.SFC<AccountManagementProps> = ({
 
   function handleUserAction(link, data) {
     setError('')
-    initializePusher(true)
     requestPost(
       link,
       data,


### PR DESCRIPTION
## WHAT
Fix bug where selected school kept reverting when a user made changes on the Account Management page.

## WHY
This was bad UX.

## HOW
Add a `ref` to the `selectedSchoolId` to get around the Javascript closure that was causing `selectedSchoolId` to be null even when it existed in the external state.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/School-filter-in-Premium-Hub-s-Account-Management-Page-does-not-stay-on-selection-while-making-chang-72ef60f9759c486eacab6933f18e1fd9

### What have you done to QA this feature?
With a local environment attached to a staging database, I switched classrooms, updated an admin account to a teacher account, and waited to confirm that when the data reloaded, the school did not change.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES