### PR TITLE
update how we save grammar concept results to cms

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/actions/responses.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/responses.ts
@@ -6,6 +6,8 @@ import { ActionTypes } from './actionTypes';
 
 import { requestDelete, requestGet, requestPost, requestPut, } from '../../../modules/request/index';
 import objectWithSnakeKeysFromCamel from '../libs/objectWithSnakeKeysFromCamel';
+import convertConceptResultsArrayToHash from '../libs/convertConceptResultsArrayToHash';
+
 
 export function deleteStatus(questionId: string) {
   return { type: ActionTypes.DELETE_RESPONSE_STATUS, data: { questionId, }, };
@@ -26,6 +28,8 @@ export function submitResponse(content: Response, prid: string, isFirstAttempt: 
   rubyConvertedResponse.created_at = moment().format('x');
   rubyConvertedResponse.first_attempt_count = isFirstAttempt ? 1 : 0;
   rubyConvertedResponse.is_first_attempt = isFirstAttempt;
+  rubyConvertedResponse.concept_results = convertConceptResultsArrayToHash(rubyConvertedResponse.conceptResults || rubyConvertedResponse.concept_results)
+
   return (dispatch: Function) => {
     requestPost(
       `${process.env.QUILL_CMS}/responses/create_or_increment`,

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/convertConceptResultsArrayToHash.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/convertConceptResultsArrayToHash.ts
@@ -1,0 +1,12 @@
+import * as _ from 'underscore';
+
+export default function convertConceptResultsArrayToHash(crArray: any) {
+  const crs = _.values(crArray);
+  const newHash: {[key:string]: Boolean} = {};
+  _.each(crs, (val) => {
+    if (val.conceptUID && val.conceptUID.length > 0) {
+      newHash[val.conceptUID] = val.correct;
+    }
+  });
+  return newHash;
+}

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/grading/rematching.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/grading/rematching.ts
@@ -4,6 +4,7 @@ import { checkGrammarQuestion, ConceptResult } from 'quill-marking-logic';
 import { requestGet, requestPost, requestPut, } from '../../../../modules/request/index';
 import { hashToCollection } from '../../../Shared/index';
 import objectWithSnakeKeysFromCamel from '../objectWithSnakeKeysFromCamel';
+import convertConceptResultsArrayToHash from '../convertConceptResultsArrayToHash'
 
 interface Question {
   conceptID: string,
@@ -146,7 +147,7 @@ function updateRematchedResponse(response: any, newResponse: any) {
     parent_id: newResponse.response.parent_id,
     author: newResponse.response.author,
     feedback: newResponse.response.feedback,
-    concept_results: convertResponsesArrayToHash(conceptResults),
+    concept_results: convertConceptResultsArrayToHash(conceptResults),
   };
   return updateResponse(response.id, newVals);
 }
@@ -170,7 +171,7 @@ function determineDelta(response: any, newResponse: any) {
   const parentIDChanged = (newResponse.response.parent_id ? Number(newResponse.response.parent_id) : null) !== response.parent_id;
   const authorChanged = newResponse.response.author !== response.author;
   const feedbackChanged = newResponse.response.feedback !== response.feedback;
-  const conceptResultsChanged = !_.isEqual(convertResponsesArrayToHash(conceptResults), response.concept_results);
+  const conceptResultsChanged = !_.isEqual(convertConceptResultsArrayToHash(conceptResults), response.concept_results);
   const changed = parentIDChanged || authorChanged || feedbackChanged || conceptResultsChanged;
   if (changed) {
     if (unmatched) {
@@ -237,15 +238,4 @@ function formatGradedResponses(jsonString: string): {[key: string]: Response} {
     delete resp.concept_results;
   });
   return bodyToObj;
-}
-
-function convertResponsesArrayToHash(crArray: any) {
-  const crs = _.values(crArray);
-  const newHash: {[key:string]: Boolean} = {};
-  _.each(crs, (val) => {
-    if (val.conceptUID && val.conceptUID.length > 0) {
-      newHash[val.conceptUID] = val.correct;
-    }
-  });
-  return newHash;
 }


### PR DESCRIPTION
## WHAT
Fix bug where Grammar concept results were not saving on first submission of new responses.

## WHY
We want these to be stored correctly.

## HOW
Rachel mentioned, and I confirmed, that this was not working on first submission, but did work when rematched. I looked to see what difference there was between the rematching code and the regular submission, and we were transforming the concept results for rematching but not regular submission, so I pulled out and renamed the transform function and applied it in both instances.

Note: in both Connect and Diagnostic, we are similarly doing this transform when we rematch but not regularly submit, but I tested and we don't seem to be having the same issue there. I don't want to make a wide-reaching change unnecessarily, so I've left the code there alone for now.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I made a test question and test activity, and played through that to make sure that new questions and responses are getting concept results saved correctly. Then I played through an existing activity and confirmed that their concept results were also still getting saved as we'd expect.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
