### PR TITLE
allow teachers to change the setting for allowing students to see their scores

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/my_account.scss
@@ -47,9 +47,7 @@
   .dropdown-toggle.btn.btn-default {
     width: 300px;
   }
-  .error {
 
-  }
   .gray-text {
     color: #969696;
     .row {
@@ -130,28 +128,6 @@
     color: $quillforestgreen;
     margin-left: 3px;
   }
-  // .modal-dialog {
-  //   .modal-header {
-  //     min-height: 59px;
-  //   }
-  //   .account-form {
-  //     margin-bottom: 50px;
-  //   }
-  //   .close {
-  //     background-color: black;
-  //   }
-  //   .form-label, #zip{
-  //     float: none;
-  //     height: inherit;
-  //   line-height: inherit;
-  //   }
-  //   .row {
-  //     padding: 0px;
-  //   }
-  //   #select_school {
-  //     width: 50%;
-  //   }
-  // }
 }
 
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
@@ -164,38 +140,6 @@
   }
 }
 
-// @media (max-width: 767px) {
-//   #my-account {
-//     .form-row {
-//       display: flex;
-//       align-items: center;
-//       &.email-row {
-//         position: relative;
-//       }
-//       .form-button {
-//         margin-left: 4%;
-//       }
-//     }
-//     .form-label {
-//       width: 110% !important;
-//     }
-//     .form-input {
-//       input {
-//         margin-left: -125%;
-//         width: 225%;
-//         height: 40px;
-//         border-radius: 3px;
-//         background-color: $quill-white;
-//         border: solid 1px #e9e9e9;
-//         &.inactive {
-//           width: 100%;
-//           background-color: #F7F5F5;
-//           border: dashed 1px #969696;
-//         }
-//       }
-//     }
-//   }
-// }
 
 @media (max-width: 767px) {
   #my-account {
@@ -351,14 +295,13 @@
 
   .checkbox-row {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     margin-bottom: 12px;
     span {
       line-height: 1.57;
     }
   }
   .quill-checkbox {
-    margin-top: 2px;
     margin-right: 24px;
   }
   @media (max-width: 580px) {
@@ -465,6 +408,12 @@
   background-color: $quill-black;
 }
 
+.subject-area-section {
+  .subject-area-row span {
+    color: $quill-grey-40;
+  }
+}
+
 .unlink-modal, .delete-account-modal {
   width: 560px;
   border-radius: 6px;
@@ -556,6 +505,41 @@
   .text {
     color: #646464;
     margin: 0px 30px 40px 0px;
+  }
+}
+
+.student-dashboard-settings-section {
+  padding-bottom: 40px;
+  h1 {
+    margin-bottom: 8px;
+  }
+  p {
+    margin-bottom: 32px;
+    color: $quill-grey-40;
+    a {
+      color: $quill-green;
+      font-weight: 600;
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+  label {
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 22px;
+    color: $quill-grey-40;
+    margin-bottom: 0px;
+  }
+  .checkbox-row {
+    margin-bottom: 0px;
+  }
+  form {
+    margin-bottom: 0px;
+  }
+  .button-section {
+    padding-bottom: 0px;
   }
 }
 

--- a/services/QuillLMS/app/controllers/teacher_infos_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_infos_controller.rb
@@ -17,7 +17,7 @@ class TeacherInfosController < ApplicationController
     end
 
     @teacher_info.update!(notification_email_frequency:) if notification_email_frequency
-    
+
     @teacher_info.update!(show_students_exact_score:) if show_students_exact_score.in?([true, false])
 
     render json: {

--- a/services/QuillLMS/app/controllers/teacher_infos_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_infos_controller.rb
@@ -16,13 +16,9 @@ class TeacherInfosController < ApplicationController
       end
     end
 
-    if notification_email_frequency
-      @teacher_info.update!(notification_email_frequency: notification_email_frequency)
-    end
-
-    if [true, false].include?(show_students_exact_score)
-      @teacher_info.update!(show_students_exact_score: show_students_exact_score)
-    end
+    @teacher_info.update!(notification_email_frequency:) if notification_email_frequency
+    
+    @teacher_info.update!(show_students_exact_score:) if show_students_exact_score.in?([true, false])
 
     render json: {
       minimum_grade_level: @teacher_info.minimum_grade_level,

--- a/services/QuillLMS/app/models/teacher_info.rb
+++ b/services/QuillLMS/app/models/teacher_info.rb
@@ -38,6 +38,7 @@ class TeacherInfo < ApplicationRecord
 
   validates :minimum_grade_level, numericality: { in: 0..12 }, :allow_nil => true
   validates :maximum_grade_level, numericality: { in: 0..12 }, :allow_nil => true
+  validates :show_students_exact_score, inclusion: [true, false]
   validates :user_id, presence: true, uniqueness: true
 
   validates :notification_email_frequency, inclusion: {in: NOTIFICATION_EMAIL_FREQUENCIES}, allow_blank: true

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -672,6 +672,7 @@ class User < ApplicationRecord
     user_attributes[:minimum_grade_level] = teacher_info&.minimum_grade_level
     user_attributes[:maximum_grade_level] = teacher_info&.maximum_grade_level
     user_attributes[:notification_email_frequency] = teacher_info&.notification_email_frequency
+    user_attributes[:show_students_exact_score] = teacher_info&.show_students_exact_score
     user_attributes[:teacher_notification_settings] = teacher_notification_settings_info
     user_attributes[:subject_area_ids] = subject_area_ids
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -248,7 +248,7 @@ class User < ApplicationRecord
   after_save :update_invitee_email_address, if: proc { saved_change_to_email? }
   after_save :check_for_school
   after_create :generate_referrer_id, if: proc { teacher? }
-  after_create :generate_default_notification_email_frequency, if: :teacher?
+  after_create :generate_default_teacher_info, if: :teacher?
   after_create :generate_default_teacher_notification_settings, if: :teacher?
 
   # This is a little weird, but in our current conception, all Admins are Teachers
@@ -961,7 +961,8 @@ class User < ApplicationRecord
     Invitation.where(invitee_email: email_before_last_save).update_all(invitee_email: email, updated_at: DateTime.current)
   end
 
-  private def generate_default_notification_email_frequency
+  private def generate_default_teacher_info
+    # in addition to setting the notification_email_frequency here, show_students_exact_score is also being set to true automatically on creation 
     create_teacher_info(notification_email_frequency: TeacherInfo::DAILY_EMAIL)
   end
 

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -962,7 +962,7 @@ class User < ApplicationRecord
   end
 
   private def generate_default_teacher_info
-    # in addition to setting the notification_email_frequency here, show_students_exact_score is also being set to true automatically on creation 
+    # in addition to setting the notification_email_frequency here, show_students_exact_score is also being set to true automatically on creation
     create_teacher_info(notification_email_frequency: TeacherInfo::DAILY_EMAIL)
   end
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/__tests__/__snapshots__/teacher_student_dashboard_settings.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/__tests__/__snapshots__/teacher_student_dashboard_settings.test.jsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TeacherStudentDashboardSettings component should render 1`] = `
+<DocumentFragment>
+  <section
+    class="user-account-section student-dashboard-settings-section"
+  >
+    <h1>
+      Student dashboard
+    </h1>
+    <p
+      class="student-dashboard-settings-description"
+    >
+      Control what your classes see on their dashboard. 
+      <a
+        href=""
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Learn more.
+      </a>
+    </p>
+    <form
+      accept-charset="UTF-8"
+    >
+      <div
+        class="fields"
+      >
+        <div
+          class="checkbox-row"
+        >
+          <button
+            aria-label="Unchecked checkbox"
+            class="quill-checkbox unselected"
+            id="show-exact-score-checkbox"
+            type="button"
+          />
+          <label
+            for="show-exact-score-checkbox"
+          >
+            Show exact score for graded activities
+          </label>
+        </div>
+      </div>
+    </form>
+  </section>
+</DocumentFragment>
+`;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/__tests__/teacher_student_dashboard_settings.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/__tests__/teacher_student_dashboard_settings.test.jsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { render, } from '@testing-library/react';
+
+import TeacherStudentDashboardSettings from '../teacher_student_dashboard_settings';
+
+describe('TeacherStudentDashboardSettings component', () => {
+  const props = {
+    active: false,
+    activateSection: jest.fn(),
+    deactivateSection: jest.fn(),
+    updateTeacherInfo: jest.fn(),
+    showStudentsExactScore: true,
+  };
+
+  it('should render', () => {
+    const asFragment = mount(<TeacherStudentDashboardSettings {...props} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/__tests__/teacher_student_dashboard_settings.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/__tests__/teacher_student_dashboard_settings.test.jsx
@@ -13,7 +13,7 @@ describe('TeacherStudentDashboardSettings component', () => {
   };
 
   it('should render', () => {
-    const asFragment = mount(<TeacherStudentDashboardSettings {...props} />);
+    const { asFragment, } = render(<TeacherStudentDashboardSettings {...props} />);
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_student_dashboard_settings.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_student_dashboard_settings.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+
+import { smallWhiteCheckIcon, } from '../../../../Shared'
+
+const TeacherStudentDashboardSettings = ({ activateSection, active, deactivateSection, passedShowStudentsExactScore, updateTeacherInfo, }) => {
+  const [showStudentsExactScore, setShowStudentsExactScore] = React.useState(passedShowStudentsExactScore)
+
+  React.useEffect(() => {
+    if (active) { return }
+
+    reset()
+  }, [active])
+
+  function reset() {
+    setShowStudentsExactScore(passedShowStudentsExactScore)
+  }
+
+  function toggleCheckbox() {
+    setShowStudentsExactScore(!showStudentsExactScore)
+  }
+
+  function resetAndDeactivateSection() {
+    reset()
+    deactivateSection()
+  }
+
+  function handleSubmit(e) {
+    e?.preventDefault()
+    const data = {
+      show_students_exact_score: showStudentsExactScore,
+    };
+    updateTeacherInfo(data, 'Settings saved')
+  }
+
+  function renderButtonSection() {
+    if (!active) { return }
+
+    const submitButtonClassName = "quill-button primary contained medium focus-on-light"
+
+    let submitButton = <input aria-label="Save changes" className={`${submitButtonClassName} disabled`} disabled type="submit" value="Save changes" />
+
+    if (showStudentsExactScore !== passedShowStudentsExactScore) {
+      submitButton = <input aria-label="Save changes" className={submitButtonClassName} type="submit" value="Save changes" />
+    }
+
+    return (
+      <div className="button-section">
+        <button className="quill-button outlined secondary medium focus-on-light" id="cancel" onClick={resetAndDeactivateSection} type="button">Cancel</button>
+        {submitButton}
+      </div>
+    )
+  }
+
+  function renderCheckbox() {
+    let checkbox = (
+      <div className="checkbox-row">
+        <button aria-label="Unchecked checkbox" className="quill-checkbox unselected" id="show-exact-score-checkbox" onClick={toggleCheckbox} type="button" />
+        <label htmlFor="show-exact-score-checkbox">Show exact score for graded activities</label>
+      </div>
+    )
+    if (showStudentsExactScore) {
+      checkbox = (
+        <div className="checkbox-row">
+          <button aria-label="Checked checkbox" className="quill-checkbox selected" id="show-exact-score-checkbox" onClick={toggleCheckbox} type="button">
+            <img alt="Checked checkbox" src={smallWhiteCheckIcon.src} />
+          </button>
+          <label htmlFor="show-exact-score-checkbox">Show exact score for graded activities</label>
+        </div>
+      )
+    }
+    return checkbox;
+  }
+
+
+  return (
+    <section className="user-account-section student-dashboard-settings-section">
+      <h1>Student dashboard</h1>
+      <p className="student-dashboard-settings-description">Control what your classes see on their dashboard. <a href="" rel="noopener noreferrer" target="_blank">Learn more.</a></p>
+      <form acceptCharset="UTF-8" onSubmit={handleSubmit} >
+        <div className="fields" onClick={activateSection} onKeyDown={activateSection}>
+          {renderCheckbox()}
+        </div>
+        {renderButtonSection()}
+      </form>
+    </section>
+  )
+}
+
+export default TeacherStudentDashboardSettings

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/TeacherAccount.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/TeacherAccount.jsx
@@ -9,6 +9,7 @@ import TeacherGradeLevels from '../components/accounts/edit/teacher_grade_levels
 import TeacherLinkedAccounts from '../components/accounts/edit/teacher_linked_accounts';
 import TeacherSubjectAreas from '../components/accounts/edit/teacher_subject_areas';
 import TeacherPasswordAccountInfo from '../components/accounts/edit/update_password';
+import TeacherStudentDashboardSettings from '../components/accounts/edit/teacher_student_dashboard_settings'
 
 function gradeLevelToOption(gradeLevel) {
   return gradeLevel ? { value: gradeLevel, label: gradeLevel, } : null
@@ -19,6 +20,7 @@ const GRADE_LEVEL = 'gradeLevel'
 const SUBJECT_AREAS = 'subjectAreas'
 const GENERAL = 'general'
 const EMAIL_NOTIFICATIONS = 'emailNotifications'
+const STUDENT_DASHBOARD_SETTINGS = 'studentDashboardSettings'
 
 export default class TeacherAccount extends React.Component {
   constructor(props) {
@@ -38,6 +40,7 @@ export default class TeacherAccount extends React.Component {
       minimum_grade_level,
       maximum_grade_level,
       subject_area_ids,
+      show_students_exact_score,
     } = props.accountInfo
     this.state = {
       activeSection: null,
@@ -57,10 +60,11 @@ export default class TeacherAccount extends React.Component {
       minimumGradeLevel: minimum_grade_level,
       maximumGradeLevel: maximum_grade_level,
       selectedSubjectAreaIds: subject_area_ids,
+      showStudentsExactScore: show_students_exact_score,
       snackbarCopy: '',
       showSnackbar: false,
       errors: {},
-      timesSubmitted: 0
+      timesSubmitted: 0,
     }
   }
 
@@ -129,7 +133,8 @@ export default class TeacherAccount extends React.Component {
           minimum_grade_level,
           maximum_grade_level,
           subject_area_ids,
-          notification_email_frequency
+          notification_email_frequency,
+          show_students_exact_score,
         } = body
 
         this.setState({
@@ -138,6 +143,7 @@ export default class TeacherAccount extends React.Component {
           selectedSubjectAreaIds: subject_area_ids,
           notificationEmailFrequency: notification_email_frequency,
           tempNotificationEmailFrequency: notification_email_frequency,
+          showStudentsExactScore: show_students_exact_score,
           snackbarCopy,
           errors: {}
         }, () => {
@@ -234,6 +240,7 @@ export default class TeacherAccount extends React.Component {
       minimumGradeLevel,
       maximumGradeLevel,
       selectedSubjectAreaIds,
+      showStudentsExactScore,
     } = this.state
 
     const { accountInfo, alternativeSchools, alternativeSchoolsNameMap, cleverLink, showDismissSchoolSelectionReminderCheckbox, subjectAreas, } = this.props
@@ -305,6 +312,13 @@ export default class TeacherAccount extends React.Component {
           deactivateSection={() => this.deactivateSection(SUBJECT_AREAS)}
           passedSelectedSubjectAreaIds={selectedSubjectAreaIds}
           subjectAreas={subjectAreas}
+          updateTeacherInfo={this.updateTeacherInfo}
+        />
+        <TeacherStudentDashboardSettings
+          activateSection={() => this.activateSection(STUDENT_DASHBOARD_SETTINGS)}
+          active={activeSection === STUDENT_DASHBOARD_SETTINGS}
+          deactivateSection={() => this.deactivateSection(STUDENT_DASHBOARD_SETTINGS)}
+          passedShowStudentsExactScore={showStudentsExactScore}
           updateTeacherInfo={this.updateTeacherInfo}
         />
         <TeacherDangerZone

--- a/services/QuillLMS/spec/controllers/teacher_infos_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teacher_infos_controller_spec.rb
@@ -22,69 +22,8 @@ describe TeacherInfosController do
     allow(controller).to receive(:current_user) { user }
   end
 
-  describe '#create' do
-
-    it 'should create a teacher info record with the data populated' do
-      post :create, params: {minimum_grade_level: 4, maximum_grade_level: 12, subject_area_ids: [subject_area1.id], notification_email_frequency: TeacherInfo::WEEKLY_EMAIL}
-
-      teacher_info = TeacherInfo.find_by(user: user)
-
-      expect(teacher_info.minimum_grade_level).to eq(4)
-      expect(teacher_info.maximum_grade_level).to eq(12)
-      expect(teacher_info.subject_areas).to eq([subject_area1])
-      expect(teacher_info.notification_email_frequency).to eq(TeacherInfo::WEEKLY_EMAIL)
-      expect(response.status).to be(200)
-    end
-  end
-
-  describe '#create with valid role_selected_at_signup' do
-
-    it 'should create a teacher info record with the data populated' do
-      session[:role] = User::INDIVIDUAL_CONTRIBUTOR
-      post :create, params: {minimum_grade_level: 4, maximum_grade_level: 12, subject_area_ids: [subject_area1.id]}
-
-      teacher_info = TeacherInfo.find_by(user: user)
-
-      expect(teacher_info.role_selected_at_signup).to eq(User::INDIVIDUAL_CONTRIBUTOR)
-      expect(response.status).to be(200)
-    end
-  end
-
-  describe '#create with invalid role_selected_at_signup' do
-
-    it 'should create a teacher info record with role_selected_at_signup defaulted to an empty string' do
-      session[:role] = 'invalid-role'
-      post :create, params: {minimum_grade_level: 4, maximum_grade_level: 12, subject_area_ids: [subject_area1.id]}
-
-      teacher_info = TeacherInfo.find_by(user: user)
-
-      expect(teacher_info.role_selected_at_signup).to eq('')
-      expect(response.status).to be(200)
-    end
-  end
-
-  describe '#create should not double-create records for a single user' do
-    it 'should create a new record if one does not exist for the user' do
-      expect do
-        post :create, params: {minimum_grade_level: 4, maximum_grade_level: 12, subject_area_ids: [subject_area1.id], notification_email_frequency: TeacherInfo::WEEKLY_EMAIL}
-
-        expect(response.status).to eq(200)
-      end.to change(TeacherInfo, :count).by(1)
-    end
-
-    it 'should not create a new record if one already exists for the user' do
-      create(:teacher_info, user: user)
-
-      expect do
-        post :create, params: {minimum_grade_level: 4, maximum_grade_level: 12, subject_area_ids: [subject_area1.id], notification_email_frequency: TeacherInfo::WEEKLY_EMAIL}
-
-        expect(response.status).to eq(400)
-      end.not_to change(TeacherInfo, :count)
-    end
-  end
-
   describe '#update' do
-    let!(:teacher_info) { create(:teacher_info, minimum_grade_level: 1, maximum_grade_level: 7, user: user) }
+    let!(:teacher_info) { create(:teacher_info, minimum_grade_level: 1, maximum_grade_level: 7, show_students_exact_score: true, user: user) }
 
     before { teacher_info.subject_areas.push(subject_area1) }
 
@@ -96,6 +35,28 @@ describe TeacherInfosController do
       expect(teacher_info.reload.subject_areas).to eq([subject_area2])
       expect(teacher_info.reload.notification_email_frequency).to eq(TeacherInfo::WEEKLY_EMAIL)
       expect(response.status).to be(200)
+    end
+
+    describe 'updating show_students_exact_score' do
+      it 'should update the teacher info record if show_students_exact_score is false' do
+        put :update, params: {show_students_exact_score: false}
+
+        expect(teacher_info.reload.show_students_exact_score).to eq(false)
+      end
+
+      it 'should update the teacher info record if show_students_exact_score is true' do
+        teacher_info.update(show_students_exact_score: false)
+
+        put :update, params: {show_students_exact_score: true}
+
+        expect(teacher_info.reload.show_students_exact_score).to eq(true)
+      end
+
+      it 'should not update the teacher info record if show_students_exact_score does not cast to true or false' do
+        put :update, params: {show_students_exact_score: nil}
+
+        expect(teacher_info.reload.show_students_exact_score).to eq(true)
+      end
     end
   end
 

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -33,7 +33,6 @@ describe TeacherInfo, type: :model, redis: true do
   it {should validate_numericality_of(:maximum_grade_level)}
 
   it {should validate_presence_of(:user_id)}
-  it {should validate_presence_of(:show_students_exact_score)}
 
   it {should validate_inclusion_of(:notification_email_frequency).in_array(TeacherInfo::NOTIFICATION_EMAIL_FREQUENCIES)}
   it {should validate_inclusion_of(:show_students_exact_score).in_array([true, false])}

--- a/services/QuillLMS/spec/models/teacher_info_spec.rb
+++ b/services/QuillLMS/spec/models/teacher_info_spec.rb
@@ -33,8 +33,10 @@ describe TeacherInfo, type: :model, redis: true do
   it {should validate_numericality_of(:maximum_grade_level)}
 
   it {should validate_presence_of(:user_id)}
+  it {should validate_presence_of(:show_students_exact_score)}
 
   it {should validate_inclusion_of(:notification_email_frequency).in_array(TeacherInfo::NOTIFICATION_EMAIL_FREQUENCIES)}
+  it {should validate_inclusion_of(:show_students_exact_score).in_array([true, false])}
 
   context 'uniqueness' do
     let!(:teacher_info) {create(:teacher_info)}

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -578,6 +578,7 @@ RSpec.describe User, type: :model do
         minimum_grade_level: teacher_info.minimum_grade_level,
         maximum_grade_level: teacher_info.maximum_grade_level,
         subject_area_ids: teacher_info.subject_area_ids,
+        show_students_exact_score: teacher_info.show_students_exact_score,
         notification_email_frequency: TeacherInfo::DAILY_EMAIL,
         teacher_notification_settings: {
           "TeacherNotifications::StudentCompletedDiagnostic" => false,
@@ -597,6 +598,7 @@ RSpec.describe User, type: :model do
         minimum_grade_level: teacher_info.minimum_grade_level,
         maximum_grade_level: teacher_info.maximum_grade_level,
         subject_area_ids: teacher_info.subject_area_ids,
+        show_students_exact_score: teacher_info.show_students_exact_score,
         notification_email_frequency: TeacherInfo::DAILY_EMAIL,
         teacher_notification_settings: {
           "TeacherNotifications::StudentCompletedDiagnostic" => false,

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1960,25 +1960,25 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#generate_default_notification_email_frequency' do
+  describe '#generate_default_teacher_info' do
     it 'should be called after creation if teacher?' do
       teacher = build(:teacher)
 
-      expect(teacher).to receive(:generate_default_notification_email_frequency)
+      expect(teacher).to receive(:generate_default_teacher_info)
       teacher.save
     end
 
     it 'should not be called after creation if not teacher?' do
       student = build(:student)
 
-      expect(student).not_to receive(:generate_default_notification_email_frequency)
+      expect(student).not_to receive(:generate_default_teacher_info)
       student.save
     end
 
     it 'should not be called on non-create updates' do
       teacher = create(:teacher)
 
-      expect(teacher).not_to receive(:generate_default_notification_email_frequency)
+      expect(teacher).not_to receive(:generate_default_teacher_info)
       teacher.name = 'New Name'
       teacher.save
     end
@@ -2002,7 +2002,7 @@ RSpec.describe User, type: :model do
     it 'should not be called on non-create updates' do
       teacher = create(:teacher)
 
-      expect(teacher).not_to receive(:generate_default_notification_email_frequency)
+      expect(teacher).not_to receive(:generate_default_teacher_info)
       teacher.name = 'New Name'
       teacher.save
     end


### PR DESCRIPTION
## WHAT
Add frontend and backend support for allowing teachers to change the setting for allowing students to see their scores.

## WHY
This attribute defaults to `true`, but we want teachers to have the option to change it from their account settings page.

## HOW
Add validations to the model file since the last PR was just migrations, then controller updates and frontend updates to enable toggling this feature on and off.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teachers-settings-page-6fb6c75b53d04f619ea5c4d9390070bf?pvs=4

### What have you done to QA this feature?
Went through a sign-up flow as a new teacher to make sure the record was created as expected, then tried toggling it on and off from the account settings page, on its own and in combination with other `teacher_info` attributes to make sure updating something else didn't have weird repercussions for this value. I am also having Peter Sharkey and Jack review it on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
