### PR TITLE
Create Evidence::Research:GenAI::LLMPrompt resource

### DIFF
--- a/services/QuillLMS/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/config/initializers/zeitwerk.rb
@@ -11,6 +11,7 @@ Rails.autoloaders.each do |autoloader|
     'graphiql' => 'GraphiQL',
     'html_tag_remover' => 'HTMLTagRemover',
     'llm_config' => 'LLMConfig',
+    'llm_prompt' => 'LLMPrompt',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'open_ai' => 'OpenAI',
     'pusher_csv_export_completed' => 'PusherCSVExportCompleted',

--- a/services/QuillLMS/db/migrate/20240315181419_create_evidence_research_gen_ai_llm_prompts.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240315181419_create_evidence_research_gen_ai_llm_prompts.evidence.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240315180944)
+class CreateEvidenceResearchGenAiLlmPrompts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompts do |t|
+      t.text :prompt, null: false
+      t.integer :llm_prompt_template_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20240315184614_create_evidence_research_gen_ai_passages.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240315184614_create_evidence_research_gen_ai_passages.evidence.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240315184312)
+class CreateEvidenceResearchGenAiPassages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passages do |t|
+      t.text :contents, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2971,6 +2971,38 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_templates_id_seq OWNED
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompts (
+    id bigint NOT NULL,
+    prompt text NOT NULL,
+    llm_prompt_template_id integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompts.id;
+
+
+--
 -- Name: evidence_text_generations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6160,6 +6192,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates ALTER COLU
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompts_id_seq'::regclass);
+
+
+--
 -- Name: evidence_text_generations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7305,6 +7344,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_configs
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_templates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompts evidence_research_gen_ai_llm_prompts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
 
 
 --
@@ -10946,6 +10993,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240307143356'),
 ('20240307182109'),
 ('20240315141121'),
-('20240315171249');
+('20240315171249'),
+('20240315181419');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3003,6 +3003,37 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passages (
+    id bigint NOT NULL,
+    contents text NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passages_id_seq OWNED BY public.evidence_research_gen_ai_passages.id;
+
+
+--
 -- Name: evidence_text_generations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6199,6 +6230,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passages ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passages_id_seq'::regclass);
+
+
+--
 -- Name: evidence_text_generations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7352,6 +7390,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passages evidence_research_gen_ai_passages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passages
+    ADD CONSTRAINT evidence_research_gen_ai_passages_pkey PRIMARY KEY (id);
 
 
 --
@@ -10994,6 +11040,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240307182109'),
 ('20240315141121'),
 ('20240315171249'),
-('20240315181419');
+('20240315181419'),
+('20240315184614');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompts
+#
+#  id                     :bigint           not null, primary key
+#  prompt                 :text             not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  llm_prompt_template_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class LLMPrompt < ApplicationRecord
+        belongs_to :llm_prompt_template, class_name: 'Evidence::Research::GenAI::LLMPromptTemplate'
+
+        validates :prompt, presence: true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passages
+#
+#  id         :bigint           not null, primary key
+#  contents   :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class Passage < ApplicationRecord
+        validates :contents, presence: true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
@@ -7,6 +7,7 @@ Rails.autoloaders.each do |autoloader|
     'gen_ai' => 'GenAI',
     'html_tag_remover' => 'HTMLTagRemover',
     'llm_config' => 'LLMConfig',
+    'llm_prompt' => 'LLMPrompt',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'open_ai' => 'OpenAI',
     'vertex_ai' => 'VertexAI'

--- a/services/QuillLMS/engines/evidence/db/migrate/20240315180944_create_evidence_research_gen_ai_llm_prompts.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240315180944_create_evidence_research_gen_ai_llm_prompts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAiLlmPrompts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompts do |t|
+      t.text :prompt, null: false
+      t.integer :llm_prompt_template_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240315184312_create_evidence_research_gen_ai_passages.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240315184312_create_evidence_research_gen_ai_passages.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAiPassages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passages do |t|
+      t.text :contents, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -961,6 +961,38 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_templates_id_seq OWNED
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompts (
+    id bigint NOT NULL,
+    prompt text NOT NULL,
+    llm_prompt_template_id integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompts.id;
+
+
+--
 -- Name: evidence_text_generations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1214,6 +1246,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates ALTER COLU
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompts_id_seq'::regclass);
+
+
+--
 -- Name: evidence_text_generations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1441,6 +1480,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_configs
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_templates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompts evidence_research_gen_ai_llm_prompts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
 
 
 --
@@ -1719,6 +1766,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240307142932'),
 ('20240307165408'),
 ('20240315140702'),
-('20240315141841');
+('20240315141841'),
+('20240315180944');
 
 

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -993,6 +993,37 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passages (
+    id bigint NOT NULL,
+    contents text NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passages_id_seq OWNED BY public.evidence_research_gen_ai_passages.id;
+
+
+--
 -- Name: evidence_text_generations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1253,6 +1284,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passages ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passages_id_seq'::regclass);
+
+
+--
 -- Name: evidence_text_generations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1488,6 +1526,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passages evidence_research_gen_ai_passages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passages
+    ADD CONSTRAINT evidence_research_gen_ai_passages_pkey PRIMARY KEY (id);
 
 
 --
@@ -1767,6 +1813,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240307165408'),
 ('20240315140702'),
 ('20240315141841'),
-('20240315180944');
+('20240315180944'),
+('20240315184312');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompts.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompts.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompts
+#
+#  id                     :bigint           not null, primary key
+#  prompt                 :text             not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  llm_prompt_template_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_llm_prompt, class: 'Evidence::Research::GenAI::LLMPrompt' do
+          llm_prompt_template { association :evidence_research_gen_ai_llm_prompt_template }
+          prompt { 'This is the prompt' }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passages.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passages.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passages
+#
+#  id         :bigint           not null, primary key
+#  contents   :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_passage, class: 'Evidence::Research::GenAI::Passage' do
+          contents { 'This is the contents' }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompts
+#
+#  id                     :bigint           not null, primary key
+#  prompt                 :text             not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  llm_prompt_template_id :integer          not null
+#
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe LLMPrompt, type: :model do
+        it { should validate_presence_of(:prompt) }
+        it { should belong_to(:llm_prompt_template) }
+
+        it { expect(build(:evidence_research_gen_ai_llm_prompt)).to be_valid }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passages
+#
+#  id         :bigint           not null, primary key
+#  contents   :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe Passage, type: :model do
+        it { should validate_presence_of(:contents) }
+
+        it { expect(build(:evidence_research_gen_ai_passage)).to be_valid}
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Create `Evidence::Research::GenAI::LLMPrompt` resource

## WHY
These records will represent instances of the `LLMPromptTemplate` used in GenAI experiments.
The reason for the separation of `LLMPrompt` and `LLMPromtpTemplate` is for transparency and reuse.  Each template specifies the prompt structure, but this record will contain the actual contents of the prompt.

## HOW
Update the zeitwerk inflection initializer so that GenAI and LLMConfig are handled correctly.
`rails g model 'Research/GenAI/LLMPrompt' prompt:text llm_prompt_template_id:integer`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
This is a component of the GenAI research architecture. No QA other than creating records.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
