### PR TITLE
Create Evidence::Research::GenAI::PassagePromptResponseFeedback resource

### DIFF
--- a/services/QuillLMS/db/migrate/20240315194005_create_evidence_research_gen_ai_passage_prompt_response_feedbacks.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240315194005_create_evidence_research_gen_ai_passage_prompt_response_feedbacks.evidence.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240315193912)
+class CreateEvidenceResearchGenAiPassagePromptResponseFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passage_prompt_response_feedbacks do |t|
+      t.integer :passage_prompt_id, null: false
+      t.string :label
+      t.text :feedback, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3003,6 +3003,39 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passage_prompt_response_feedbacks (
+    id bigint NOT NULL,
+    passage_prompt_id integer NOT NULL,
+    label character varying,
+    feedback text NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq OWNED BY public.evidence_research_gen_ai_passage_prompt_response_feedbacks.id;
+
+
+--
 -- Name: evidence_research_gen_ai_passage_prompts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6264,6 +6297,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompt_response_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_passage_prompts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7431,6 +7471,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbacks evidence_research_gen_ai_passage_prompt_response_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompt_response_feedbacks
+    ADD CONSTRAINT evidence_research_gen_ai_passage_prompt_response_feedbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -11091,6 +11139,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315171249'),
 ('20240315181419'),
 ('20240315184614'),
-('20240315191827');
+('20240315191827'),
+('20240315194005');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt.rb
@@ -23,6 +23,7 @@ module Evidence
         ].freeze
 
         belongs_to :passage, class_name: 'Evidence::Research::GenAI::Passage'
+        has_many :passage_prompt_response_feedbacks, class_name: 'Evidence::Research::GenAI::PassagePromptResponseFeedback'
 
         validates :prompt, presence: true
         validates :conjunction, presence: true, inclusion: { in: CONJUNCTIONS }

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response_feedback.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passage_prompt_response_feedbacks
+#
+#  id                :bigint           not null, primary key
+#  feedback          :text             not null
+#  label             :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  passage_prompt_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class PassagePromptResponseFeedback < ApplicationRecord
+        belongs_to :passage_prompt, class_name: 'Evidence::Research::GenAI::PassagePrompt'
+
+        validates :feedback, presence: true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240315193912_create_evidence_research_gen_ai_passage_prompt_response_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240315193912_create_evidence_research_gen_ai_passage_prompt_response_feedbacks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAiPassagePromptResponseFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passage_prompt_response_feedbacks do |t|
+      t.integer :passage_prompt_id, null: false
+      t.string :label
+      t.text :feedback, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -993,6 +993,39 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passage_prompt_response_feedbacks (
+    id bigint NOT NULL,
+    passage_prompt_id integer NOT NULL,
+    label character varying,
+    feedback text NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq OWNED BY public.evidence_research_gen_ai_passage_prompt_response_feedbacks.id;
+
+
+--
 -- Name: evidence_research_gen_ai_passage_prompts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1318,6 +1351,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompt_response_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passage_prompt_response_feedbac_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_passage_prompts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1567,6 +1607,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_response_feedbacks evidence_research_gen_ai_passage_prompt_response_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompt_response_feedbacks
+    ADD CONSTRAINT evidence_research_gen_ai_passage_prompt_response_feedbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -1864,6 +1912,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315141841'),
 ('20240315180944'),
 ('20240315184312'),
-('20240315191401');
+('20240315191401'),
+('20240315193912');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passage_prompt_response_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passage_prompt_response_feedbacks.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passage_prompt_response_feedbacks
+#
+#  id                :bigint           not null, primary key
+#  feedback          :text             not null
+#  label             :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  passage_prompt_id :integer          not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory(:evidence_research_gen_ai_passage_prompt_response_feedback,
+          class: 'Evidence::Research::GenAI::PassagePromptResponseFeedback') do
+
+          label { 'Optimal_1' }
+          feedback { 'This is the feedback' }
+          passage_prompt { association :evidence_research_gen_ai_passage_prompt }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_feedback_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passage_prompt_response_feedbacks
+#
+#  id                :bigint           not null, primary key
+#  feedback          :text             not null
+#  label             :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  passage_prompt_id :integer          not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe PassagePromptResponseFeedback, type: :model do
+        it { belong_to(:passage_prompt).class_name('Evidence::Research::GenAI::PassagePrompt') }
+
+        it { should validate_presence_of(:feedback) }
+
+        it { expect(build(:evidence_research_gen_ai_passage_prompt_response_feedback)).to be_valid }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_spec.rb
@@ -24,6 +24,7 @@ module Evidence
         it { should validate_inclusion_of(:conjunction).in_array(described_class::CONJUNCTIONS)}
         it { should validate_presence_of(:instructions) }
         it { belong_to(:passage).class_name('Evidence::Research::GenAI::Passage') }
+        it { have_many(:passage_prompt_response_feedbacks).class_name('Evidence::Research::GenAI::PassagePromptResponseFeedback') }
 
         it { expect(build(:evidence_research_gen_ai_passage_prompt)).to be_valid }
       end


### PR DESCRIPTION
## WHAT
Create Evidence::Research::GenAI::PassagePromptResponseFeedback resource

## WHY
This will provide a useful record for feedback and an optional label that will be matched with corresponding  response examplars.

## HOW
`rails g model 'Research/GenAI/PassagePromptResponseFeedback' passage_prompt_id:integer label:string feedback:text`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
This is a component of the GenAI research architecture. No QA other than creating records.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
