### PR TITLE
batch concept results save workers and use pusher to notify frontend

### DIFF
--- a/services/QuillLMS/app/workers/batch_save_activity_session_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/batch_save_activity_session_concept_results_worker.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class BatchSaveActivitySessionConceptResultsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: SidekiqQueue::CRITICAL
+
+  def perform(concept_results, activity_session_id, activity_session_uid)
+    batch_runner(activity_session_uid) do
+      concept_results
+        .map { |cr| concept_results_hash(cr, activity_session_id) }
+        .reject(&:empty?)
+        .each { |crh| SaveActivitySessionConceptResultsWorker.perform_async(crh) }
+    end
+  end
+
+  def on_success(_status, options)
+    PusherTrigger.run(options['activity_session_uid'], 'concept-results-saved', "Concept results saved for activity session with uid: #{options['activity_session_uid']}")
+  end
+
+  private def batch_runner(activity_session_uid, &save_concept_results)
+    batch = Sidekiq::Batch.new
+    batch.description = 'Saving Concept Results for Activity Session'
+    batch.callback_queue = SidekiqQueue::CRITICAL
+    batch.on(:success, self.class, activity_session_uid: activity_session_uid)
+    batch.jobs { save_concept_results.call }
+  end
+
+  private def concept_results_hash(concept_result, activity_session_id)
+    concept = Concept.find_by(uid: concept_result["concept_uid"])
+    return {} if concept.blank?
+
+    concept_result.merge(concept_id: concept.id, activity_session_id: activity_session_id)
+  end
+end

--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
@@ -220,9 +220,14 @@ export class Lesson extends React.Component {
       window.pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
     }
     const channel = window.pusher.subscribe(activitySessionUid);
+    
     channel.bind('concept-results-saved', () => {
       document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${activitySessionUid}`;
       this.setState({ saved: true, });
+    });
+
+    channel.bind('concept-results-partially-saved', () => {
+      document.location.href = process.env.DEFAULT_URL;
     });
   }
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -264,9 +264,14 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         window.pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
       }
       const channel = window.pusher.subscribe(activitySessionUid);
+      
       channel.bind('concept-results-saved', () => {
         document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${activitySessionUid}`;
         this.setState({ saved: true, });
+      });
+
+      channel.bind('concept-results-partially-saved', () => {
+        document.location.href = process.env.DEFAULT_URL;
       });
     }
 

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -312,6 +312,10 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
       channel.bind('concept-results-saved', () => {
         document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${activitySessionUid}`;
       });
+
+      channel.bind('concept-results-partially-saved', () => {
+        document.location.href = process.env.DEFAULT_URL;
+      });
     }
 
     handleCheckWorkClickSession = (sessionID: string, results: ConceptResultObject[], score: number, data) => {

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/container.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import * as Redux from "redux";
 import { sentences } from 'sbd';
+import Pusher from 'pusher-js';
 
 const directionSrc = `${process.env.CDN_URL}/images/icons/direction.svg`
 
@@ -300,7 +301,21 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
       }
     }
 
+    initializeSubscription(activitySessionUid) {
+      if (process.env.NODE_ENV === 'development') {
+        Pusher.logToConsole = true;
+      }
+      if (!window.pusher) {
+        window.pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
+      }
+      const channel = window.pusher.subscribe(activitySessionUid);
+      channel.bind('concept-results-saved', () => {
+        document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${activitySessionUid}`;
+      });
+    }
+
     handleCheckWorkClickSession = (sessionID: string, results: ConceptResultObject[], score: number, data) => {
+      this.initializeSubscription(sessionID)
       requestPut(
         `${process.env.DEFAULT_URL}/api/v1/activity_sessions/${sessionID}`,
         {
@@ -310,7 +325,7 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
           data
         },
         (body) => {
-          document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${sessionID}`;
+          // not doing anything here because Pusher should handle the redirect once the concept results are saved
         }
       )
     }
@@ -326,7 +341,7 @@ export class PlayProofreaderContainer extends React.Component<PlayProofreaderCon
           data
         },
         (body) => {
-          document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${body.activity_session.uid}`;
+          this.initializeSubscription(body.activity_session.uid)
         }
       )
 

--- a/services/QuillLMS/spec/workers/batch_save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/batch_save_activity_session_concept_results_worker_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe BatchSaveActivitySessionConceptResultsWorker, type: :worker do
+  describe '#perform' do
+    let(:activity_session_id) { 1 }
+    let(:activity_session_uid) { 'unique_id' }
+    let(:concept1) { create(:concept, uid: 'concept1' )}
+    let(:concept2) { create(:concept, uid: 'concept2' )}
+    let(:concept_results) do
+      [
+        { 'concept_uid' => concept1.uid, 'correct' => true },
+        { 'concept_uid' => concept2.uid, 'correct' => false }
+      ]
+    end
+
+    it 'processes concept results and enqueues jobs' do
+      expect {
+        subject.perform(concept_results, activity_session_id, activity_session_uid)
+      }.to change(SaveActivitySessionConceptResultsWorker.jobs, :size).by(concept_results.size)
+    end
+  end
+
+  describe '#on_success' do
+    let(:activity_session_uid) { 'unique_id' }
+    let(:options) { { 'activity_session_uid' => activity_session_uid } }
+
+    it 'triggers Pusher event' do
+      expect(PusherTrigger).to receive(:run).with(activity_session_uid, 'concept-results-saved', anything)
+      subject.on_success(nil, options)
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/batch_save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/batch_save_activity_session_concept_results_worker_spec.rb
@@ -6,8 +6,8 @@ describe BatchSaveActivitySessionConceptResultsWorker, type: :worker do
   describe '#perform' do
     let(:activity_session_id) { 1 }
     let(:activity_session_uid) { 'unique_id' }
-    let(:concept1) { create(:concept, uid: 'concept1' )}
-    let(:concept2) { create(:concept, uid: 'concept2' )}
+    let(:concept1) { create(:concept, uid: 'concept1') }
+    let(:concept2) { create(:concept, uid: 'concept2') }
     let(:concept_results) do
       [
         { 'concept_uid' => concept1.uid, 'correct' => true },
@@ -22,13 +22,35 @@ describe BatchSaveActivitySessionConceptResultsWorker, type: :worker do
     end
   end
 
-  describe '#on_success' do
-    let(:activity_session_uid) { 'unique_id' }
-    let(:options) { { 'activity_session_uid' => activity_session_uid } }
+  describe '#on_complete' do
+    context 'when all jobs succeed' do
+      let(:activity_session_uid) { 'unique_id' }
+      let(:options) { { 'activity_session_uid' => activity_session_uid } }
+      let(:status) { double('status', failures: 0, total: 2) }
 
-    it 'triggers Pusher event' do
-      expect(PusherTrigger).to receive(:run).with(activity_session_uid, 'concept-results-saved', anything)
-      subject.on_success(nil, options)
+      it 'triggers Pusher event for success' do
+        expect(PusherTrigger).to receive(:run).with(
+          activity_session_uid,
+          'concept-results-saved',
+          "Concept results saved for activity session with uid: #{activity_session_uid}"
+        )
+        subject.on_complete(status, options)
+      end
+    end
+
+    context 'when some jobs fail' do
+      let(:activity_session_uid) { 'unique_id' }
+      let(:options) { { 'activity_session_uid' => activity_session_uid } }
+      let(:status) { double('status', failures: 1, total: 2) }
+
+      it 'triggers Pusher event for partial success' do
+        expect(PusherTrigger).to receive(:run).with(
+          activity_session_uid,
+          'concept-results-partially-saved',
+          "Concept results partially saved for activity session with uid: #{activity_session_uid}, 1 succeeded, 1 failed"
+        )
+        subject.on_complete(status, options)
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Batch our Concept Results save workers so that we can send a Pusher notification when they're all saved to the frontend.

## WHY
We were seeing a bug where students would sometimes wind up at the results page before all the concept results for the session have actually been saved. This prevents that by waiting until the concept results are saved before sending them there.

## HOW
Just batch the workers following the structure we use for `BatchAssignRecommendationsWorker`, and update the frontends to listen with Pusher for these jobs to complete. Note: neither Lessons, Diagnostics, or Evidence activities send students to the Results page, so it wasn't necessary to update those apps here.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/RFC-for-saving-concept-results-037c580b64ce4ca5a8ab5d47caf97169

### What have you done to QA this feature?
I played through a Grammar, Connect, and Proofreader activity as a logged-in student and confirmed that I was successfully sent to the activity session results page with saved concept results; then I did the same thing as a logged-out user (testing the anonymous path).

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
