### PR TITLE
clean up logic for showing/hiding premium banner

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
@@ -76,11 +76,10 @@ const PremiumHubContainer = ({ id, history, location, children, user, }) => {
 
     if (accessType() === FULL || accessType() === LOADING) { return <span /> }
 
-    // this checks that the last part of the path (after the final '/') matches the overview page (which is just /teachers/premium_hub) or the integrations page
-    const onPageThatShouldNotShowBanner = ['integrations', 'premium_hub', 'usage_snapshot_report', 'data_export', 'diagnostic_growth_report', 'district_concept_reports', 'district_activity_scores', 'district_standards_reports'].some((path) => location.pathname.split('/').pop() === path)
+    const onPageThatShouldShowBanner = ['subscriptions', 'account_management'].some((path) => location.pathname.includes(path))
     const onSubscriptionPageWithExpiredPremium = location.pathname.includes('subscriptions') && administers_school_with_current_or_expired_premium
 
-    if (accessType() === LIMITED && !(onPageThatShouldNotShowBanner || onSubscriptionPageWithExpiredPremium)) {
+    if (accessType() === LIMITED && onPageThatShouldShowBanner && !onSubscriptionPageWithExpiredPremium) {
       return (
         <Banner
           bodyText="Subscribe to School or District Premium to unlock all Premium Hub features. Manage teacher accounts, access teacher reports, and view school-wide student data."


### PR DESCRIPTION
## WHAT
Clean up the logic for showing/hiding the premium banner.

## WHY
It was a) not properly hiding it on the integrations page (which actually ends in `/canvas`, `/google`, or `/clever`) and b) the list of "exceptions" now greatly exceeds the list of places it's actually supposed to ever show.

## HOW
Just rewrite the code to list where it SHOULD show instead of where it shouldn't.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Status-bar-is-being-shown-on-admin-integrations-page-in-State-F-when-it-should-be-hidden-6707e8d75a2c47b581f3dc80ec39606a?pvs=4

### What have you done to QA this feature?
Logged in as the teacher Peter Sharkey wrote the bug report about on staging (recent enough data that the relevant info is the same) and confirm that the banner shows on the pages we want it to and not on the pages we don't.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
