### PR TITLE
Add neighbor gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
     working_directory: ~/Empirical-Core
     parallelism: 3
     docker:
-      - image: circleci/node:fermium
+      - image: cimg/node:14.21
     steps:
       - checkout
       - run:
@@ -371,7 +371,7 @@ jobs:
   node_lint:
     working_directory: ~/Empirical-Core
     docker:
-      - image: circleci/node:erbium
+      - image: cimg/node:14.21
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,12 @@ jobs:
           PG_USER: ubuntu
           RAILS_ENV: test
           RACK_ENV: test
-      - image: postgres:15.6-alpine
+      - image: pgvector/pgvector:pg15
         environment:
           POSTGRES_DB: quill_test_db
           POSTGRES_USER: ubuntu
           POSTGRES_PASSWORD: password
-      - image: postgres:15.6-alpine
+      - image: pgvector/pgvector:pg15
         name: test_replica
         environment:
           POSTGRES_DB: quill_test_db
@@ -78,7 +78,7 @@ jobs:
           RACK_ENV: test
           SELENIUM_DRIVER_URL: http://localhost:4444/wd/hub
           DEFAULT_URL: http://localhost:3000
-      - image: postgres:15.6-alpine
+      - image: pgvector/pgvector:pg15
         environment:
           POSTGRES_DB: quill_test_db
           POSTGRES_USER: ubuntu
@@ -123,6 +123,7 @@ jobs:
             echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
             sudo apt-get update
             sudo apt-get install -y postgresql-client-15
+
       - run:
           name: Copy Config files
           command: |
@@ -155,12 +156,12 @@ jobs:
           PG_USER: ubuntu
           RAILS_ENV: test
           RACK_ENV: test
-      - image: postgres:15.6-alpine
+      - image: pgvector/pgvector:pg15
         environment:
           POSTGRES_DB: quill_test_db
           POSTGRES_USER: ubuntu
           POSTGRES_PASSWORD: password
-      - image: postgres:15.6-alpine
+      - image: pgvector/pgvector:pg15
         name: test_replica
         environment:
           POSTGRES_DB: quill_test_db
@@ -319,12 +320,12 @@ jobs:
           PG_USER: ubuntu
           RAILS_ENV: test
           RACK_ENV: test
-      - image: postgres:15.6-alpine
+      - image: pgvector/pgvector:pg15
         environment:
           POSTGRES_USER: ubuntu
           POSTGRES_DB: quill_evidence_test_db
           POSTGRES_PASSWORD: password
-      - image: circleci/redis:6.0.9
+      - image: cimg/redis:6.0.20
     steps:
       - checkout
       - restore_cache:

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
     evidence (0.0.11)
       google-cloud-ai_platform (~> 1.0.0)
       hotwater (= 0.1.2)
+      neighbor (~> 0.3.2)
       pragmatic_segmenter (~> 0.3.23)
       rails (= 7.0.6)
       sprockets-rails (= 3.2.2)
@@ -439,6 +440,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
+    neighbor (0.3.2)
+      activerecord (>= 6.1)
     nested_form (0.3.2)
     net-imap (0.3.7)
       date

--- a/services/QuillLMS/db/migrate/20240221192859_install_neighbor_vector.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240221192859_install_neighbor_vector.evidence.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class InstallNeighborVector < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension "vector"
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -80,6 +80,20 @@ COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching
 
 
 --
+-- Name: vector; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION vector; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION vector IS 'vector data type and ivfflat and hnsw access methods';
+
+
+--
 -- Name: blog_posts_search_trigger(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -10757,6 +10771,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231207135455'),
 ('20231207151344'),
 ('20231214182438'),
-('20240111143245');
+('20240111143245'),
+('20240221192859');
 
 

--- a/services/QuillLMS/engines/evidence/Gemfile.lock
+++ b/services/QuillLMS/engines/evidence/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     evidence (0.0.11)
       google-cloud-ai_platform (~> 1.0.0)
       hotwater (= 0.1.2)
+      neighbor (~> 0.3.2)
       pragmatic_segmenter (~> 0.3.23)
       rails (= 7.0.6)
       sprockets-rails (= 3.2.2)
@@ -192,6 +193,8 @@ GEM
     minitest-stub_any_instance (1.0.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
+    neighbor (0.3.2)
+      activerecord (>= 6.1)
     net-imap (0.3.7)
       date
       net-protocol

--- a/services/QuillLMS/engines/evidence/db/migrate/20240221192859_install_neighbor_vector.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240221192859_install_neighbor_vector.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class InstallNeighborVector < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension "vector"
+  end
+end

--- a/services/QuillLMS/engines/evidence/evidence.gemspec
+++ b/services/QuillLMS/engines/evidence/evidence.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'google-cloud-ai_platform', '~> 1.0.0'
   s.add_dependency 'hotwater', '0.1.2'
+  s.add_dependency 'neighbor', '~> 0.3.2'
   s.add_dependency 'pragmatic_segmenter', '~> 0.3.23'
   s.add_dependency 'rails', '7.0.6'
   s.add_dependency 'sprockets-rails', '3.2.2'

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -9,6 +9,20 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+--
+-- Name: vector; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION vector; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION vector IS 'vector data type and ivfflat and hnsw access methods';
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -1511,6 +1525,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230306215123'),
 ('20230306215326'),
 ('20230306215624'),
-('20230911142601');
+('20230911142601'),
+('20240221192859');
 
 


### PR DESCRIPTION
## WHAT
1.  Add the `neighbor` gem
2. Enable the postgres extension `vector`

## WHY
1.  The gem offers convenience methods for calculating similarity between vector types
2.  The vector extension allows for postgres to handle embeddings effectively

## HOW
1.  Add `neighbor` to the engine's gemspec.
2.  `rails generate neighbor:vector` produces a migration file that will enable the vector extension.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Backend-for-Embeddings-Caching-for-Evidence-2f735c61f06848eeb8fc5c2130390c1f?pvs=4

### What have you done to QA this feature?
This is more of a configuration for future features.  There isn't really much to test here other than the migration going through successfully.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Just configuration
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
