### PR TITLE
handle commas in skill group names

### DIFF
--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
@@ -1,4 +1,4 @@
-import { tierUDF, studentwiseSkillGroupUDF } from "./BigQueryUDFs"
+import { tierUDF, studentwiseSkillGroupUDF, findLastIndex } from "./BigQueryUDFs"
 
 describe('studentwiseSkillGroupUDF', () => {
   it('should return skillGroup-score pairs', () => {
@@ -50,6 +50,39 @@ describe('studentwiseSkillGroupUDF', () => {
     expect(parsedResult.recommendedActivityCount).toEqual(10)
   })
 
+  it('should remove commas from skill group names that have commas', () => {
+    const activityIds = ["1663", "1664"];
+    const completedAts = ['2022-01-01T00:00:00Z', '2022-01-02T00:00:00Z'];
+    const scores = [false, true];
+    const skillGroupNames = ['Compound Subjects, Objects, and Predicates', 'Compound Subjects, Objects, and Predicates']
+
+    const result = studentwiseSkillGroupUDF(scores, activityIds, completedAts, skillGroupNames);
+    const parsedResult = JSON.parse(result)
+
+    expect(parsedResult['Compound Subjects Objects and Predicates_pre']).toEqual(0)
+    expect(parsedResult['Compound Subjects Objects and Predicates_post']).toEqual(1)
+
+  })
+})
+
+describe('findLastIndex', () => {
+  it('should return the correct index', () => {
+    const finderFn = (x) => x == 4
+    const arr = [2, 4, 6, 4]
+    expect(findLastIndex(arr, 0, finderFn)).toEqual(3)
+  })
+
+  it('should return the correct index, with 2-element array', () => {
+    const finderFn = (x) => x == 4
+    const arr = [2, 4]
+    expect(findLastIndex(arr, 0, finderFn)).toEqual(1)
+  })
+
+  it('should return the correct index, with 1-element array', () => {
+    const finderFn = (x) => x == 4
+    const arr = [2, 4]
+    expect(findLastIndex(arr, 1, finderFn)).toEqual(1)
+  })
 })
 
 describe('tierUDF', () => {


### PR DESCRIPTION
## WHAT
Out of the 30-odd skill groups required in this particular rollup, 2 of them have commas in their names. BigQuery does not handle strings-with-commas in arguments to `JSON_VALUE`. Screenshot:
<img width="1283" alt="Screenshot 2024-03-11 at 2 57 15 PM" src="https://github.com/empirical-org/Empirical-Core/assets/90669/07b8ec40-a2cd-4795-9c76-408ef71afe15">

Screenshot, after this patch:
<img width="1195" alt="Screenshot 2024-03-11 at 3 08 29 PM" src="https://github.com/empirical-org/Empirical-Core/assets/90669/23ee4f5b-6720-44dd-be18-8ea8d8ab3bf3">

## WHY
We want to handle skill groups that have commas in their names 

## HOW
Employ a regex that removes commas in the appropriate places in the JavaScript UDF

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/P1-Query-of-diagnostic-data-with-recommendation-data-c0686b88bd0540c5984bc360f29ac09d

### What have you done to QA this feature?
I ran the above screenshotted query after deploying this patch to BigQuery prod, and the query completed successfully.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | n/a 
Self-Review: Have you done an initial self-review of the code below on Github? |
