### PR TITLE
Display questions and responses as HTML in admin panels

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/concepts/concept.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/concepts/concept.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import _ from 'underscore'
+import { decode } from 'html-entities'
 
 import { hashToCollection, Spinner } from '../../../Shared/index'
 
@@ -32,7 +33,7 @@ export const Concept = ({ concepts, match, questions, fillInBlank }) => {
       const archivedTag = flag === 'archived' ? <strong>ARCHIVED - </strong> : ''
       return (
         <li key={key}>
-          <Link to={'/admin/questions/' + key + '/responses'}>{archivedTag}{prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")}</Link>
+          <Link to={'/admin/questions/' + key + '/responses'}>{archivedTag}{decode(prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))}</Link>
         </li>
       )
     })

--- a/services/QuillLMS/client/app/bundles/Connect/components/concepts/concept.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/concepts/concept.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import _ from 'underscore'
-import { decode } from 'html-entities'
 
 import { hashToCollection, Spinner } from '../../../Shared/index'
 
@@ -33,9 +32,9 @@ export const Concept = ({ concepts, match, questions, fillInBlank }) => {
       const archivedTag = flag === 'archived' ? <strong>ARCHIVED - </strong> : ''
       return (
         <li key={key}>
-          <a href={'/connect#/admin/questions/' + key + '/responses'}>
-            <div dangerouslySetInnerHTML={{ __html: archivedTag + prompt }} />
-          </a>
+          <Link to={'/admin/questions/' + key + '/responses'}>
+            <span dangerouslySetInnerHTML={{ __html: archivedTag + prompt }} />
+          </Link>
         </li>
       )
     })

--- a/services/QuillLMS/client/app/bundles/Connect/components/concepts/concept.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/concepts/concept.tsx
@@ -33,7 +33,9 @@ export const Concept = ({ concepts, match, questions, fillInBlank }) => {
       const archivedTag = flag === 'archived' ? <strong>ARCHIVED - </strong> : ''
       return (
         <li key={key}>
-          <Link to={'/admin/questions/' + key + '/responses'}>{archivedTag}{decode(prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))}</Link>
+          <a href={'/connect#/admin/questions/' + key + '/responses'}>
+            <div dangerouslySetInnerHTML={{ __html: archivedTag + prompt }} />
+          </a>
         </li>
       )
     })

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
@@ -1,7 +1,6 @@
 import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import _ from 'underscore';
-import { decode } from 'html-entities';
 
 import {
   Modal,
@@ -509,7 +508,7 @@ export default class Response extends React.Component<ResponseProps, ResponseSta
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><pre dangerouslySetInnerHTML={{ __html: response.text }}></pre> {author}</p>
+                <p><pre dangerouslySetInnerHTML={{ __html: response.text }} />{author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
@@ -509,7 +509,7 @@ export default class Response extends React.Component<ResponseProps, ResponseSta
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><pre>{decode(response.text)}</pre> {author}</p>
+                <p><pre dangerouslySetInnerHTML={{ __html: response.text }}></pre> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
@@ -1,6 +1,8 @@
 import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import _ from 'underscore';
+import { decode } from 'html-entities';
+
 import {
   Modal,
   TextEditor
@@ -507,7 +509,7 @@ export default class Response extends React.Component<ResponseProps, ResponseSta
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><pre>{response.text}</pre> {author}</p>
+                <p><pre>{decode(response.text)}</pre> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-
+import { Link } from 'react-router-dom';
 
 export class QuestionList extends React.Component<any, {}> {
 
@@ -17,9 +17,9 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <a href={'connect#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
-          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
-        </a>
+        <Link to={'/admin/questions/' + question.key + '/responses'}>
+          <span dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
+        </Link>
       ));
     }
   }

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionList.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { decode } from 'html-entities';
 
-import { LinkListItem } from './linkListItem';
 
 export class QuestionList extends React.Component<any, {}> {
 
@@ -19,12 +17,9 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <LinkListItem
-          basePath={this.props.basePath}
-          itemKey={question.key}
-          key={question.key}
-          text={question.prompt ? decode(question.prompt) : decode(question.title)}
-        />
+        <a href={'connect#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
+          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
+        </a>
       ));
     }
   }

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionList.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 export class QuestionList extends React.Component<any, {}> {
 
   renderListItems = () => {
+    const { basePath } = this.props;
     const questions = this.props.questions;
     if (questions.length !== 0) {
       let filtered;
@@ -17,7 +18,7 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <Link to={'/admin/questions/' + question.key + '/responses'}>
+        <Link to={'/admin/' + basePath + '/' + question.key + '/responses'}>
           <span dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
         </Link>
       ));

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionList.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { decode } from 'html-entities';
+
 import { LinkListItem } from './linkListItem';
 
 export class QuestionList extends React.Component<any, {}> {
@@ -21,7 +23,7 @@ export class QuestionList extends React.Component<any, {}> {
           basePath={this.props.basePath}
           itemKey={question.key}
           key={question.key}
-          text={question.prompt ? question.prompt : question.title}
+          text={question.prompt ? decode(question.prompt) : decode(question.title)}
         />
       ));
     }

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import * as React from 'react'
+import { Link } from 'react-router-dom';
 
 import { hashToCollection, } from '../../../Shared/index'
 
@@ -14,6 +15,7 @@ export class QuestionListByConcept extends React.Component<any, any> {
   }
 
   renderQuestionLinks = (questions) => {
+    const { basePath } = this.props;
     let filtered;
     if (!this.props.showOnlyArchived) {
       filtered = questions.filter((question) => question.flag !== "archived" )
@@ -23,9 +25,9 @@ export class QuestionListByConcept extends React.Component<any, any> {
     return filtered.map((question) => {
       if (question.prompt) {
         return (
-          <a href={'connect#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
+          <Link to={'/admin/' + basePath + '/' + question.key + '/responses'}>
             <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
-          </a>
+          </Link>
         );
       }
     });

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
@@ -1,9 +1,7 @@
 import _ from 'lodash'
 import * as React from 'react'
-import { decode } from 'html-entities';
 
 import { hashToCollection, } from '../../../Shared/index'
-import { LinkListItem } from './linkListItem'
 
 export class QuestionListByConcept extends React.Component<any, any> {
 
@@ -24,14 +22,10 @@ export class QuestionListByConcept extends React.Component<any, any> {
     }
     return filtered.map((question) => {
       if (question.prompt) {
-        const formattedPrompt = decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))
         return (
-          <LinkListItem
-            basePath={this.props.basePath}
-            itemKey={question.key}
-            key={question.key}
-            text={formattedPrompt}
-          />
+          <a href={'connect#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
+            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </a>
         );
       }
     });

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
@@ -1,5 +1,7 @@
 import _ from 'lodash'
 import * as React from 'react'
+import { decode } from 'html-entities';
+
 import { hashToCollection, } from '../../../Shared/index'
 import { LinkListItem } from './linkListItem'
 
@@ -22,7 +24,7 @@ export class QuestionListByConcept extends React.Component<any, any> {
     }
     return filtered.map((question) => {
       if (question.prompt) {
-        const formattedPrompt = question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")
+        const formattedPrompt = decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))
         return (
           <LinkListItem
             basePath={this.props.basePath}

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/questionListByConcept.tsx
@@ -24,7 +24,7 @@ export class QuestionListByConcept extends React.Component<any, any> {
       if (question.prompt) {
         return (
           <a href={'connect#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
-            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
+            <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
           </a>
         );
       }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/concepts/concept.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/concepts/concept.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
+import { decode } from 'html-entities'
 import _ from 'underscore'
 import { hashToCollection } from '../../../Shared/index'
 import actions from '../../actions/concepts'
@@ -49,7 +50,7 @@ class Concept extends React.Component {
   renderQuestionsForConcept = () => {
     const questionsForConcept = this.questionsForConcept()
     const listItems = questionsForConcept.map((question) => {
-      return <li key={question.key}><Link to={'/admin/questions/' + question.key + '/responses'}>{question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")}</Link></li>;
+      return <li key={question.key}><Link to={'/admin/questions/' + question.key + '/responses'}>{decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))}</Link></li>;
     })
     return (
       <ul>{listItems}</ul>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/concepts/concept.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/concepts/concept.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
-import { decode } from 'html-entities'
 import _ from 'underscore'
 import { hashToCollection } from '../../../Shared/index'
 import actions from '../../actions/concepts'
@@ -52,9 +51,9 @@ class Concept extends React.Component {
     const listItems = questionsForConcept.map((question) => {
       return (
         <li key={question.key}>
-          <a href={'/diagnostic#/admin/questions/' + question.key + '/responses'}>
-            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
-          </a>
+          <Link to={'/admin/questions/' + question.key + '/responses'}>
+            <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </Link>
         </li>
       );
     })

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/concepts/concept.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/concepts/concept.jsx
@@ -50,7 +50,13 @@ class Concept extends React.Component {
   renderQuestionsForConcept = () => {
     const questionsForConcept = this.questionsForConcept()
     const listItems = questionsForConcept.map((question) => {
-      return <li key={question.key}><Link to={'/admin/questions/' + question.key + '/responses'}>{decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))}</Link></li>;
+      return (
+        <li key={question.key}>
+          <a href={'/diagnostic#/admin/questions/' + question.key + '/responses'}>
+            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </a>
+        </li>
+      );
     })
     return (
       <ul>{listItems}</ul>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
@@ -359,7 +359,7 @@ const Response = ({allExpanded, ascending, concepts, dispatch, expand, expanded,
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><pre>{decode(response.text)}</pre> {author}</p>
+                <p><pre dangerouslySetInnerHTML={{ __html: response.text }}></pre> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as jsDiff from 'diff'
 
-import { decode } from 'html-entities';
 import { ContentState, EditorState } from 'draft-js'
 import _ from 'underscore'
 
@@ -359,7 +358,7 @@ const Response = ({allExpanded, ascending, concepts, dispatch, expand, expanded,
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><pre dangerouslySetInnerHTML={{ __html: response.text }}></pre> {author}</p>
+                <p><pre dangerouslySetInnerHTML={{ __html: response.text }} /> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as jsDiff from 'diff'
 
+import { decode } from 'html-entities';
 import { ContentState, EditorState } from 'draft-js'
 import _ from 'underscore'
 
@@ -358,7 +359,7 @@ const Response = ({allExpanded, ascending, concepts, dispatch, expand, expanded,
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><pre>{response.text}</pre> {author}</p>
+                <p><pre>{decode(response.text)}</pre> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
@@ -17,7 +17,7 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <a href={this.props.basePath} key={question.key}>
+        <a href={'/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
           <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
         </a>
       ));

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
@@ -18,7 +18,7 @@ export class QuestionList extends React.Component<any, {}> {
       }
       return filtered.map((question: any) => (
         <a href={this.props.basePath} key={question.key}>
-          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />;
+          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
         </a>
       ));
     }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { decode } from 'html-entities';
+
 import { LinkListItem } from './linkListItem';
 
 export class QuestionList extends React.Component<any, {}> {
@@ -21,7 +23,7 @@ export class QuestionList extends React.Component<any, {}> {
           basePath={this.props.basePath}
           itemKey={question.key}
           key={question.key}
-          text={question.prompt ? question.prompt : question.title}
+          text={question.prompt ? decode(question.prompt) : decode(question.title)}
         />
       ));
     }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-
+import { Link } from 'react-router-dom';
 
 export class QuestionList extends React.Component<any, {}> {
 
@@ -17,9 +17,9 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <a href={'/diagnostic#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
-          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
-        </a>
+        <Link to={'/admin/questions/' + question.key + '/responses'}>
+          <span dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
+        </Link>
       ));
     }
   }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 export class QuestionList extends React.Component<any, {}> {
 
   renderListItems = () => {
+    const { basePath } = this.props
     const questions = this.props.questions;
     if (questions.length !== 0) {
       let filtered;
@@ -17,7 +18,7 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <Link to={'/admin/questions/' + question.key + '/responses'}>
+        <Link to={'/admin/' + basePath + '/' + question.key + '/responses'}>
           <span dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
         </Link>
       ));

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 export class QuestionList extends React.Component<any, {}> {
 
   renderListItems = () => {
+    console.log(this.props);
     const questions = this.props.questions;
     if (questions.length !== 0) {
       let filtered;
@@ -17,7 +18,7 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <a href={'/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
+        <a href={'/diagnostic#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
           <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
         </a>
       ));

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 export class QuestionList extends React.Component<any, {}> {
 
   renderListItems = () => {
-    console.log(this.props);
     const questions = this.props.questions;
     if (questions.length !== 0) {
       let filtered;

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionList.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { decode } from 'html-entities';
 
-import { LinkListItem } from './linkListItem';
 
 export class QuestionList extends React.Component<any, {}> {
 
@@ -19,12 +17,9 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <LinkListItem
-          basePath={this.props.basePath}
-          itemKey={question.key}
-          key={question.key}
-          text={question.prompt ? decode(question.prompt) : decode(question.title)}
-        />
+        <a href={this.props.basePath} key={question.key}>
+          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />;
+        </a>
       ));
     }
   }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
@@ -24,7 +24,7 @@ export class QuestionListByConcept extends React.Component<any, any> {
     return filtered.map((question) => {
       if (question.prompt) {
         return (
-          <a href={this.props.basePath} key={question.key}>
+          <a href={'/diagnostic#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
             <div dangerouslySetInnerHTML={{ __html: question.prompt  }} />
           </a>
         );

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
@@ -25,7 +25,7 @@ export class QuestionListByConcept extends React.Component<any, any> {
       if (question.prompt) {
         return (
           <a href={this.props.basePath} key={question.key}>
-            <div dangerouslySetInnerHTML={{ __html: question.prompt  }} />;
+            <div dangerouslySetInnerHTML={{ __html: question.prompt  }} />
           </a>
         );
       }

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
@@ -16,6 +16,7 @@ export class QuestionListByConcept extends React.Component<any, any> {
   }
 
   renderQuestionLinks = (questions) => {
+    const { basePath } = this.props;
     let filtered;
     if (!this.props.showOnlyArchived) {
       filtered = questions.filter((question) => question.flag !== "archived" )
@@ -25,7 +26,7 @@ export class QuestionListByConcept extends React.Component<any, any> {
     return filtered.map((question) => {
       if (question.prompt) {
         return (
-          <Link to={'/admin/questions/' + question.key + '/responses'}>
+          <Link to={'/admin/' + basePath + '/' + question.key + '/responses'}>
             <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
           </Link>
         );

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import * as React from 'react'
+import { Link } from 'react-router-dom';
 
 import { hashToCollection } from '../../../Shared/index'
 
@@ -24,9 +25,9 @@ export class QuestionListByConcept extends React.Component<any, any> {
     return filtered.map((question) => {
       if (question.prompt) {
         return (
-          <a href={'/diagnostic#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
-            <div dangerouslySetInnerHTML={{ __html: question.prompt  }} />
-          </a>
+          <Link to={'/admin/questions/' + question.key + '/responses'}>
+            <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </Link>
         );
       }
     });

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
@@ -1,9 +1,8 @@
 import _ from 'lodash'
 import * as React from 'react'
-import { decode } from 'html-entities';
 
 import { hashToCollection } from '../../../Shared/index'
-import { LinkListItem } from './linkListItem'
+
 
 export class QuestionListByConcept extends React.Component<any, any> {
 
@@ -24,14 +23,10 @@ export class QuestionListByConcept extends React.Component<any, any> {
     }
     return filtered.map((question) => {
       if (question.prompt) {
-        const formattedPrompt = decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))
         return (
-          <LinkListItem
-            basePath={this.props.basePath}
-            itemKey={question.key}
-            key={question.key}
-            text={formattedPrompt}
-          />
+          <a href={this.props.basePath} key={question.key}>
+            <div dangerouslySetInnerHTML={{ __html: question.prompt  }} />;
+          </a>
         );
       }
     });

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/questionListByConcept.tsx
@@ -1,5 +1,7 @@
 import _ from 'lodash'
 import * as React from 'react'
+import { decode } from 'html-entities';
+
 import { hashToCollection } from '../../../Shared/index'
 import { LinkListItem } from './linkListItem'
 
@@ -22,7 +24,7 @@ export class QuestionListByConcept extends React.Component<any, any> {
     }
     return filtered.map((question) => {
       if (question.prompt) {
-        const formattedPrompt = question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")
+        const formattedPrompt = decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))
         return (
           <LinkListItem
             basePath={this.props.basePath}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
@@ -2,6 +2,7 @@ import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { decode } from 'html-entities'
 
 import { FlagDropdown, TextEditor, hashToCollection, } from '../../../Shared/index';
 import * as questionActions from '../../actions/questions';
@@ -67,7 +68,7 @@ class Concept extends React.Component<ConceptProps, ConceptState> {
     const questionsForConcept = this.questionsForConcept()
     const listItems = questionsForConcept.map((question: Question) => {
       const archivedTag = question.flag === 'archived' ? <strong>ARCHIVED - </strong> : ''
-      return <li key={question.key}><Link to={'/admin/questions/' + question.key + '/responses'}>{archivedTag}{question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")}</Link></li>;
+      return <li key={question.key}><Link to={'/admin/questions/' + question.key + '/responses'}>{archivedTag}{decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))}</Link></li>;
     })
     return (
       <ul>{listItems}</ul>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
@@ -2,7 +2,6 @@ import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { decode } from 'html-entities'
 
 import { FlagDropdown, TextEditor, hashToCollection, } from '../../../Shared/index';
 import * as questionActions from '../../actions/questions';
@@ -70,9 +69,9 @@ class Concept extends React.Component<ConceptProps, ConceptState> {
       const archivedTag = question.flag === 'archived' ? <strong>ARCHIVED - </strong> : ''
       return (
         <li key={question.key}>
-          <a href={'/grammar#/admin/questions/' + question.key + '/responses'}>
-            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
-          </a>
+          <Link to={'/admin/questions/' + question.key + '/responses'}>
+            <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </Link>
         </li>
       );
     })

--- a/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
@@ -68,7 +68,13 @@ class Concept extends React.Component<ConceptProps, ConceptState> {
     const questionsForConcept = this.questionsForConcept()
     const listItems = questionsForConcept.map((question: Question) => {
       const archivedTag = question.flag === 'archived' ? <strong>ARCHIVED - </strong> : ''
-      return <li key={question.key}><Link to={'/admin/questions/' + question.key + '/responses'}>{archivedTag}{decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))}</Link></li>;
+      return (
+        <li key={question.key}>
+          <a href={'/grammar#/admin/questions/' + question.key + '/responses'}>
+            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </a>
+        </li>
+      );
     })
     return (
       <ul>{listItems}</ul>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import * as React from 'react'
+import { Link } from 'react-router-dom'
 
 import { hashToCollection } from '../../../Shared/index'
 import { Concept } from '../../interfaces/concepts'
@@ -41,9 +42,9 @@ export default class QuestionListByConcept extends React.Component<QuestionListB
     return filtered.map((question: Question) => {
       if (question.prompt) {
         return (
-          <a href={'/grammar#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
-            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
-          </a>
+          <Link to={'/admin/questions/' + question.key + '/responses'}>
+            <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </Link>
         );
       }
     });

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
@@ -1,5 +1,7 @@
 import _ from 'lodash'
 import * as React from 'react'
+import { decode } from 'html-entities';
+
 import { hashToCollection } from '../../../Shared/index'
 import { Concept } from '../../interfaces/concepts'
 import { Question } from '../../interfaces/questions'
@@ -39,7 +41,7 @@ export default class QuestionListByConcept extends React.Component<QuestionListB
     }
     return filtered.map((question: Question) => {
       if (question.prompt) {
-        const formattedPrompt = question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")
+        const formattedPrompt = decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))
         return (
           <LinkListItem
             basePath={this.props.basePath}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
@@ -41,7 +41,7 @@ export default class QuestionListByConcept extends React.Component<QuestionListB
     return filtered.map((question: Question) => {
       if (question.prompt) {
         return (
-          <a href={this.props.basePath + "/responses"} key={question.key}>
+          <a href={'/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
             <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
           </a>
         );

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
@@ -41,7 +41,7 @@ export default class QuestionListByConcept extends React.Component<QuestionListB
     return filtered.map((question: Question) => {
       if (question.prompt) {
         return (
-          <a href={'/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
+          <a href={'/grammar#/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
             <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
           </a>
         );

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
@@ -1,13 +1,12 @@
 import _ from 'lodash'
 import * as React from 'react'
-import { decode } from 'html-entities';
 
 import { hashToCollection } from '../../../Shared/index'
 import { Concept } from '../../interfaces/concepts'
 import { Question } from '../../interfaces/questions'
 import { ConceptReducerState } from '../../reducers/conceptsReducer'
 import { QuestionsReducerState } from '../../reducers/questionsReducer'
-import LinkListItem from '../shared/linkListItem'
+
 
 interface QuestionListByConceptProps {
   concepts: ConceptReducerState;
@@ -41,15 +40,10 @@ export default class QuestionListByConcept extends React.Component<QuestionListB
     }
     return filtered.map((question: Question) => {
       if (question.prompt) {
-        const formattedPrompt = decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))
         return (
-          <LinkListItem
-            basePath={this.props.basePath}
-            itemKey={question.key}
-            key={question.key}
-            subpath="responses"
-            text={formattedPrompt}
-          />
+          <a href={this.props.basePath + "/responses"} key={question.key}>
+            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </a>
         );
       }
     });

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionListByConcept.tsx
@@ -33,6 +33,7 @@ export default class QuestionListByConcept extends React.Component<QuestionListB
   }
 
   renderQuestionLinks(questions: Question[]): Array<JSX.Element|undefined> {
+    const { basePath } = this.props;
     let filtered;
     if (!this.props.showOnlyArchived) {
       filtered = questions.filter((question) => question.flag !== "archived" )
@@ -42,7 +43,7 @@ export default class QuestionListByConcept extends React.Component<QuestionListB
     return filtered.map((question: Question) => {
       if (question.prompt) {
         return (
-          <Link to={'/admin/questions/' + question.key + '/responses'}>
+          <Link to={'/admin/' + basePath + '/' + question.key + '/responses'}>
             <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
           </Link>
         );

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
@@ -2,7 +2,6 @@ import * as jsDiff from 'diff';
 import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import * as _ from 'underscore';
-import { decode } from 'html-entities';
 
 import ConceptResults from './conceptResults';
 import ResponseList from './responseList';
@@ -415,7 +414,7 @@ export default class extends React.Component<ResponseProps, ResponseState> {
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><pre dangerouslySetInnerHTML={{ __html: response.text }}></pre> {author}</p>
+                <p><pre dangerouslySetInnerHTML={{ __html: response.text }} /> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
@@ -415,7 +415,7 @@ export default class extends React.Component<ResponseProps, ResponseState> {
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><pre>{decode(response.text)}</pre> {author}</p>
+                <p><pre dangerouslySetInnerHTML={{ __html: response.text }}></pre> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
@@ -2,6 +2,7 @@ import * as jsDiff from 'diff';
 import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import * as _ from 'underscore';
+import { decode } from 'html-entities';
 
 import ConceptResults from './conceptResults';
 import ResponseList from './responseList';
@@ -414,7 +415,7 @@ export default class extends React.Component<ResponseProps, ResponseState> {
           <div className="content">
             <div className="media">
               <div className="media-content">
-                <p><pre>{response.text}</pre> {author}</p>
+                <p><pre>{decode(response.text)}</pre> {author}</p>
               </div>
               <div className="media-right" style={{ textAlign: 'right', }}>
                 <figure className="image is-32x32">

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
@@ -1,8 +1,4 @@
 import * as React from 'react';
-import { decode } from 'html-entities';
-
-import { LinkListItem } from './linkListItem';
-
 // interface QuestionListProps {
 //   showOnlyArchived: boolean;
 //   questions: Array<any>;
@@ -30,12 +26,9 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <LinkListItem
-          basePath={this.props.basePath}
-          itemKey={question.key}
-          key={question.key}
-          text={question.prompt ? decode(question.prompt) : decode(question.title)}
-        />
+        <a href={this.props.basePath} key={question.key}>
+          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />;
+        </a>
       ));
     }
   }

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { decode } from 'html-entities';
+
 import { LinkListItem } from './linkListItem';
 
 // interface QuestionListProps {
@@ -32,7 +34,7 @@ export class QuestionList extends React.Component<any, {}> {
           basePath={this.props.basePath}
           itemKey={question.key}
           key={question.key}
-          text={question.prompt ? question.prompt : question.title}
+          text={question.prompt ? decode(question.prompt) : decode(question.title)}
         />
       ));
     }

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 // interface QuestionListProps {
 //   showOnlyArchived: boolean;
 //   questions: Array<any>;
@@ -26,9 +27,9 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <a href={'/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
-          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
-        </a>
+        <Link to={'/admin/questions/' + question.key + '/responses'}>
+          <span dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
+        </Link>
       ));
     }
   }

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
@@ -26,7 +26,7 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <a href={this.props.basePath} key={question.key}>
+        <a href={'/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
           <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
         </a>
       ));

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
@@ -27,7 +27,7 @@ export class QuestionList extends React.Component<any, {}> {
       }
       return filtered.map((question: any) => (
         <a href={this.props.basePath} key={question.key}>
-          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />;
+          <div dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
         </a>
       ));
     }

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionList.tsx
@@ -14,6 +14,7 @@ export class QuestionList extends React.Component<any, {}> {
   }
 
   renderListItems() {
+    const { basePath } = this.props;
     const questions = this.props.questions;
     if (questions.length !== 0) {
       let filtered;
@@ -27,7 +28,7 @@ export class QuestionList extends React.Component<any, {}> {
         )
       }
       return filtered.map((question: any) => (
-        <Link to={'/admin/questions/' + question.key + '/responses'}>
+        <Link to={'/admin/' + basePath + '/' + question.key + '/responses'}>
           <span dangerouslySetInnerHTML={{ __html: question.prompt ? question.prompt : question.title }} />
         </Link>
       ));

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
@@ -21,6 +21,7 @@ class QuestionListByConcept extends React.Component<any, any> {
   }
 
   renderQuestionLinks(questions) {
+    const { basePath } = this.props;
     let filtered;
     if (!this.props.showOnlyArchived) {
       filtered = questions.filter((question) => question.flag !== "archived" )
@@ -30,7 +31,7 @@ class QuestionListByConcept extends React.Component<any, any> {
     return filtered.map((question) => {
       if (question.prompt) {
         return (
-          <Link to={'/admin/questions/' + question.key + '/responses'}>
+          <Link to={'/admin/' + basePath + '/' + question.key + '/responses'}>
             <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
           </Link>
         );

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Link } from 'react-router-dom'
 
 import { hashToCollection } from '../../libs/hashToCollection'
 
@@ -29,9 +30,9 @@ class QuestionListByConcept extends React.Component<any, any> {
     return filtered.map((question) => {
       if (question.prompt) {
         return (
-          <a href={'/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
-            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
-          </a>
+          <Link to={'/admin/questions/' + question.key + '/responses'}>
+            <span dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </Link>
         );
       }
     });

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
-import { decode } from 'html-entities';
 
 import { hashToCollection } from '../../libs/hashToCollection'
-import { LinkListItem } from './linkListItem'
+
 
 class QuestionListByConcept extends React.Component<any, any> {
   constructor(props) {
@@ -29,14 +28,10 @@ class QuestionListByConcept extends React.Component<any, any> {
     }
     return filtered.map((question) => {
       if (question.prompt) {
-        const formattedPrompt = decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))
         return (
-          <LinkListItem
-            basePath={this.props.basePath}
-            itemKey={question.key}
-            key={question.key}
-            text={formattedPrompt}
-          />
+          <a href={this.props.basePath} key={question.key}>
+            <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
+          </a>
         );
       }
     });

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
@@ -29,7 +29,7 @@ class QuestionListByConcept extends React.Component<any, any> {
     return filtered.map((question) => {
       if (question.prompt) {
         return (
-          <a href={this.props.basePath} key={question.key}>
+          <a href={'/admin/' + this.props.basePath + '/' + question.key + '/responses'} key={question.key}>
             <div dangerouslySetInnerHTML={{ __html: question.prompt }} />
           </a>
         );

--- a/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/questionList/questionListByConcept.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+import { decode } from 'html-entities';
+
 import { hashToCollection } from '../../libs/hashToCollection'
 import { LinkListItem } from './linkListItem'
 
@@ -27,7 +29,7 @@ class QuestionListByConcept extends React.Component<any, any> {
     }
     return filtered.map((question) => {
       if (question.prompt) {
-        const formattedPrompt = question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, "")
+        const formattedPrompt = decode(question.prompt.replace(/(<([^>]+)>)/ig, "").replace(/&nbsp;/ig, ""))
         return (
           <LinkListItem
             basePath={this.props.basePath}


### PR DESCRIPTION
## WHAT
Display the questions (i.e. prompts) and responses as HTML instead of as a pure string on the admin CMS for connect, grammar, diagnostic.

## WHY
We save question and response strings inconsistently, sometimes as readable strings and sometimes as html (e.g. with HTML formatting tags like bold/italic tags and HTML entities for punctuation). But we only display questions and responses as regular strings, which leads to the HTML markup being displayed to admin. 

This causes frustration on the admin side because they want to see readable question and responses. Ultimately, we should solve the problem by getting rid of the inconsistencies in the data; however, for now we can just display both questions and responses to admin as HTML, because both regular non-HTML strings and HTML strings can be displayed this way in a readable manner.

## HOW
Use dangerouslySetHTML to display html directly wherever we display questions or responses in code to admin.

### Screenshots
![Screenshot 2024-03-06 at 8 52 47 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/8bf86bbf-fd6d-4c2a-9e79-360046ac826e)
![Screenshot 2024-03-06 at 8 52 34 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/66ef7365-4925-4527-bf8b-193c44144d98)
![Screenshot 2024-03-06 at 8 51 37 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/e106e663-93e9-4cac-92de-0e67628851e1)


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Apostrophes-and-formatting-aren-t-rendering-consistently-in-Diagnostic-Connect-and-Grammar-CMSs-37f9b862406f4962812bc829bb172bd3?pvs=4)

### What have you done to QA this feature?
Admin provided me a list of problematic questions and responses in the Notion spec, and I tested them before and after on Staging to make sure they are visually appearing in the desired way. Additionally, since I changed all the questions/responses display for all the apps, I manually went in and checked that all question types are displaying normally and the links are working in Connect, Grammar, and Diagnostic CMS.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, no front-end unit tests for this part of the code base.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
