### PR TITLE
fix some more incorrect sequence bugs

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/editIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/editIncorrectSequenceContainer.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import questionActions from '../../actions/questions';
 import sentenceFragmentActions from '../../actions/sentenceFragments';
 import IncorrectSequencesInputAndConceptSelectorForm from '../shared/incorrectSequencesInputAndConceptSelectorForm.jsx';
+import { hashToCollection, } from '../../../Shared/index'
 
 class EditIncorrectSequencesContainer extends Component {
   constructor() {
@@ -36,7 +37,10 @@ class EditIncorrectSequencesContainer extends Component {
     const { match } = this.props
     const { params } = match
     const { incorrectSequenceID, questionID } = params
-    return this.props[questionType].data[questionID].incorrectSequences[incorrectSequenceID];
+
+    const { incorrectSequences, } = this.props[questionType].data[questionID]
+    const sequencesArray = Array.isArray(incorrectSequences) && incorrectSequences.every(is => is.key) ? incorrectSequences : hashToCollection(incorrectSequences)
+    return sequencesArray.find(is => is.key === incorrectSequenceID);
   }
 
   submitForm = (data, incorrectSequenceID) => {

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -42,6 +42,12 @@ class IncorrectSequencesContainer extends Component {
     };
   }
 
+  getSequenceIndexByKey = (key) => {
+    const { incorrectSequences, } = this.state
+
+    return incorrectSequences.findIndex(is => is.key === key)
+  }
+
   getSequences = (question) => {
     return hashToCollection(question.incorrectSequences).map(is => {
       is.uid = is.uid || uuid()
@@ -58,7 +64,7 @@ class IncorrectSequencesContainer extends Component {
     if (confirm('⚠️ Are you sure you want to delete this? 😱')) {
       const data = incorrectSequences[sequenceKey];
       delete data.conceptResults[conceptResultKey];
-      dispatch(submitEditedIncorrectSequence(questionID, data, sequenceKey));
+      dispatch(actionFile.submitEditedIncorrectSequence(questionID, data, data.key));
     }
   }
 
@@ -77,11 +83,13 @@ class IncorrectSequencesContainer extends Component {
 
   sequencesSortedByOrder = () => {
     const { orderedIds, incorrectSequences } = this.state
+    
+    const sequencesCollection = Array.isArray(incorrectSequences) ? incorrectSequences : hashToCollection(incorrectSequences)
+
     if (orderedIds) {
-      const sequencesCollection = hashToCollection(incorrectSequences)
-      return orderedIds.map(id => sequencesCollection.find(sequence => sequence.uid === id))
+      return orderedIds.map(id => sequencesCollection.find(s => s.uid === id))
     } else {
-      return hashToCollection(incorrectSequences).sort((a, b) => a.order - b.order);
+      return sequencesCollection.sort((a, b) => a.order - b.order);
     }
   }
 
@@ -105,10 +113,11 @@ class IncorrectSequencesContainer extends Component {
     const { questionID } = params
     const { incorrectSequences } = this.state
     const filteredSequences = this.removeEmptySequences(incorrectSequences)
-    let data = filteredSequences[key]
+    const index = this.getSequenceIndexByKey(key)
+    let data = filteredSequences[index]
     delete data.conceptResults.null;
     if (data.text === '') {
-      delete filteredSequences[key]
+      delete filteredSequences[index]
       dispatch(deleteIncorrectSequence(questionID, key));
     } else if (data.text.split('|||').some(sequence => !isValidRegex(sequence))) {
       alert('Your regex syntax is invalid. Try again!')
@@ -131,7 +140,7 @@ class IncorrectSequencesContainer extends Component {
     const { incorrectSequences } = this.state
     const className = `regex-${key}`
     const value = `${Array.from(document.getElementsByClassName(className)).map(i => i.value).filter(val => val !== '').join('|||')}|||`;
-    incorrectSequences[key].text = value;
+    incorrectSequences[this.getSequenceIndexByKey(key)].text = value;
     this.setState({incorrectSequences: incorrectSequences})
   }
 
@@ -144,19 +153,19 @@ class IncorrectSequencesContainer extends Component {
         return
       }
     }
-    incorrectSequences[key].text = value;
+    incorrectSequences[this.getSequenceIndexByKey(key)].text = value;
     this.setState({incorrectSequences: incorrectSequences})
   }
 
   handleNameChange = (e, key) => {
     const { incorrectSequences } = this.state
-    incorrectSequences[key].name = e.target.value
+    incorrectSequences[this.getSequenceIndexByKey(key)].name = e.target.value
     this.setState({incorrectSequences: incorrectSequences})
   }
 
   handleFeedbackChange = (e, key) => {
     const { incorrectSequences } = this.state
-    incorrectSequences[key].feedback = e
+    incorrectSequences[this.getSequenceIndexByKey(key)].feedback = e
     this.setState({incorrectSequences: incorrectSequences})
   }
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/editIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/editIncorrectSequenceContainer.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import questionActions from '../../actions/questions.ts';
 import sentenceFragmentActions from '../../actions/sentenceFragments.ts';
 import IncorrectSequencesInputAndConceptSelectorForm from '../shared/incorrectSequencesInputAndConceptSelectorForm.jsx';
+import { hashToCollection, } from '../../../Shared/index'
 
 class EditIncorrectSequencesContainer extends Component {
   constructor(props) {
@@ -35,7 +36,10 @@ class EditIncorrectSequencesContainer extends Component {
     const { match } = this.props;
     const { params } = match;
     const { incorrectSequenceID, questionID } = params;
-    return this.props[questionType].data[questionID].incorrectSequences[incorrectSequenceID];
+
+    const { incorrectSequences, } = this.props[questionType].data[questionID]
+    const sequencesArray = Array.isArray(incorrectSequences) && incorrectSequences.every(is => is.key) ? incorrectSequences : hashToCollection(incorrectSequences)
+    return sequencesArray.find(is => is.key === incorrectSequenceID);
   }
 
   submitForm = (data, incorrectSequenceID) => {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -47,11 +47,17 @@ class IncorrectSequencesContainer extends Component {
     this.setState({ incorrectSequences, orderedIds: null, });
   }
 
+  getSequenceIndexByKey = (key) => {
+    const { incorrectSequences, } = this.state
+
+    return incorrectSequences.findIndex(is => is.key === key)
+  }
+
   getSequences(question) {
-    return question.incorrectSequences.map(is => {
+    return hashToCollection(question.incorrectSequences).map(is => {
       is.uid = is.uid || uuid()
       return is
-    });
+    }).filter(incorrectSequence => incorrectSequence);
   }
 
   deleteSequence = sequenceID => {
@@ -74,7 +80,7 @@ class IncorrectSequencesContainer extends Component {
     if (confirm('⚠️ Are you sure you want to delete this? 😱')) {
       const data = incorrectSequences[sequenceKey];
       delete data.conceptResults[conceptResultKey];
-      dispatch(actionFile.submitEditedIncorrectSequence(questionID, data, sequenceKey));
+      dispatch(actionFile.submitEditedIncorrectSequence(questionID, data, data.key));
     }
   }
 
@@ -86,10 +92,11 @@ class IncorrectSequencesContainer extends Component {
     const { questionID } = params
     const { incorrectSequences } = this.state
     const filteredSequences = this.removeEmptySequences(incorrectSequences)
-    let data = filteredSequences[key]
+    const index = this.getSequenceIndexByKey(key)
+    let data = filteredSequences[index]
     delete data.conceptResults.null;
     if (data.text === '') {
-      delete filteredSequences[key]
+      delete filteredSequences[index]
       dispatch(deleteIncorrectSequence(questionID, key));
     } else {
       dispatch(submitEditedIncorrectSequence(questionID, data, key));
@@ -110,13 +117,13 @@ class IncorrectSequencesContainer extends Component {
     const { incorrectSequences } = this.state
     const className = `regex-${key}`
     const value = `${Array.from(document.getElementsByClassName(className)).map(i => i.value).filter(val => val !== '').join('|||')}|||`;
-    incorrectSequences[key].text = value;
+    incorrectSequences[this.getSequenceIndexByKey(key)].text = value;
     this.setState({incorrectSequences: incorrectSequences})
   }
 
   handleNameChange = (e, key) => {
     const { incorrectSequences } = this.state
-    incorrectSequences[key].name = e.target.value
+    incorrectSequences[this.getSequenceIndexByKey(key)].name = e.target.value
     this.setState({incorrectSequences: incorrectSequences})
   }
 
@@ -129,13 +136,13 @@ class IncorrectSequencesContainer extends Component {
         return
       }
     }
-    incorrectSequences[key].text = value;
+    incorrectSequences[this.getSequenceIndexByKey(key)].text = value;
     this.setState({incorrectSequences: incorrectSequences})
   }
 
   handleFeedbackChange = (e, key) => {
     const { incorrectSequences } = this.state
-    incorrectSequences[key].feedback = e
+    incorrectSequences[this.getSequenceIndexByKey(key)].feedback = e
     this.setState({incorrectSequences: incorrectSequences})
   }
 
@@ -145,11 +152,12 @@ class IncorrectSequencesContainer extends Component {
 
   sequencesSortedByOrder = () => {
     const { orderedIds, incorrectSequences } = this.state
+    const sequencesCollection = Array.isArray(incorrectSequences) ? incorrectSequences : hashToCollection(incorrectSequences)
+
     if (orderedIds) {
-      const sequencesCollection = hashToCollection(incorrectSequences)
       return orderedIds.map(id => sequencesCollection.find(s => s.uid === id))
     } else {
-      return hashToCollection(incorrectSequences).sort((a, b) => a.order - b.order);
+      return sequencesCollection.sort((a, b) => a.order - b.order);
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -93,7 +93,6 @@ class IncorrectSequencesContainer extends React.Component {
   handleSequenceChange = (e, key) => {
     const { incorrectSequences } = this.state
     const className = `regex-${key}`
-    debugger;
     const value = `${Array.from(document.getElementsByClassName(className)).map(i => i.value).filter(val => val !== '').join('|||')}`;
     if (value === '') {
       if (!confirm("Deleting this regex will delete the whole incorrect sequence. Are you sure you want that?")) {


### PR DESCRIPTION
## WHAT
There is a super fun issue, which existed prior to the recent round of incorrect sequence updates but has been uncovered by them, where the way we save incorrect sequences when they are first created for new questions (as a hash) is not how they are saved when they are reordered (as an array). This is fixable on its own, but I'm afraid that changing the structure here is going to mess with the actual grading logic, which doesn't actually take an "order" attribute into account for any of the question types the way it does for focus points. At some point soon, I think we really do need to do that revisitation of how we store and update these things, but in the meanwhile I think this series of changes will get us around that problem.

## WHY
We want the curriculum team to be able to create and edit incorrect sequences.

## HOW
Make incorrect sequences retrievable regardless of whether they actually have an index as a key or a real key.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-edit-Incorrect-Sequences-in-Connect-d75bc38569c546bda091c7611b3ed265?d=a7bdb1ffb07146ec80f31c63efc6bb32

### What have you done to QA this feature?
I tested creating new questions, adding incorrect sequences to them, editing those incorrect sequences from both the main page and the individual edit page, and reordering them for both Connect and Diagnostic. Grammar did not appear to have this problem for some reason. I am also asking Rachel to QA so hopefully we can stop getting related bug tickets.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
