### PR TITLE
fix grammar incorrect sequences page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -13,11 +13,7 @@ class IncorrectSequencesContainer extends React.Component {
     super(props);
 
     const question = this.props.questions.data[this.props.match.params.questionID]
-    const incorrectSequencesWithUids = question.incorrectSequences.map(is => {
-      is.uid = is.uid || uuid()
-      return is
-    });
-    this.state = { orderedIds: null, incorrectSequences: incorrectSequencesWithUids, }
+    this.state = { orderedIds: null, incorrectSequences: question.incorrectSequences, }
   }
 
   UNSAFE_componentWillMount() {
@@ -122,7 +118,7 @@ class IncorrectSequencesContainer extends React.Component {
     const { orderedIds, incorrectSequences } = this.state
     if (orderedIds) {
       const sequencesCollection = hashToCollection(incorrectSequences)
-      return orderedIds.map(id => sequencesCollection.find(s => s.uid === id))
+      return orderedIds.map(id => sequencesCollection.find(s => s.key === id))
     } else {
       return hashToCollection(incorrectSequences).sort((a, b) => a.order - b.order);
     }
@@ -166,7 +162,7 @@ class IncorrectSequencesContainer extends React.Component {
     const components = this.sequencesSortedByOrder().map((seq) => {
       const onClickDelete = () => { this.handleDeleteSequence(seq.key) }
       return (
-        <div className="card is-fullwidth has-bottom-margin" id={seq.uid} key={seq.uid}>
+        <div className="card is-fullwidth has-bottom-margin" id={seq.key} key={seq.key}>
           <header className="card-header">
             <input className="regex-name" onChange={(e) => this.handleNameChange(e, seq.key)} placeholder="Name" type="text" value={seq.name || ''} />
           </header>


### PR DESCRIPTION
## WHAT
Stop trying to `map` a hash and use the `key` attribute rather than a generated iud, since apparently grammar incorrect sequences are actually structured the way focus points are elsewhere.

## WHY
This fixes a bug I introduced this morning.

## HOW
Remove code I added this morning, and use `key` as the attribute for the `id` and `key` of the components because it actually is a unique identifier here (unlike in Connect and Diagnostic).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-access-Grammar-Incorrect-Sequences-0682db2a6d0346e9b464a61c1531661b

### What have you done to QA this feature?
I reloaded the page, confirmed that it does load now, and edited and reordered some incorrect sequences to confirm that other page behaviors work as well.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? |  NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
