### PR TITLE
Add prompt response feedback model

### DIFF
--- a/services/QuillLMS/db/migrate/20240307143356_create_evidence_prompt_response_feedbacks.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240307143356_create_evidence_prompt_response_feedbacks.evidence.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240307142932)
+class CreateEvidencePromptResponseFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_prompt_response_feedbacks do |t|
+      t.integer :prompt_response_id, null: false
+      t.text :feedback, null: false
+      t.jsonb :metadata
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2775,6 +2775,39 @@ ALTER SEQUENCE public.evidence_prompt_healths_id_seq OWNED BY public.evidence_pr
 
 
 --
+-- Name: evidence_prompt_response_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_prompt_response_feedbacks (
+    id bigint NOT NULL,
+    prompt_response_id integer NOT NULL,
+    feedback text NOT NULL,
+    metadata jsonb,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_prompt_response_feedbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_prompt_response_feedbacks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_prompt_response_feedbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_prompt_response_feedbacks_id_seq OWNED BY public.evidence_prompt_response_feedbacks.id;
+
+
+--
 -- Name: evidence_prompt_responses; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6021,6 +6054,13 @@ ALTER TABLE ONLY public.evidence_prompt_healths ALTER COLUMN id SET DEFAULT next
 
 
 --
+-- Name: evidence_prompt_response_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_response_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_prompt_response_feedbacks_id_seq'::regclass);
+
+
+--
 -- Name: evidence_prompt_responses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7139,6 +7179,14 @@ ALTER TABLE ONLY public.evidence_hints
 
 ALTER TABLE ONLY public.evidence_prompt_healths
     ADD CONSTRAINT evidence_prompt_healths_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_prompt_response_feedbacks evidence_prompt_response_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_response_feedbacks
+    ADD CONSTRAINT evidence_prompt_response_feedbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -10800,6 +10848,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240111143245'),
 ('20240221192859'),
 ('20240229153806'),
-('20240306124720');
+('20240306124720'),
+('20240307143356');
 
 

--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -93,8 +93,7 @@ then
     echo "Deploy screen opened in your browser, you can monitor from there."
 
     if [ "$osx_notification" -eq 1 ]; then
-      ./script/osx_notification_on_build_completion.sh $HEROKU_APP &
-      disown
+      ./script/osx_notification_on_build_completion.sh $HEROKU_APP
     fi
 else
     echo "Ok, we won't deploy. Have a good day!"

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_response.rb
@@ -22,7 +22,7 @@ module Evidence
 
     has_neighbors :embedding
 
-    validates :text, presence: true, uniqueness: true
+    validates :text, presence: true
     validates :embedding, presence: true
     validates :prompt, presence: true
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_response_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_response_feedback.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_prompt_response_feedbacks
+#
+#  id                 :bigint           not null, primary key
+#  feedback           :text             not null
+#  metadata           :jsonb
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  prompt_response_id :integer          not null
+#
+module Evidence
+  class PromptResponseFeedback < ApplicationRecord
+    belongs_to :prompt_response
+
+    validates :feedback, presence: true
+    validates :prompt_response, presence: true
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240307142932_create_evidence_prompt_response_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240307142932_create_evidence_prompt_response_feedbacks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateEvidencePromptResponseFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_prompt_response_feedbacks do |t|
+      t.integer :prompt_response_id, null: false
+      t.text :feedback, null: false
+      t.jsonb :metadata
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -765,6 +765,39 @@ ALTER SEQUENCE public.evidence_prompt_healths_id_seq OWNED BY public.evidence_pr
 
 
 --
+-- Name: evidence_prompt_response_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_prompt_response_feedbacks (
+    id bigint NOT NULL,
+    prompt_response_id integer NOT NULL,
+    feedback text NOT NULL,
+    metadata jsonb,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_prompt_response_feedbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_prompt_response_feedbacks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_prompt_response_feedbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_prompt_response_feedbacks_id_seq OWNED BY public.evidence_prompt_response_feedbacks.id;
+
+
+--
 -- Name: evidence_prompt_responses; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1075,6 +1108,13 @@ ALTER TABLE ONLY public.evidence_prompt_healths ALTER COLUMN id SET DEFAULT next
 
 
 --
+-- Name: evidence_prompt_response_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_response_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_prompt_response_feedbacks_id_seq'::regclass);
+
+
+--
 -- Name: evidence_prompt_responses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1275,6 +1315,14 @@ ALTER TABLE ONLY public.evidence_hints
 
 ALTER TABLE ONLY public.evidence_prompt_healths
     ADD CONSTRAINT evidence_prompt_healths_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_prompt_response_feedbacks evidence_prompt_response_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_prompt_response_feedbacks
+    ADD CONSTRAINT evidence_prompt_response_feedbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -1573,6 +1621,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230306215624'),
 ('20230911142601'),
 ('20240221192859'),
-('20240305224710');
+('20240305224710'),
+('20240307142932');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_response_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_response_feedbacks.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_prompt_response_feedbacks
+#
+#  id                 :bigint           not null, primary key
+#  feedback           :text             not null
+#  metadata           :jsonb
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  prompt_response_id :integer          not null
+#
+
+FactoryBot.define do
+  factory :evidence_prompt_response_feedback, class: 'Evidence::PromptResponseFeedback' do
+    feedback { Faker::Lorem.sentence }
+    association :prompt_response, factory: :evidence_prompt_response
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_response_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_response_feedback_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+# == Schema Information
+#
+# Table name: evidence_prompt_response_feedbacks
+#
+#  id                 :bigint           not null, primary key
+#  feedback           :text             not null
+#  metadata           :jsonb
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  prompt_response_id :integer          not null
+#
+
+module Evidence
+  RSpec.describe PromptResponseFeedback, type: :model do
+    it { is_expected.to belong_to(:prompt_response) }
+
+    it { is_expected.to validate_presence_of(:feedback) }
+    it { is_expected.to validate_presence_of(:prompt_response) }
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_response_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_response_spec.rb
@@ -14,28 +14,17 @@ require 'rails_helper'
 
 module Evidence
   RSpec.describe PromptResponse do
-    let(:text) { 'sample text' }
-
-    context 'validations' do
-      it { is_expected.to validate_presence_of(:prompt) }
-      it { is_expected.to validate_presence_of(:text) }
-      it { is_expected.to validate_presence_of(:embedding) }
-
-      context 'uniqueness' do
-        subject { FactoryBot.build(:evidence_prompt_response) }
-
-        before { FactoryBot.create(:evidence_prompt_response, text: subject.text) }
-
-        it { is_expected.to validate_uniqueness_of(:text) }
-      end
-    end
+    it { is_expected.to validate_presence_of(:prompt) }
+    it { is_expected.to validate_presence_of(:text) }
+    it { is_expected.to validate_presence_of(:embedding) }
 
     context 'with stubbed embedding' do
       subject { FactoryBot.build(:evidence_prompt_response, text:, embedding: initial_embedding) }
 
-      let(:fetcher_class) { Evidence::OpenAI::EmbeddingFetcher }
+      let(:text) { 'sample text' }
       let(:initial_embedding) { nil }
       let(:embedding) { Array.new(Evidence::PromptResponse::DIMENSION) { rand(-1.0..1.0) } }
+      let(:fetcher_class) { Evidence::OpenAI::EmbeddingFetcher }
 
       before { allow(fetcher_class).to receive(:run).and_return(embedding) }
 

--- a/services/QuillLMS/lib/tasks/auto_annotate_models.rake
+++ b/services/QuillLMS/lib/tasks/auto_annotate_models.rake
@@ -23,7 +23,7 @@ if Rails.env.development?
       'show_complete_foreign_keys'  => 'false',
       'show_indexes'                => 'true',
       'simple_indexes'              => 'false',
-      'model_dir'                   => 'app/models',
+      'model_dir'                   => 'app/models, engines/evidence/app/models',
       'root_dir'                    => '',
       'include_version'             => 'false',
       'require'                     => '',

--- a/services/QuillLMS/script/osx_notification_on_build_completion.sh
+++ b/services/QuillLMS/script/osx_notification_on_build_completion.sh
@@ -8,7 +8,7 @@ fi
 # Set your Heroku app name
 APP_NAME="$1"
 
-echo "Build is in progress..."
+echo "Build is in progress...(ctrl+c to exit monitoring; note that the build will continue)"
 
 # wait for the build to start;
 # otherwise FOURTH LINE return "succeeded" from a previous build

--- a/services/QuillLMS/script/osx_notification_on_build_completion.sh
+++ b/services/QuillLMS/script/osx_notification_on_build_completion.sh
@@ -5,8 +5,14 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-# Set your Heroku app name from the first command line argument
+# Set your Heroku app name
 APP_NAME="$1"
+
+echo "Build is in progress..."
+
+# wait for the build to start;
+# otherwise FOURTH LINE return "succeeded" from a previous build
+sleep 30
 
 # Fetch the latest build status
 FOURTH_LINE=$(heroku builds -a $APP_NAME | sed -n 4p)
@@ -22,8 +28,6 @@ else
   STATUS="unknown"
 fi
 
-# Wait for the build to finish
-echo "Build is in progress..."
 while [ "$STATUS" == "pending" ]; do
   sleep 5
   FOURTH_LINE=$(heroku builds -a $APP_NAME | sed -n 4p)


### PR DESCRIPTION
## WHAT
Create the `Evidence:PromptResponseFeedback` model

## WHY
These records will be used in Generative AI experiments

## HOW
From the engine root `rails g model PromptResponseFeedback`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Backend-for-Embeddings-Caching-for-Evidence-2f735c61f06848eeb8fc5c2130390c1f?pvs=4

### What have you done to QA this feature?
I created/destroyed a few records on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
