### PR TITLE
replace ascii with apostrophe literal on usage snapshot report non-premium view

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/NonPremiumReport.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/NonPremiumReport.tsx
@@ -65,8 +65,8 @@ const NonPremiumReport = ({ showNewTag, headerText, subheaderText, bezelPath, te
           <h1>{headerText}</h1>
           <p>{subheaderText}</p>
           <div className="buttons">
-            <a className="quill-button contained primary large focus-on-light" href="https://calendly.com/alex-quill" rel="noopener noreferrer" target="_blank">Talk to sales</a>
-            <a className="quill-button contained primary large focus-on-light" href="/premium" target="_blank">Explore premium</a>
+            <a className="quill-button contained primary large focus-on-light" href="https://calendly.com/alex-quill" rel="noopener noreferrer" target="_blank">Talk to Sales</a>
+            <a className="quill-button contained primary large focus-on-light" href="/premium" target="_blank">Explore Premium</a>
           </div>
           <img alt="" className="bezel" src={`${nonPremiumReportViewImgSrc}/${bezelPath}`} />
         </section>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -409,7 +409,7 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
           subheaderText="Key insights to help you succeed. Included with Quill Premium."
           testimonial={{
             attribution: "Shannon Browne, Professional Learning Manager",
-            quote: "“The Usage Snapshot Report completely redefines the way administrators use Quill. It enables them to make faster, more informed decisions that directly benefit their students&#39; success. This report is a game-changer for any administrator seeking to enhance educational outcomes.“",
+            quote: "“The Usage Snapshot Report completely redefines the way administrators use Quill. It enables them to make faster, more informed decisions that directly benefit their students' success. This report is a game-changer for any administrator seeking to enhance educational outcomes.“",
             imgSrc: "overview/shannon_headshot.png"
           }}
         />

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DistrictActivityScores.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DistrictActivityScores.test.jsx.snap
@@ -103,14 +103,14 @@ exports[`DistrictActivityScores when the access type is limited renders 1`] = `
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Talk to sales
+                  Talk to Sales
                 </a>
                 <a
                   className="quill-button contained primary large focus-on-light"
                   href="/premium"
                   target="_blank"
                 >
-                  Explore premium
+                  Explore Premium
                 </a>
               </div>
               <img
@@ -230,14 +230,14 @@ exports[`DistrictActivityScores when the access type is restricted renders 1`] =
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Talk to sales
+                  Talk to Sales
                 </a>
                 <a
                   className="quill-button contained primary large focus-on-light"
                   href="/premium"
                   target="_blank"
                 >
-                  Explore premium
+                  Explore Premium
                 </a>
               </div>
               <img

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DistrictConceptReports.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DistrictConceptReports.test.jsx.snap
@@ -102,14 +102,14 @@ exports[`DistrictConceptReports when the access type is limited renders 1`] = `
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Talk to sales
+                  Talk to Sales
                 </a>
                 <a
                   className="quill-button contained primary large focus-on-light"
                   href="/premium"
                   target="_blank"
                 >
-                  Explore premium
+                  Explore Premium
                 </a>
               </div>
               <img
@@ -228,14 +228,14 @@ exports[`DistrictConceptReports when the access type is restricted renders 1`] =
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Talk to sales
+                  Talk to Sales
                 </a>
                 <a
                   className="quill-button contained primary large focus-on-light"
                   href="/premium"
                   target="_blank"
                 >
-                  Explore premium
+                  Explore Premium
                 </a>
               </div>
               <img

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DistrictStandardsReports.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DistrictStandardsReports.test.jsx.snap
@@ -80,14 +80,14 @@ exports[`DistrictStandardsReports when the access type is limited renders 1`] = 
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Talk to sales
+                  Talk to Sales
                 </a>
                 <a
                   className="quill-button contained primary large focus-on-light"
                   href="/premium"
                   target="_blank"
                 >
-                  Explore premium
+                  Explore Premium
                 </a>
               </div>
               <img
@@ -184,14 +184,14 @@ exports[`DistrictStandardsReports when the access type is restricted renders 1`]
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Talk to sales
+                  Talk to Sales
                 </a>
                 <a
                   className="quill-button contained primary large focus-on-light"
                   href="/premium"
                   target="_blank"
                 >
-                  Explore premium
+                  Explore Premium
                 </a>
               </div>
               <img

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/NonPremiumReport.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/NonPremiumReport.test.tsx.snap
@@ -31,14 +31,14 @@ exports[`NonPremiumReport it should render if all optional props are passed in 1
             rel="noopener noreferrer"
             target="_blank"
           >
-            Talk to sales
+            Talk to Sales
           </a>
           <a
             class="quill-button contained primary large focus-on-light"
             href="/premium"
             target="_blank"
           >
-            Explore premium
+            Explore Premium
           </a>
         </div>
         <img
@@ -143,14 +143,14 @@ exports[`NonPremiumReport it should render if only required props are passed in 
             rel="noopener noreferrer"
             target="_blank"
           >
-            Talk to sales
+            Talk to Sales
           </a>
           <a
             class="quill-button contained primary large focus-on-light"
             href="/premium"
             target="_blank"
           >
-            Explore premium
+            Explore Premium
           </a>
         </div>
         <img


### PR DESCRIPTION
## WHAT
Replace ascii with apostrophe literal on usage snapshot report non-premium view.

## WHY
It was rendering literally.

## HOW
Just replace the text.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
Peter Sharkey just Slacked me about it

### What have you done to QA this feature?
Deploying to staging to confirm change renders correctly.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
