### PR TITLE
Speed up create_admin_report

### DIFF
--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -105,7 +105,7 @@ class Demo::CreateAdminReport
         .where(classroom_units: {classroom_id: classroom.id})
         .where.not(activity_id: Activity::PRE_TEST_DIAGNOSTIC_IDS)
         .sample(rand(RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY))
-        .each(&:destroy)
+        .each(&:delete)
     end
   end
 


### PR DESCRIPTION
## WHAT
Change a `destroy` call on a collection of activity session records to a `delete` call

## WHY
The circleci `lms_rails_build` has been taking significantly longer than [normal](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/27312/workflows/c9012cce-47fe-493d-8494-90a0bae70ea8/jobs/303771/parallel-runs/3/steps/3-108).  I did some profiling and noticed that it's due to the admin report specs:
![image](https://github.com/empirical-org/Empirical-Core/assets/2057805/8cf79c37-cda5-497a-86dc-55275f50829b)

## HOW
`destroy` can take much longer due to the callbacks and validations.

Important:  I'm making an assumption that we're not counting on the destroy call to in turn do some cleanup with other associated items.  If it is, we'll need to update the script.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO', this is meant to change the cleanup of records.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES.
