### PR TITLE
add migration to add show_students_exact_score to teacher_infos

### DIFF
--- a/services/QuillLMS/app/models/teacher_info.rb
+++ b/services/QuillLMS/app/models/teacher_info.rb
@@ -9,6 +9,7 @@
 #  minimum_grade_level          :integer
 #  notification_email_frequency :text
 #  role_selected_at_signup      :string           default("")
+#  show_students_exact_score    :boolean          default(TRUE), not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  user_id                      :bigint           not null

--- a/services/QuillLMS/db/migrate/20240229153806_add_show_students_exact_score_to_teacher_info.rb
+++ b/services/QuillLMS/db/migrate/20240229153806_add_show_students_exact_score_to_teacher_info.rb
@@ -1,0 +1,5 @@
+class AddShowStudentsExactScoreToTeacherInfo < ActiveRecord::Migration[7.0]
+  def change
+    add_column :teacher_infos, :show_students_exact_score, :boolean, default: true, null: false
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -17,27 +17,6 @@ CREATE SCHEMA heroku_ext;
 
 
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: hstore; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -4860,7 +4839,8 @@ CREATE TABLE public.teacher_infos (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     role_selected_at_signup character varying DEFAULT ''::character varying,
-    notification_email_frequency text
+    notification_email_frequency text,
+    show_students_exact_score boolean DEFAULT true NOT NULL
 );
 
 
@@ -10219,7 +10199,7 @@ ALTER TABLE ONLY public.learn_worlds_account_course_events
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user", public, heroku_ext;
+SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20121024193845'),
@@ -10772,6 +10752,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231207151344'),
 ('20231214182438'),
 ('20240111143245'),
-('20240221192859');
+('20240221192859'),
+('20240229153806');
 
 

--- a/services/QuillLMS/spec/factories/teacher_infos.rb
+++ b/services/QuillLMS/spec/factories/teacher_infos.rb
@@ -9,6 +9,7 @@
 #  minimum_grade_level          :integer
 #  notification_email_frequency :text
 #  role_selected_at_signup      :string           default("")
+#  show_students_exact_score    :boolean          default(TRUE), not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  user_id                      :bigint           not null

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -9,6 +9,7 @@
 #  minimum_grade_level          :integer
 #  notification_email_frequency :text
 #  role_selected_at_signup      :string           default("")
+#  show_students_exact_score    :boolean          default(TRUE), not null
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  user_id                      :bigint           not null


### PR DESCRIPTION
## WHAT
Add a migration to add a `show_students_exact_score` attribute to `teacher_infos`.

## WHY
We will be using this new attribute for the project around showing students their score.

## HOW
Just add a migration, with default: true as specified in the spec, and annotate (with help from @brendanshean!)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-settings-migration-7f7f89860e8e4a238b524086e08d25e2?pvs=4

### What have you done to QA this feature?
I just ran a migration.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - just a migration
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
