### PR TITLE
Timeframse: loosen specs for year. Add threshold spec.

### DIFF
--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -102,11 +102,13 @@ module Snapshots
     it_behaves_like 'snapshots period length', 'last-school-year', Date.leap?(DateTime.current.prev_year.year) ? 366 : 365
     it_behaves_like 'snapshots period length', 'custom', 4, (DateTime.current - 3.days).to_s, DateTime.current.to_s
 
-    # last-month and last-school-year may not match the previous period
     it_behaves_like 'snapshots period length matches previous', 'last-30-days'
     it_behaves_like 'snapshots period length matches previous', 'last-90-days'
     it_behaves_like 'snapshots period length matches previous', 'this-month'
-    it_behaves_like 'snapshots period length matches previous', 'this-school-year'
     it_behaves_like 'snapshots period length matches previous', 'custom', (DateTime.current - 3.days).to_s, DateTime.current.to_s
+
+    it_behaves_like 'snapshots period length, previous within threshold', 'this-school-year', 1
+    it_behaves_like 'snapshots period length, previous within threshold', 'last-month', 1
+    it_behaves_like 'snapshots period length, previous within threshold', 'last-school-year', 1
   end
 end

--- a/services/QuillLMS/spec/support/shared_examples/snapshots/snapshots_period_length_previous_with_threshold_rspec.rb
+++ b/services/QuillLMS/spec/support/shared_examples/snapshots/snapshots_period_length_previous_with_threshold_rspec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'snapshots period length, previous within threshold' do |timeframe_key, threshold, custom_start, custom_end|
+  context "'#{timeframe_key}'" do
+    let(:now) { DateTime.current }
+    let(:timeframe) {described_class.calculate_timeframes(timeframe_key, custom_start:, custom_end:)}
+    let(:previous_timeframe) {described_class.calculate_timeframes(timeframe_key, custom_start:, custom_end:, previous_timeframe: true)}
+
+    # Periods are from beginning of day to end of day,
+    # so they are 1 second under the full amount, e.g. 29.999999999
+    # rounding at 6 decimals to make comparison deterministic
+    let(:previous_timeframe_length) {(previous_timeframe.last - previous_timeframe.first).to_f.round(6)}
+    let(:current_timeframe_length) {(timeframe.last - timeframe.first).to_f.round(6)}
+
+    before do
+      allow(DateTime).to receive(:current).and_return(now)
+    end
+
+    subject {(current_timeframe_length - previous_timeframe_length).abs}
+
+    it { expect(subject).to be <= threshold }
+  end
+end


### PR DESCRIPTION
## WHAT
Leap year makes the 'this year' timeframe off by one day. Loosening the spec on this to be within one day.
## WHY
Making the day counts match might be stranger for edge cases, e.g. On the last day of the year, the previous year would include the first day of this year. I think the `Start of year to this day of the year` logic is a little easier to understand, so just sticking with that for now. Will adjust if there is a product requirement to change.
## HOW
Add a new threshold spec.

### What have you done to QA this feature?
No QA, since this is just a spec fix. The tests pass.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
