### PR TITLE
display student scores on their dashboard

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
@@ -240,7 +240,7 @@
       margin-bottom: 0px;
     }
     .dropdown-container {
-      min-width: 127px;
+      min-width: 156px;
     }
     .input-container .dropdown .dropdown__single-value {
       font-size: 14px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -123,6 +123,7 @@
       }
       .data-table-headers, .data-table-header, .data-table-row, .data-table-row-section {
         min-width: auto !important;
+        width: auto !important;
       }
       .data-table-row {
         flex-wrap: wrap;

--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -106,7 +106,7 @@
     }
 
     @media (max-width: 1200px) {
-      .tool-icon-section, .completed-due-date-section {
+      .tool-icon-section, .completed-due-date-section, .completed-date-section {
         display: none;
       }
       .name-section {
@@ -128,7 +128,7 @@
         flex-wrap: wrap;
       }
     }
-    @media (max-width: 682px) {
+    @media (max-width: 850px) {
       .name-section {
         white-space: normal;
       }
@@ -152,13 +152,18 @@
       .score-section {
         flex: 1;
         overflow: visible;
+        margin-right: 0px;
+        .quill-tooltip-trigger {
+          margin-right: 0px;
+        }
         .score {
-          position: relative;
+          flex-direction: column;
+          align-items: flex-start;
+          div {
+            margin-bottom: 8px;
+          }
           span {
-            position: absolute;
-            top: 32px;
-            max-width: 80px;
-            white-space: normal
+            white-space: normal;
           }
         }
       }

--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -3,6 +3,9 @@
   border: solid 1px $quill-grey-5;
   background-color: $quill-white;
   margin-bottom: 24px;
+  .score-tooltip-activator {
+    position: relative;
+  }
   &.selected-unit {
     .unit-name-and-staggered-release-status {
       animation: highlight 5s 1;

--- a/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/main.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/main.scss
@@ -3,7 +3,7 @@
   i, svg {
     position: absolute;
     top: -20px;
-    left: 146px;
+    left: 188px;
     font-size: 34px;
     color: $quill-white;
     &.border-color {

--- a/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/main.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/main.scss
@@ -55,6 +55,7 @@
       justify-content: space-between;
       padding-top: 10px;
       border-top: 1px solid $quill-grey-15;
+      white-space: normal;
       &.no-border-top {
         border-top: none;
         padding-bottom: 0 !important;

--- a/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/scorebook-tooltip.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/scorebook-tooltip.scss
@@ -37,6 +37,7 @@
   padding: 24px;
 
   .title {
+    white-space: normal;
     text-align: left;
     font-weight: 700;
     padding-bottom: 10px;

--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -29,7 +29,7 @@ class GradesController < ApplicationController
       )
       .order(:completed_at)
 
-    activity_sessions.map { |activity_session| activity_session.format_activity_sessions_for_tooltip(current_user) }
+    activity_sessions.map { |activity_session| format_activity_session_for_tooltip(activity_session, current_user) }
   end
 
   private def authorize!

--- a/services/QuillLMS/app/controllers/grades_controller.rb
+++ b/services/QuillLMS/app/controllers/grades_controller.rb
@@ -29,41 +29,7 @@ class GradesController < ApplicationController
       )
       .order(:completed_at)
 
-    activity_sessions.map { |activity_session| format_activity_sessions_for_tooltip(activity_session) }
-  end
-
-  private def format_activity_sessions_for_tooltip(activity_session)
-    unit_activity = UnitActivity.find_by(unit: activity_session.unit, activity: activity_session.activity)
-
-    questions = activity_session.concept_results.group_by { |cr| cr.question_number }
-
-    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, activity_session) }
-
-    correct_key_target_skill_concepts = key_target_skill_concepts.filter { |ktsc| ktsc[:correct] }
-
-    {
-      id: activity_session.id,
-      percentage: activity_session.percentage,
-      description: activity_session.activity.description,
-      due_date: unit_activity.due_date,
-      completed_at: activity_session.completed_at + current_user.utc_offset.seconds,
-      grouped_key_target_skill_concepts: format_grouped_key_target_skill_concepts(key_target_skill_concepts),
-      number_of_questions: questions.length,
-      number_of_correct_questions: correct_key_target_skill_concepts.length,
-      timespent: activity_session.timespent
-    }
-  end
-
-  private def format_grouped_key_target_skill_concepts(key_target_skill_concepts)
-    key_target_skill_concepts
-      .group_by { |ktsc| ktsc[:name] }
-      .map do |key, key_target_skill_group|
-        {
-          name: key_target_skill_group.first[:name],
-          correct: key_target_skill_group.filter { |ktsc| ktsc[:correct] }.length,
-          incorrect: key_target_skill_group.filter { |ktsc| ktsc[:correct] == false }.length,
-        }
-      end
+    activity_sessions.map { |activity_session| activity_session.format_activity_sessions_for_tooltip(current_user) }
   end
 
   private def authorize!

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -33,12 +33,15 @@ class ProfilesController < ApplicationController
 
   def student_profile_data
     if current_user.classrooms.any?
+      classroom_id = params[:current_classroom_id]
+
       render json: {
-        scores: student_profile_data_sql(params[:current_classroom_id]),
+        scores: student_profile_data_sql(classroom_id),
         next_activity_session: next_activity_session,
         student: student_data,
-        classroom_id: params[:current_classroom_id],
-        metrics: StudentDashboardMetrics.new(current_user, params[:current_classroom_id]).run
+        classroom_id: classroom_id,
+        show_scores: Classroom.find_by_id(classroom_id)&.owner&.teacher_info&.show_students_exact_score,
+        metrics: StudentDashboardMetrics.new(current_user, classroom_id).run
       }
     else
       render json: {error: 'Current user has no classrooms'}

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ProfilesController < ApplicationController
+  include PublicProgressReports
+
   before_action :signed_in!
 
   def show
@@ -66,7 +68,7 @@ class ProfilesController < ApplicationController
         .where(user_id: current_user.id, activity_id: ua['activity_id'], classroom_unit_id: ua['classroom_unit_id'])
       completed_sessions = activity_sessions.where(state: ActivitySession::STATE_FINISHED)
 
-      ua['sessions'] = activity_sessions.map { |as| as.format_activity_sessions_for_tooltip(current_user) }
+      ua['sessions'] = activity_sessions.map { |as| format_activity_session_for_tooltip(as, current_user) }
       ua['completed_attempts'] = completed_sessions.length
 
       ua

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -32,17 +32,19 @@ class ProfilesController < ApplicationController
   end
 
   def student_profile_data
-    if current_user.classrooms.any?
-      classroom_id = params[:current_classroom_id]
+    classroom_id = params[:current_classroom_id]
 
+    if current_user.classrooms.any? && classroom_id
       render json: {
         scores: student_profile_data_sql(classroom_id),
         next_activity_session: next_activity_session,
         student: student_data,
         classroom_id: classroom_id,
-        show_scores: Classroom.find_by_id(classroom_id)&.owner&.teacher_info&.show_students_exact_score,
+        show_exact_scores: Classroom.find_by_id(classroom_id)&.owner&.teacher_info&.show_students_exact_score,
         metrics: StudentDashboardMetrics.new(current_user, classroom_id).run
       }
+    elsif current_user.classrooms.any?
+      render json: {}
     else
       render json: {error: 'Current user has no classrooms'}
     end

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -65,11 +65,15 @@ class ProfilesController < ApplicationController
     exact_scores_data = params[:data].map do |ua|
       activity_sessions = ActivitySession
         .includes(:concept_results, :activity, :unit)
-        .where(user_id: current_user.id, activity_id: ua['activity_id'], classroom_unit_id: ua['classroom_unit_id'])
-      completed_sessions = activity_sessions.where(state: ActivitySession::STATE_FINISHED)
+        .where(
+          user_id: current_user.id,
+          activity_id: ua['activity_id'],
+          classroom_unit_id: ua['classroom_unit_id'],
+          state: ActivitySession::STATE_FINISHED
+        )
 
       ua['sessions'] = activity_sessions.map { |as| format_activity_session_for_tooltip(as, current_user) }
-      ua['completed_attempts'] = completed_sessions.length
+      ua['completed_attempts'] = activity_sessions.length
 
       ua
     end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -40,6 +40,7 @@ class ActivitySession < ApplicationRecord
 
   include Uid
   include Concepts
+  include PublicProgressReports
 
   COMPLETED = 'Completed'
 
@@ -512,6 +513,26 @@ class ActivitySession < ApplicationRecord
 
   def is_evidence?
     classification.key == ActivityClassification::EVIDENCE_KEY
+  end
+
+  def format_activity_sessions_for_tooltip(current_user)
+    questions = concept_results.group_by { |cr| cr.question_number }
+
+    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, self) }
+
+    correct_key_target_skill_concepts = key_target_skill_concepts.filter { |ktsc| ktsc[:correct] }
+
+    {
+      id:id,
+      percentage:percentage,
+      description:activity.description,
+      due_date: unit_activity.due_date,
+      completed_at:completed_at + current_user.utc_offset.seconds,
+      grouped_key_target_skill_concepts: format_grouped_key_target_skill_concepts(key_target_skill_concepts),
+      number_of_questions: questions.length,
+      number_of_correct_questions: correct_key_target_skill_concepts.length,
+      timespent:timespent
+    }
   end
 
   private def correctly_assigned

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -515,26 +515,6 @@ class ActivitySession < ApplicationRecord
     classification.key == ActivityClassification::EVIDENCE_KEY
   end
 
-  def format_activity_sessions_for_tooltip(user)
-    questions = concept_results.group_by { |cr| cr.question_number }
-
-    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, self) }
-
-    correct_key_target_skill_concepts = key_target_skill_concepts.filter { |ktsc| ktsc[:correct] }
-
-    {
-      id: id,
-      percentage: percentage,
-      description: activity.description,
-      due_date: unit_activity.due_date,
-      completed_at: completed_at + user.utc_offset.seconds,
-      grouped_key_target_skill_concepts: format_grouped_key_target_skill_concepts(key_target_skill_concepts),
-      number_of_questions: questions.length,
-      number_of_correct_questions: correct_key_target_skill_concepts.length,
-      timespent: timespent
-    }
-  end
-
   private def correctly_assigned
     if classroom_unit && (classroom_unit.validate_assigned_student(user_id) == false)
       ErrorNotifier.report(StudentNotAssignedActivityError.new)

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -515,7 +515,7 @@ class ActivitySession < ApplicationRecord
     classification.key == ActivityClassification::EVIDENCE_KEY
   end
 
-  def format_activity_sessions_for_tooltip(current_user)
+  def format_activity_sessions_for_tooltip(user)
     questions = concept_results.group_by { |cr| cr.question_number }
 
     key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, self) }
@@ -523,15 +523,15 @@ class ActivitySession < ApplicationRecord
     correct_key_target_skill_concepts = key_target_skill_concepts.filter { |ktsc| ktsc[:correct] }
 
     {
-      id:id,
-      percentage:percentage,
-      description:activity.description,
+      id: id,
+      percentage: percentage,
+      description: activity.description,
       due_date: unit_activity.due_date,
-      completed_at:completed_at + current_user.utc_offset.seconds,
+      completed_at: completed_at + user.utc_offset.seconds,
       grouped_key_target_skill_concepts: format_grouped_key_target_skill_concepts(key_target_skill_concepts),
       number_of_questions: questions.length,
       number_of_correct_questions: correct_key_target_skill_concepts.length,
-      timespent:timespent
+      timespent: timespent
     }
   end
 

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -207,6 +207,26 @@ module PublicProgressReports
     }
   end
 
+  def format_activity_session_for_tooltip(activity_session, user)
+    questions = activity_session.concept_results.group_by { |cr| cr.question_number }
+
+    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, activity_session) }
+
+    correct_key_target_skill_concepts = key_target_skill_concepts.filter { |ktsc| ktsc[:correct] }
+
+    {
+      id: activity_session.id,
+      percentage: activity_session.percentage,
+      description: activity_session.activity.description,
+      due_date: activity_session.unit_activity.due_date,
+      completed_at: activity_session.completed_at + user.utc_offset.seconds,
+      grouped_key_target_skill_concepts: format_grouped_key_target_skill_concepts(key_target_skill_concepts),
+      number_of_questions: questions.length,
+      number_of_correct_questions: correct_key_target_skill_concepts.length,
+      timespent: activity_session.timespent
+    }
+  end
+
   def format_grouped_key_target_skill_concepts(key_target_skill_concepts)
     key_target_skill_concepts
       .group_by { |ktsc| ktsc[:name] }

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -207,6 +207,17 @@ module PublicProgressReports
     }
   end
 
+  def format_grouped_key_target_skill_concepts(key_target_skill_concepts)
+    key_target_skill_concepts
+      .group_by { |ktsc| ktsc[:name] }
+      .map do |key, key_target_skill_group|
+        {
+          name: key_target_skill_group.first[:name],
+          correct: key_target_skill_group.filter { |ktsc| ktsc[:correct] }.length,
+          incorrect: key_target_skill_group.filter { |ktsc| ktsc[:correct] == false }.length,
+        }
+      end
+  end
 
   def get_time_in_minutes(activity_session)
     return 'Untracked' if !(activity_session.started_at && activity_session.completed_at)

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -150,20 +150,30 @@ class UnitActivity < ApplicationRecord
           cu.id AS classroom_unit_id,
           COALESCE(cuas.completed, false) AS marked_complete,
           ua.activity_id,
+          MAX(acts.updated_at) AS act_sesh_updated_at,
           ua.order_number,
           ua.due_date #{student_timezone_offset_string} AS due_date,
+          MIN(acts.completed_at) #{student_timezone_offset_string} AS completed_date,
           pre_activity.id AS pre_activity_id,
           cu.created_at AS unit_activity_created_at,
           upsi.status AS user_pack_sequence_item_status,
           COALESCE(cuas.locked, false) AS locked,
           COALESCE(cuas.pinned, false) AS pinned,
+          MAX(acts.percentage) AS max_percentage,
           CASE WHEN unit.open = false THEN true ELSE false END as closed,
-          SUM(CASE WHEN pre_activity_sessions_classroom_units.id > 0 AND pre_activity_sessions.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) > 0 AS completed_pre_activity_session
+          SUM(CASE WHEN pre_activity_sessions_classroom_units.id > 0 AND pre_activity_sessions.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) > 0 AS completed_pre_activity_session,
+          SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) > 0 AS #{ActivitySession::STATE_FINISHED_KEY},
+          SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_STARTED}' THEN 1 ELSE 0 END) AS resume_link
         FROM unit_activities AS ua
         JOIN units AS unit
           ON unit.id = ua.unit_id
         JOIN classroom_units AS cu
           ON unit.id = cu.unit_id
+        LEFT JOIN activity_sessions AS acts
+          ON cu.id = acts.classroom_unit_id
+          AND acts.activity_id = ua.activity_id
+          AND acts.visible = true
+          AND acts.user_id = #{user_id.to_i}
         JOIN activities AS activity
           ON activity.id = ua.activity_id
         LEFT JOIN activities AS pre_activity
@@ -214,11 +224,13 @@ class UnitActivity < ApplicationRecord
           teachers.time_zone,
           psi.id,
           upsi.id,
-          upsi.status
+          upsi.status,
+          acts.visible
         ORDER BY
           pinned DESC,
           locked ASC,
           unit.created_at ASC,
+          max_percentage DESC,
           ua.order_number ASC,
           ua.due_date ASC,
           ua.id ASC
@@ -228,37 +240,19 @@ class UnitActivity < ApplicationRecord
     # we could also do this with a HAVING clause, but it is pretty difficult to read because the logic for computing those values is complex
     data.filter { |ua| ua['finished'] || !ua['closed'] }
 
+    return data if !include_session_data
+
     data.map do |ua|
       activity_sessions = ActivitySession
         .includes(:concept_results, :activity, :unit)
         .where(user_id:, activity_id: ua['activity_id'], classroom_unit_id: ua['classroom_unit_id'])
-      most_recently_updated_session = activity_sessions.order('activity_sessions.updated_at DESC').first
-      highest_scoring_session = activity_sessions.order('percentage DESC').first
-      first_completed_session = activity_sessions.order('completed_at ASC').first
-
       completed_sessions = activity_sessions.where(state: ActivitySession::STATE_FINISHED)
 
-      if include_session_data
-        ua['sessions'] = activity_sessions.map { |as| as.format_activity_sessions_for_tooltip(student) }
-      end
-
-      # MAX(acts.updated_at) AS act_sesh_updated_at,
-      #
-      # MIN(acts.completed_at) #{student_timezone_offset_string} AS completed_date,
-      #
-      # MAX(acts.percentage) AS max_percentage,
-      #
-      # SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_FINISHED}' THEN 1 ELSE 0 END) > 0 AS #{ActivitySession::STATE_FINISHED_KEY},
-      # SUM(CASE WHEN acts.state = '#{ActivitySession::STATE_STARTED}' THEN 1 ELSE 0 END) AS resume_link
-
-      ua['act_sesh_updated_at'] = most_recently_updated_session&.updated_at
-      ua['max_percentage'] = highest_scoring_session&.percentage
-      ua['completed_date'] = first_completed_session&.completed_at ? first_completed_session.completed_at + student.utc_offset.seconds : nil
-      ua['resume_link'] = activity_sessions.any? { |as| as.state == ActivitySession::STATE_STARTED }
-      ua["#{ActivitySession::STATE_FINISHED_KEY}"] = completed_sessions.any?
+      ua['sessions'] = activity_sessions.map { |as| as.format_activity_sessions_for_tooltip(student) }
       ua['completed_attempts'] = completed_sessions.length
 
       ua
     end
+
   end
 end

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -154,6 +154,7 @@ class UnitActivity < ApplicationRecord
           ua.order_number,
           ua.due_date #{student_timezone_offset_string} AS due_date,
           MIN(acts.completed_at) #{student_timezone_offset_string} AS completed_date,
+          ua.publish_date #{student_timezone_offset_string} AS publish_date,
           pre_activity.id AS pre_activity_id,
           cu.created_at AS unit_activity_created_at,
           upsi.status AS user_pack_sequence_item_status,

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -125,7 +125,7 @@ class UnitActivity < ApplicationRecord
     hide_all_activity_sessions
   end
 
-  def self.get_classroom_user_profile(classroom_id, user_id)
+  def self.get_classroom_user_profile(classroom_id, user_id, include_session_data)
     return [] unless classroom_id && user_id
 
     student = User.find(user_id)
@@ -238,7 +238,9 @@ class UnitActivity < ApplicationRecord
 
       completed_sessions = activity_sessions.where(state: ActivitySession::STATE_FINISHED)
 
-      ua['sessions'] = activity_sessions.map { |as| as.format_activity_sessions_for_tooltip(student) }
+      if include_session_data
+        ua['sessions'] = activity_sessions.map { |as| as.format_activity_sessions_for_tooltip(student) }
+      end
 
       # MAX(acts.updated_at) AS act_sesh_updated_at,
       #

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -125,7 +125,7 @@ class UnitActivity < ApplicationRecord
     hide_all_activity_sessions
   end
 
-  def self.get_classroom_user_profile(classroom_id, user_id, include_session_data)
+  def self.get_classroom_user_profile(classroom_id, user_id)
     return [] unless classroom_id && user_id
 
     student = User.find(user_id)
@@ -239,20 +239,5 @@ class UnitActivity < ApplicationRecord
 
     # we could also do this with a HAVING clause, but it is pretty difficult to read because the logic for computing those values is complex
     data.filter { |ua| ua['finished'] || !ua['closed'] }
-
-    return data if !include_session_data
-
-    data.map do |ua|
-      activity_sessions = ActivitySession
-        .includes(:concept_results, :activity, :unit)
-        .where(user_id:, activity_id: ua['activity_id'], classroom_unit_id: ua['classroom_unit_id'])
-      completed_sessions = activity_sessions.where(state: ActivitySession::STATE_FINISHED)
-
-      ua['sessions'] = activity_sessions.map { |as| as.format_activity_sessions_for_tooltip(student) }
-      ua['completed_attempts'] = completed_sessions.length
-
-      ua
-    end
-
   end
 end

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -139,7 +139,7 @@ class UnitActivity < ApplicationRecord
         SELECT
           unit.name,
           activity.name,
-          activity.description,
+          activity.description AS activity_description,
           activity.repeatable,
           activity.activity_classification_id,
           activity_classifications.key AS activity_classification_key,

--- a/services/QuillLMS/client/app/actions/student_profile.js
+++ b/services/QuillLMS/client/app/actions/student_profile.js
@@ -5,9 +5,13 @@ export const receiveStudentProfile = data => ({
   data
 })
 
-export const fetchStudentProfile = (classroomId) => {
+export const setLoading = () => ({
+  type: 'SET_LOADING'
+})
+
+export const fetchStudentProfile = (classroomId, includeSessionData) => {
   return (dispatch) => {
-    const qs = classroomId ? `?current_classroom_id=${classroomId}` : ''
+    const qs = classroomId ? `?current_classroom_id=${classroomId}&include_session_data=${includeSessionData}` : ''
     requestGet(
       `${process.env.DEFAULT_URL}/student_profile_data${qs}`,
       (body) => {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/key_target_skill_concepts.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/key_target_skill_concepts.test.tsx.snap
@@ -57,10 +57,5 @@ exports[`KeyTargetSkillConcepts component should render 1`] = `
       </div>
     </div>
   </div>
-  <p
-    class="tooltip-message"
-  >
-    Clicking on the activity icon loads the report
-  </p>
 </DocumentFragment>
 `;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
@@ -775,6 +775,7 @@ exports[`ScorebookTooltip component scoring should display a scoring explanation
           </p>
         </div>
       </div>
+      <span />
       <p
         class="tooltip-message"
       >
@@ -914,6 +915,7 @@ exports[`ScorebookTooltip component scoring should display the scoring informati
           </div>
         </div>
       </div>
+      <span />
       <p
         class="tooltip-message"
       >
@@ -1053,6 +1055,7 @@ exports[`ScorebookTooltip component should render 1`] = `
           </div>
         </div>
       </div>
+      <span />
       <p
         class="tooltip-message"
       >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
@@ -148,6 +148,11 @@ exports[`ScorebookTooltip component key target and skills explanation activity h
       >
         This activity has not been completed.
       </p>
+      <p
+        class="tooltip-message"
+      >
+        Clicking on the activity icon loads the report
+      </p>
     </div>
   </div>
 </DocumentFragment>
@@ -300,6 +305,11 @@ exports[`ScorebookTooltip component key target and skills explanation activity h
         class="no-data-message"
       >
         This scheduled activity has not been published.
+      </p>
+      <p
+        class="tooltip-message"
+      >
+        Clicking on the activity icon loads the report
       </p>
     </div>
   </div>
@@ -454,6 +464,11 @@ exports[`ScorebookTooltip component key target and skills explanation activity i
       >
         This activity is set for staggered release and has not been unlocked by this student.
       </p>
+      <p
+        class="tooltip-message"
+      >
+        Clicking on the activity icon loads the report
+      </p>
     </div>
   </div>
 </DocumentFragment>
@@ -606,6 +621,11 @@ exports[`ScorebookTooltip component key target and skills explanation student mi
         class="no-data-message"
       >
         This student has missed this lesson. To make up this material, you can assign this lesson again to the students who missed it.
+      </p>
+      <p
+        class="tooltip-message"
+      >
+        Clicking on the activity icon loads the report
       </p>
     </div>
   </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
@@ -1,5 +1,478 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ScorebookTooltip component in student view should render if the percentage is above the proficient threshold  1`] = `
+<DocumentFragment>
+  <div
+    class="scorebook-tooltip"
+  >
+    <i
+      class="fas fa-caret-up"
+    />
+    <i
+      class="fas fa-caret-up border-color"
+    />
+    <div
+      class="title"
+    >
+      Capitalizing Holidays, People, & Places - Mixed Topics
+    </div>
+    <div
+      class="main"
+    >
+      <div
+        class="activity-overview"
+      >
+        <div
+          class="activity-details"
+        >
+          <div
+            class="activity-detail"
+          >
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Objectives
+              </p>
+              <p
+                class="description"
+              >
+                Students rewrite sentences, adding the correct capitalization.
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Published
+              </p>
+              <p
+                class="description"
+              >
+                December 10, 2021 at 9:00 am
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Due
+              </p>
+              <p
+                class="description"
+              >
+                N/A
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            1st score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                8 of 10 Target Skills Correct (80%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 12, 2021 at 9:00 am / 2 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            2nd score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                6 of 10 Target Skills Correct (60%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 17, 2021 at 9:00 am / 4 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            Scoring
+          </p>
+          <p
+            class="description"
+          >
+            The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color.
+          </p>
+        </div>
+      </div>
+      <p
+        class="no-data-message"
+      >
+        This activity has not been completed.
+      </p>
+      <div
+        class="activity-tooltip-details-section "
+      >
+        <p
+          class="header"
+        >
+          Why Green?
+        </p>
+        <div
+          class="description-block"
+        >
+          <p
+            class="description"
+          >
+            Frequently Demonstrated Skill
+          </p>
+          <p
+            class="description"
+          >
+            100 - 83% of prompts exhibit skill
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ScorebookTooltip component in student view should render if the percentage is below the nearly proficient threshold  1`] = `
+<DocumentFragment>
+  <div
+    class="scorebook-tooltip"
+  >
+    <i
+      class="fas fa-caret-up"
+    />
+    <i
+      class="fas fa-caret-up border-color"
+    />
+    <div
+      class="title"
+    >
+      Capitalizing Holidays, People, & Places - Mixed Topics
+    </div>
+    <div
+      class="main"
+    >
+      <div
+        class="activity-overview"
+      >
+        <div
+          class="activity-details"
+        >
+          <div
+            class="activity-detail"
+          >
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Objectives
+              </p>
+              <p
+                class="description"
+              >
+                Students rewrite sentences, adding the correct capitalization.
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Published
+              </p>
+              <p
+                class="description"
+              >
+                December 10, 2021 at 9:00 am
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Due
+              </p>
+              <p
+                class="description"
+              >
+                N/A
+              </p>
+            </div>
+          </div>
+        </div>
+        <span />
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            Scoring
+          </p>
+          <p
+            class="description"
+          >
+            The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color.
+          </p>
+        </div>
+      </div>
+      <p
+        class="no-data-message"
+      >
+        This activity has not been completed.
+      </p>
+      <div
+        class="activity-tooltip-details-section "
+      >
+        <p
+          class="header"
+        >
+          Why Red?
+        </p>
+        <div
+          class="description-block"
+        >
+          <p
+            class="description"
+          >
+            Rarely Demonstrated Skill
+          </p>
+          <p
+            class="description"
+          >
+            31 - 0% of prompts exhibit skill
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ScorebookTooltip component in student view should render if the percentage is between the nearly proficient threshold and the proficient threshold  1`] = `
+<DocumentFragment>
+  <div
+    class="scorebook-tooltip"
+  >
+    <i
+      class="fas fa-caret-up"
+    />
+    <i
+      class="fas fa-caret-up border-color"
+    />
+    <div
+      class="title"
+    >
+      Capitalizing Holidays, People, & Places - Mixed Topics
+    </div>
+    <div
+      class="main"
+    >
+      <div
+        class="activity-overview"
+      >
+        <div
+          class="activity-details"
+        >
+          <div
+            class="activity-detail"
+          >
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Objectives
+              </p>
+              <p
+                class="description"
+              >
+                Students rewrite sentences, adding the correct capitalization.
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Published
+              </p>
+              <p
+                class="description"
+              >
+                December 10, 2021 at 9:00 am
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Due
+              </p>
+              <p
+                class="description"
+              >
+                N/A
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            1st score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                8 of 10 Target Skills Correct (80%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 12, 2021 at 9:00 am / 2 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            2nd score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                6 of 10 Target Skills Correct (60%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 17, 2021 at 9:00 am / 4 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            Scoring
+          </p>
+          <p
+            class="description"
+          >
+            The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color.
+          </p>
+        </div>
+      </div>
+      <p
+        class="no-data-message"
+      >
+        This activity has not been completed.
+      </p>
+      <div
+        class="activity-tooltip-details-section "
+      >
+        <p
+          class="header"
+        >
+          Why Yellow?
+        </p>
+        <div
+          class="description-block"
+        >
+          <p
+            class="description"
+          >
+            Sometimes Demonstrated Skill
+          </p>
+          <p
+            class="description"
+          >
+            82 - 32% of prompts exhibit skill
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`ScorebookTooltip component key target and skills explanation activity has not been completed 1`] = `
 <DocumentFragment>
   <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/scorebook_tooltip.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/scorebook_tooltip.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import ScorebookTooltip from '../scorebook_tooltip';
 
 describe('ScorebookTooltip component', () => {
-  const mockProps = {
+  const mockData = {
     activity_classification_id: 2,
     activity_description: "Students rewrite sentences, adding the correct capitalization.",
     completed_attempts: 1,
@@ -35,13 +35,15 @@ describe('ScorebookTooltip component', () => {
     ],
     started: 0
   }
+
   it('should render', () => {
-    const { asFragment } = render(<ScorebookTooltip data={mockProps} />);
+    const { asFragment } = render(<ScorebookTooltip data={mockData} />);
     expect(asFragment()).toMatchSnapshot();
   })
+
   describe('scoring', () => {
     it('should display the scoring information for each session', () => {
-      const { asFragment } = render(<ScorebookTooltip data={mockProps} />);
+      const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
       expect(screen.getByText(/1st score/i)).toBeInTheDocument()
       expect(screen.getByText(/December 12, 2021/i)).toBeInTheDocument()
@@ -51,40 +53,59 @@ describe('ScorebookTooltip component', () => {
       expect(screen.getByText(/4 min/i)).toBeInTheDocument()
     })
     it('should display a scoring explanation if it is a Diagnostic activity', () => {
-      mockProps.activity_classification_id = 4
-      const { asFragment } = render(<ScorebookTooltip data={mockProps} />);
+      mockData.activity_classification_id = 4
+      const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
       expect(screen.getByText(/The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color./i)).toBeInTheDocument()
     })
   })
+
   describe('key target and skills explanation', () => {
     it('student missed the lesson', () => {
-      mockProps.marked_complete = true
-      mockProps.completed_attempts = 0
-      const { asFragment } = render(<ScorebookTooltip data={mockProps} />);
+      mockData.marked_complete = true
+      mockData.completed_attempts = 0
+      const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
       expect(screen.getByText(/This student has missed this lesson. To make up this material, you can assign this lesson again to the students who missed it./i)).toBeInTheDocument()
     })
     it('activity has not been published', () => {
-      mockProps.scheduled = true
-      mockProps.completed_attempts = null
-      const { asFragment } = render(<ScorebookTooltip data={mockProps} />);
+      mockData.scheduled = true
+      mockData.completed_attempts = null
+      const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
       expect(screen.getByText(/This scheduled activity has not been published./i)).toBeInTheDocument()
     })
     it('activity is locked', () => {
-      mockProps.scheduled = false
-      mockProps.locked = true
-      const { asFragment } = render(<ScorebookTooltip data={mockProps} />);
+      mockData.scheduled = false
+      mockData.locked = true
+      const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
       expect(screen.getByText(/This activity is set for staggered release and has not been unlocked by this student./i)).toBeInTheDocument()
     })
     it('activity has not been completed', () => {
-      mockProps.locked = false
-      mockProps.completed_attempts = null
-      const { asFragment } = render(<ScorebookTooltip data={mockProps} />);
+      mockData.locked = false
+      mockData.completed_attempts = null
+      const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
       expect(screen.getByText(/This activity has not been completed./i)).toBeInTheDocument()
     })
+  })
+
+  describe('in student view', () => {
+    it('should render if the percentage is below the nearly proficient threshold ', () => {
+      const { asFragment } = render(<ScorebookTooltip data={{ ...mockData, percentage: 0 }} inStudentView={true} />);
+      expect(asFragment()).toMatchSnapshot();
+    })
+
+    it('should render if the percentage is between the nearly proficient threshold and the proficient threshold ', () => {
+      const { asFragment } = render(<ScorebookTooltip data={{ ...mockData, percentage: 0.5 }} inStudentView={true} />);
+      expect(asFragment()).toMatchSnapshot();
+    })
+
+    it('should render if the percentage is above the proficient threshold ', () => {
+      const { asFragment } = render(<ScorebookTooltip data={{ ...mockData, percentage: 0.9 }} inStudentView={true} />);
+      expect(asFragment()).toMatchSnapshot();
+    })
+
   })
 });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/key_target_skill_concepts.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/key_target_skill_concepts.tsx
@@ -28,9 +28,7 @@ export const KeyTargetSkillConcepts = ({ groupedKeyTargetSkillConcepts, }) => {
     </div>
   )
   return(
-    <React.Fragment>
-      {!!groupedKeyTargetSkillConcepts?.length && <ActivityDetailsSection customClass="target-skills-section" description={descriptionElement} header="Target Skills" />}
-    </React.Fragment>
+    !!groupedKeyTargetSkillConcepts?.length ? <ActivityDetailsSection customClass="target-skills-section" description={descriptionElement} header="Target Skills" /> : <span />
   )
 }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/key_target_skill_concepts.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/key_target_skill_concepts.tsx
@@ -30,7 +30,6 @@ export const KeyTargetSkillConcepts = ({ groupedKeyTargetSkillConcepts, }) => {
   return(
     <React.Fragment>
       {!!groupedKeyTargetSkillConcepts?.length && <ActivityDetailsSection customClass="target-skills-section" description={descriptionElement} header="Target Skills" />}
-      <p className="tooltip-message">Clicking on the activity icon loads the report</p>
     </React.Fragment>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
+import moment from 'moment';
 
-import { getTimeSpent } from '../../../helpers/studentReports';
 import ActivityDetails from './activity_details';
 import KeyTargetSkillConcepts from './key_target_skill_concepts';
+import ActivityDetailsSection from './activity_details_section';
+
+import { getTimeSpent } from '../../../helpers/studentReports';
 import numberSuffixBuilder from '../../modules/numberSuffixBuilder';
 import PercentageDisplayer from '../../modules/percentage_displayer.jsx';
 import { proficiencyCutoffsAsPercentage } from '../../../../../modules/proficiency_cutoffs';
-import ActivityDetailsSection from './activity_details_section';
 import { NOT_APPLICABLE, Spinner } from '../../../../Shared'
-import moment from 'moment';
+import useWindowSize from '../../../../Shared/hooks/useWindowSize'
+
+const CARET_LEFT = 146 // from the css file here: https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/main.scss#L6-L7
 
 const ORDINAL_NUMBERS = ['Zeroth', 'First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth']
 const QUILL_DIAGNOSTIC_SCORING_EXPLANATION = "The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color."
@@ -51,8 +55,46 @@ interface ScorebookTooltipProps {
 }
 
 export const ScorebookTooltip = ({ data, inStudentView, }: ScorebookTooltipProps) => {
+  const tooltipRef = React.useRef(null);
+  const [tooltipStyle, setTooltipStyle] = React.useState({});
+  const [caretStyle, setCaretStyle] = React.useState({});
+  const size = useWindowSize()
 
   if (!Object.keys(data).length) { return <span /> }
+
+  React.useEffect(() => {
+    if (tooltipRef.current) {
+      const tooltipRect = tooltipRef.current.getBoundingClientRect();
+      const viewportWidth = size.width;
+
+      let { right, left } = tooltipRect;
+
+      if (left < 0) {
+        setTooltipStyle({
+          left: '0px',
+          right: 'unset'
+        });
+
+        setCaretStyle({
+          left: '16px',
+          right: 'unset'
+        })
+      }
+
+      if (right > viewportWidth) {
+        setTooltipStyle({
+          left: 'unset',
+          right: '0px',
+        });
+
+        setCaretStyle({
+          right: '16px',
+          left: 'unset'
+        })
+      }
+    }
+  }, [size]);
+
 
   const { marked_complete, completed_attempts, locked, scheduled, sessions, started, activity, name } = data
 
@@ -159,9 +201,9 @@ export const ScorebookTooltip = ({ data, inStudentView, }: ScorebookTooltipProps
 
   const title = activity ? activity.name : name;
   return (
-    <div className="scorebook-tooltip">
-      <i className="fas fa-caret-up" />
-      <i className="fas fa-caret-up border-color" />
+    <div className="scorebook-tooltip" ref={tooltipRef} style={tooltipStyle}>
+      <i className="fas fa-caret-up" style={caretStyle} />
+      <i className="fas fa-caret-up border-color" style={caretStyle} />
       <div className="title">
         {title}
       </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
@@ -12,8 +12,6 @@ import { proficiencyCutoffsAsPercentage } from '../../../../../modules/proficien
 import { NOT_APPLICABLE, Spinner } from '../../../../Shared'
 import useWindowSize from '../../../../Shared/hooks/useWindowSize'
 
-const CARET_LEFT = 146 // from the css file here: https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/main.scss#L6-L7
-
 const ORDINAL_NUMBERS = ['Zeroth', 'First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth']
 const QUILL_DIAGNOSTIC_SCORING_EXPLANATION = "The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color."
 const percentageDisplayer = new PercentageDisplayer()
@@ -63,35 +61,37 @@ export const ScorebookTooltip = ({ data, inStudentView, }: ScorebookTooltipProps
   if (!Object.keys(data).length) { return <span /> }
 
   React.useEffect(() => {
-    if (tooltipRef.current) {
-      const tooltipRect = tooltipRef.current.getBoundingClientRect();
-      const viewportWidth = size.width;
+    // this hook makes sure the tooltip doesn't end up off the screen to the left or the right, and repositions the caret if the tooltip itself has moved
 
-      let { right, left } = tooltipRect;
+    if (!tooltipRef.current) { return }
 
-      if (left < 0) {
-        setTooltipStyle({
-          left: '0px',
-          right: 'unset'
-        });
+    const tooltipRect = tooltipRef.current.getBoundingClientRect();
+    const viewportWidth = size.width;
 
-        setCaretStyle({
-          left: '16px',
-          right: 'unset'
-        })
-      }
+    let { right, left } = tooltipRect;
 
-      if (right > viewportWidth) {
-        setTooltipStyle({
-          left: 'unset',
-          right: '0px',
-        });
+    if (left < 0) {
+      setTooltipStyle({
+        left: '0px',
+        right: 'unset'
+      });
 
-        setCaretStyle({
-          right: '16px',
-          left: 'unset'
-        })
-      }
+      setCaretStyle({
+        left: '16px',
+        right: 'unset'
+      })
+    }
+
+    if (right > viewportWidth) {
+      setTooltipStyle({
+        left: 'unset',
+        right: '0px',
+      });
+
+      setCaretStyle({
+        left: 'unset',
+        right: '16px'
+      })
     }
   }, [size]);
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
@@ -13,7 +13,42 @@ const ORDINAL_NUMBERS = ['Zeroth', 'First', 'Second', 'Third', 'Fourth', 'Fifth'
 const QUILL_DIAGNOSTIC_SCORING_EXPLANATION = "The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color."
 const percentageDisplayer = new PercentageDisplayer()
 
-export const ScorebookTooltip = ({ data }) => {
+interface Session {
+  grouped_key_target_skill_concepts: any;
+  percentage: number;
+  number_of_correct_questions: number;
+  number_of_questions: number;
+  completed_at: string;
+  timespent: number;
+}
+
+interface ActivityClassification {
+  id: number;
+}
+
+interface Activity {
+  classification: ActivityClassification;
+  name: string;
+}
+
+interface ScorebookTooltipData {
+  completed_attempts: Number;
+  name: string; // this is the activity name
+  activity_classification_id: Boolean;
+  percentage: number;
+  activity?: Activity;
+  started?: number;
+  sessions?: Array<Session>
+  locked?: Boolean;
+  scheduled?: Boolean;
+  marked_complete?: Boolean;
+}
+
+interface ScorebookTooltipProps {
+  data: ScorebookTooltipData
+}
+
+export const ScorebookTooltip = ({ data }: ScorebookTooltipProps) => {
 
   if (!Object.keys(data).length) { return <span /> }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
@@ -1102,7 +1102,8 @@ exports[`StudentProfileUnit component should render 1`] = `
               "attribute": "name",
               "headerClassName": "name-section",
               "name": "Activity",
-              "rowSectionClassName": "name-section",
+              "noTooltip": true,
+              "rowSectionClassName": "name-section tooltip-section",
               "width": "474px",
             },
             Object {
@@ -1118,7 +1119,7 @@ exports[`StudentProfileUnit component should render 1`] = `
               "headerClassName": "tool-icon-section",
               "name": "Tool",
               "noTooltip": true,
-              "rowSectionClassName": "tool-icon-section",
+              "rowSectionClassName": "tool-icon-section tooltip-section",
               "width": "24px",
             },
             Object {
@@ -1126,7 +1127,7 @@ exports[`StudentProfileUnit component should render 1`] = `
               "headerClassName": "completed-due-date-section",
               "name": "Due date",
               "noTooltip": true,
-              "rowSectionClassName": "completed-due-date-section",
+              "rowSectionClassName": "completed-due-date-section tooltip-section",
               "width": "110px",
             },
             Object {
@@ -1134,7 +1135,7 @@ exports[`StudentProfileUnit component should render 1`] = `
               "headerClassName": "completed-date-section",
               "name": "Completed date",
               "noTooltip": true,
-              "rowSectionClassName": "completed-date-section",
+              "rowSectionClassName": "completed-date-section tooltip-section",
               "width": "110px",
             },
             Object {
@@ -1311,7 +1312,7 @@ exports[`StudentProfileUnit component should render 1`] = `
               key="9"
             >
               <td
-                className="data-table-row-section name-section"
+                className="data-table-row-section name-section tooltip-section"
                 key="name-9"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -1354,7 +1355,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                 </TableCellContentWrapper>
               </td>
               <td
-                className="data-table-row-section tool-icon-section"
+                className="data-table-row-section tool-icon-section tooltip-section"
                 key="tool-9"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -1369,7 +1370,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                 <TableCellContentWrapper />
               </td>
               <td
-                className="data-table-row-section completed-due-date-section"
+                className="data-table-row-section completed-due-date-section tooltip-section"
                 key="dueDate-9"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -1386,7 +1387,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                 </TableCellContentWrapper>
               </td>
               <td
-                className="data-table-row-section completed-date-section"
+                className="data-table-row-section completed-date-section tooltip-section"
                 key="completedDate-9"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -1429,7 +1430,7 @@ exports[`StudentProfileUnit component should render 1`] = `
               key="5"
             >
               <td
-                className="data-table-row-section name-section"
+                className="data-table-row-section name-section tooltip-section"
                 key="name-5"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -1472,7 +1473,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                 </TableCellContentWrapper>
               </td>
               <td
-                className="data-table-row-section tool-icon-section"
+                className="data-table-row-section tool-icon-section tooltip-section"
                 key="tool-5"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -1487,7 +1488,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                 <TableCellContentWrapper />
               </td>
               <td
-                className="data-table-row-section completed-due-date-section"
+                className="data-table-row-section completed-due-date-section tooltip-section"
                 key="dueDate-5"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -1504,7 +1505,7 @@ exports[`StudentProfileUnit component should render 1`] = `
                 </TableCellContentWrapper>
               </td>
               <td
-                className="data-table-row-section completed-date-section"
+                className="data-table-row-section completed-date-section tooltip-section"
                 key="completedDate-5"
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
@@ -1,1552 +1,1500 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StudentProfileUnit component should render 1`] = `
-<StudentProfileUnit
-  data={
-    Object {
-      "complete": Array [
-        Object {
-          "act_sesh_updated_at": "2020-01-16 18:04:02.957825",
-          "activity_classification_id": 2,
-          "activity_id": 138,
-          "classroom_unit_id": 1,
-          "description": "Write ten sentences using the articles a or an.",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": true,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": 1,
-          "name": "A, An",
-          "order_number": 1,
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 9,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-        Object {
-          "act_sesh_updated_at": "2020-01-16 18:07:57.261188",
-          "activity_classification_id": 1,
-          "activity_id": 516,
-          "classroom_unit_id": 1,
-          "description": "Find and correct the 9 errors in this passage.",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": true,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": 0.764705882352941,
-          "name": "Age of Exploration: Spices",
-          "order_number": 5,
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 5,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-      ],
-      "incomplete": Array [
-        Object {
-          "act_sesh_updated_at": null,
-          "activity_classification_id": 5,
-          "activity_id": 608,
-          "classroom_unit_id": 1,
-          "description": "",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": false,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": null,
-          "name": "The Travels of Marco Polo",
-          "order_number": 1,
-          "pack_sequence_item_status": "unlocked",
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 1,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-        Object {
-          "act_sesh_updated_at": null,
-          "activity_classification_id": 5,
-          "activity_id": 607,
-          "classroom_unit_id": 1,
-          "description": "",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": false,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": null,
-          "name": "Christopher Columbus",
-          "order_number": 2,
-          "pack_sequence_item_status": "locked",
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 2,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-        Object {
-          "act_sesh_updated_at": null,
-          "activity_classification_id": 2,
-          "activity_id": 140,
-          "classroom_unit_id": 1,
-          "description": "Write ten sentences using the determiners a, an, or the.",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": false,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": null,
-          "name": "A, An, The",
-          "order_number": 2,
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 10,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-        Object {
-          "act_sesh_updated_at": null,
-          "activity_classification_id": 5,
-          "activity_id": 605,
-          "classroom_unit_id": 1,
-          "description": "",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": false,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": null,
-          "name": "Magellan",
-          "order_number": 3,
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 3,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-        Object {
-          "act_sesh_updated_at": null,
-          "activity_classification_id": 5,
-          "activity_id": 606,
-          "classroom_unit_id": 1,
-          "description": "",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": false,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": null,
-          "name": "Jamestown",
-          "order_number": 4,
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 4,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-        Object {
-          "act_sesh_updated_at": null,
-          "activity_classification_id": 1,
-          "activity_id": 503,
-          "classroom_unit_id": 1,
-          "description": "Find and correct the ten errors in this passage.",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": false,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": null,
-          "name": "Age of Exploration: Sailing with the Stars",
-          "order_number": 6,
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 6,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-        Object {
-          "act_sesh_updated_at": null,
-          "activity_classification_id": 1,
-          "activity_id": 504,
-          "classroom_unit_id": 1,
-          "description": "Find and correct the nine errors in this passage.",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": false,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": null,
-          "name": "Age of Exploration: The Cape of Good Hope",
-          "order_number": 7,
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 7,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-        Object {
-          "act_sesh_updated_at": null,
-          "activity_classification_id": 1,
-          "activity_id": 517,
-          "classroom_unit_id": 1,
-          "description": "Find and correct the 6 errors in this passage.",
-          "due_date": "2020-02-29 05:00:00",
-          "finished": false,
-          "locked": false,
-          "marked_complete": false,
-          "max_percentage": null,
-          "name": "Age of Exploration: Roanoke",
-          "order_number": 8,
-          "pinned": false,
-          "repeatable": true,
-          "resume_link": 0,
-          "ua_id": 8,
-          "unit_activity_created_at": "2020-01-16 17:57:24.712361",
-          "unit_created_at": "2020-01-16 17:57:24.518561",
-          "unit_id": 7,
-          "unit_name": "History: Age of Exploration",
-        },
-      ],
-    }
-  }
-  unitName="Unit"
->
+exports[`StudentProfileUnit component should render completed activities when showExactScores is false 1`] = `
+<DocumentFragment>
   <div
-    className="student-profile-unit undefined"
+    class="student-profile-unit undefined"
   >
     <div
-      className="unit-name-and-staggered-release-status"
+      class="unit-name-and-staggered-release-status"
     >
       <h2
-        className="unit-name"
+        class="unit-name"
       >
         Unit
       </h2>
       <span />
     </div>
     <div
-      className="activities-container incomplete-activities"
+      class="activities-container completed-activities"
     >
-      <DataTable
-        averageFontWidth={7}
-        headers={
-          Array [
-            Object {
-              "attribute": "name",
-              "headerClassName": "name-section",
-              "name": "Activity",
-              "noTooltip": true,
-              "rowSectionClassName": "name-section",
-              "width": "823px",
-            },
-            Object {
-              "attribute": "tool",
-              "headerClassName": "tool-icon-section",
-              "name": "Tool",
-              "noTooltip": true,
-              "rowSectionClassName": "tool-icon-section",
-              "width": "24px",
-            },
-            Object {
-              "attribute": "dueDate",
-              "headerClassName": "due-date-section",
-              "name": "Due date",
-              "noTooltip": true,
-              "rowSectionClassName": "due-date-section",
-              "width": "100px",
-            },
-            Object {
-              "attribute": "actionButton",
-              "headerClassName": "action-button-section",
-              "name": "",
-              "noTooltip": true,
-              "rowSectionClassName": "action-button-section",
-              "width": "88px",
-            },
-          ]
-        }
-        rows={
-          Array [
-            Object {
-              "actionButton": <a
-                aria-label="Start The Travels of Marco Polo"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/608"
-              >
-                Start
-              </a>,
-              "dueDate": "Feb 29, 5am",
-              "id": 1,
-              "name": "The Travels of Marco Polo",
-              "tool": undefined,
-            },
-            Object {
-              "actionButton": <a
-                aria-label="Start Christopher Columbus"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/607"
-              >
-                Start
-              </a>,
-              "dueDate": "Feb 29, 5am",
-              "id": 2,
-              "name": "Christopher Columbus",
-              "tool": undefined,
-            },
-            Object {
-              "actionButton": <a
-                aria-label="Start A, An, The"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/140"
-              >
-                Start
-              </a>,
-              "dueDate": "Feb 29, 5am",
-              "id": 10,
-              "name": "A, An, The",
-              "tool": undefined,
-            },
-            Object {
-              "actionButton": <a
-                aria-label="Start Magellan"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/605"
-              >
-                Start
-              </a>,
-              "dueDate": "Feb 29, 5am",
-              "id": 3,
-              "name": "Magellan",
-              "tool": undefined,
-            },
-            Object {
-              "actionButton": <a
-                aria-label="Start Jamestown"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/606"
-              >
-                Start
-              </a>,
-              "dueDate": "Feb 29, 5am",
-              "id": 4,
-              "name": "Jamestown",
-              "tool": undefined,
-            },
-            Object {
-              "actionButton": <a
-                aria-label="Start Age of Exploration: Sailing with the Stars"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/503"
-              >
-                Start
-              </a>,
-              "dueDate": "Feb 29, 5am",
-              "id": 6,
-              "name": "Age of Exploration: Sailing with the Stars",
-              "tool": undefined,
-            },
-            Object {
-              "actionButton": <a
-                aria-label="Start Age of Exploration: The Cape of Good Hope"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/504"
-              >
-                Start
-              </a>,
-              "dueDate": "Feb 29, 5am",
-              "id": 7,
-              "name": "Age of Exploration: The Cape of Good Hope",
-              "tool": undefined,
-            },
-            Object {
-              "actionButton": <a
-                aria-label="Start Age of Exploration: Roanoke"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/517"
-              >
-                Start
-              </a>,
-              "dueDate": "Feb 29, 5am",
-              "id": 8,
-              "name": "Age of Exploration: Roanoke",
-              "tool": undefined,
-            },
-          ]
-        }
+      <table
+        class="data-table undefined"
       >
-        <table
-          className="data-table undefined"
-        >
-          <thead>
-            <tr
-              className="data-table-headers"
-            >
-              <th
-                className="data-table-header name-section"
-                key="0"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "823px",
-                    "textAlign": "left",
-                    "width": "823px",
-                  }
-                }
-              >
-                <span>
-                  Activity
-                </span>
-              </th>
-              <th
-                className="data-table-header tool-icon-section"
-                key="1"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <span>
-                  Tool
-                </span>
-              </th>
-              <th
-                className="data-table-header due-date-section"
-                key="2"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                  Due date
-                </span>
-              </th>
-              <th
-                className="data-table-header action-button-section"
-                key="3"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <span />
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className="data-table-body"
+        <thead>
+          <tr
+            class="data-table-headers"
           >
-            <tr
-              className="data-table-row  "
-              key="1"
+            <th
+              class="data-table-header name-section"
+              scope="col"
+              style="width: 474px; min-width: 474px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section"
-                key="name-1"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "823px",
-                    "textAlign": "left",
-                    "width": "823px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  The Travels of Marco Polo
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section"
-                key="tool-1"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section due-date-section"
-                key="dueDate-1"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section action-button-section"
-                key="actionButton-1"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Start The Travels of Marco Polo"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/608"
-                  >
-                    Start
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-            <tr
-              className="data-table-row  "
-              key="2"
+              <span>
+                Activity
+              </span>
+            </th>
+            <th
+              class="data-table-header score-section tooltip-section"
+              scope="col"
+              style="width: 230px; min-width: 230px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section"
-                key="name-2"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "823px",
-                    "textAlign": "left",
-                    "width": "823px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Christopher Columbus
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section"
-                key="tool-2"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section due-date-section"
-                key="dueDate-2"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section action-button-section"
-                key="actionButton-2"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Start Christopher Columbus"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/607"
-                  >
-                    Start
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-            <tr
-              className="data-table-row  "
-              key="10"
+              <span>
+                Score
+              </span>
+            </th>
+            <th
+              class="data-table-header tool-icon-section"
+              scope="col"
+              style="width: 24px; min-width: 24px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section"
-                key="name-10"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "823px",
-                    "textAlign": "left",
-                    "width": "823px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  A, An, The
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section"
-                key="tool-10"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section due-date-section"
-                key="dueDate-10"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section action-button-section"
-                key="actionButton-10"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Start A, An, The"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/140"
-                  >
-                    Start
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-            <tr
-              className="data-table-row  "
-              key="3"
+              <span>
+                Tool
+              </span>
+            </th>
+            <th
+              class="data-table-header completed-due-date-section"
+              scope="col"
+              style="width: 110px; min-width: 110px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section"
-                key="name-3"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "823px",
-                    "textAlign": "left",
-                    "width": "823px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Magellan
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section"
-                key="tool-3"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section due-date-section"
-                key="dueDate-3"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section action-button-section"
-                key="actionButton-3"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Start Magellan"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/605"
-                  >
-                    Start
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-            <tr
-              className="data-table-row  "
-              key="4"
+              <span>
+                Due date
+              </span>
+            </th>
+            <th
+              class="data-table-header completed-date-section"
+              scope="col"
+              style="width: 110px; min-width: 110px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section"
-                key="name-4"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "823px",
-                    "textAlign": "left",
-                    "width": "823px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Jamestown
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section"
-                key="tool-4"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section due-date-section"
-                key="dueDate-4"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section action-button-section"
-                key="actionButton-4"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Start Jamestown"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/606"
-                  >
-                    Start
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-            <tr
-              className="data-table-row  "
-              key="6"
+              <span>
+                Completed date
+              </span>
+            </th>
+            <th
+              class="data-table-header action-button-section tooltip-section"
+              scope="col"
+              style="width: 88px; min-width: 88px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section"
-                key="name-6"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "823px",
-                    "textAlign": "left",
-                    "width": "823px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Age of Exploration: Sailing with the Stars
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section"
-                key="tool-6"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section due-date-section"
-                key="dueDate-6"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section action-button-section"
-                key="actionButton-6"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Start Age of Exploration: Sailing with the Stars"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/503"
-                  >
-                    Start
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-            <tr
-              className="data-table-row  "
-              key="7"
+              <span />
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="data-table-body"
+        >
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section"
-                key="name-7"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "823px",
-                    "textAlign": "left",
-                    "width": "823px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Age of Exploration: The Cape of Good Hope
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section"
-                key="tool-7"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section due-date-section"
-                key="dueDate-7"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section action-button-section"
-                key="actionButton-7"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Start Age of Exploration: The Cape of Good Hope"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/504"
-                  >
-                    Start
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-            <tr
-              className="data-table-row  "
-              key="8"
+              Capitalizing People, Places, & the Pronoun - Mixed Topics
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section"
-                key="name-8"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "823px",
-                    "textAlign": "left",
-                    "width": "823px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Age of Exploration: Roanoke
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section"
-                key="tool-8"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section due-date-section"
-                key="dueDate-8"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "100px",
-                    "textAlign": "left",
-                    "width": "100px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section action-button-section"
-                key="actionButton-8"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Start Age of Exploration: Roanoke"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/517"
-                  >
-                    Start
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </DataTable>
-    </div>
-    <div
-      className="activities-container completed-activities"
-    >
-      <DataTable
-        averageFontWidth={7}
-        headers={
-          Array [
-            Object {
-              "attribute": "name",
-              "headerClassName": "name-section",
-              "name": "Activity",
-              "noTooltip": true,
-              "rowSectionClassName": "name-section tooltip-section",
-              "width": "474px",
-            },
-            Object {
-              "attribute": "score",
-              "headerClassName": "score-section tooltip-section",
-              "name": "Score",
-              "noTooltip": true,
-              "rowSectionClassName": "score-section tooltip-section",
-              "width": "230px",
-            },
-            Object {
-              "attribute": "tool",
-              "headerClassName": "tool-icon-section",
-              "name": "Tool",
-              "noTooltip": true,
-              "rowSectionClassName": "tool-icon-section tooltip-section",
-              "width": "24px",
-            },
-            Object {
-              "attribute": "dueDate",
-              "headerClassName": "completed-due-date-section",
-              "name": "Due date",
-              "noTooltip": true,
-              "rowSectionClassName": "completed-due-date-section tooltip-section",
-              "width": "110px",
-            },
-            Object {
-              "attribute": "completedDate",
-              "headerClassName": "completed-date-section",
-              "name": "Completed date",
-              "noTooltip": true,
-              "rowSectionClassName": "completed-date-section tooltip-section",
-              "width": "110px",
-            },
-            Object {
-              "attribute": "actionButton",
-              "headerClassName": "action-button-section tooltip-section",
-              "name": "",
-              "noTooltip": true,
-              "rowSectionClassName": "action-button-section tooltip-section",
-              "width": "88px",
-            },
-          ]
-        }
-        rows={
-          Array [
-            Object {
-              "actionButton": <a
-                aria-label="Replay A, An"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/138"
-              >
-                Replay
-              </a>,
-              "completedDate": null,
-              "dueDate": "Feb 29, 5am",
-              "id": 9,
-              "name": "A, An",
-              "score": <div
-                className="score"
+              <div
+                class="score"
               >
                 <div
-                  className="frequently-demonstrated-skill"
+                  class="frequently-demonstrated-skill"
                 />
                 <span>
                   Frequently demonstrated skill
                 </span>
-              </div>,
-              "tool": undefined,
-            },
-            Object {
-              "actionButton": <a
-                aria-label="Replay Age of Exploration: Spices"
-                className="quill-button medium focus-on-light secondary outlined"
-                href="/activity_sessions/classroom_units/1/activities/516"
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing People, Places, & the Pronoun - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/886"
               >
                 Replay
-              </a>,
-              "completedDate": null,
-              "dueDate": "Feb 29, 5am",
-              "id": 5,
-              "name": "Age of Exploration: Spices",
-              "score": <div
-                className="score"
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Names of People & the Pronoun  - Mixed Topics
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
               >
                 <div
-                  className="sometimes-demonstrated-skill"
+                  class="frequently-demonstrated-skill"
+                />
+                <span>
+                  Frequently demonstrated skill
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Names of People & the Pronoun  - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/885"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Names of People - Mixed Topics 1
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="frequently-demonstrated-skill"
+                />
+                <span>
+                  Frequently demonstrated skill
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Names of People - Mixed Topics 1"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/804"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Holidays, People, & Places - Mixed Topics
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="frequently-demonstrated-skill"
+                />
+                <span>
+                  Frequently demonstrated skill
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Holidays, People, & Places - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/887"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Dates & Holidays - Mixed Topics 1
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="sometimes-demonstrated-skill"
                 />
                 <span>
                   Sometimes demonstrated skill
                 </span>
-              </div>,
-              "tool": undefined,
-            },
-          ]
-        }
-      >
-        <table
-          className="data-table undefined"
-        >
-          <thead>
-            <tr
-              className="data-table-headers"
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
             >
-              <th
-                className="data-table-header name-section"
-                key="0"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "474px",
-                    "textAlign": "left",
-                    "width": "474px",
-                  }
-                }
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Dates & Holidays - Mixed Topics 1"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/801"
               >
-                <span>
-                  Activity
-                </span>
-              </th>
-              <th
-                className="data-table-header score-section tooltip-section"
-                key="1"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "230px",
-                    "textAlign": "left",
-                    "width": "230px",
-                  }
-                }
-              >
-                <span>
-                  Score
-                </span>
-              </th>
-              <th
-                className="data-table-header tool-icon-section"
-                key="2"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <span>
-                  Tool
-                </span>
-              </th>
-              <th
-                className="data-table-header completed-due-date-section"
-                key="3"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "110px",
-                    "textAlign": "left",
-                    "width": "110px",
-                  }
-                }
-              >
-                <span>
-                  Due date
-                </span>
-              </th>
-              <th
-                className="data-table-header completed-date-section"
-                key="4"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "110px",
-                    "textAlign": "right",
-                    "width": "110px",
-                  }
-                }
-              >
-                <span>
-                  Completed date
-                </span>
-              </th>
-              <th
-                className="data-table-header action-button-section tooltip-section"
-                key="5"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <span />
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className="data-table-body"
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
           >
-            <tr
-              className="data-table-row  "
-              key="9"
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section tooltip-section"
-                key="name-9"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "474px",
-                    "textAlign": "left",
-                    "width": "474px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  A, An
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section score-section tooltip-section"
-                key="score-9"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "230px",
-                    "textAlign": "left",
-                    "width": "230px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <div
-                    className="score"
-                  >
-                    <div
-                      className="frequently-demonstrated-skill"
-                    />
-                    <span>
-                      Frequently demonstrated skill
-                    </span>
-                  </div>
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section tooltip-section"
-                key="tool-9"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section completed-due-date-section tooltip-section"
-                key="dueDate-9"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "110px",
-                    "textAlign": "left",
-                    "width": "110px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section completed-date-section tooltip-section"
-                key="completedDate-9"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "110px",
-                    "textAlign": "right",
-                    "width": "110px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section action-button-section tooltip-section"
-                key="actionButton-9"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Replay A, An"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/138"
-                  >
-                    Replay
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-            <tr
-              className="data-table-row  "
-              key="5"
+              Capitalizing Geographic Names - Mixed Topics 1
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
             >
-              <td
-                className="data-table-row-section name-section tooltip-section"
-                key="name-5"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "474px",
-                    "textAlign": "left",
-                    "width": "474px",
-                  }
-                }
+              <div
+                class="score"
               >
-                <TableCellContentWrapper>
-                  Age of Exploration: Spices
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section score-section tooltip-section"
-                key="score-5"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "230px",
-                    "textAlign": "left",
-                    "width": "230px",
-                  }
-                }
+                <div
+                  class="sometimes-demonstrated-skill"
+                />
+                <span>
+                  Sometimes demonstrated skill
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Geographic Names - Mixed Topics 1"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/802"
               >
-                <TableCellContentWrapper>
-                  <div
-                    className="score"
-                  >
-                    <div
-                      className="sometimes-demonstrated-skill"
-                    />
-                    <span>
-                      Sometimes demonstrated skill
-                    </span>
-                  </div>
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section tool-icon-section tooltip-section"
-                key="tool-5"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "24px",
-                    "textAlign": "right",
-                    "width": "24px",
-                  }
-                }
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Geographic Names & Holidays - Mixed Topics
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
               >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section completed-due-date-section tooltip-section"
-                key="dueDate-5"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "110px",
-                    "textAlign": "left",
-                    "width": "110px",
-                  }
-                }
+                <div
+                  class="rarely-demonstrated-skill"
+                />
+                <span>
+                  Rarely demonstrated skill
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Geographic Names & Holidays - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/181"
               >
-                <TableCellContentWrapper>
-                  Feb 29, 5am
-                </TableCellContentWrapper>
-              </td>
-              <td
-                className="data-table-row-section completed-date-section tooltip-section"
-                key="completedDate-5"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "110px",
-                    "textAlign": "right",
-                    "width": "110px",
-                  }
-                }
-              >
-                <TableCellContentWrapper />
-              </td>
-              <td
-                className="data-table-row-section action-button-section tooltip-section"
-                key="actionButton-5"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "minWidth": "88px",
-                    "textAlign": "left",
-                    "width": "88px",
-                  }
-                }
-              >
-                <TableCellContentWrapper>
-                  <a
-                    aria-label="Replay Age of Exploration: Spices"
-                    className="quill-button medium focus-on-light secondary outlined"
-                    href="/activity_sessions/classroom_units/1/activities/516"
-                  >
-                    Replay
-                  </a>
-                </TableCellContentWrapper>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </DataTable>
+                Replay
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
-</StudentProfileUnit>
+</DocumentFragment>
+`;
+
+exports[`StudentProfileUnit component should render completed activities when showExactScores is true 1`] = `
+<DocumentFragment>
+  <div
+    class="student-profile-unit undefined"
+  >
+    <div
+      class="unit-name-and-staggered-release-status"
+    >
+      <h2
+        class="unit-name"
+      >
+        Unit
+      </h2>
+      <span />
+    </div>
+    <div
+      class="activities-container completed-activities"
+    >
+      <table
+        class="data-table undefined"
+      >
+        <thead>
+          <tr
+            class="data-table-headers"
+          >
+            <th
+              class="data-table-header name-section"
+              scope="col"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              <span>
+                Activity
+              </span>
+            </th>
+            <th
+              class="data-table-header score-section tooltip-section"
+              scope="col"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <span>
+                Score
+              </span>
+            </th>
+            <th
+              class="data-table-header tool-icon-section"
+              scope="col"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <span>
+                Tool
+              </span>
+            </th>
+            <th
+              class="data-table-header completed-due-date-section"
+              scope="col"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <span>
+                Due date
+              </span>
+            </th>
+            <th
+              class="data-table-header completed-date-section"
+              scope="col"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <span>
+                Completed date
+              </span>
+            </th>
+            <th
+              class="data-table-header action-button-section tooltip-section"
+              scope="col"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <span />
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="data-table-body"
+        >
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Capitalizing People, Places, & the Pronoun - Mixed Topics
+              </div>
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <div
+                  class="score"
+                >
+                  <div
+                    class="frequently-demonstrated-skill"
+                  />
+                  <span>
+                    <span>
+                      10 of 10 (100%)
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <img
+                  alt="Puzzle piece representing Quill Grammar"
+                  src="undefined/images/icons/tool-grammar-gray.svg"
+                />
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Mar 27, 5am
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Feb 22, 1:59pm
+              </div>
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <a
+                  aria-label="Replay Capitalizing People, Places, & the Pronoun - Mixed Topics"
+                  class="quill-button medium focus-on-light secondary outlined"
+                  href="/activity_sessions/classroom_units/8392402/activities/886"
+                >
+                  Replay
+                </a>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Capitalizing Names of People & the Pronoun  - Mixed Topics
+              </div>
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <div
+                  class="score"
+                >
+                  <div
+                    class="frequently-demonstrated-skill"
+                  />
+                  <span>
+                    <span>
+                      10 of 10 (100%)
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <img
+                  alt="Puzzle piece representing Quill Grammar"
+                  src="undefined/images/icons/tool-grammar-gray.svg"
+                />
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Mar 27, 5am
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Feb 22, 1:59pm
+              </div>
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <a
+                  aria-label="Replay Capitalizing Names of People & the Pronoun  - Mixed Topics"
+                  class="quill-button medium focus-on-light secondary outlined"
+                  href="/activity_sessions/classroom_units/8392402/activities/885"
+                >
+                  Replay
+                </a>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Capitalizing Names of People - Mixed Topics 1
+              </div>
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <div
+                  class="score"
+                >
+                  <div
+                    class="frequently-demonstrated-skill"
+                  />
+                  <span>
+                    <span>
+                      10 of 10 (100%)
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <img
+                  alt="Puzzle piece representing Quill Grammar"
+                  src="undefined/images/icons/tool-grammar-gray.svg"
+                />
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Mar 27, 5am
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Feb 22, 1:59pm
+              </div>
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <a
+                  aria-label="Replay Capitalizing Names of People - Mixed Topics 1"
+                  class="quill-button medium focus-on-light secondary outlined"
+                  href="/activity_sessions/classroom_units/8392402/activities/804"
+                >
+                  Replay
+                </a>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Capitalizing Holidays, People, & Places - Mixed Topics
+              </div>
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <div
+                  class="score"
+                >
+                  <div
+                    class="frequently-demonstrated-skill"
+                  />
+                  <span>
+                    <span>
+                      9 of 10 (90%)
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <img
+                  alt="Puzzle piece representing Quill Grammar"
+                  src="undefined/images/icons/tool-grammar-gray.svg"
+                />
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Mar 27, 5am
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Feb 22, 1:59pm
+              </div>
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <a
+                  aria-label="Replay Capitalizing Holidays, People, & Places - Mixed Topics"
+                  class="quill-button medium focus-on-light secondary outlined"
+                  href="/activity_sessions/classroom_units/8392402/activities/887"
+                >
+                  Replay
+                </a>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Capitalizing Dates & Holidays - Mixed Topics 1
+              </div>
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <div
+                  class="score"
+                >
+                  <div
+                    class="sometimes-demonstrated-skill"
+                  />
+                  <span>
+                    <span>
+                      4 of 10 (40%)
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <img
+                  alt="Puzzle piece representing Quill Grammar"
+                  src="undefined/images/icons/tool-grammar-gray.svg"
+                />
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Mar 27, 5am
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Feb 22, 1:59pm
+              </div>
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <a
+                  aria-label="Replay Capitalizing Dates & Holidays - Mixed Topics 1"
+                  class="quill-button medium focus-on-light secondary outlined"
+                  href="/activity_sessions/classroom_units/8392402/activities/801"
+                >
+                  Replay
+                </a>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Capitalizing Geographic Names - Mixed Topics 1
+              </div>
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <div
+                  class="score"
+                >
+                  <div
+                    class="sometimes-demonstrated-skill"
+                  />
+                  <span>
+                    <span>
+                      4 of 10 (40%)
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <img
+                  alt="Puzzle piece representing Quill Grammar"
+                  src="undefined/images/icons/tool-grammar-gray.svg"
+                />
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Mar 27, 5am
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Feb 22, 1:59pm
+              </div>
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <a
+                  aria-label="Replay Capitalizing Geographic Names - Mixed Topics 1"
+                  class="quill-button medium focus-on-light secondary outlined"
+                  href="/activity_sessions/classroom_units/8392402/activities/802"
+                >
+                  Replay
+                </a>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Capitalizing Geographic Names & Holidays - Mixed Topics
+              </div>
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <div
+                  class="score"
+                >
+                  <div
+                    class="rarely-demonstrated-skill"
+                  />
+                  <span>
+                    <span>
+                      2 of 9 (22%)
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <img
+                  alt="Puzzle piece representing Quill Grammar"
+                  src="undefined/images/icons/tool-grammar-gray.svg"
+                />
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Mar 27, 5am
+              </div>
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                Feb 22, 1:59pm
+              </div>
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <div
+                class="score-tooltip-activator"
+              >
+                <a
+                  aria-label="Replay Capitalizing Geographic Names & Holidays - Mixed Topics"
+                  class="quill-button medium focus-on-light secondary outlined"
+                  href="/activity_sessions/classroom_units/8392402/activities/181"
+                >
+                  Replay
+                </a>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`StudentProfileUnit component should render incomplete activities 1`] = `
+<DocumentFragment>
+  <div
+    class="student-profile-unit undefined"
+  >
+    <div
+      class="unit-name-and-staggered-release-status"
+    >
+      <h2
+        class="unit-name"
+      >
+        Unit
+      </h2>
+      <span />
+    </div>
+    <div
+      class="activities-container incomplete-activities"
+    >
+      <table
+        class="data-table undefined"
+      >
+        <thead>
+          <tr
+            class="data-table-headers"
+          >
+            <th
+              class="data-table-header name-section"
+              scope="col"
+              style="width: 823px; min-width: 823px; text-align: left;"
+            >
+              <span>
+                Activity
+              </span>
+            </th>
+            <th
+              class="data-table-header tool-icon-section"
+              scope="col"
+              style="width: 24px; min-width: 24px; text-align: right;"
+            >
+              <span>
+                Tool
+              </span>
+            </th>
+            <th
+              class="data-table-header due-date-section"
+              scope="col"
+              style="width: 100px; min-width: 100px; text-align: left;"
+            >
+              <span>
+                Due date
+              </span>
+            </th>
+            <th
+              class="data-table-header action-button-section"
+              scope="col"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <span />
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="data-table-body"
+        >
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section"
+              style="width: 823px; min-width: 823px; text-align: left;"
+            >
+              The Travels of Marco Polo
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section"
+              style="width: 24px; min-width: 24px; text-align: right;"
+            />
+            <td
+              class="data-table-row-section due-date-section"
+              style="width: 100px; min-width: 100px; text-align: left;"
+            >
+              Feb 29, 5am
+            </td>
+            <td
+              class="data-table-row-section action-button-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Start The Travels of Marco Polo"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/1/activities/608"
+              >
+                Start
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section"
+              style="width: 823px; min-width: 823px; text-align: left;"
+            >
+              Christopher Columbus
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section"
+              style="width: 24px; min-width: 24px; text-align: right;"
+            />
+            <td
+              class="data-table-row-section due-date-section"
+              style="width: 100px; min-width: 100px; text-align: left;"
+            >
+              Feb 29, 5am
+            </td>
+            <td
+              class="data-table-row-section action-button-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Start Christopher Columbus"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/1/activities/607"
+              >
+                Start
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section"
+              style="width: 823px; min-width: 823px; text-align: left;"
+            >
+              A, An, The
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section"
+              style="width: 24px; min-width: 24px; text-align: right;"
+            />
+            <td
+              class="data-table-row-section due-date-section"
+              style="width: 100px; min-width: 100px; text-align: left;"
+            >
+              Feb 29, 5am
+            </td>
+            <td
+              class="data-table-row-section action-button-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Start A, An, The"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/1/activities/140"
+              >
+                Start
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section"
+              style="width: 823px; min-width: 823px; text-align: left;"
+            >
+              Magellan
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section"
+              style="width: 24px; min-width: 24px; text-align: right;"
+            />
+            <td
+              class="data-table-row-section due-date-section"
+              style="width: 100px; min-width: 100px; text-align: left;"
+            >
+              Feb 29, 5am
+            </td>
+            <td
+              class="data-table-row-section action-button-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Start Magellan"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/1/activities/605"
+              >
+                Start
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section"
+              style="width: 823px; min-width: 823px; text-align: left;"
+            >
+              Jamestown
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section"
+              style="width: 24px; min-width: 24px; text-align: right;"
+            />
+            <td
+              class="data-table-row-section due-date-section"
+              style="width: 100px; min-width: 100px; text-align: left;"
+            >
+              Feb 29, 5am
+            </td>
+            <td
+              class="data-table-row-section action-button-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Start Jamestown"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/1/activities/606"
+              >
+                Start
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section"
+              style="width: 823px; min-width: 823px; text-align: left;"
+            >
+              Age of Exploration: Sailing with the Stars
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section"
+              style="width: 24px; min-width: 24px; text-align: right;"
+            />
+            <td
+              class="data-table-row-section due-date-section"
+              style="width: 100px; min-width: 100px; text-align: left;"
+            >
+              Feb 29, 5am
+            </td>
+            <td
+              class="data-table-row-section action-button-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Start Age of Exploration: Sailing with the Stars"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/1/activities/503"
+              >
+                Start
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section"
+              style="width: 823px; min-width: 823px; text-align: left;"
+            >
+              Age of Exploration: The Cape of Good Hope
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section"
+              style="width: 24px; min-width: 24px; text-align: right;"
+            />
+            <td
+              class="data-table-row-section due-date-section"
+              style="width: 100px; min-width: 100px; text-align: left;"
+            >
+              Feb 29, 5am
+            </td>
+            <td
+              class="data-table-row-section action-button-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Start Age of Exploration: The Cape of Good Hope"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/1/activities/504"
+              >
+                Start
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section"
+              style="width: 823px; min-width: 823px; text-align: left;"
+            >
+              Age of Exploration: Roanoke
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section"
+              style="width: 24px; min-width: 24px; text-align: right;"
+            />
+            <td
+              class="data-table-row-section due-date-section"
+              style="width: 100px; min-width: 100px; text-align: left;"
+            >
+              Feb 29, 5am
+            </td>
+            <td
+              class="data-table-row-section action-button-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Start Age of Exploration: Roanoke"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/1/activities/517"
+              >
+                Start
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</DocumentFragment>
 `;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
@@ -4384,7 +4384,8 @@ exports[`StudentProfileUnits component should render only completed activities i
                   "attribute": "name",
                   "headerClassName": "name-section",
                   "name": "Activity",
-                  "rowSectionClassName": "name-section",
+                  "noTooltip": true,
+                  "rowSectionClassName": "name-section tooltip-section",
                   "width": "474px",
                 },
                 Object {
@@ -4400,7 +4401,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                   "headerClassName": "tool-icon-section",
                   "name": "Tool",
                   "noTooltip": true,
-                  "rowSectionClassName": "tool-icon-section",
+                  "rowSectionClassName": "tool-icon-section tooltip-section",
                   "width": "24px",
                 },
                 Object {
@@ -4408,7 +4409,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                   "headerClassName": "completed-due-date-section",
                   "name": "Due date",
                   "noTooltip": true,
-                  "rowSectionClassName": "completed-due-date-section",
+                  "rowSectionClassName": "completed-due-date-section tooltip-section",
                   "width": "110px",
                 },
                 Object {
@@ -4416,7 +4417,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                   "headerClassName": "completed-date-section",
                   "name": "Completed date",
                   "noTooltip": true,
-                  "rowSectionClassName": "completed-date-section",
+                  "rowSectionClassName": "completed-date-section tooltip-section",
                   "width": "110px",
                 },
                 Object {
@@ -4593,7 +4594,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                   key="9"
                 >
                   <td
-                    className="data-table-row-section name-section"
+                    className="data-table-row-section name-section tooltip-section"
                     key="name-9"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
@@ -4636,7 +4637,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     </TableCellContentWrapper>
                   </td>
                   <td
-                    className="data-table-row-section tool-icon-section"
+                    className="data-table-row-section tool-icon-section tooltip-section"
                     key="tool-9"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
@@ -4651,7 +4652,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     <TableCellContentWrapper />
                   </td>
                   <td
-                    className="data-table-row-section completed-due-date-section"
+                    className="data-table-row-section completed-due-date-section tooltip-section"
                     key="dueDate-9"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
@@ -4668,7 +4669,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     </TableCellContentWrapper>
                   </td>
                   <td
-                    className="data-table-row-section completed-date-section"
+                    className="data-table-row-section completed-date-section tooltip-section"
                     key="completedDate-9"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
@@ -4711,7 +4712,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                   key="5"
                 >
                   <td
-                    className="data-table-row-section name-section"
+                    className="data-table-row-section name-section tooltip-section"
                     key="name-5"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
@@ -4754,7 +4755,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     </TableCellContentWrapper>
                   </td>
                   <td
-                    className="data-table-row-section tool-icon-section"
+                    className="data-table-row-section tool-icon-section tooltip-section"
                     key="tool-5"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
@@ -4769,7 +4770,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     <TableCellContentWrapper />
                   </td>
                   <td
-                    className="data-table-row-section completed-due-date-section"
+                    className="data-table-row-section completed-due-date-section tooltip-section"
                     key="dueDate-5"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
@@ -4786,7 +4787,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                     </TableCellContentWrapper>
                   </td>
                   <td
-                    className="data-table-row-section completed-date-section"
+                    className="data-table-row-section completed-date-section tooltip-section"
                     key="completedDate-5"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/student_profile_unit.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/student_profile_unit.test.jsx
@@ -1,31 +1,44 @@
-import { mount } from 'enzyme';
 import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { incompleteCategorizedActivities, completeCategorizedActivities, exactScoresData } from './test_data';
 
 import { DataTable } from '../../../../Shared/index';
 import StudentProfileUnit from '../student_profile_unit';
 
-import { categorizedActivities } from './test_data';
-
 describe('StudentProfileUnit component', () => {
 
-  it('should render', () => {
-    const wrapper = mount(
+  it('should render incomplete activities', () => {
+    const { asFragment, } = render(
       <StudentProfileUnit
-        data={categorizedActivities}
+        data={incompleteCategorizedActivities}
         unitName="Unit"
       />
     );
-    expect(wrapper).toMatchSnapshot()
-    expect(wrapper.find('.unit-name').text()).toBe('Unit');
+    expect(asFragment()).toMatchSnapshot()
   });
 
-  it('should render a data table for both complete activities and incomplete activities', () => {
-    const wrapper = mount(
+  it('should render completed activities when showExactScores is false', () => {
+    const { asFragment, } = render(
       <StudentProfileUnit
-        data={categorizedActivities}
+        data={completeCategorizedActivities}
+        showExactScores={false}
         unitName="Unit"
       />
     );
-    expect(wrapper.find(DataTable).length).toBe(Object.keys(categorizedActivities).length);
+    expect(asFragment()).toMatchSnapshot()
+  });
+
+  it('should render completed activities when showExactScores is true', () => {
+    const { asFragment, } = render(
+      <StudentProfileUnit
+        data={completeCategorizedActivities}
+        exactScoresData={exactScoresData}
+        showExactScores={true}
+        unitName="Unit"
+      />
+    );
+    expect(asFragment()).toMatchSnapshot()
   })
 });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/test_data.js
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/test_data.js
@@ -309,52 +309,7 @@ export const activities = [
   }
 ]
 
-export const categorizedActivities = {
-  complete: [
-    {
-      name: "A, An",
-      description: "Write ten sentences using the articles a or an.",
-      repeatable: true,
-      activity_classification_id: 2,
-      unit_id: 7,
-      ua_id: 9,
-      unit_created_at: "2020-01-16 17:57:24.518561",
-      unit_name: "History: Age of Exploration",
-      classroom_unit_id: 1,
-      marked_complete: false,
-      activity_id: 138,
-      act_sesh_updated_at: "2020-01-16 18:04:02.957825",
-      order_number: 1,
-      due_date: "2020-02-29 05:00:00",
-      unit_activity_created_at: "2020-01-16 17:57:24.712361",
-      locked: false,
-      pinned: false,
-      max_percentage: 1,
-      finished: true,
-      resume_link: 0
-    }, {
-      name: "Age of Exploration: Spices",
-      description: "Find and correct the 9 errors in this passage.",
-      repeatable: true,
-      activity_classification_id: 1,
-      unit_id: 7,
-      ua_id: 5,
-      unit_created_at: "2020-01-16 17:57:24.518561",
-      unit_name: "History: Age of Exploration",
-      classroom_unit_id: 1,
-      marked_complete: false,
-      activity_id: 516,
-      act_sesh_updated_at: "2020-01-16 18:07:57.261188",
-      order_number: 5,
-      due_date: "2020-02-29 05:00:00",
-      unit_activity_created_at: "2020-01-16 17:57:24.712361",
-      locked: false,
-      pinned: false,
-      max_percentage: 0.764705882352941,
-      finished: true,
-      resume_link: 0
-    }
-  ],
+export const incompleteCategorizedActivities = {
   incomplete: [
     {
       name: "The Travels of Marco Polo",
@@ -529,3 +484,739 @@ export const categorizedActivities = {
     }
   ]
 }
+
+export const completeCategorizedActivities = {
+  "complete": [
+    {
+      "name": "Capitalizing People, Places, & the Pronoun - Mixed Topics",
+      "activity_description": "Students rewrite sentences, adding the correct capitalization.",
+      "repeatable": true,
+      "activity_classification_id": 2,
+      "activity_classification_key": "sentence",
+      "unit_id": 3318251,
+      "ua_id": 18646930,
+      "unit_created_at": "2024-02-22 17:59:22.421856",
+      "unit_name": "Capitalization (Starter Baseline Recommendation)",
+      "classroom_unit_id": 8392402,
+      "marked_complete": false,
+      "activity_id": 886,
+      "act_sesh_updated_at": "2024-02-22 17:59:26.054736",
+      "order_number": null,
+      "due_date": "2024-03-27 05:00:00",
+      "completed_date": "2024-02-22 13:59:26.054683",
+      "pre_activity_id": null,
+      "unit_activity_created_at": "2024-02-22 17:59:23.156781",
+      "user_pack_sequence_item_status": null,
+      "locked": false,
+      "pinned": false,
+      "max_percentage": 1,
+      "closed": false,
+      "completed_pre_activity_session": false,
+      "finished": true,
+      "resume_link": 0
+    },
+    {
+      "name": "Capitalizing Names of People & the Pronoun  - Mixed Topics",
+      "activity_description": "Students rewrite sentences, adding the correct capitalization.",
+      "repeatable": true,
+      "activity_classification_id": 2,
+      "activity_classification_key": "sentence",
+      "unit_id": 3318251,
+      "ua_id": 18646933,
+      "unit_created_at": "2024-02-22 17:59:22.421856",
+      "unit_name": "Capitalization (Starter Baseline Recommendation)",
+      "classroom_unit_id": 8392402,
+      "marked_complete": false,
+      "activity_id": 885,
+      "act_sesh_updated_at": "2024-02-22 17:59:26.215308",
+      "order_number": null,
+      "due_date": "2024-03-27 05:00:00",
+      "completed_date": "2024-02-22 13:59:26.215264",
+      "pre_activity_id": null,
+      "unit_activity_created_at": "2024-02-22 17:59:23.156781",
+      "user_pack_sequence_item_status": null,
+      "locked": false,
+      "pinned": false,
+      "max_percentage": 1,
+      "closed": false,
+      "completed_pre_activity_session": false,
+      "finished": true,
+      "resume_link": 0
+    },
+    {
+      "name": "Capitalizing Names of People - Mixed Topics 1",
+      "activity_description": "Students rewrite sentences, adding the correct capitalization.",
+      "repeatable": true,
+      "activity_classification_id": 2,
+      "activity_classification_key": "sentence",
+      "unit_id": 3318251,
+      "ua_id": 18646934,
+      "unit_created_at": "2024-02-22 17:59:22.421856",
+      "unit_name": "Capitalization (Starter Baseline Recommendation)",
+      "classroom_unit_id": 8392402,
+      "marked_complete": false,
+      "activity_id": 804,
+      "act_sesh_updated_at": "2024-02-22 17:59:26.006863",
+      "order_number": null,
+      "due_date": "2024-03-27 05:00:00",
+      "completed_date": "2024-02-22 13:59:26.006813",
+      "pre_activity_id": null,
+      "unit_activity_created_at": "2024-02-22 17:59:23.156781",
+      "user_pack_sequence_item_status": null,
+      "locked": false,
+      "pinned": false,
+      "max_percentage": 1,
+      "closed": false,
+      "completed_pre_activity_session": false,
+      "finished": true,
+      "resume_link": 0
+    },
+    {
+      "name": "Capitalizing Holidays, People, & Places - Mixed Topics",
+      "activity_description": "Students rewrite sentences, adding the correct capitalization.",
+      "repeatable": true,
+      "activity_classification_id": 2,
+      "activity_classification_key": "sentence",
+      "unit_id": 3318251,
+      "ua_id": 18646931,
+      "unit_created_at": "2024-02-22 17:59:22.421856",
+      "unit_name": "Capitalization (Starter Baseline Recommendation)",
+      "classroom_unit_id": 8392402,
+      "marked_complete": false,
+      "activity_id": 887,
+      "act_sesh_updated_at": "2024-02-22 17:59:26.099396",
+      "order_number": null,
+      "due_date": "2024-03-27 05:00:00",
+      "completed_date": "2024-02-22 13:59:26.099356",
+      "pre_activity_id": null,
+      "unit_activity_created_at": "2024-02-22 17:59:23.156781",
+      "user_pack_sequence_item_status": null,
+      "locked": false,
+      "pinned": false,
+      "max_percentage": 0.9,
+      "closed": false,
+      "completed_pre_activity_session": false,
+      "finished": true,
+      "resume_link": 0
+    },
+    {
+      "name": "Capitalizing Dates & Holidays - Mixed Topics 1",
+      "activity_description": "Students rewrite sentences, adding the correct capitalization.",
+      "repeatable": true,
+      "activity_classification_id": 2,
+      "activity_classification_key": "sentence",
+      "unit_id": 3318251,
+      "ua_id": 18646932,
+      "unit_created_at": "2024-02-22 17:59:22.421856",
+      "unit_name": "Capitalization (Starter Baseline Recommendation)",
+      "classroom_unit_id": 8392402,
+      "marked_complete": false,
+      "activity_id": 801,
+      "act_sesh_updated_at": "2024-02-22 17:59:26.152417",
+      "order_number": null,
+      "due_date": "2024-03-27 05:00:00",
+      "completed_date": "2024-02-22 13:59:26.152373",
+      "pre_activity_id": null,
+      "unit_activity_created_at": "2024-02-22 17:59:23.156781",
+      "user_pack_sequence_item_status": null,
+      "locked": false,
+      "pinned": false,
+      "max_percentage": 0.4,
+      "closed": false,
+      "completed_pre_activity_session": false,
+      "finished": true,
+      "resume_link": 0
+    },
+    {
+      "name": "Capitalizing Geographic Names - Mixed Topics 1",
+      "activity_description": "Students rewrite sentences, adding the correct capitalization.",
+      "repeatable": true,
+      "activity_classification_id": 2,
+      "activity_classification_key": "sentence",
+      "unit_id": 3318251,
+      "ua_id": 18646936,
+      "unit_created_at": "2024-02-22 17:59:22.421856",
+      "unit_name": "Capitalization (Starter Baseline Recommendation)",
+      "classroom_unit_id": 8392402,
+      "marked_complete": false,
+      "activity_id": 802,
+      "act_sesh_updated_at": "2024-02-22 17:59:26.312848",
+      "order_number": null,
+      "due_date": "2024-03-27 05:00:00",
+      "completed_date": "2024-02-22 13:59:26.312801",
+      "pre_activity_id": null,
+      "unit_activity_created_at": "2024-02-22 17:59:23.156781",
+      "user_pack_sequence_item_status": null,
+      "locked": false,
+      "pinned": false,
+      "max_percentage": 0.4,
+      "closed": false,
+      "completed_pre_activity_session": false,
+      "finished": true,
+      "resume_link": 0
+    },
+    {
+      "name": "Capitalizing Geographic Names & Holidays - Mixed Topics",
+      "activity_description": "Students rewrite sentences, adding the correct capitalization.",
+      "repeatable": true,
+      "activity_classification_id": 2,
+      "activity_classification_key": "sentence",
+      "unit_id": 3318251,
+      "ua_id": 18646935,
+      "unit_created_at": "2024-02-22 17:59:22.421856",
+      "unit_name": "Capitalization (Starter Baseline Recommendation)",
+      "classroom_unit_id": 8392402,
+      "marked_complete": false,
+      "activity_id": 181,
+      "act_sesh_updated_at": "2024-02-22 17:59:26.257562",
+      "order_number": null,
+      "due_date": "2024-03-27 05:00:00",
+      "completed_date": "2024-02-22 13:59:26.257528",
+      "pre_activity_id": null,
+      "unit_activity_created_at": "2024-02-22 17:59:23.156781",
+      "user_pack_sequence_item_status": null,
+      "locked": false,
+      "pinned": false,
+      "max_percentage": 0.22,
+      "closed": false,
+      "completed_pre_activity_session": false,
+      "finished": true,
+      "resume_link": 0
+    }
+  ]
+}
+
+export const exactScoresData = [
+  {
+    "ua_id": 18646929,
+    "unit_id": 3318250,
+    "activity_id": 1663,
+    "classroom_unit_id": 8392401,
+    "sessions": [
+      {
+        "id": 226957659,
+        "percentage": 1,
+        "description": "Assess students on the basics like using adverbs, adjectives, and proper capitalization, and receive a series of recommended activities for each student based on the results.",
+        "due_date": null,
+        "completed_at": "2024-02-22T13:59:25.954Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Compound Predicates",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Single Adjectives",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Coordinate Adjectives",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Commonly Confused Words",
+            "correct": 2,
+            "incorrect": 0
+          },
+          {
+            "name": "Adjectives & Adverbs",
+            "correct": 0,
+            "incorrect": 2
+          },
+          {
+            "name": "Plural vs. Possessive Nouns",
+            "correct": 0,
+            "incorrect": 2
+          },
+          {
+            "name": "Capitalization",
+            "correct": 0,
+            "incorrect": 2
+          },
+          {
+            "name": "Listing Objects",
+            "correct": 1,
+            "incorrect": 0
+          },
+          {
+            "name": "Comparative Adjectives",
+            "correct": 2,
+            "incorrect": 0
+          },
+          {
+            "name": "Compound Subjects",
+            "correct": 1,
+            "incorrect": 0
+          },
+          {
+            "name": "Cumulative Adjectives",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Subject Verb Agreement",
+            "correct": 3,
+            "incorrect": 0
+          },
+          {
+            "name": "Prepositional Phrases",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Adverbs of Manner",
+            "correct": 0,
+            "incorrect": 1
+          }
+        ],
+        "number_of_questions": 21,
+        "number_of_correct_questions": 9,
+        "timespent": null
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646930,
+    "unit_id": 3318251,
+    "activity_id": 886,
+    "classroom_unit_id": 8392402,
+    "sessions": [
+      {
+        "id": 226957661,
+        "percentage": 1,
+        "description": "Students rewrite sentences, adding the correct capitalization.",
+        "due_date": "2024-03-27T09:00:00.000Z",
+        "completed_at": "2024-02-22T13:59:26.054Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Capitalization",
+            "correct": 10,
+            "incorrect": 0
+          }
+        ],
+        "number_of_questions": 10,
+        "number_of_correct_questions": 10,
+        "timespent": null
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646933,
+    "unit_id": 3318251,
+    "activity_id": 885,
+    "classroom_unit_id": 8392402,
+    "sessions": [
+      {
+        "id": 226957664,
+        "percentage": 1,
+        "description": "Students rewrite sentences, adding the correct capitalization.",
+        "due_date": "2024-03-27T09:00:00.000Z",
+        "completed_at": "2024-02-22T13:59:26.215Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Capitalization",
+            "correct": 5,
+            "incorrect": 0
+          },
+          {
+            "name": "Capitalizing the Pronoun I",
+            "correct": 5,
+            "incorrect": 0
+          }
+        ],
+        "number_of_questions": 10,
+        "number_of_correct_questions": 10,
+        "timespent": null
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646934,
+    "unit_id": 3318251,
+    "activity_id": 804,
+    "classroom_unit_id": 8392402,
+    "sessions": [
+      {
+        "id": 226957660,
+        "percentage": 1,
+        "description": "Students rewrite sentences, adding the correct capitalization.",
+        "due_date": "2024-03-27T09:00:00.000Z",
+        "completed_at": "2024-02-22T13:59:26.006Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Capitalizing Formal Titles",
+            "correct": 4,
+            "incorrect": 0
+          },
+          {
+            "name": "Capitalizing Names of People",
+            "correct": 6,
+            "incorrect": 0
+          }
+        ],
+        "number_of_questions": 10,
+        "number_of_correct_questions": 10,
+        "timespent": null
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646931,
+    "unit_id": 3318251,
+    "activity_id": 887,
+    "classroom_unit_id": 8392402,
+    "sessions": [
+      {
+        "id": 226957662,
+        "percentage": 0.9,
+        "description": "Students rewrite sentences, adding the correct capitalization.",
+        "due_date": "2024-03-27T09:00:00.000Z",
+        "completed_at": "2024-02-22T13:59:26.099Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Capitalization",
+            "correct": 9,
+            "incorrect": 1
+          }
+        ],
+        "number_of_questions": 10,
+        "number_of_correct_questions": 9,
+        "timespent": null
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646932,
+    "unit_id": 3318251,
+    "activity_id": 801,
+    "classroom_unit_id": 8392402,
+    "sessions": [
+      {
+        "id": 226957663,
+        "percentage": 0.4,
+        "description": "Students rewrite sentences, adding the correct capitalization.",
+        "due_date": "2024-03-27T09:00:00.000Z",
+        "completed_at": "2024-02-22T13:59:26.152Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Capitalizing Holidays",
+            "correct": 4,
+            "incorrect": 1
+          },
+          {
+            "name": "Capitalizing Dates",
+            "correct": 0,
+            "incorrect": 5
+          }
+        ],
+        "number_of_questions": 10,
+        "number_of_correct_questions": 4,
+        "timespent": null
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646936,
+    "unit_id": 3318251,
+    "activity_id": 802,
+    "classroom_unit_id": 8392402,
+    "sessions": [
+      {
+        "id": 226957666,
+        "percentage": 0.4,
+        "description": "Students rewrite sentences, adding the correct capitalization.",
+        "due_date": "2024-03-27T09:00:00.000Z",
+        "completed_at": "2024-02-22T13:59:26.312Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Capitalizing Geographic Names",
+            "correct": 4,
+            "incorrect": 6
+          }
+        ],
+        "number_of_questions": 10,
+        "number_of_correct_questions": 4,
+        "timespent": null
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646935,
+    "unit_id": 3318251,
+    "activity_id": 181,
+    "classroom_unit_id": 8392402,
+    "sessions": [
+      {
+        "id": 226957665,
+        "percentage": 0.22,
+        "description": "Students rewrite sentences, adding the correct capitalization.",
+        "due_date": "2024-03-27T09:00:00.000Z",
+        "completed_at": "2024-02-22T13:59:26.257Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Capitalizing Geographic Names",
+            "correct": 2,
+            "incorrect": 3
+          },
+          {
+            "name": "Capitalizing Holidays",
+            "correct": 0,
+            "incorrect": 4
+          }
+        ],
+        "number_of_questions": 9,
+        "number_of_correct_questions": 2,
+        "timespent": null
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646937,
+    "unit_id": 3318252,
+    "activity_id": 1440,
+    "classroom_unit_id": 8392403,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646938,
+    "unit_id": 3318252,
+    "activity_id": 283,
+    "classroom_unit_id": 8392403,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646939,
+    "unit_id": 3318252,
+    "activity_id": 252,
+    "classroom_unit_id": 8392403,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646940,
+    "unit_id": 3318252,
+    "activity_id": 808,
+    "classroom_unit_id": 8392403,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646941,
+    "unit_id": 3318252,
+    "activity_id": 1308,
+    "classroom_unit_id": 8392403,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646942,
+    "unit_id": 3318252,
+    "activity_id": 803,
+    "classroom_unit_id": 8392403,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646943,
+    "unit_id": 3318253,
+    "activity_id": 846,
+    "classroom_unit_id": 8392404,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646944,
+    "unit_id": 3318253,
+    "activity_id": 600,
+    "classroom_unit_id": 8392404,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646945,
+    "unit_id": 3318253,
+    "activity_id": 712,
+    "classroom_unit_id": 8392404,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646946,
+    "unit_id": 3318253,
+    "activity_id": 599,
+    "classroom_unit_id": 8392404,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646947,
+    "unit_id": 3318253,
+    "activity_id": 765,
+    "classroom_unit_id": 8392404,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646948,
+    "unit_id": 3318254,
+    "activity_id": 1664,
+    "classroom_unit_id": 8392405,
+    "sessions": [
+      {
+        "id": 226957667,
+        "percentage": 1,
+        "description": null,
+        "due_date": null,
+        "completed_at": "2024-02-22T13:59:26.380Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Listing Objects",
+            "correct": 1,
+            "incorrect": 0
+          },
+          {
+            "name": "Cumulative Adjectives",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Plural vs. Possessive Nouns",
+            "correct": 1,
+            "incorrect": 1
+          },
+          {
+            "name": "Comparative Adjectives",
+            "correct": 2,
+            "incorrect": 0
+          },
+          {
+            "name": "Subject Verb Agreement",
+            "correct": 3,
+            "incorrect": 0
+          },
+          {
+            "name": "Capitalization",
+            "correct": 0,
+            "incorrect": 2
+          },
+          {
+            "name": "Compound Predicates",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Adjectives & Adverbs",
+            "correct": 2,
+            "incorrect": 0
+          },
+          {
+            "name": "Coordinate Adjectives",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Single Adjectives",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Commonly Confused Words",
+            "correct": 2,
+            "incorrect": 0
+          },
+          {
+            "name": "Compound Subjects",
+            "correct": 1,
+            "incorrect": 0
+          },
+          {
+            "name": "Prepositional Phrases",
+            "correct": 0,
+            "incorrect": 1
+          },
+          {
+            "name": "Adverbs of Manner",
+            "correct": 0,
+            "incorrect": 1
+          }
+        ],
+        "number_of_questions": 21,
+        "number_of_correct_questions": 12,
+        "timespent": null
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646949,
+    "unit_id": 3318255,
+    "activity_id": 2371,
+    "classroom_unit_id": 8392406,
+    "sessions": [
+      {
+        "id": 226957670,
+        "percentage": null,
+        "description": "Students will read a text that explores the idea that oxpeckers can help black rhinos to avoid humans. Then, they’ll write three sentences using evidence from the text. Students will revise their work up to five times per sentence based on immediate feedback.",
+        "due_date": null,
+        "completed_at": "2024-02-22T14:07:52.044Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Writing with Evidence",
+            "correct": 3,
+            "incorrect": 0
+          }
+        ],
+        "number_of_questions": 3,
+        "number_of_correct_questions": 3,
+        "timespent": 98
+      }
+    ],
+    "completed_attempts": 1
+  },
+  {
+    "ua_id": 18646950,
+    "unit_id": 3318255,
+    "activity_id": 2317,
+    "classroom_unit_id": 8392406,
+    "sessions": [],
+    "completed_attempts": 0
+  },
+  {
+    "ua_id": 18646951,
+    "unit_id": 3318255,
+    "activity_id": 1676,
+    "classroom_unit_id": 8392406,
+    "sessions": [
+      {
+        "id": 226957669,
+        "percentage": null,
+        "description": "Students will read about how building a surge barrier could protect New York City from hurricane damage but potentially have a negative effect on the local ecosystem of the Hudson River. Then, students will write three sentences using evidence from the text. Students will revise their work up to five times per sentence based on immediate feedback.",
+        "due_date": null,
+        "completed_at": "2024-02-22T14:05:33.252Z",
+        "grouped_key_target_skill_concepts": [
+          {
+            "name": "Writing with Evidence",
+            "correct": 3,
+            "incorrect": 0
+          }
+        ],
+        "number_of_questions": 3,
+        "number_of_correct_questions": 3,
+        "timespent": 171
+      }
+    ],
+    "completed_attempts": 1
+  }
+]

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../../Shared/index';
 import { formatDateTimeForDisplay, } from '../../helpers/unitActivityDates';
 import activityLaunchLink from '../modules/generate_activity_launch_link.js';
+import ScorebookTooltip from '../general_components/tooltip/scorebook_tooltip'
 
 const diagnosticSrc = `${process.env.CDN_URL}/images/icons/tool-diagnostic-gray.svg`
 const connectSrc = `${process.env.CDN_URL}/images/icons/tool-connect-gray.svg`
@@ -67,8 +68,9 @@ const completeHeaders = [
     width: '474px',
     name: 'Activity',
     attribute: 'name',
+    noTooltip: true,
     headerClassName: 'name-section',
-    rowSectionClassName: 'name-section'
+    rowSectionClassName: 'name-section tooltip-section'
   }, {
     width: '230px',
     name: 'Score',
@@ -82,21 +84,21 @@ const completeHeaders = [
     attribute: 'tool',
     noTooltip: true,
     headerClassName: 'tool-icon-section',
-    rowSectionClassName: 'tool-icon-section'
+    rowSectionClassName: 'tool-icon-section tooltip-section'
   }, {
     width: '110px',
     name: 'Due date',
     attribute: 'dueDate',
     noTooltip: true,
     headerClassName: 'completed-due-date-section',
-    rowSectionClassName: 'completed-due-date-section'
+    rowSectionClassName: 'completed-due-date-section tooltip-section'
   }, {
     width: '110px',
     name: 'Completed date',
     attribute: 'completedDate',
     noTooltip: true,
     headerClassName: 'completed-date-section',
-    rowSectionClassName: 'completed-date-section'
+    rowSectionClassName: 'completed-date-section tooltip-section'
   }, {
     width: '88px',
     name: '',
@@ -106,6 +108,35 @@ const completeHeaders = [
     rowSectionClassName: 'action-button-section tooltip-section'
   }
 ]
+
+const TooltipWrapper = ({ activity, exactScoresData, children, }) => {
+  const [showTooltip, setShowTooltip] = React.useState(false)
+
+  function handleMouseEnter() { setShowTooltip(true) }
+  function handleMouseLeave() { setShowTooltip(false) }
+
+  const relevantExactScore = exactScoresData.find(es => es.ua_id === activity.ua_id && es.classroom_unit_id === activity.classroom_unit_id)
+  const tooltipData = { ...activity, ...relevantExactScore, percentage: activity.max_percentage, }
+
+  let tooltip
+
+  if (showTooltip) {
+    tooltip = (
+      <ScorebookTooltip data={tooltipData} inStudentView={true} />
+    )
+  }
+
+  return (
+    <div
+      className="score-tooltip-activator"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+      {tooltip}
+    </div>
+  )
+}
 
 export default class StudentProfileUnit extends React.Component {
   actionButton = (act, nextActivitySession) => {
@@ -174,8 +205,10 @@ export default class StudentProfileUnit extends React.Component {
   }
 
   score = (act) => {
-    const { activity_classification_key, max_percentage, } = act
+    const { exactScoresData, showExactScores, } = this.props
+    const { activity_classification_key, max_percentage, ua_id, classroom_unit_id, } = act
     const maxPercentage = Number(max_percentage)
+
     if (UNGRADED_ACTIVITY_CLASSIFICATIONS.includes(activity_classification_key)) {
       return (
         <Tooltip
@@ -190,15 +223,30 @@ export default class StudentProfileUnit extends React.Component {
       )
     }
 
+    let exactScoreCopy
+
+    if (showExactScores) {
+      const relevantExactScore = exactScoresData.find(es => es.ua_id === ua_id && es.classroom_unit_id === classroom_unit_id)
+      const bestSession = relevantExactScore.sessions.reduce(
+        (a, b) => {
+          return a.percentage < b.percentage ? a : b
+        }
+      )
+      const { number_of_questions, number_of_correct_questions, percentage, } = bestSession
+
+      exactScoreCopy = (<span>{number_of_correct_questions} of {number_of_questions} ({percentage * 100}%)</span>)
+    }
+
     if (maxPercentage >= FREQUENTLY_DEMONSTRATED_SKILL_CUTOFF) {
-      return (<div className="score"><div className="frequently-demonstrated-skill" /><span>Frequently demonstrated skill</span></div>)
+      return (<div className="score"><div className="frequently-demonstrated-skill" /><span>{exactScoreCopy || 'Frequently demonstrated skill'}</span></div>)
     }
 
     if (maxPercentage >= SOMETIMES_DEMONSTRATED_SKILL_CUTOFF) {
-      return (<div className="score"><div className="sometimes-demonstrated-skill" /><span>Sometimes demonstrated skill</span></div>)
+      return (<div className="score"><div className="sometimes-demonstrated-skill" /><span>{exactScoreCopy || 'Sometimes demonstrated skill'}</span></div>)
     }
 
-    return (<div className="score"><div className="rarely-demonstrated-skill" /><span>Rarely demonstrated skill</span></div>)
+    return (<div className="score"><div className="rarely-demonstrated-skill" /><span>{exactScoreCopy || 'Rarely demonstrated skill'}</span></div>)
+
   }
 
   toolIcon = (key) => {
@@ -221,11 +269,25 @@ export default class StudentProfileUnit extends React.Component {
   }
 
   renderCompletedActivities = () => {
-    const { data, nextActivitySession, } = this.props
+    const { data, nextActivitySession, showExactScores, exactScoresData, } = this.props
     if (!(data.complete && data.complete.length)) { return null}
 
     const rows = data.complete.map(act => {
       const { name, activity_classification_key, ua_id, due_date, completed_date, } = act
+
+      if (showExactScores && !UNGRADED_ACTIVITY_CLASSIFICATIONS.includes(activity_classification_key)) {
+        return {
+          name: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{name}</TooltipWrapper>,
+          score: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{this.score(act)}</TooltipWrapper>,
+          tool: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{this.toolIcon(activity_classification_key)}</TooltipWrapper>,
+          actionButton: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{this.actionButton(act, nextActivitySession)}</TooltipWrapper>,
+          dueDate: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{due_date ? formatDateTimeForDisplay(moment.utc(due_date)) : null}</TooltipWrapper>,
+          completedDate: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{completed_date ? formatDateTimeForDisplay(moment.utc(completed_date)) : null}</TooltipWrapper>,
+          id: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{ua_id}</TooltipWrapper>
+        }
+
+      }
+
       return {
         name,
         score: this.score(act),

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -115,8 +115,10 @@ const TooltipWrapper = ({ activity, exactScoresData, children, }) => {
   function handleMouseEnter() { setShowTooltip(true) }
   function handleMouseLeave() { setShowTooltip(false) }
 
-  const relevantExactScore = exactScoresData.find(es => es.ua_id === activity.ua_id && es.classroom_unit_id === activity.classroom_unit_id)
-  const tooltipData = { ...activity, ...relevantExactScore, percentage: activity.max_percentage, }
+  const { ua_id, classroom_unit_id, max_percentage, unit_activity_created_at, publish_date, } = activity
+
+  const relevantExactScore = exactScoresData.find(es => es.ua_id === ua_id && es.classroom_unit_id === classroom_unit_id)
+  const tooltipData = { ...activity, ...relevantExactScore, percentage: max_percentage, unitActivityCreatedAt: unit_activity_created_at, publishDate: publish_date, }
 
   let tooltip
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_units.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_units.jsx
@@ -94,7 +94,7 @@ export default class StudentProfileUnits extends React.Component {
   }
 
   renderContent = () => {
-    const { loading, nextActivitySession, isBeingPreviewed, selectedUnitId, } = this.props
+    const { loading, nextActivitySession, isBeingPreviewed, selectedUnitId, exactScoresData, showExactScores, } = this.props
     if (loading) { return <LoadingIndicator /> }
 
     const content = this.displayedUnits().map(unit => {
@@ -102,12 +102,14 @@ export default class StudentProfileUnits extends React.Component {
       return (
         <StudentProfileUnit
           data={unit}
+          exactScoresData={exactScoresData}
           id={unit_id}
           isBeingPreviewed={isBeingPreviewed}
           isSelectedUnit={String(unit_id) === selectedUnitId}
           key={unit_id}
           nextActivitySession={nextActivitySession}
           onShowPreviewModal={this.handleShowPreviewModal}
+          showExactScores={showExactScores}
           staggeredReleaseStatus={user_pack_sequence_item_status}
           unitName={unit_name}
         />

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -28,13 +28,12 @@ class StudentProfile extends React.Component {
 
     if (classroomId) {
       handleClassroomClick(classroomId);
-      fetchStudentProfile(classroomId, false);
+      this.getStudentProfileForClassroom(classroomId)
       fetchStudentsClassrooms();
     } else {
       fetchStudentProfile();
       fetchStudentsClassrooms();
     }
-
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -58,20 +57,30 @@ class StudentProfile extends React.Component {
     }
   }
 
+  getStudentProfileForClassroom = (classroomId) => {
+    const {
+      fetchStudentProfile,
+    } = this.props;
+
+    // we run false then true because true loads the completed session data but takes several seconds longer, so it can load in the background since we always load on the to-do activities tab
+    fetchStudentProfile(classroomId, false)
+    fetchStudentProfile(classroomId, true)
+  }
+
   parsedQueryParams = () => {
     const { history, } = this.props
     return qs.parse(history.location.search.replace('?', ''))
   }
 
   handleClassroomTabClick = (classroomId) => {
-    const { loading, handleClassroomClick, fetchStudentProfile, history, } = this.props;
+    const { loading, handleClassroomClick, history, } = this.props;
 
     if (!loading) {
       const newUrl = `/classrooms/${classroomId}`;
       history.push(newUrl);
       handleClassroomClick(classroomId);
-      fetchStudentProfile(classroomId, false);
       updateActiveClassworkTab(TO_DO_ACTIVITIES)
+      this.getStudentProfileForClassroom(classroomId)
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -7,9 +7,10 @@ import {
   fetchStudentProfile,
   fetchStudentsClassrooms,
   handleClassroomClick,
-  updateActiveClassworkTab
+  updateActiveClassworkTab,
+  setLoading,
 } from '../../../actions/student_profile';
-import { TO_DO_ACTIVITIES } from '../../../constants/student_profile';
+import { TO_DO_ACTIVITIES, COMPLETED_ACTIVITIES } from '../../../constants/student_profile';
 import SelectAClassroom from '../../Student/components/selectAClassroom';
 import LoadingIndicator from '../components/shared/loading_indicator';
 import StudentProfileClassworkTabs from '../components/student_profile/student_profile_classwork_tabs';
@@ -27,7 +28,7 @@ class StudentProfile extends React.Component {
 
     if (classroomId) {
       handleClassroomClick(classroomId);
-      fetchStudentProfile(classroomId);
+      fetchStudentProfile(classroomId, false);
       fetchStudentsClassrooms();
     } else {
       fetchStudentProfile();
@@ -69,7 +70,7 @@ class StudentProfile extends React.Component {
       const newUrl = `/classrooms/${classroomId}`;
       history.push(newUrl);
       handleClassroomClick(classroomId);
-      fetchStudentProfile(classroomId);
+      fetchStudentProfile(classroomId, false);
       updateActiveClassworkTab(TO_DO_ACTIVITIES)
     }
   }
@@ -81,8 +82,14 @@ class StudentProfile extends React.Component {
   }
 
   handleClickClassworkTab = (classworkTab) => {
-    const { updateActiveClassworkTab, } = this.props
+    const { updateActiveClassworkTab, classroomId, fetchStudentProfile, scores, setLoading, } = this.props
     updateActiveClassworkTab(classworkTab)
+
+    // this is only necessary to run the first time a student clicks over to the completed activities tab
+    if (scores?.length && !scores[0].sessions && classworkTab === COMPLETED_ACTIVITIES) {
+      setLoading()
+      fetchStudentProfile(classroomId, true);
+    }
   }
 
   initializePusher = (nextProps) => {
@@ -161,10 +168,11 @@ class StudentProfile extends React.Component {
 
 const mapStateToProps = state => state;
 const mapDispatchToProps = dispatch => ({
-  fetchStudentProfile: classroomId => dispatch(fetchStudentProfile(classroomId)),
+  fetchStudentProfile: (classroomId, includeSessionData) => dispatch(fetchStudentProfile(classroomId, includeSessionData)),
   fetchStudentsClassrooms: () => dispatch(fetchStudentsClassrooms()),
   handleClassroomClick: classroomId => dispatch(handleClassroomClick(classroomId)),
-  updateActiveClassworkTab: tab => dispatch(updateActiveClassworkTab(tab))
+  updateActiveClassworkTab: tab => dispatch(updateActiveClassworkTab(tab)),
+  setLoading: () => dispatch(setLoading())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(StudentProfile);

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -115,13 +115,14 @@ class StudentProfile extends React.Component {
       isBeingPreviewed,
       history,
       metrics,
-      exactScoresDataLoading,
+      loadingExactScoresData,
       exactScoresData,
+      showExactScores,
     } = this.props;
 
     if (loading) { return <LoadingIndicator /> }
 
-    if (activeClassworkTab === COMPLETED_ACTIVITIES && exactScoresDataLoading)  { return <LoadingIndicator /> }
+    if (activeClassworkTab === COMPLETED_ACTIVITIES && loadingExactScoresData)  { return <LoadingIndicator /> }
 
     if (!selectedClassroomId) { return (<SelectAClassroom classrooms={classrooms} isBeingPreviewed={isBeingPreviewed} onClickCard={this.handleClassroomTabClick} />)}
 
@@ -155,6 +156,7 @@ class StudentProfile extends React.Component {
             loading={loading}
             nextActivitySession={nextActivitySession}
             selectedUnitId={this.parsedQueryParams().unit_id}
+            showExactScores={showExactScores}
             teacherName={student.classroom.teacher.name}
           />
         </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -62,7 +62,7 @@ class StudentProfile extends React.Component {
   }
 
   handleClassroomTabClick = (classroomId) => {
-    const { loading, handleClassroomClick, history, } = this.props;
+    const { loading, handleClassroomClick, history, fetchStudentProfile, } = this.props;
 
     if (!loading) {
       const newUrl = `/classrooms/${classroomId}`;

--- a/services/QuillLMS/client/app/reducers/student_profile.js
+++ b/services/QuillLMS/client/app/reducers/student_profile.js
@@ -17,6 +17,10 @@ export default (state, action) => {
   state = state || initialState;
 
   switch(action.type) {
+    case 'SET_LOADING':
+      return Object.assign({}, state, {
+        loading: true,
+      });
     case 'HANDLE_CLASSROOM_CLICK':
       return Object.assign({}, state, {
         loading: true,

--- a/services/QuillLMS/client/app/reducers/student_profile.js
+++ b/services/QuillLMS/client/app/reducers/student_profile.js
@@ -31,7 +31,8 @@ export default (state, action) => {
         student: action.data.student,
         nextActivitySession: action.data.next_activity_session,
         selectedClassroomId: action.data.classroom_id,
-        metrics: action.data.metrics
+        metrics: action.data.metrics,
+        showExactScores: action.data.show_exact_scores
       });
     case 'UPDATE_ACTIVE_CLASSWORK_TAB':
       return Object.assign({}, state, { activeClassworkTab: action.activeClassworkTab });

--- a/services/QuillLMS/client/app/reducers/student_profile.js
+++ b/services/QuillLMS/client/app/reducers/student_profile.js
@@ -11,7 +11,7 @@ const initialState = {
   student: null,
   nextActivitySession: null,
   activeClassworkTab: TO_DO_ACTIVITIES,
-  loadingExactScoresData: true
+  loadingExactScoresData: false
 };
 
 export default (state, action) => {
@@ -21,7 +21,7 @@ export default (state, action) => {
     case 'HANDLE_CLASSROOM_CLICK':
       return Object.assign({}, state, {
         loading: true,
-        loadingExactScoresData: true,
+        loadingExactScoresData: false,
         selectedClassroomId: action.selectedClassroomId
       });
     case 'RECEIVE_STUDENTS_CLASSROOMS':
@@ -34,7 +34,8 @@ export default (state, action) => {
         nextActivitySession: action.data.next_activity_session,
         selectedClassroomId: action.data.classroom_id,
         metrics: action.data.metrics,
-        showExactScores: action.data.show_exact_scores
+        showExactScores: action.data.show_exact_scores,
+        loadingExactScoresData: action.data.show_exact_scores // if this value is true, we set off another request to get this data, so it is now loading
       });
     case 'RECEIVE_EXACT_SCORES_DATA': {
       return Object.assign({}, state, {

--- a/services/QuillLMS/client/app/reducers/student_profile.js
+++ b/services/QuillLMS/client/app/reducers/student_profile.js
@@ -10,20 +10,18 @@ const initialState = {
   scores: null,
   student: null,
   nextActivitySession: null,
-  activeClassworkTab: TO_DO_ACTIVITIES
+  activeClassworkTab: TO_DO_ACTIVITIES,
+  loadingExactScoresData: true
 };
 
 export default (state, action) => {
   state = state || initialState;
 
   switch(action.type) {
-    case 'SET_LOADING':
-      return Object.assign({}, state, {
-        loading: true,
-      });
     case 'HANDLE_CLASSROOM_CLICK':
       return Object.assign({}, state, {
         loading: true,
+        loadingExactScoresData: true,
         selectedClassroomId: action.selectedClassroomId
       });
     case 'RECEIVE_STUDENTS_CLASSROOMS':
@@ -38,6 +36,12 @@ export default (state, action) => {
         metrics: action.data.metrics,
         showExactScores: action.data.show_exact_scores
       });
+    case 'RECEIVE_EXACT_SCORES_DATA': {
+      return Object.assign({}, state, {
+        loadingExactScoresData: false,
+        exactScoresData: action.data.exact_scores_data
+      })
+    }
     case 'UPDATE_ACTIVE_CLASSWORK_TAB':
       return Object.assign({}, state, { activeClassworkTab: action.activeClassworkTab });
     default:

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -164,6 +164,7 @@ EmpiricalGrammar::Application.routes.draw do
 
   get 'students_classrooms_json' => 'profiles#students_classrooms_json'
   get 'student_profile_data' => 'profiles#student_profile_data'
+  post 'student_exact_scores_data' => 'profiles#student_exact_scores_data'
   get 'student_mobile_profile_data/:current_classroom_id' => 'profiles#mobile_profile_data'
 
   resources :activities, only: [] do

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -249,6 +249,7 @@ describe ProfilesController, type: :controller do
                 'completed_date' => activity_session&.completed_at,
                 'order_number' => unit_activity.order_number,
                 'due_date' => unit_activity.due_date,
+                'publish_date' => unit_activity.publish_date,
                 'pre_activity_id' => pre_test&.id,
                 'unit_activity_created_at' => classroom_unit.created_at,
                 'user_pack_sequence_item_status' => nil,

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -118,7 +118,7 @@ describe ProfilesController, type: :controller do
 
       context 'when the student has a single classroom' do
         it "returns student, classroom, and teacher info when the current user has classrooms" do
-          get :student_profile_data
+          get :student_profile_data, params: { current_classroom_id: classroom.id }
           response_body = JSON.parse(response.body)
           expect(student.classrooms.count).to eq(1)
           students_classroom = student.classrooms.first
@@ -153,7 +153,7 @@ describe ProfilesController, type: :controller do
         end
 
         it 'sorts pinned activities to the front' do
-          get :student_profile_data
+          get :student_profile_data, params: { current_classroom_id: classroom.id }
           scores = JSON.parse(response.body)['scores']
           pinned_flags = scores.map { |score| score['pinned'].to_s }
           expect(pinned_flags).to eq(pinned_flags.sort.reverse)
@@ -164,7 +164,7 @@ describe ProfilesController, type: :controller do
             activity_state.pinned = false
             activity_state.save
           end
-          get :student_profile_data
+          get :student_profile_data, params: { current_classroom_id: classroom.id }
           scores = JSON.parse(response.body)['scores']
           locked_flags = scores.map { |score| score['locked'].to_s }
           expect(locked_flags).to eq(locked_flags.sort)
@@ -176,7 +176,7 @@ describe ProfilesController, type: :controller do
             activity_state.locked = false
             activity_state.save
           end
-          get :student_profile_data
+          get :student_profile_data, params: { current_classroom_id: classroom.id }
           scores = JSON.parse(response.body)['scores']
           unit_created_at_times = scores.map { |score| score['unit_created_at'] }
           expect(unit_created_at_times).to eq(unit_created_at_times.sort)
@@ -190,7 +190,7 @@ describe ProfilesController, type: :controller do
           end
           # Note that our current sorting algorithm uses "max_percentage" as a weak proxy for this
           # It may ultimately result in some unexpected behavior
-          get :student_profile_data
+          get :student_profile_data, params: { current_classroom_id: classroom.id }
           scores = JSON.parse(response.body)['scores']
           single_unit_scores = scores.select { |item| item['unit_id'] == units[0].id }
           max_percentages = single_unit_scores.map { |score| score['max_percentage'] }.compact
@@ -203,7 +203,7 @@ describe ProfilesController, type: :controller do
             activity_state.locked = false
             activity_state.save
           end
-          get :student_profile_data
+          get :student_profile_data, params: { current_classroom_id: classroom.id }
           scores = JSON.parse(response.body)['scores']
           single_unit_scores = scores.select { |item| item['unit_id'] == units[0].id }
           single_unit_scores = scores.reject { |item| item['max_percentage'].nil? }
@@ -215,7 +215,7 @@ describe ProfilesController, type: :controller do
           # This test attempts to do a complex, total sorting algorithm comparison
           # It's probably doing too much in one place, but the coverage is nice
 
-          get :student_profile_data
+          get :student_profile_data, params: { current_classroom_id: classroom.id }
           scores = JSON.parse(response.body)['scores']
           relevant_classroom = student.classrooms.last
           scores_array = []
@@ -234,7 +234,7 @@ describe ProfilesController, type: :controller do
 
               scores_array << {
                 'name' => activity.name,
-                'description' => activity.description,
+                'activity_description' => activity.description,
                 'repeatable' => activity.repeatable,
                 'activity_classification_id' => activity.activity_classification_id,
                 'activity_classification_key' => activity.classification.key,
@@ -276,7 +276,7 @@ describe ProfilesController, type: :controller do
         end
 
         it 'returns next activity session' do
-          get :student_profile_data
+          get :student_profile_data, params: { current_classroom_id: classroom.id }
           response_body = JSON.parse(response.body)
           expect(response_body['next_activity_session']).to eq(response_body['scores'].first)
         end


### PR DESCRIPTION
## WHAT
Show students their scores on their dashboard when the classroom's owner has `show_students_exact_scores` enabled.

## WHY
This is a long-requested feature!

## HOW
After a couple of false starts where I tried to just add this info to the existing query (it takes too long), I added a new endpoint to get the data we need for the exact scores (with question counts) and all the tooltip data, then set up the frontend to load that as necessary and display the data according to the spec. Also fixed some existing issues with the student dashboard on mobile and the tooltips moving off the edge of the page.

### Screenshots
<img width="977" alt="Screenshot 2024-03-11 at 11 39 57 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/22a6e9ad-7a43-4dae-9175-44844070d454">

### Notion Card Links
https://www.notion.so/quill/Student-activity-table-ce06641cb91a4ba09c632d053c50d36f?pvs=4

### What have you done to QA this feature?
Tested this out with multiple students on staging in classrooms owned by teachers that do and do not have this feature enabled, with all different activity types, and check for responsiveness in the page. Also made sure the tooltip still looks and functions the same way as always on the activity summary page for teachers. Jack and PS have reviewed and approved.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
