### PR TITLE
Update Admin Premium banners to use new Banner component

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
@@ -1,5 +1,12 @@
 #premium-hub {
 
+  .banner-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    margin-top: 32px;
+    margin-bottom: 32px;
+  }
+
   .sub-container {
     section {
       padding: 0;

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
@@ -17,19 +17,6 @@ import ActivityScoresStudentOverview from '../components/activity_scores_student
 import SubnavTabs from '../components/subnav_tabs.tsx';
 import { APPROVED, DENIED, FULL, LIMITED, LOADING, PENDING, RESTRICTED, SKIPPED } from '../shared';
 
-const BANNER_BUTTON_CLASS_NAME = "quill-button small secondary outlined focus-on-light"
-
-const Banner = ({ bodyText, headerText, buttons, }) => (
-  <section className="admin-banner">
-    <div className="banner-content">
-      <div>
-        <h3>{headerText}</h3>
-        <p>{bodyText}</p>
-      </div>
-      {buttons}
-    </div>
-  </section>
-)
 
 const ScrollToTop = ({ history, children, }) => {
   React.useEffect(() => {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
@@ -11,7 +11,6 @@ import AccountManagement from './AccountManagement';
 import SchoolSubscriptionsContainer from './SchoolSubscriptionsContainer'
 
 import { requestGet, } from '../../../modules/request/index';
-import { PostNavigationBanner } from '../../Shared/index';
 import { NOT_LISTED, NO_SCHOOL_SELECTED, PostNavigationBanner, Spinner } from '../../Shared/index';
 import ActivityScoresStudentOverview from '../components/activity_scores_student_overview.tsx';
 import SubnavTabs from '../components/subnav_tabs.tsx';

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
@@ -11,7 +11,8 @@ import AccountManagement from './AccountManagement';
 import SchoolSubscriptionsContainer from './SchoolSubscriptionsContainer'
 
 import { requestGet, } from '../../../modules/request/index';
-import { NOT_LISTED, NO_SCHOOL_SELECTED, Spinner } from '../../Shared/index';
+import { PostNavigationBanner } from '../../Shared/index';
+import { NOT_LISTED, NO_SCHOOL_SELECTED, PostNavigationBanner, Spinner } from '../../Shared/index';
 import ActivityScoresStudentOverview from '../components/activity_scores_student_overview.tsx';
 import SubnavTabs from '../components/subnav_tabs.tsx';
 import { APPROVED, DENIED, FULL, LIMITED, LOADING, PENDING, RESTRICTED, SKIPPED } from '../shared';
@@ -81,55 +82,106 @@ const PremiumHubContainer = ({ id, history, location, children, user, }) => {
 
     if (accessType() === LIMITED && onPageThatShouldShowBanner && !onSubscriptionPageWithExpiredPremium) {
       return (
-        <Banner
+        <PostNavigationBanner
+          bannerStyle="gold"
           bodyText="Subscribe to School or District Premium to unlock all Premium Hub features. Manage teacher accounts, access teacher reports, and view school-wide student data."
-          buttons={(
-            <div className="banner-buttons">
-              <a className={BANNER_BUTTON_CLASS_NAME} href="https://calendly.com/alex-quill" rel="noopener noreferrer" target="_blank">Talk to sales</a>
-              <a className={BANNER_BUTTON_CLASS_NAME} href="/premium" target="_blank">Explore premium</a>
-            </div>
-          )}
-          headerText="Unlock with Quill Premium"
+          buttons={[
+            {
+              href: "https://calendly.com/alex-quill",
+              standardButtonStyle: true,
+              text: "Contact sales",
+              target: "_blank"
+            },
+            {
+              href: "/premium",
+              standardButtonStyle: true,
+              text: "Explore Premium",
+              target: "_blank"
+            }
+          ]}
+          icon={{ alt: "Image of a school building", src: "https://assets.quill.org/images/banners/large-school-campus-gold.svg" }}
+          primaryHeaderText="Unlock with Quill Premium"
+          tagText=""
         />
       )
     }
 
     if (!associated_school || [NOT_LISTED, NO_SCHOOL_SELECTED].includes(associated_school.name)) {
       return (
-        <Banner
+        <PostNavigationBanner
+          bannerStyle="gold"
           bodyText="Please select a school to use the Premium Hub."
-          buttons={<a className={BANNER_BUTTON_CLASS_NAME} href="/teachers/my_account">Select school</a>}
-          headerText="Action required"
+          buttons={[
+            {
+              href: "/teachers/my_account",
+              standardButtonStyle: true,
+              text: "Select school",
+              target: ""
+            }
+          ]}
+          icon={{ alt: "Image of a school building", src: "https://assets.quill.org/images/banners/large-school-campus-gold.svg" }}
+          primaryHeaderText="Action required"
+          tagText=""
         />
       )
     }
 
     if (admin_approval_status === DENIED) {
       return (
-        <Banner
+        <PostNavigationBanner
+          bannerStyle="gold"
           bodyText={`Sorry, we couldn’t verify you as an admin of ${associated_school?.name}. If you need help, contact support.`}
-          buttons={<a className={BANNER_BUTTON_CLASS_NAME} href="mailto:hello@quill.org">Contact us</a>}
-          headerText="We couldn't verify you"
+          buttons={[
+            {
+              href: "mailto:hello@quill.org",
+              standardButtonStyle: true,
+              text: "Contact us",
+              target: "_blank"
+            }
+          ]}
+          icon={{ alt: "Image of a school building", src: "https://assets.quill.org/images/banners/large-school-campus-gold.svg" }}
+          primaryHeaderText="We couldn't verify you"
+          tagText=""
         />
       )
     }
 
     if (admin_approval_status === PENDING) {
       return (
-        <Banner
+        <PostNavigationBanner
+          bannerStyle="gold"
           bodyText="Your verification request is pending approval. Once approved, you will be able to use the Premium Hub. If you need help in the meantime, contact us."
-          buttons={<a className={BANNER_BUTTON_CLASS_NAME} href="mailto:hello@quill.org">Contact us</a>}
-          headerText="We’re reviewing your request"
+          buttons={[
+            {
+              href: "mailto:hello@quill.org",
+              standardButtonStyle: true,
+              text: "Contact us",
+              target: ""
+            }
+          ]}
+          icon={{ alt: "Image of a school building", src: "https://assets.quill.org/images/banners/large-school-campus-gold.svg" }}
+          primaryHeaderText="We're reviewing your request"
+          tagText=""
         />
       )
     }
 
     if (admin_approval_status === SKIPPED) {
       return (
-        <Banner
+        <PostNavigationBanner
+          bannerStyle="gold"
           bodyText={`Please verify your connection to ${associated_school?.name} to use the Premium Hub.`}
-          buttons={<a className={BANNER_BUTTON_CLASS_NAME} href="/sign-up/verify-school">Begin verification</a>}
-          headerText="Action required"
+          buttons={[
+            {
+              href: "/sign-up/verify-school",
+              standardButtonStyle: true,
+              text: "Begin verification",
+              target: ""
+            }
+          ]}
+          icon={{ alt: "Image of a school building", src: "https://assets.quill.org/images/banners/large-school-campus-gold.svg" }}
+          primaryHeaderText="Action required"
+          tagText=""
         />
       )
     }

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumHubContainer.jsx
@@ -69,7 +69,7 @@ const PremiumHubContainer = ({ id, history, location, children, user, }) => {
     if (accessType() === LIMITED && onPageThatShouldShowBanner && !onSubscriptionPageWithExpiredPremium) {
       return (
         <PostNavigationBanner
-          bannerStyle="gold"
+          bannerStyle="premium"
           bodyText="Subscribe to School or District Premium to unlock all Premium Hub features. Manage teacher accounts, access teacher reports, and view school-wide student data."
           buttons={[
             {
@@ -95,7 +95,7 @@ const PremiumHubContainer = ({ id, history, location, children, user, }) => {
     if (!associated_school || [NOT_LISTED, NO_SCHOOL_SELECTED].includes(associated_school.name)) {
       return (
         <PostNavigationBanner
-          bannerStyle="gold"
+          bannerStyle="premium"
           bodyText="Please select a school to use the Premium Hub."
           buttons={[
             {
@@ -115,7 +115,7 @@ const PremiumHubContainer = ({ id, history, location, children, user, }) => {
     if (admin_approval_status === DENIED) {
       return (
         <PostNavigationBanner
-          bannerStyle="gold"
+          bannerStyle="premium"
           bodyText={`Sorry, we couldn’t verify you as an admin of ${associated_school?.name}. If you need help, contact support.`}
           buttons={[
             {
@@ -135,7 +135,7 @@ const PremiumHubContainer = ({ id, history, location, children, user, }) => {
     if (admin_approval_status === PENDING) {
       return (
         <PostNavigationBanner
-          bannerStyle="gold"
+          bannerStyle="premium"
           bodyText="Your verification request is pending approval. Once approved, you will be able to use the Premium Hub. If you need help in the meantime, contact us."
           buttons={[
             {
@@ -155,7 +155,7 @@ const PremiumHubContainer = ({ id, history, location, children, user, }) => {
     if (admin_approval_status === SKIPPED) {
       return (
         <PostNavigationBanner
-          bannerStyle="gold"
+          bannerStyle="premium"
           bodyText={`Please verify your connection to ${associated_school?.name} to use the Premium Hub.`}
           buttons={[
             {


### PR DESCRIPTION
## WHAT
Update all admin premium hub banners to use the new PostNavigationBanner component.

## WHY
So we have uniform design throughout the site for all banners.

## HOW
Just update the subcomponent used in the PremiumHub component.

### Screenshots
![Screenshot 2024-03-20 at 1 04 49 AM](https://github.com/empirical-org/Empirical-Core/assets/57366100/af839d59-69b9-4443-844b-e37da6d3fa35)
![Screenshot 2024-03-20 at 1 03 50 AM](https://github.com/empirical-org/Empirical-Core/assets/57366100/e2d3bf77-b5cb-40c1-8e64-7c1f25ad175c)
![Screenshot 2024-03-20 at 1 03 22 AM](https://github.com/empirical-org/Empirical-Core/assets/57366100/3af97cf0-bfc9-4705-ad02-7f9128c3e721)
![Screenshot 2024-03-20 at 1 02 48 AM](https://github.com/empirical-org/Empirical-Core/assets/57366100/33421390-c79c-43bd-a4d5-9f0d9fe24477)
![Screenshot 2024-03-20 at 1 01 23 AM](https://github.com/empirical-org/Empirical-Core/assets/57366100/90f163ba-9685-4ab9-bf44-e96734f3ff8e)


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Update-Premium-Banners-across-the-Site-2a79fae4418c4265a2f9e05da5190e41?pvs=4)

### What have you done to QA this feature?
Deployed to staging and created a new admin account. Looked at the Premium Hub page to verify all styling working as intended, then used the back end to change the admin approval status manually to trigger each of the banner states and check the visual appearance and button functionality of each one.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
