### PR TITLE
lms/multi-count-students-in-filter-scope

### DIFF
--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_student_view_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_student_view_query.rb
@@ -68,6 +68,7 @@ module AdminDiagnosticReports
         aggregate_id,
         #{aggregate_sort_clause},
         student_id,
+        student_name,
         pre_activity_session_completed_at,
         post_activity_session_completed_at,
         performance.classroom_id,
@@ -82,6 +83,9 @@ module AdminDiagnosticReports
     def limit_clause = " LIMIT 5000"
 
     def relevant_date_column = "performance.pre_assigned_at"
+
+    def aggregate_by_clause = "CONCAT(performance.classroom_id, ':', performance.student_id)"
+    def aggregate_sort_clause = "students.name"
 
     private def post_process(result)
       # This is an override of the base post_process without a Ruby-based

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/student_count_by_filter_scope_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/student_count_by_filter_scope_query.rb
@@ -64,7 +64,6 @@ module AdminDiagnosticReports
     end
 
     def timeframe_where_clause = "#{relevant_date_column} BETWEEN '#{timeframe_start.to_fs(:db)}' AND '#{timeframe_end.to_fs(:db)}'"
-    def classroom_ids_where_clause = ("AND classrooms.id IN (#{classroom_ids.join(',')})" if classroom_ids.present?)
     def classroom_ids_where_clause = ("AND filter.classroom_id IN (#{classroom_ids.join(',')})" if classroom_ids.present?)
     def grades_where_clause = ("AND (filter.grade IN (#{grades.map { |g| "'#{g}'" }.join(',')}) #{grades_where_null_clause})" if grades.present?)
     def grades_where_null_clause = ("OR filter.grade IS NULL" if grades.include?('null'))

--- a/services/QuillLMS/lib/query_examples/admin_diagnostics/filter-scope.sql
+++ b/services/QuillLMS/lib/query_examples/admin_diagnostics/filter-scope.sql
@@ -1,25 +1,21 @@
         /*
-           Data Processed By Query: 0.59 GB
-           Bytes Billed For Query:  0.0 GB
-           Total Query Time:        1931 ms
-           Total Slot Time:         3859 ms
+           Data Processed By Query: 0.67 GB
+           Bytes Billed For Query:  0.13 GB
+           Total Query Time:        792 ms
+           Total Slot Time:         1635 ms
            BI Engine Mode Used:     FULL_INPUT
              BI Engine Code:          
              BI Engine Message:       
         */
-        SELECT COUNT(DISTINCT student_id) AS count
+        SELECT COUNT(DISTINCT CONCAT(performance.classroom_id, ':', performance.student_id)) AS count
                 FROM lms.pre_post_diagnostic_skill_group_performance_view AS performance
-        JOIN lms.active_classroom_stubs_view AS classrooms ON performance.classroom_id = classrooms.id
-        JOIN lms.classrooms_teachers ON classrooms.id = classrooms_teachers.classroom_id AND classrooms_teachers.role = 'owner'
-        JOIN lms.schools_users ON classrooms_teachers.user_id = schools_users.user_id
-        JOIN lms.schools ON schools_users.school_id = schools.id
+        JOIN lms.school_classroom_teachers_view AS filter ON performance.classroom_id = filter.classroom_id
 
                 WHERE performance.pre_assigned_at BETWEEN '2023-08-01 00:00:00' AND '2023-11-30 23:59:59'
           
           
-          AND classrooms_teachers.role = 'owner'
           AND performance.activity_id IN (1663,1668,1678,1161,1568,1590,992,1229,1230,1432)
-          AND schools_users.school_id IN (38811,38804,38801,38800,38779,38784,38780,38773,38765,38764)
+          AND filter.school_id IN (38811,38804,38801,38800,38779,38784,38780,38773,38765,38764)
           
           AND performance.activity_id = 1663
 

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/student_count_by_filter_scope_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/student_count_by_filter_scope_query_spec.rb
@@ -40,6 +40,12 @@ module AdminDiagnosticReports
 
       let(:count) { results[:count] }
 
+      context 'students have results from multiple classrooms' do
+        let(:classroom_count) { 2 }
+
+        it { expect(count).to eq(students.count * 2) }
+      end
+
       context 'filter by school_ids only' do
         let(:grades) { nil }
         let(:teacher_ids) { nil }


### PR DESCRIPTION
## WHAT
- Modify filter scope query to count students once for each classroom that they're in (to match the behavior of the report itself)
- Also update the filter scope query to use the new, more efficient JOIN structure from our performance pass on other queries
## WHY
- We want admins to get an accurate addressable size calculation for this report
- We want all of our queries to be as performant as possible (and to use the same patterns when possible)
## HOW
- Count on `DISTINCT CONCAT` of the two ids that we care about 
- Update the JOIN chain to use the pattern established in our performance pass: use the filter materialized view

### Notion Card Links
https://quill.slack.com/archives/C06HG01B2BS/p1710785291565199

### What have you done to QA this feature?
Using a known user that has repeated students, run the scope size query and compare it against the length of the Student report.  Confirm that in old code, the Student report has more entries than the count indicates, then confirm that the count and the length of the Student report are identical in this branch.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
