### PR TITLE
Add two additional author types to Connect and Grammar filters

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/constants.js
+++ b/services/QuillLMS/client/app/bundles/Connect/constants.js
@@ -218,6 +218,8 @@ export default {
     'Parts of Speech',
     'Spelling Hint',
     'Quotation Mark Hint',
+    'Words Out of Order Hint',
+    'Spacing After Comma Hint',
   ],
 
   // cONCEPTS FEEDBACK ACTIONS

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/actionTypes.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/actionTypes.ts
@@ -141,7 +141,9 @@ export const ActionTypes = {
     'Spelling Hint',
     'Focus Point Hint',
     'Incorrect Sequence Hint',
-    'Quotation Mark Hint'
+    'Quotation Mark Hint',
+    'Words Out of Order Hint',
+    'Spacing After Comma Hint',
   ],
 
   // STATE


### PR DESCRIPTION
## WHAT
Add the two author types, "Words Out of Order HInt" and "Spacing After Comma HInt", to the filters on Connect and Grammar admin panels.

## WHY
So admin can easily grade all types of hint authors on these two tools.

## HOW
Add in the hints to the Constants lists where filters are created.

### Screenshots
![Screenshot 2024-03-11 at 5 30 11 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/5db05804-a9b3-4bbb-95a5-4a2efc72b4a9)
![Screenshot 2024-03-11 at 5 24 47 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/ad502790-8057-4539-b4da-2e1ed8c5c98d)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=10466ac87020487e87eed7f72eff4681&pm=c) (See problem 4 on this notion card).

### What have you done to QA this feature?
I went into the Connect and Grammar staging panels and manually tested all 4 of the use cases that admin mentioned on the Notion card.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, tested manually.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
