### PR TITLE
fix rails admin search

### DIFF
--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -146,6 +146,14 @@ end
 # Monkey patch for a known issue: RailsAdmin tries to parse search strings as JSON
 # https://github.com/railsadminteam/rails_admin/issues/2502
 class RailsAdmin::Config::Fields::Types::Json
+  register_instance_option :formatted_value do
+    if value.is_a?(Hash) || value.is_a?(Array)
+      JSON.pretty_generate(value)
+    else
+      value
+    end
+  end
+
   def parse_value(value)
     value.present? ? JSON.parse(value) : nil
   rescue JSON::ParserError

--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -142,3 +142,13 @@ Rails.application.config.eager_load do
     config.excluded_models.push(*MODELS_TO_EXCLUDE)
   end
 end
+
+# Monkey patch for a known issue: RailsAdmin tries to parse search strings as JSON
+# https://github.com/railsadminteam/rails_admin/issues/2502
+class RailsAdmin::Config::Fields::Types::Json
+  def parse_value(value)
+    value.present? ? JSON.parse(value) : nil
+  rescue JSON::ParserError
+    value
+  end
+end

--- a/services/QuillLMS/spec/controllers/rails_admin_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/rails_admin_controller_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RailsAdmin::MainController, type: :controller do
+  routes { RailsAdmin::Engine.routes }
+
+  context 'as an admin' do
+    describe '#index' do
+      it 'should not raise an error on queries of type string' do
+        expect do
+          get :index, params: { model_name: 'activity', query: 'example_string_query_param', utf8: true}
+        end.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
- rescues Json parse failures within RailsAdmin

## WHY
- so that RailsAdmin search is not broken 

## HOW
monkey patch 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/500-error-when-searching-in-Master-CMS-38cdffcf5a374879b627763d141423b4

### What have you done to QA this feature?
1. Browse to http://localhost:5000/staff/activity 
2. Search activities for a integer value, confirm successful result
3. Search activities for a string value, confirm successful result

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No; config change only
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
