### PR TITLE
Bugfixes in Diagnostic admin

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseComponent.jsx
@@ -7,6 +7,7 @@ import {
   ResponseSortFields,
   ResponseToggleFields,
   hashToCollection,
+  responsesWithStatus,
 } from '../../../Shared/index';
 import * as filterActions from '../../actions/filters';
 import massEdit from '../../actions/massEdit';
@@ -194,6 +195,12 @@ class ResponseComponent extends React.Component {
     return _.mapObject(this.responsesGroupedByStatus(), (val, key) => _.reduce(val, (memo, resp) => memo + (resp.count || 0), 0));
   };
 
+  responsesWithStatus = () => {
+    const { filters } = this.props
+
+    return hashToCollection(responsesWithStatus(filters.responses));
+  };
+
   formatForQuestionBar = () => {
     // {"human_optimal":153,"human_suboptimal":140,"algo_optimal":0,"algo_suboptimal":8780,"unmatched":28820}
     const totalResponseCount = this.state.health.total_number_of_attempts;
@@ -236,6 +243,7 @@ class ResponseComponent extends React.Component {
     if (this.state.viewingResponses) {
       const { responses } = this.state;
       const { questionID, selectedIncorrectSequences, selectedFocusPoints } = this.props;
+      const sortedResponses = _.sortBy(hashToCollection(responses), 'sortOrder')
       return (
         <ResponseList
           admin={this.props.admin}
@@ -250,7 +258,7 @@ class ResponseComponent extends React.Component {
           mode={this.props.mode}
           question={this.props.question}
           questionID={questionID}
-          responses={hashToCollection(responses)}
+          responses={sortedResponses}
           selectedFocusPoints={selectedFocusPoints}
           selectedIncorrectSequences={selectedIncorrectSequences}
           states={this.props.states}


### PR DESCRIPTION
## WHAT
Two bug fixes caused by things I did in the last Diagnostic admin panel rehaul (https://github.com/empirical-org/Empirical-Core/pull/11569).

## WHY
Certain features aren't working properly in the admin panel after I refactored the code. These two fixes will put everything back in working order.

## HOW
1. I removed a function responsesWithStatus(), thinking it was unused, but in fact the "Expand" feature is using it so it's causing that feature to break.
2. I removed a line of code sorting all responses by `sortOrder` before passing them into ResponseList. This removal accidentally broke sorting.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Sorting-not-working-as-expected-in-the-Diagnostic-CMS-27faa5afcd7c4ed7808f069638aba1a4?pvs=4

### What have you done to QA this feature?
Go into a CMS Diagnostic question and try sorting by Submissions descinding and ascending. Then try Expand button to make sure that button is properly expanding responses.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No unit tests here, manually tested.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
