### PR TITLE
Add option for OSX system notification for heroku build completion

### DIFF
--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -3,6 +3,16 @@
 current_branch=`git rev-parse --abbrev-ref HEAD`
 app_name="QuillLMS"
 
+osx_notification=0
+
+for arg in "$@"; do
+  case $arg in
+    --osx-notification)
+      osx_notification=1
+      ;;
+  esac
+done
+
 case $1 in
   prod)
     DEPLOY_GIT_BRANCH=deploy-lms-prod
@@ -81,6 +91,11 @@ then
     open "https://dashboard.heroku.com/apps/$HEROKU_APP/activity"
     open $URL
     echo "Deploy screen opened in your browser, you can monitor from there."
+
+    if [ "$osx_notification" -eq 1 ]; then
+      ./script/osx_notification_on_build_completion.sh $HEROKU_APP &
+      disown
+    fi
 else
     echo "Ok, we won't deploy. Have a good day!"
 fi

--- a/services/QuillLMS/script/osx_notification_on_build_completion.sh
+++ b/services/QuillLMS/script/osx_notification_on_build_completion.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <heroku_app_name>"
+  exit 1
+fi
+
+# Set your Heroku app name from the first command line argument
+APP_NAME="$1"
+
+# Fetch the latest build status
+FOURTH_LINE=$(heroku builds -a $APP_NAME | sed -n 4p)
+STATUS=""
+
+if echo "$FOURTH_LINE" | grep -q "pending"; then
+  STATUS="pending"
+elif echo "$FOURTH_LINE" | grep -q "succeeded"; then
+  STATUS="succeeded"
+elif echo "$FOURTH_LINE" | grep -q "failed"; then
+  STATUS="failed"
+else
+  STATUS="unknown"
+fi
+
+# Wait for the build to finish
+echo "Build is in progress..."
+while [ "$STATUS" == "pending" ]; do
+  sleep 5
+  FOURTH_LINE=$(heroku builds -a $APP_NAME | sed -n 4p)
+
+  if echo "$FOURTH_LINE" | grep -q "pending"; then
+    STATUS="pending"
+  elif echo "$FOURTH_LINE" | grep -q "succeeded"; then
+    STATUS="succeeded"
+  elif echo "$FOURTH_LINE" | grep -q "failed"; then
+    STATUS="failed"
+  else
+    STATUS="unknown"
+  fi
+done
+
+osascript -e "display notification \"build_status: $STATUS\" with title \"Heroku: $APP_NAME\""


### PR DESCRIPTION
## WHAT
Add an option to deploy script that sends OSX notification when heroku build completes.
![Screenshot 2024-03-06 at 12 25 30 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/34997900-c723-4337-962c-f26d8a83d711)

## WHY
Monitoring build through browser is not helpful since the progress meter idles even when it is complete:

https://github.com/empirical-org/Empirical-Core/assets/2057805/1ad78a99-f21c-4d9f-a22a-4a3d16adfa70


It's also nice to have another reminder in case attention gets distracted away from browser.

## HOW
Add a command line argument for the deploy script `--osx-notification` which will call the script `script/osx_notification_on_build_completion.sh` a script that calls `heroku builds -a app_name` and parses the status of the latest build.  When the build status changes to complete, fire a notifiation using `osascript`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I pushed this feature up to staging and the notification fired correctly when the build was complete.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  This is non-app.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
