### PR TITLE
Create Evidence::Research::GenAI::Passage resource

### DIFF
--- a/services/QuillLMS/db/migrate/20240315184614_create_evidence_research_gen_ai_passages.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240315184614_create_evidence_research_gen_ai_passages.evidence.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 # This migration comes from evidence (originally 20240315184312)
 class CreateEvidenceResearchGenAiPassages < ActiveRecord::Migration[7.0]
   def change
     create_table :evidence_research_gen_ai_passages do |t|
-      t.text :full_text
-      t.text :abridged_text
+      t.text :full_text, null: false
+      t.text :abridged_text, null: false
 
       t.timestamps
     end

--- a/services/QuillLMS/db/migrate/20240315184614_create_evidence_research_gen_ai_passages.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240315184614_create_evidence_research_gen_ai_passages.evidence.rb
@@ -1,0 +1,11 @@
+# This migration comes from evidence (originally 20240315184312)
+class CreateEvidenceResearchGenAiPassages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passages do |t|
+      t.text :full_text
+      t.text :abridged_text
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20240315184614_create_evidence_research_gen_ai_passages.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240315184614_create_evidence_research_gen_ai_passages.evidence.rb
@@ -4,8 +4,7 @@
 class CreateEvidenceResearchGenAiPassages < ActiveRecord::Migration[7.0]
   def change
     create_table :evidence_research_gen_ai_passages do |t|
-      t.text :full_text, null: false
-      t.text :abridged_text, null: false
+      t.text :contents, null: false
 
       t.timestamps
     end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3008,8 +3008,8 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 CREATE TABLE public.evidence_research_gen_ai_passages (
     id bigint NOT NULL,
-    full_text text,
-    abridged_text text,
+    full_text text NOT NULL,
+    abridged_text text NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3008,8 +3008,7 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 CREATE TABLE public.evidence_research_gen_ai_passages (
     id bigint NOT NULL,
-    full_text text NOT NULL,
-    abridged_text text NOT NULL,
+    contents text NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3003,6 +3003,38 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passages (
+    id bigint NOT NULL,
+    full_text text,
+    abridged_text text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passages_id_seq OWNED BY public.evidence_research_gen_ai_passages.id;
+
+
+--
 -- Name: evidence_text_generations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6199,6 +6231,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passages ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passages_id_seq'::regclass);
+
+
+--
 -- Name: evidence_text_generations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7352,6 +7391,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passages evidence_research_gen_ai_passages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passages
+    ADD CONSTRAINT evidence_research_gen_ai_passages_pkey PRIMARY KEY (id);
 
 
 --
@@ -10994,6 +11041,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240307182109'),
 ('20240315141121'),
 ('20240315171249'),
-('20240315181419');
+('20240315181419'),
+('20240315184614');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
@@ -5,8 +5,8 @@
 # Table name: evidence_research_gen_ai_passages
 #
 #  id            :bigint           not null, primary key
-#  abridged_text :text
-#  full_text     :text
+#  abridged_text :text             not null
+#  full_text     :text             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
@@ -4,18 +4,16 @@
 #
 # Table name: evidence_research_gen_ai_passages
 #
-#  id            :bigint           not null, primary key
-#  abridged_text :text             not null
-#  full_text     :text             not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id         :bigint           not null, primary key
+#  contents   :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 module Evidence
   module Research
     module GenAI
       class Passage < ApplicationRecord
-        validates :full_text, presence: true
-        validates :abridged_text, presence: true
+        validates :contents, presence: true
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passages
+#
+#  id            :bigint           not null, primary key
+#  abridged_text :text
+#  full_text     :text
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class Passage < ApplicationRecord
+        validates :full_text, presence: true
+        validates :abridged_text, presence: true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240315184312_create_evidence_research_gen_ai_passages.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240315184312_create_evidence_research_gen_ai_passages.rb
@@ -1,0 +1,10 @@
+class CreateEvidenceResearchGenAiPassages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passages do |t|
+      t.text :full_text
+      t.text :abridged_text
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240315184312_create_evidence_research_gen_ai_passages.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240315184312_create_evidence_research_gen_ai_passages.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class CreateEvidenceResearchGenAiPassages < ActiveRecord::Migration[7.0]
   def change
     create_table :evidence_research_gen_ai_passages do |t|
-      t.text :full_text
-      t.text :abridged_text
+      t.text :full_text, null: false
+      t.text :abridged_text, null: false
 
       t.timestamps
     end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240315184312_create_evidence_research_gen_ai_passages.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240315184312_create_evidence_research_gen_ai_passages.rb
@@ -3,8 +3,7 @@
 class CreateEvidenceResearchGenAiPassages < ActiveRecord::Migration[7.0]
   def change
     create_table :evidence_research_gen_ai_passages do |t|
-      t.text :full_text, null: false
-      t.text :abridged_text, null: false
+      t.text :contents, null: false
 
       t.timestamps
     end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -993,6 +993,38 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passages (
+    id bigint NOT NULL,
+    full_text text,
+    abridged_text text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passages_id_seq OWNED BY public.evidence_research_gen_ai_passages.id;
+
+
+--
 -- Name: evidence_text_generations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1253,6 +1285,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passages ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passages_id_seq'::regclass);
+
+
+--
 -- Name: evidence_text_generations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1488,6 +1527,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passages evidence_research_gen_ai_passages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passages
+    ADD CONSTRAINT evidence_research_gen_ai_passages_pkey PRIMARY KEY (id);
 
 
 --
@@ -1767,6 +1814,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240307165408'),
 ('20240315140702'),
 ('20240315141841'),
-('20240315180944');
+('20240315180944'),
+('20240315184312');
 
 

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -998,8 +998,8 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 CREATE TABLE public.evidence_research_gen_ai_passages (
     id bigint NOT NULL,
-    full_text text,
-    abridged_text text,
+    full_text text NOT NULL,
+    abridged_text text NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -998,8 +998,7 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 CREATE TABLE public.evidence_research_gen_ai_passages (
     id bigint NOT NULL,
-    full_text text NOT NULL,
-    abridged_text text NOT NULL,
+    contents text NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passages.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passages.rb
@@ -4,11 +4,10 @@
 #
 # Table name: evidence_research_gen_ai_passages
 #
-#  id            :bigint           not null, primary key
-#  abridged_text :text
-#  full_text     :text
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id         :bigint           not null, primary key
+#  contents   :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 module Evidence
@@ -16,8 +15,7 @@ module Evidence
     module GenAI
       FactoryBot.define do
         factory :evidence_research_gen_ai_passage, class: 'Evidence::Research::GenAI::Passage' do
-          full_text { 'This is the full text' }
-          abridged_text { 'This is the abridged text' }
+          contents { 'This is the contents' }
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passages.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passages.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passages
+#
+#  id            :bigint           not null, primary key
+#  abridged_text :text
+#  full_text     :text
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_passage, class: 'Evidence::Research::GenAI::Passage' do
+          full_text { 'This is the full text' }
+          abridged_text { 'This is the abridged text' }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
@@ -4,11 +4,10 @@
 #
 # Table name: evidence_research_gen_ai_passages
 #
-#  id            :bigint           not null, primary key
-#  abridged_text :text             not null
-#  full_text     :text             not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id         :bigint           not null, primary key
+#  contents   :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 require 'rails_helper'
@@ -17,8 +16,7 @@ module Evidence
   module Research
     module GenAI
       RSpec.describe Passage, type: :model do
-        it { should validate_presence_of(:full_text) }
-        it { should validate_presence_of(:abridged_text) }
+        it { should validate_presence_of(:contents) }
 
         it { expect(build(:evidence_research_gen_ai_passage)).to be_valid}
       end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
@@ -5,8 +5,8 @@
 # Table name: evidence_research_gen_ai_passages
 #
 #  id            :bigint           not null, primary key
-#  abridged_text :text
-#  full_text     :text
+#  abridged_text :text             not null
+#  full_text     :text             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passages
+#
+#  id            :bigint           not null, primary key
+#  abridged_text :text
+#  full_text     :text
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe Passage, type: :model do
+        it { should validate_presence_of(:full_text) }
+        it { should validate_presence_of(:abridged_text) }
+
+        it { expect(build(:evidence_research_gen_ai_passage)).to be_valid}
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Create `Evidence::Research::GenAI::Passage` resource

## WHY
These records will store the entire passage text and also provide a link between passage_prompts
 
## HOW
`rails g model 'Research/GenAI/Passage' contents:text`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
This is a component of the GenAI research architecture. No QA other than creating records.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
