### PR TITLE
Create Evidence::Research::GenAI::PassagePromptResponse

### DIFF
--- a/services/QuillLMS/db/migrate/20240318141154_create_evidence_research_gen_ai_passage_prompt_responses.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240318141154_create_evidence_research_gen_ai_passage_prompt_responses.evidence.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240318140506)
+class CreateEvidenceResearchGenAiPassagePromptResponses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passage_prompt_responses do |t|
+      t.integer :passage_prompt_id, null: false
+      t.text :response, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3003,6 +3003,38 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompt_responses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passage_prompt_responses (
+    id bigint NOT NULL,
+    passage_prompt_id integer NOT NULL,
+    response text NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_responses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passage_prompt_responses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_responses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passage_prompt_responses_id_seq OWNED BY public.evidence_research_gen_ai_passage_prompt_responses.id;
+
+
+--
 -- Name: evidence_research_gen_ai_passage_prompts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6264,6 +6296,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompt_responses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompt_responses ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passage_prompt_responses_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_passage_prompts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7431,6 +7470,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_responses evidence_research_gen_ai_passage_prompt_responses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompt_responses
+    ADD CONSTRAINT evidence_research_gen_ai_passage_prompt_responses_pkey PRIMARY KEY (id);
 
 
 --
@@ -11091,6 +11138,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315171249'),
 ('20240315181419'),
 ('20240315184614'),
-('20240315191827');
+('20240315191827'),
+('20240318141154');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt.rb
@@ -23,6 +23,7 @@ module Evidence
         ].freeze
 
         belongs_to :passage, class_name: 'Evidence::Research::GenAI::Passage'
+        has_many :passage_prompt_responses, class_name: 'Evidence::Research::GenAI::PassagePromptResponse'
 
         validates :prompt, presence: true
         validates :conjunction, presence: true, inclusion: { in: CONJUNCTIONS }

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passage_prompt_responses
+#
+#  id                :bigint           not null, primary key
+#  response          :text             not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  passage_prompt_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class PassagePromptResponse < ApplicationRecord
+        belongs_to :passage_prompt, class_name: 'Evidence::Research::GenAI::PassagePrompt'
+
+        validates :response, presence: true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240318140506_create_evidence_research_gen_ai_passage_prompt_responses.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240318140506_create_evidence_research_gen_ai_passage_prompt_responses.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAiPassagePromptResponses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_passage_prompt_responses do |t|
+      t.integer :passage_prompt_id, null: false
+      t.text :response, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -993,6 +993,38 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompts_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompt_responses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_passage_prompt_responses (
+    id bigint NOT NULL,
+    passage_prompt_id integer NOT NULL,
+    response text NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_responses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_passage_prompt_responses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_responses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_passage_prompt_responses_id_seq OWNED BY public.evidence_research_gen_ai_passage_prompt_responses.id;
+
+
+--
 -- Name: evidence_research_gen_ai_passage_prompts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1318,6 +1350,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_passage_prompt_responses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompt_responses ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_passage_prompt_responses_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_passage_prompts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1567,6 +1606,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_templates
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompts
     ADD CONSTRAINT evidence_research_gen_ai_llm_prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_passage_prompt_responses evidence_research_gen_ai_passage_prompt_responses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_passage_prompt_responses
+    ADD CONSTRAINT evidence_research_gen_ai_passage_prompt_responses_pkey PRIMARY KEY (id);
 
 
 --
@@ -1864,6 +1911,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315141841'),
 ('20240315180944'),
 ('20240315184312'),
-('20240315191401');
+('20240315191401'),
+('20240318140506');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passage_prompt_responses.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/passage_prompt_responses.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passage_prompt_responses
+#
+#  id                :bigint           not null, primary key
+#  response          :text             not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  passage_prompt_id :integer          not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_passage_prompt_response, class: 'Evidence::Research::GenAI::PassagePromptResponse' do
+          passage_prompt { association :evidence_research_gen_ai_passage_prompt }
+          response { 'This is the response' }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_passage_prompt_responses
+#
+#  id                :bigint           not null, primary key
+#  response          :text             not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  passage_prompt_id :integer          not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe PassagePromptResponse, type: :model do
+        it { should belong_to(:passage_prompt)}
+        it { should validate_presence_of(:response) }
+
+        it { expect(build(:evidence_research_gen_ai_passage_prompt_response)).to be_valid }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_spec.rb
@@ -23,7 +23,9 @@ module Evidence
         it { should validate_presence_of(:conjunction) }
         it { should validate_inclusion_of(:conjunction).in_array(described_class::CONJUNCTIONS)}
         it { should validate_presence_of(:instructions) }
+
         it { belong_to(:passage).class_name('Evidence::Research::GenAI::Passage') }
+        it { have_many(:passage_prompt_responses).class_name('Evidence::Research::GenAI::PassagePromptResponse') }
 
         it { expect(build(:evidence_research_gen_ai_passage_prompt)).to be_valid }
       end


### PR DESCRIPTION
## WHAT
Create `Evidence::Research::GenAI::PassagePromptResponse` resource

## WHY
These records persist the responses used for `ExamplePromptResponseFeedback` as well as  `LlmPromptResponseFeedback`

## HOW
`rails g model 'Research/GenAI/PassagePromptResponse' passage_prompt_id:integer response:text` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
This is a component of the GenAI research architecture. No QA other than creating records.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
