### PR TITLE
Create Evidence::Research::GenAI::LLMPromptResponseFeedback

### DIFF
--- a/services/QuillLMS/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/config/initializers/zeitwerk.rb
@@ -12,6 +12,7 @@ Rails.autoloaders.each do |autoloader|
     'html_tag_remover' => 'HTMLTagRemover',
     'llm_config' => 'LLMConfig',
     'llm_prompt' => 'LLMPrompt',
+    'llm_prompt_response_feedback' => 'LLMPromptResponseFeedback',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'open_ai' => 'OpenAI',
     'pusher_csv_export_completed' => 'PusherCSVExportCompleted',

--- a/services/QuillLMS/db/migrate/20240318143324_create_evidence_research_gen_ai_llm_prompt_response_feedbacks.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240318143324_create_evidence_research_gen_ai_llm_prompt_response_feedbacks.evidence.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240318143146)
+class CreateEvidenceResearchGenAiLlmPromptResponseFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompt_response_feedbacks do |t|
+      t.integer :passage_prompt_response_id, null: false
+      t.text :feedback, null: false
+      t.string :label
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2972,6 +2972,39 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_configs_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompt_response_feedbacks (
+    id bigint NOT NULL,
+    passage_prompt_response_id integer NOT NULL,
+    feedback text NOT NULL,
+    label character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompt_response_feedbacks.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6322,6 +6355,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_configs ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_response_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7502,6 +7542,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbac
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_configs
     ADD CONSTRAINT evidence_research_gen_ai_llm_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks evidence_research_gen_ai_llm_prompt_response_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_response_feedbacks
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_response_feedbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -11188,6 +11236,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315184614'),
 ('20240315191827'),
 ('20240318141154'),
-('20240318142126');
+('20240318142126'),
+('20240318143324');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_response_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_response_feedback.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_response_feedbacks
+#
+#  id                         :bigint           not null, primary key
+#  feedback                   :text             not null
+#  label                      :string
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  passage_prompt_response_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class LLMPromptResponseFeedback < ApplicationRecord
+        belongs_to :passage_prompt_response, class_name: 'Evidence::Research::GenAI::PassagePromptResponse'
+        validates :feedback, presence: true
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
@@ -14,10 +14,14 @@ module Evidence
   module Research
     module GenAI
       class PassagePromptResponse < ApplicationRecord
-        belongs_to :passage_prompt, class_name: 'Evidence::Research::GenAI::PassagePrompt'
+        belongs_to :passage_prompt,
+          class_name: 'Evidence::Research::GenAI::PassagePrompt'
 
         has_many :example_prompt_response_feedbacks,
           class_name: 'Evidence::Research::GenAI::ExamplePromptResponseFeedback'
+
+        has_many :llm_prompt_response_feedbacks,
+          class_name: 'Evidence::Research::GenAI::LLMPromptResponseFeedback'
 
         validates :response, presence: true
       end

--- a/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
@@ -8,6 +8,7 @@ Rails.autoloaders.each do |autoloader|
     'html_tag_remover' => 'HTMLTagRemover',
     'llm_config' => 'LLMConfig',
     'llm_prompt' => 'LLMPrompt',
+    'llm_prompt_response_feedback' => 'LLMPromptResponseFeedback',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'open_ai' => 'OpenAI',
     'vertex_ai' => 'VertexAI'

--- a/services/QuillLMS/engines/evidence/db/migrate/20240318143146_create_evidence_research_gen_ai_llm_prompt_response_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240318143146_create_evidence_research_gen_ai_llm_prompt_response_feedbacks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAiLlmPromptResponseFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompt_response_feedbacks do |t|
+      t.integer :passage_prompt_response_id, null: false
+      t.text :feedback, null: false
+      t.string :label
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -962,6 +962,39 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_configs_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompt_response_feedbacks (
+    id bigint NOT NULL,
+    passage_prompt_response_id integer NOT NULL,
+    feedback text NOT NULL,
+    label character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompt_response_feedbacks.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1376,6 +1409,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_configs ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_response_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompt_response_feedbacks_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1638,6 +1678,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_example_prompt_response_feedbac
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_configs
     ADD CONSTRAINT evidence_research_gen_ai_llm_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_response_feedbacks evidence_research_gen_ai_llm_prompt_response_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_response_feedbacks
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_response_feedbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -1961,6 +2009,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240315184312'),
 ('20240315191401'),
 ('20240318140506'),
-('20240318141942');
+('20240318141942'),
+('20240318143146');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_response_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_response_feedbacks.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_response_feedbacks
+#
+#  id                         :bigint           not null, primary key
+#  feedback                   :text             not null
+#  label                      :string
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  passage_prompt_response_id :integer          not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_llm_prompt_response_feedback,
+          class: 'Evidence::Research::GenAI::LLMPromptResponseFeedback' do
+
+          passage_prompt_response { association :evidence_research_gen_ai_passage_prompt_response }
+          feedback { 'This is the feedback' }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_response_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_response_feedback_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_response_feedbacks
+#
+#  id                         :bigint           not null, primary key
+#  feedback                   :text             not null
+#  label                      :string
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  passage_prompt_response_id :integer          not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe LLMPromptResponseFeedback, type: :model do
+        it { should validate_presence_of(:feedback) }
+        it { should belong_to(:passage_prompt_response).class_name('Evidence::Research::GenAI::PassagePromptResponse')}
+
+        it { expect(build(:evidence_research_gen_ai_llm_prompt_response_feedback)).to be_valid}
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
@@ -21,6 +21,7 @@ module Evidence
 
         it { should belong_to(:passage_prompt)}
         it { should have_many(:example_prompt_response_feedbacks).class_name('Evidence::Research::GenAI::ExamplePromptResponseFeedback') }
+        it { should have_many(:llm_prompt_response_feedbacks).class_name('Evidence::Research::GenAI::LLMPromptResponseFeedback') }
 
         it { expect(build(:evidence_research_gen_ai_passage_prompt_response)).to be_valid }
       end


### PR DESCRIPTION
## WHAT
Create `Evidence::Research::GenAI::LLMPassagePromptFeedback` resource

## WHY
These records persist generated feedback of particular `PassagePromptResponse` from an LLM. Unlike `ExamplePromptResponseFeedback` these records have an optional `label` attribute

## HOW
`rails g model 'Research/GenAI/LLMPassagePromptFeedback' passage_prompt_response_id:integer feedback:text label:string` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
This is a component of the GenAI research architecture. No QA other than creating records.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
