### PR TITLE
Bug Fix: Synthetic Data - remove blank examples.

### DIFF
--- a/services/QuillLMS/engines/evidence/lib/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/synthetic/seed_data_generator.rb
@@ -162,7 +162,7 @@ module Evidence
         return unless label_configs.present?
 
         label_configs.each do |label_config|
-          label_config[EXAMPLES_KEY].map(&:strip).uniq.compact.each.with_index do |example, index|
+          label_config[EXAMPLES_KEY].map(&:strip).uniq.compact_blank.each.with_index do |example, index|
             prompt = Evidence::OpenAI::PARAPHRASE_INSTRUCTION + example
             generator = Evidence::TextGeneration.create(
               type: Evidence::TextGeneration::TYPE_LABEL_EXAMPLE,

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -451,8 +451,8 @@ module Evidence
         let(:label2) {'label2'}
         let(:example1) {'some sentence'}
         let(:example2) {'sentence other'}
-        let(:label_config1) {{'label' => label1, 'example1' => example1, 'example2' => example2}}
-        let(:label_config2) {{'label' => label2, 'example1' => example1, 'example2' => example2}}
+        let(:label_config1) {{'label' => label1, 'examples' => [example1, example2]}}
+        let(:label_config2) {{'label' => label2, 'examples' => [example1, example2]}}
         let(:label_configs) {{'so' => [label_config1, label_config2], 'because' => [label_config2]}}
 
         it "should call background worker" do
@@ -460,6 +460,18 @@ module Evidence
           post :seed_data, params: { id: activity.id, nouns: "", label_configs: label_configs }
 
           expect(response).to have_http_status(:success)
+        end
+
+        context 'blank example' do
+          let(:label_config1_blank) {{'label' => label1, 'examples' => [example1, example2, ' ', "\n", '', ]}}
+          let(:label_configs_with_blanks) {{'so' => [label_config1_blank, label_config2], 'because' => [label_config2]}}
+
+          it "should call background worker" do
+            expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs, true)
+            post :seed_data, params: { id: activity.id, nouns: "", label_configs: label_configs_with_blanks }
+
+            expect(response).to have_http_status(:success)
+          end
         end
       end
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -463,7 +463,7 @@ module Evidence
         end
 
         context 'blank example' do
-          let(:label_config1_blank) {{'label' => label1, 'examples' => [example1, example2, ' ', "\n", '', ]}}
+          let(:label_config1_blank) {{'label' => label1, 'examples' => [example1, example2, ' ', "\n", '']}}
           let(:label_configs_with_blanks) {{'so' => [label_config1_blank, label_config2], 'because' => [label_config2]}}
 
           it "should call background worker" do

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -466,7 +466,7 @@ module Evidence
           let(:label_config1_blank) {{'label' => label1, 'examples' => [example1, example2, ' ', "\n", '']}}
           let(:label_configs_with_blanks) {{'so' => [label_config1_blank, label_config2], 'because' => [label_config2]}}
 
-          it "should call background worker" do
+          it "should call background worker with no blank examples" do
             expect(Evidence::ActivitySeedDataWorker).to receive(:perform_async).with(activity.id, [], label_configs, true)
             post :seed_data, params: { id: activity.id, nouns: "", label_configs: label_configs_with_blanks }
 


### PR DESCRIPTION
## WHAT
Bug fix to remove blanks from Label Examples in the Synthetic Seed data
## WHY
The blanks get sent to OpenAI as `“rephrase with some synonyms:\\n\\n”` with no text after it, as opposed to the expected `"rephrase with some synonyms:\\n\\nexample sentence that we want paraphrased”`, which adds some junk to the seed data.
## HOW
Write a failing test, fix that test. Strip the blanks out early in the process and at the end.
### Screenshots
Coming through as blank
<img width="1074" alt="Screenshot 2024-03-13 at 10 56 51 AM" src="https://github.com/empirical-org/Empirical-Core/assets/1304933/a2f08a1f-a141-42a9-abb9-5ad01d7cafcd">
Normal Example
<img width="1173" alt="Screenshot 2024-03-13 at 10 56 59 AM" src="https://github.com/empirical-org/Empirical-Core/assets/1304933/3cd81b81-7968-4c75-9de4-2cc90e954673">


### Notion Card Links
https://www.notion.so/quill/Unrelated-responses-and-what-looks-like-prompt-language-showing-up-in-seed-data-generated-from-label-3fc94a65988b401fb70a71a4f4a94f91

### What have you done to QA this feature?
Loading the page locally, submitted a form with blanks and confirmed it made it to the job without blanks.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
