### PR TITLE
Create Evidence::Research::GenAI::Experiment resource

### DIFF
--- a/services/QuillLMS/db/migrate/20240318144601_create_evidence_research_gen_ai_experiments.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240318144601_create_evidence_research_gen_ai_experiments.evidence.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240318144447)
+class CreateEvidenceResearchGenAiExperiments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_experiments do |t|
+      t.integer :passage_prompt_id, null: false
+      t.integer :llm_config_id, null: false
+      t.integer :llm_prompt_id, null: false
+      t.string :status, null: false
+      t.jsonb :results
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2940,6 +2940,41 @@ ALTER SEQUENCE public.evidence_research_gen_ai_example_prompt_response_feedbac_i
 
 
 --
+-- Name: evidence_research_gen_ai_experiments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_experiments (
+    id bigint NOT NULL,
+    passage_prompt_id integer NOT NULL,
+    llm_config_id integer NOT NULL,
+    llm_prompt_id integer NOT NULL,
+    status character varying NOT NULL,
+    results jsonb,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_experiments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_experiments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_experiments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_experiments_id_seq OWNED BY public.evidence_research_gen_ai_experiments.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6348,6 +6383,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbac
 
 
 --
+-- Name: evidence_research_gen_ai_experiments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_experiments ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_experiments_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7534,6 +7576,14 @@ ALTER TABLE ONLY public.evidence_prompt_texts
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbacks
     ADD CONSTRAINT evidence_research_gen_ai_example_prompt_response_feedbacks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_experiments evidence_research_gen_ai_experiments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_experiments
+    ADD CONSTRAINT evidence_research_gen_ai_experiments_pkey PRIMARY KEY (id);
 
 
 --
@@ -11237,6 +11287,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315191827'),
 ('20240318141154'),
 ('20240318142126'),
-('20240318143324');
+('20240318143324'),
+('20240318144601');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_experiments
+#
+#  id                :bigint           not null, primary key
+#  results           :jsonb
+#  status            :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  llm_config_id     :integer          not null
+#  llm_prompt_id     :integer          not null
+#  passage_prompt_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class Experiment < ApplicationRecord
+        belongs_to :llm_config, class_name: 'Evidence::Research::GenAI::LLMConfig'
+        belongs_to :llm_prompt, class_name: 'Evidence::Research::GenAI::LLMPrompt'
+        belongs_to :passage_prompt, class_name: 'Evidence::Research::GenAI::PassagePrompt'
+
+        validates :status, presence: true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240318144447_create_evidence_research_gen_ai_experiments.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240318144447_create_evidence_research_gen_ai_experiments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAiExperiments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_experiments do |t|
+      t.integer :passage_prompt_id, null: false
+      t.integer :llm_config_id, null: false
+      t.integer :llm_prompt_id, null: false
+      t.string :status, null: false
+      t.jsonb :results
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -930,6 +930,41 @@ ALTER SEQUENCE public.evidence_research_gen_ai_example_prompt_response_feedbac_i
 
 
 --
+-- Name: evidence_research_gen_ai_experiments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_experiments (
+    id bigint NOT NULL,
+    passage_prompt_id integer NOT NULL,
+    llm_config_id integer NOT NULL,
+    llm_prompt_id integer NOT NULL,
+    status character varying NOT NULL,
+    results jsonb,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_experiments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_experiments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_experiments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_experiments_id_seq OWNED BY public.evidence_research_gen_ai_experiments.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1402,6 +1437,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbac
 
 
 --
+-- Name: evidence_research_gen_ai_experiments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_experiments ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_experiments_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1670,6 +1712,14 @@ ALTER TABLE ONLY public.evidence_prompt_texts
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbacks
     ADD CONSTRAINT evidence_research_gen_ai_example_prompt_response_feedbacks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_experiments evidence_research_gen_ai_experiments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_experiments
+    ADD CONSTRAINT evidence_research_gen_ai_experiments_pkey PRIMARY KEY (id);
 
 
 --
@@ -2010,6 +2060,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315191401'),
 ('20240318140506'),
 ('20240318141942'),
-('20240318143146');
+('20240318143146'),
+('20240318144447');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/experiments.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/experiments.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_experiments
+#
+#  id                :bigint           not null, primary key
+#  results           :jsonb
+#  status            :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  llm_config_id     :integer          not null
+#  llm_prompt_id     :integer          not null
+#  passage_prompt_id :integer          not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_experiment, class: 'Evidence::Research::GenAI::Experiment' do
+          status { 'pending '}
+          llm_config { association :evidence_research_gen_ai_llm_config }
+          llm_prompt { association :evidence_research_gen_ai_llm_prompt }
+          passage_prompt { association :evidence_research_gen_ai_passage_prompt }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_experiments
+#
+#  id                :bigint           not null, primary key
+#  results           :jsonb
+#  status            :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  llm_config_id     :integer          not null
+#  llm_prompt_id     :integer          not null
+#  passage_prompt_id :integer          not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe Experiment, type: :model do
+        it { belong_to(:llm_config).class_name('Evidence::Research::GenAI::LLMConfig') }
+        it { belong_to(:llm_prompt).class_name('Evidence::Research::GenAI::LLMPrompt') }
+        it { belong_to(:passage_prompt).class_name('Evidence::Research::GenAI::PassagePrompt') }
+
+        it { should validate_presence_of(:status) }
+
+        it { expect(build(:evidence_research_gen_ai_experiment)).to be_valid }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Create `Evidence::Research::GenAI::Experiment` resource

## WHY
This will provide a record for each Generative AI experiment along with result and the configuration.

## HOW
`rails g model 'Research/GenAI/Experiment' passage_prompt_id:integer llm_prompt_id:integer llm_config_id:integer status:string results:jsonb`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
This is a component of the GenAI research architecture. No QA other than creating records.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
