### PR TITLE
Add closest feedback method

### DIFF
--- a/services/QuillLMS/db/migrate/20240307182109_change_prompt_response_text_name.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240307182109_change_prompt_response_text_name.evidence.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240307165408)
+class ChangePromptResponseTextName < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :evidence_prompt_responses, :text, :response_text
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2814,7 +2814,7 @@ ALTER SEQUENCE public.evidence_prompt_response_feedbacks_id_seq OWNED BY public.
 CREATE TABLE public.evidence_prompt_responses (
     id bigint NOT NULL,
     prompt_id integer NOT NULL,
-    text text NOT NULL,
+    response_text text NOT NULL,
     embedding public.vector(1536) NOT NULL
 );
 
@@ -10849,6 +10849,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240221192859'),
 ('20240229153806'),
 ('20240306124720'),
-('20240307143356');
+('20240307143356'),
+('20240307182109');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_response.rb
@@ -32,18 +32,15 @@ module Evidence
     before_validation :set_embedding
 
     def closest_prompt_response
-      @closest_prompt_response ||= begin
-        nearest_neighbors(:embedding, distance: DISTANCE_METRIC)
-          .where(prompt_id:)
-          .first
-      end
+      nearest_neighbors(:embedding, distance: DISTANCE_METRIC)
+        .where(prompt_id:)
+        .first
     end
 
     def closest_feedback
-      {
-        distance: closest_prompt_response&.neighbor_distance,
-        feedback: closest_prompt_response&.prompt_response_feedback&.feedback
-      }
+      val = closest_prompt_response
+
+      { distance: val&.neighbor_distance, feedback: val&.prompt_response_feedback&.feedback }
     end
 
     private def set_embedding

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_response.rb
@@ -4,10 +4,10 @@
 #
 # Table name: evidence_prompt_responses
 #
-#  id        :bigint           not null, primary key
-#  embedding :vector(1536)     not null
-#  text      :text             not null
-#  prompt_id :integer          not null
+#  id            :bigint           not null, primary key
+#  embedding     :vector(1536)     not null
+#  response_text :text             not null
+#  prompt_id     :integer          not null
 #
 
 require 'neighbor'
@@ -19,19 +19,22 @@ module Evidence
     MODEL = 'text-embedding-3-small'
 
     belongs_to :prompt
+    has_one :prompt_response_feedback, dependent: :destroy
 
     has_neighbors :embedding
 
-    validates :text, presence: true
+    validates :response_text, presence: true
     validates :embedding, presence: true
     validates :prompt, presence: true
 
     before_validation :set_embedding
 
-    private def set_embedding
-      return if text.blank? || embedding.present?
+    delegate :feedback, to: :prompt_response_feedback, allow_nil: true
 
-      self.embedding = Evidence::OpenAI::EmbeddingFetcher.run(dimension: DIMENSION, input: text, model: MODEL)
+    private def set_embedding
+      return if response_text.blank? || embedding.present?
+
+      self.embedding = Evidence::OpenAI::EmbeddingFetcher.run(dimension: DIMENSION, input: response_text, model: MODEL)
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240307165408_change_prompt_response_text_name.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240307165408_change_prompt_response_text_name.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangePromptResponseTextName < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :evidence_prompt_responses, :text, :response_text
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -804,7 +804,7 @@ ALTER SEQUENCE public.evidence_prompt_response_feedbacks_id_seq OWNED BY public.
 CREATE TABLE public.evidence_prompt_responses (
     id bigint NOT NULL,
     prompt_id integer NOT NULL,
-    text text NOT NULL,
+    response_text text NOT NULL,
     embedding public.vector(1536) NOT NULL
 );
 
@@ -1622,6 +1622,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230911142601'),
 ('20240221192859'),
 ('20240305224710'),
-('20240307142932');
+('20240307142932'),
+('20240307165408');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_responses.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_responses.rb
@@ -4,10 +4,10 @@
 #
 # Table name: evidence_prompt_responses
 #
-#  id        :bigint           not null, primary key
-#  embedding :vector(1536)     not null
-#  text      :text             not null
-#  prompt_id :integer          not null
+#  id            :bigint           not null, primary key
+#  embedding     :vector(1536)     not null
+#  response_text :text             not null
+#  prompt_id     :integer          not null
 #
 
 FactoryBot.define do

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_responses.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/prompt_responses.rb
@@ -12,7 +12,7 @@
 
 FactoryBot.define do
   factory :evidence_prompt_response, class: 'Evidence::PromptResponse' do
-    text { Faker::Lorem.sentence }
+    response_text { Faker::Lorem.sentence }
     embedding { Array.new(Evidence::PromptResponse::DIMENSION) { rand(-1.0..1.0) } }
 
     association :prompt, factory: :evidence_prompt

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_response_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_response_spec.rb
@@ -4,10 +4,10 @@
 #
 # Table name: evidence_prompt_responses
 #
-#  id        :bigint           not null, primary key
-#  embedding :vector(1536)     not null
-#  text      :text             not null
-#  prompt_id :integer          not null
+#  id            :bigint           not null, primary key
+#  embedding     :vector(1536)     not null
+#  response_text :text             not null
+#  prompt_id     :integer          not null
 #
 
 require 'rails_helper'


### PR DESCRIPTION
## WHAT
1. Add `closest_feedback` method to `Evidence::PromptResponse`
2.  Rename `PromptResponse` text field to `response_text`

## WHY
1.  The method will be useful when populating `Evidence::PromptResponseFeedback`
2.  `text` feels kind of ambiguous since there is also text associated with the prompt.

## HOW
1.  Utilize the neighbor gem's `nearest_neighbors` method and return the top result.
2.  Add migration that renames column

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Backend-for-Embeddings-Caching-for-Evidence-2f735c61f06848eeb8fc5c2130390c1f?pvs=4

### What have you done to QA this feature?
I created some records in the console on staging and verified that the nearest neighbor worked.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
