### PR TITLE
Add Evidence::Research::GenAI::PassagePrompt resource

### DIFF
--- a/services/QuillLMS/db/migrate/20240315191827_create_evidence_research_gen_ai_passage_prompts.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240315191827_create_evidence_research_gen_ai_passage_prompts.evidence.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240315191401)
+class CreateEvidenceResearchGenAiPassagePrompts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passage_prompts do |t|
+      t.integer :passage_id, null: false
+      t.text :prompt, null: false
+      t.text :instructions, null: false
+      t.string :conjunction, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3003,6 +3003,40 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passage_prompts (
+    id bigint NOT NULL,
+    passage_id integer NOT NULL,
+    prompt text NOT NULL,
+    instructions text NOT NULL,
+    conjunction character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passage_prompts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passage_prompts_id_seq OWNED BY public.evidence_research_gen_ai_passage_prompts.id;
+
+
+--
 -- Name: evidence_research_gen_ai_passages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6230,6 +6264,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passage_prompts_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_passages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7390,6 +7431,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompts evidence_research_gen_ai_passage_prompts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompts
+    ADD CONSTRAINT evidence_research_gen_ai_passage_prompts_pkey PRIMARY KEY (id);
 
 
 --
@@ -11041,6 +11090,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315141121'),
 ('20240315171249'),
 ('20240315181419'),
-('20240315184614');
+('20240315184614'),
+('20240315191827');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage.rb
@@ -13,6 +13,8 @@ module Evidence
   module Research
     module GenAI
       class Passage < ApplicationRecord
+        has_many :passage_prompts, class_name: 'Evidence::Research::GenAI::PassagePrompt'
+
         validates :contents, presence: true
       end
     end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passage_prompts
+#
+#  id           :bigint           not null, primary key
+#  conjunction  :string           not null
+#  instructions :text             not null
+#  prompt       :text             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  passage_id   :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class PassagePrompt < ApplicationRecord
+        CONJUNCTIONS = [
+          BECAUSE = 'because',
+          BUT = 'but',
+          SO = 'so'
+        ].freeze
+
+        belongs_to :passage, class_name: 'Evidence::Research::GenAI::Passage'
+
+        validates :prompt, presence: true
+        validates :conjunction, presence: true, inclusion: { in: CONJUNCTIONS }
+        validates :instructions, presence: true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240315191401_create_evidence_research_gen_ai_passage_prompts.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240315191401_create_evidence_research_gen_ai_passage_prompts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAiPassagePrompts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passage_prompts do |t|
+      t.integer :passage_id, null: false
+      t.text :prompt, null: false
+      t.text :instructions, null: false
+      t.string :conjunction, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -993,6 +993,40 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passage_prompts (
+    id bigint NOT NULL,
+    passage_id integer NOT NULL,
+    prompt text NOT NULL,
+    instructions text NOT NULL,
+    conjunction character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passage_prompts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passage_prompts_id_seq OWNED BY public.evidence_research_gen_ai_passage_prompts.id;
+
+
+--
 -- Name: evidence_research_gen_ai_passages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1284,6 +1318,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passage_prompts_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_passages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1526,6 +1567,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompts evidence_research_gen_ai_passage_prompts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompts
+    ADD CONSTRAINT evidence_research_gen_ai_passage_prompts_pkey PRIMARY KEY (id);
 
 
 --
@@ -1814,6 +1863,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315140702'),
 ('20240315141841'),
 ('20240315180944'),
-('20240315184312');
+('20240315184312'),
+('20240315191401');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passage_prompts.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passage_prompts.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passage_prompts
+#
+#  id           :bigint           not null, primary key
+#  conjunction  :string           not null
+#  instructions :text             not null
+#  prompt       :text             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  passage_id   :integer          not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_passage_prompt, class: 'Evidence::Research::GenAI::PassagePrompt' do
+          prompt { "This is the prompt #{conjunction}" }
+          passage { association :evidence_research_gen_ai_passage }
+          conjunction { PassagePrompt::CONJUNCTIONS.sample }
+          instructions { 'These are the instructions' }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passage_prompts
+#
+#  id           :bigint           not null, primary key
+#  conjunction  :string           not null
+#  instructions :text             not null
+#  prompt       :text             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  passage_id   :integer          not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe PassagePrompt, type: :model do
+        it { should validate_presence_of(:prompt) }
+        it { should validate_presence_of(:conjunction) }
+        it { should validate_inclusion_of(:conjunction).in_array(described_class::CONJUNCTIONS)}
+        it { should validate_presence_of(:instructions) }
+        it { belong_to(:passage).class_name('Evidence::Research::GenAI::Passage') }
+
+        it { expect(build(:evidence_research_gen_ai_passage_prompt)).to be_valid }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_spec.rb
@@ -17,8 +17,9 @@ module Evidence
     module GenAI
       RSpec.describe Passage, type: :model do
         it { should validate_presence_of(:contents) }
+        it { should have_many(:passage_prompts).class_name('Evidence::Research::GenAI::PassagePrompt') }
 
-        it { expect(build(:evidence_research_gen_ai_passage)).to be_valid}
+        it { expect(build(:evidence_research_gen_ai_passage)).to be_valid }
       end
     end
   end


### PR DESCRIPTION
## WHAT
Create `Evidence::Research::GenAI::PassagePrompt` resource

## WHY
These records will allow for reusable pieces in GenAI experiments.

## HOW
`rails g model 'Research/GenAI/PassagePrompt' passage_id:integer prompt:text instructions:text conjunction:string` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
This is a component of the GenAI research architecture. No QA other than creating records.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
