### PR TITLE
Update osx notifications script for builds.

### DIFF
--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -93,8 +93,7 @@ then
     echo "Deploy screen opened in your browser, you can monitor from there."
 
     if [ "$osx_notification" -eq 1 ]; then
-      ./script/osx_notification_on_build_completion.sh $HEROKU_APP &
-      disown
+      ./script/osx_notification_on_build_completion.sh $HEROKU_APP
     fi
 else
     echo "Ok, we won't deploy. Have a good day!"

--- a/services/QuillLMS/script/osx_notification_on_build_completion.sh
+++ b/services/QuillLMS/script/osx_notification_on_build_completion.sh
@@ -8,7 +8,7 @@ fi
 # Set your Heroku app name
 APP_NAME="$1"
 
-echo "Build is in progress..."
+echo "Build is in progress...(ctrl+c to exit monitoring; note that the build will continue)"
 
 # wait for the build to start;
 # otherwise FOURTH LINE return "succeeded" from a previous build

--- a/services/QuillLMS/script/osx_notification_on_build_completion.sh
+++ b/services/QuillLMS/script/osx_notification_on_build_completion.sh
@@ -5,8 +5,14 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-# Set your Heroku app name from the first command line argument
+# Set your Heroku app name
 APP_NAME="$1"
+
+echo "Build is in progress..."
+
+# wait for the build to start;
+# otherwise FOURTH LINE return "succeeded" from a previous build
+sleep 30
 
 # Fetch the latest build status
 FOURTH_LINE=$(heroku builds -a $APP_NAME | sed -n 4p)
@@ -22,8 +28,6 @@ else
   STATUS="unknown"
 fi
 
-# Wait for the build to finish
-echo "Build is in progress..."
 while [ "$STATUS" == "pending" ]; do
   sleep 5
   FOURTH_LINE=$(heroku builds -a $APP_NAME | sed -n 4p)


### PR DESCRIPTION
## WHAT
Some updates from the OSX notification [script](https://github.com/empirical-org/Empirical-Core/pull/11574) to improve consistency with the notification showing

1.  Remove process detaching and just run the script in the current process
2. Add some sleep before looping over the pending status.

## WHY
1. Background job handling in the shell seems flaky when other terminals are opened, so keep the monitoring within the current session. 
2. The script pings the `heroku builds -a app-name` and then parses the contents of the fourth row.  If the build hasn't begun, the script will actually parse the build status from the previous build which will not be `pending`, resulting in an early exit.

## HOW
1.  Remove `&` and subsequent `disown` call.
2.  Add a `sleep 30` before the initial setting of `FOURTH_LINE`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I've deployed this branch a few times with a few versions and the notification consistently displays.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
