### PR TITLE
lms/allow-multiple-view-refreshes

### DIFF
--- a/services/QuillLMS/app/controllers/quill_big_query/materialized_views_controller.rb
+++ b/services/QuillLMS/app/controllers/quill_big_query/materialized_views_controller.rb
@@ -10,7 +10,7 @@ module QuillBigQuery
     class InvalidRequestError < ::StandardError; end
 
     def refresh
-      QuillBigQuery::MaterializedViewRefreshWorker.perform_async(view_key)
+      view_keys.each { |view_key| QuillBigQuery::MaterializedViewRefreshWorker.perform_async(view_key) }
 
       render json: {}, status: 200
     end
@@ -23,6 +23,6 @@ module QuillBigQuery
 
     private def refresh_params = params.permit(:api_key, :view_key)
     private def api_key = refresh_params[:api_key]
-    private def view_key = refresh_params[:view_key]
+    private def view_keys = refresh_params[:view_key].split(",")
   end
 end

--- a/services/QuillLMS/spec/controllers/quill_big_query/materialized_view_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/quill_big_query/materialized_view_controller_spec.rb
@@ -21,6 +21,19 @@ RSpec.describe QuillBigQuery::MaterializedViewsController do
       subject
     end
 
+    context 'multiple keys' do
+      let(:view_key2) { 'some_other_key' }
+      let(:view_key_param) { "#{view_key},#{view_key2}" }
+      let(:params) { { api_key:, view_key: view_key_param } }
+
+      it 'should enqueue every comma-separated job passed in' do
+        expect(QuillBigQuery::MaterializedViewRefreshWorker).to receive(:perform_async).with(view_key)
+        expect(QuillBigQuery::MaterializedViewRefreshWorker).to receive(:perform_async).with(view_key2)
+
+        subject
+      end
+    end
+
     context 'no API_KEY set' do
       before do
         stub_const('QuillBigQuery::MaterializedViewsController::API_KEY', '')


### PR DESCRIPTION
## WHAT
Update materialized view refresh controller to take multiple views
## WHY
We're only allowed to make one HTTP request when Airbyte finishes syncing a dataset, so that call needs to be able to refresh multiple materialized views.
## HOW
Parse the URL `param` and split it on commas.  NOTE: This means that we can't use commas in our view names, but I think that may be syntactically invalid already.

### What have you done to QA this feature?
Deployed code to my staging environment, manually dropped the view, manually hit the URL to refresh both views on my staging environment, confirmed that the view got created in BigQuery.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
