### PR TITLE
some additional demo changes

### DIFF
--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -52,7 +52,15 @@ class Demo::CreateAdminReport
     UserSubscription.create!(user_id: user.id, subscription: subscription)
     user.record_login # necessary to populate the active teachers count for the usage snapshot report
 
+    create_milestones_and_teacher_info_for_user(user)
+
     user
+  end
+
+  private def create_milestones_and_teacher_info_for_user(user)
+    milestone = Milestone.find_by_name(Milestone::TYPES[:see_welcome_modal])
+    UserMilestone.find_or_create_by(milestone: milestone, user: user)
+    TeacherInfo.create(user: user, minimum_grade_level: 0, maximum_grade_level: 12)
   end
 
   private def create_demo
@@ -65,6 +73,10 @@ class Demo::CreateAdminReport
       password: SecureRandom.urlsafe_base64
     )
     subscription = Subscription.create!(purchaser_id: admin_teacher.id, account_type: Subscription::SCHOOL_DISTRICT_PAID, expiration: Date.current + 100.years)
+    school = find_or_create_school(data[0]['School'])
+    SchoolsUsers.find_or_create_by(school: school, user: admin_teacher)
+
+    create_milestones_and_teacher_info_for_user(admin_teacher)
 
     all_classrooms = []
 

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -59,7 +59,8 @@ class Demo::CreateAdminReport
   private def create_milestones_and_teacher_info_for_user(user)
     milestone = Milestone.find_by_name(Milestone::TYPES[:see_welcome_modal])
     UserMilestone.find_or_create_by(milestone: milestone, user: user)
-    TeacherInfo.create(user: user, minimum_grade_level: 0, maximum_grade_level: 12)
+    teacher_info = TeacherInfo.find_or_create_by(user: user)
+    teacher_info.update(minimum_grade_level: 0, maximum_grade_level: 12)
   end
 
   private def create_demo

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -58,8 +58,8 @@ class Demo::CreateAdminReport
 
   private def create_milestones_and_teacher_info_for_user(user)
     milestone = Milestone.find_by_name(Milestone::TYPES[:see_welcome_modal])
-    UserMilestone.find_or_create_by(milestone: milestone, user: user)
-    teacher_info = TeacherInfo.find_or_create_by(user: user)
+    UserMilestone.find_or_create_by(milestone:, user:)
+    teacher_info = TeacherInfo.find_or_create_by(user:)
     teacher_info.update(minimum_grade_level: 0, maximum_grade_level: 12)
   end
 
@@ -100,9 +100,12 @@ class Demo::CreateAdminReport
 
     # delete some activity sessions to make data more varied
     all_classrooms.each do |classroom|
-      activity_sessions_for_classroom = ActivitySession.joins(:classroom_unit).where('classroom_units.classroom_id = ?', classroom.id).where.not(activity_id: Activity::PRE_TEST_DIAGNOSTIC_IDS)
-      number_of_sessions_to_destroy = (RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY).to_a.sample
-      activity_sessions_for_classroom.sample(number_of_sessions_to_destroy).each { |as| as.destroy }
+      ActivitySession
+        .joins(:classroom_unit)
+        .where(classroom_units: {classroom_id: classroom.id})
+        .where.not(activity_id: Activity::PRE_TEST_DIAGNOSTIC_IDS)
+        .sample(rand(RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY))
+        .each(&:destroy)
     end
   end
 

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -2,8 +2,7 @@
 
 class Demo::CreateAdminReport
 
-  NUMBER_OF_CLASSROOMS_TO_DESTROY_SESSIONS_FOR = 20
-  RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY = 14..28 # 10-20% of 140
+  RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY = 1..20
   BATCH_DELAY = 1.minute
   NUMBER_OF_STUDENTS_PER_CLASSROOM = 25
 
@@ -99,8 +98,8 @@ class Demo::CreateAdminReport
     end
 
     # delete some activity sessions to make data more varied
-    all_classrooms.sample(NUMBER_OF_CLASSROOMS_TO_DESTROY_SESSIONS_FOR).each do |classroom|
-      activity_sessions_for_classroom = ActivitySession.joins(:classroom_unit).where('classroom_units.classroom_id = ?', classroom.id)
+    all_classrooms.each do |classroom|
+      activity_sessions_for_classroom = ActivitySession.joins(:classroom_unit).where('classroom_units.classroom_id = ?', classroom.id).where.not(activity_id: Activity::PRE_TEST_DIAGNOSTIC_IDS)
       number_of_sessions_to_destroy = (RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY).to_a.sample
       activity_sessions_for_classroom.sample(number_of_sessions_to_destroy).each { |as| as.destroy }
     end

--- a/services/QuillLMS/lib/data/demo/admin_demo_data.yml
+++ b/services/QuillLMS/lib/data/demo/admin_demo_data.yml
@@ -54,157 +54,157 @@
   Teacher: Madeleine L'engle
   Classroom: Period 5
 
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Celeste Ng
   Classroom: English Honors
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Celeste Ng
   Classroom: English I
 
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Lorrie Moore
   Classroom: English II - 1a
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Lorrie Moore
   Classroom: English II - 2a
 
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Julia Alvarez
   Classroom: Pre-AP
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Julia Alvarez
   Classroom: AP
 
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Ta-Nehisi Coates
   Classroom: Intro to Journalism I
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Ta-Nehisi Coates
   Classroom: Intro to Journalism II
 
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Jhumpa Lahiri
   Classroom: Short Story Writing
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Jhumpa Lahiri
   Classroom: Short Story Writing (Honors)
 
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Zora Neale Hurston
   Classroom: Pre-AP English - 7b
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: Zora Neale Hurston
   Classroom: Pre-AP English - 8a
 
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: N.K. Jemisin
   Classroom: English AP
-- School: MLK Middle School
+- School: Parks Elementary School
   Teacher: N.K. Jemisin
   Classroom: English Pre-AP
 
-- School: MLK Middle School
+- School: Tubman Leadership Academy
   Teacher: Nick Hornby
   Classroom: Period 3
-- School: MLK Middle School
+- School: Tubman Leadership Academy
   Teacher: Nick Hornby
   Classroom: Period 4
 
-- School: MLK Middle School
+- School: Tubman Leadership Academy
   Teacher: Octavia Butler
   Classroom: Creative Writing 1
-- School: MLK Middle School
+- School: Tubman Leadership Academy
   Teacher: Octavia Butler
   Classroom: Creative Writing 2
 
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: Kevin Kwan
   Classroom: Period 4
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: Kevin Kwan
   Classroom: Period 5
 
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: Bram Stoker
   Classroom: ELA Block 2
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: Bram Stoker
   Classroom: ELA Block 3
 
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: Emily Acevedo
   Classroom: Period 2
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: Emily Acevedo
   Classroom: Period 3
 
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: Paul Coelho
   Classroom: Humanities 1a
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: Paul Coelho
   Classroom: Humanities 2a
 
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: George Orwell
   Classroom: Period 8
-- School: Douglass High School
+- School: Tubman Leadership Academy
   Teacher: George Orwell
   Classroom: Period 7
 
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: James Joyce
   Classroom: European Literature 7a
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: James Joyce
   Classroom: European Literature 8a
 
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Harriet Beecher Stowe
   Classroom: Period 9
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Harriet Beecher Stowe
   Classroom: Period 8
 
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Ralph Ellison
   Classroom: AP English - Composition
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Ralph Ellison
   Classroom: AP English - American Literature
 
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Judy Blume
   Classroom: AP English - Composition
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Judy Blume
   Classroom: AP English - American Literature
 
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Zadie Smith
   Classroom: English II - Period 1
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Zadie Smith
   Classroom: English II - Period 2
 
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Marie Shelley
   Classroom: Period 5
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Marie Shelley
   Classroom: Period 6
 
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Margaret Atwood
   Classroom: ELA 1H
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: Margaret Atwood
   Classroom: ELA 2H
 
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: James McBride
   Classroom: English - Period 6
-- School: Douglass High School
+- School: Chavez Community School
   Teacher: James McBride
   Classroom: English - Period 7
 

--- a/services/QuillLMS/spec/factories/milestones.rb
+++ b/services/QuillLMS/spec/factories/milestones.rb
@@ -73,5 +73,9 @@ FactoryBot.define do
       name { 'Dismiss Unassign Warning Modal' }
     end
 
+    factory :see_welcome_modal do
+      name { 'See Welcome Modal' }
+    end
+
   end
 end

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Demo::CreateAdminReport do
   }
   let(:admin) { User.find_by(email: teacher_email, role: User::ADMIN) }
   let(:subscription) { Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID) }
+  let!(:milestone) { create(:see_welcome_modal) }
 
   subject { described_class.new(teacher_email, passed_data) }
 

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe Demo::CreateAdminReport do
   let(:admin) { User.find_by(email: teacher_email, role: User::ADMIN) }
   let(:subscription) { Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID) }
   let!(:milestone) { create(:see_welcome_modal) }
+  let(:delay) { 0 }
 
-  subject { described_class.new(teacher_email, passed_data, 0) }
+  subject { described_class.new(teacher_email, passed_data, delay) }
 
   before do
     Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Demo::CreateAdminReport do
   let(:subscription) { Subscription.find_by(purchaser: admin, account_type: Subscription::SCHOOL_DISTRICT_PAID) }
   let!(:milestone) { create(:see_welcome_modal) }
 
-  subject { described_class.new(teacher_email, passed_data) }
+  subject { described_class.new(teacher_email, passed_data, 0) }
 
   before do
     Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES
@@ -36,7 +36,7 @@ RSpec.describe Demo::CreateAdminReport do
   it 'should create an admin user with the passed email who has purchased a district subscription, has premium, and has the see welcome modal milestone and teacher info' do
     expect(admin).to be
     expect(subscription).to be
-    expect(admin.district_premium?).to be
+    expect(admin.subscription).to be
     expect(UserMilestone.exists?(user: admin, milestone: milestone)).to be true
     expect(TeacherInfo.exists?(user: admin)).to be true
   end

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -33,9 +33,12 @@ RSpec.describe Demo::CreateAdminReport do
     subject.call
   end
 
-  it 'should create an admin user with the passed email who has purchased a district subscription' do
+  it 'should create an admin user with the passed email who has purchased a district subscription, has premium, and has the see welcome modal milestone and teacher info' do
     expect(admin).to be
     expect(subscription).to be
+    expect(admin.district_premium?).to be
+    expect(UserMilestone.exists?(user: admin, milestone: milestone)).to be true
+    expect(TeacherInfo.exists?(user: admin)).to be true
   end
 
   it 'should create the schools from the data hash and make the admin an administrator of them' do
@@ -48,7 +51,7 @@ RSpec.describe Demo::CreateAdminReport do
     end
   end
 
-  it 'should create every teacher account from the data hash, associated with the correct school and with a login record' do
+  it 'should create every teacher account from the data hash, associated with the correct school, and with a login record, see welcome modal milestone, and teacher info' do
     schools_and_teachers = subject.data.map { |d| { 'School' => d['School'], 'Teacher' => d['Teacher'] } }.uniq
     schools_and_teachers.each do |row|
       teacher = User.find_by_name(row['Teacher'])
@@ -56,6 +59,8 @@ RSpec.describe Demo::CreateAdminReport do
       expect(SchoolsUsers.find_by(school: school, user: teacher)).to be
       expect(UserSubscription.find_by(user: teacher, subscription: subscription)).to be
       expect(UserLogin.exists?(user: teacher)).to be true
+      expect(UserMilestone.exists?(user: teacher, milestone: milestone)).to be true
+      expect(TeacherInfo.exists?(user: admin)).to be true
     end
   end
 


### PR DESCRIPTION
## WHAT
Some additional demo changes to make sure all fields in the usage snapshot report are accounted for and look good, none of the new-account modals pop up when you use the account or any of the associated teacher accounts, and that the data is split between five schools.

## WHY
We want this to meet all of our needs.

## HOW
Just tweaking the generation script and data.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Follow-up-updates-for-admin-demo-account-e95d5a2ea99d431ea540b1c01063906a?pvs=4

### What have you done to QA this feature?
Ran the worker on staging and confirmed that all the data that is accessible (ie, not in BigQuery) looks the way that it should. When I run this on production, I will call the worker with an alternative email and have Alex and Peter Sharkey review before I port the data over to the main admin_demo account.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
