### PR TITLE
Create Evidence::Research::GenAI::ExamplePromptResponseFeedback

### DIFF
--- a/services/QuillLMS/db/migrate/20240318142126_create_evidence_research_gen_ai_example_prompt_response_feedbacks.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240318142126_create_evidence_research_gen_ai_example_prompt_response_feedbacks.evidence.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240318141942)
+class CreateEvidenceResearchGenAiExamplePromptResponseFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_example_prompt_response_feedbacks do |t|
+      t.integer :passage_prompt_response_id, null: false
+      t.text :feedback, null: false
+      t.string :label, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2907,6 +2907,39 @@ ALTER SEQUENCE public.evidence_prompt_texts_id_seq OWNED BY public.evidence_prom
 
 
 --
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_example_prompt_response_feedbacks (
+    id bigint NOT NULL,
+    passage_prompt_response_id integer NOT NULL,
+    feedback text NOT NULL,
+    label character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbac_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_example_prompt_response_feedbac_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbac_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_example_prompt_response_feedbac_id_seq OWNED BY public.evidence_research_gen_ai_example_prompt_response_feedbacks.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6275,6 +6308,13 @@ ALTER TABLE ONLY public.evidence_prompt_texts ALTER COLUMN id SET DEFAULT nextva
 
 
 --
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_example_prompt_response_feedbac_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7446,6 +7486,14 @@ ALTER TABLE ONLY public.evidence_prompt_text_batches
 
 ALTER TABLE ONLY public.evidence_prompt_texts
     ADD CONSTRAINT evidence_prompt_texts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbacks evidence_research_gen_ai_example_prompt_response_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbacks
+    ADD CONSTRAINT evidence_research_gen_ai_example_prompt_response_feedbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -11139,6 +11187,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315181419'),
 ('20240315184614'),
 ('20240315191827'),
-('20240318141154');
+('20240318141154'),
+('20240318142126');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_prompt_response_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_prompt_response_feedback.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_example_prompt_response_feedbacks
+#
+#  id                         :bigint           not null, primary key
+#  feedback                   :text             not null
+#  label                      :string           not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  passage_prompt_response_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class ExamplePromptResponseFeedback < ApplicationRecord
+        belongs_to :passage_prompt_response, class_name: 'Evidence::Research::GenAI::PassagePromptResponse'
+
+        validates :feedback, presence: true
+        validates :label, presence: true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
@@ -16,6 +16,9 @@ module Evidence
       class PassagePromptResponse < ApplicationRecord
         belongs_to :passage_prompt, class_name: 'Evidence::Research::GenAI::PassagePrompt'
 
+        has_many :example_prompt_response_feedbacks,
+          class_name: 'Evidence::Research::GenAI::ExamplePromptResponseFeedback'
+
         validates :response, presence: true
       end
     end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240318141942_create_evidence_research_gen_ai_example_prompt_response_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240318141942_create_evidence_research_gen_ai_example_prompt_response_feedbacks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAiExamplePromptResponseFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_example_prompt_response_feedbacks do |t|
+      t.integer :passage_prompt_response_id, null: false
+      t.text :feedback, null: false
+      t.string :label, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -897,6 +897,39 @@ ALTER SEQUENCE public.evidence_prompt_texts_id_seq OWNED BY public.evidence_prom
 
 
 --
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_example_prompt_response_feedbacks (
+    id bigint NOT NULL,
+    passage_prompt_response_id integer NOT NULL,
+    feedback text NOT NULL,
+    label character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbac_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_example_prompt_response_feedbac_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbac_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_example_prompt_response_feedbac_id_seq OWNED BY public.evidence_research_gen_ai_example_prompt_response_feedbacks.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1329,6 +1362,13 @@ ALTER TABLE ONLY public.evidence_prompt_texts ALTER COLUMN id SET DEFAULT nextva
 
 
 --
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_example_prompt_response_feedbac_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1582,6 +1622,14 @@ ALTER TABLE ONLY public.evidence_prompt_text_batches
 
 ALTER TABLE ONLY public.evidence_prompt_texts
     ADD CONSTRAINT evidence_prompt_texts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_example_prompt_response_feedbacks evidence_research_gen_ai_example_prompt_response_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbacks
+    ADD CONSTRAINT evidence_research_gen_ai_example_prompt_response_feedbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -1912,6 +1960,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315180944'),
 ('20240315184312'),
 ('20240315191401'),
-('20240318140506');
+('20240318140506'),
+('20240318141942');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/example_prompt_response_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/example_prompt_response_feedbacks.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_example_prompt_response_feedbacks
+#
+#  id                         :bigint           not null, primary key
+#  feedback                   :text             not null
+#  label                      :string           not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  passage_prompt_response_id :integer          not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_example_prompt_response_feedback,
+          class: 'Evidence::Research::GenAI::ExamplePromptResponseFeedback' do
+
+          passage_prompt_response { association :evidence_research_gen_ai_passage_prompt_response }
+          feedback { 'This is the feedback' }
+          label { 'Optimal_1' }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_prompt_response_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_prompt_response_feedback_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_example_prompt_response_feedbacks
+#
+#  id                         :bigint           not null, primary key
+#  feedback                   :text             not null
+#  label                      :string           not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  passage_prompt_response_id :integer          not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe ExamplePromptResponseFeedback, type: :model do
+        it { should validate_presence_of(:feedback) }
+        it { should validate_presence_of(:label) }
+
+        it { should belong_to(:passage_prompt_response) }
+
+        it { expect(build(:evidence_research_gen_ai_example_prompt_response_feedback)).to be_valid}
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
@@ -17,8 +17,10 @@ module Evidence
   module Research
     module GenAI
       RSpec.describe PassagePromptResponse, type: :model do
-        it { should belong_to(:passage_prompt)}
         it { should validate_presence_of(:response) }
+
+        it { should belong_to(:passage_prompt)}
+        it { should have_many(:example_prompt_response_feedbacks).class_name('Evidence::Research::GenAI::ExamplePromptResponseFeedback') }
 
         it { expect(build(:evidence_research_gen_ai_passage_prompt_response)).to be_valid }
       end


### PR DESCRIPTION
## WHAT
Create `Evidence::Research::GenAI::ExamplePassagePromptFeedback` resource

## WHY
These records persist hand labeled feedback of particular `PassagePromptResponse`. Unlike `LlmPromptResponseFeedback` these records have a required `label` attribute

## HOW
`rails g model 'Research/GenAI/ExamplePassagePromptFeedback' passage_prompt_response_id:integer feedback:text label:string` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
This is a component of the GenAI research architecture. No QA other than creating records.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
