### PR TITLE
fix bug with feedback text editor for incorrect sequences/focus points

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/sortableList.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/sortableList.tsx
@@ -66,17 +66,28 @@ export class KeyboardSensorThatHandlesElementType extends KeyboardSensor {
     {
       eventName: 'onKeyDown' as const,
       handler: ({ nativeEvent: event }: React.KeyboardEvent<Element>) => {
-        return shouldHandleKeyboardEvent(event)
+        return shouldHandleEvent(event)
       }
     }
   ]
 }
 
-function shouldHandleKeyboardEvent(event) {
+export class PointerSensorThatHandlesElementType extends PointerSensor {
+  static activators = [
+    {
+      eventName: 'onPointerDown' as const,
+      handler: ({ nativeEvent: event }: React.PointerEvent<Element>) => {
+        return shouldHandleEvent(event)
+      }
+    }
+  ]
+}
+
+function shouldHandleEvent(event) {
   const activeElement = document.activeElement;
   const tagNames = [INPUT, SELECT, TEXTAREA, BUTTON];
-  // Prevent keyboard sensor activation if focused on input, select, textarea, or button
-  if (activeElement && (tagNames.includes(activeElement.tagName) || activeElement.attributes['contenteditable'].value === 'true')) {
+  // Prevent sensor activation if focused on input, select, textarea, or button
+  if (activeElement && (tagNames.includes(activeElement.tagName) || activeElement.attributes['contenteditable']?.value === 'true')) {
     return false;
   }
   return true; // Return true to allow activation in other cases
@@ -87,7 +98,7 @@ export const SortableList = ({ data, sortCallback, helperClass, useDragHandle, }
   const [activeId, setActiveId] = React.useState(null)
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(PointerSensorThatHandlesElementType, {
       activationConstraint: {
         distance: 8,
       },


### PR DESCRIPTION
## WHAT
Fix bug with the feedback text editor for incorrect sequences and focus points.

## WHY
We want the curriculum team to be able to highlight text to delete or overwrite it without anything weird happening.

## HOW
Replace the `PointerSensor` in the sortable list component with a sensor that does not activate on inputs, textareas, buttons, or contenteditable elements -- the issue was that the component was perceiving the highlight action as a drag.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Inline-editing-not-working-in-Connect-CMS-b6c43cf969d440cc81f85610e3728023?d=f6aae71e3ec3451e85d18c7f27c8d8da

### What have you done to QA this feature?
I reproduced the issue locally following the same actions Rachel did in the video, and then I made the code change and performed the same actions, confirming that the bug no longer occurs.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
