### PR TITLE
lms/stop-double-counting-post-assigned

### DIFF
--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_assigned_view_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_assigned_view_query.rb
@@ -2,7 +2,7 @@
 
 module AdminDiagnosticReports
   class PostDiagnosticAssignedViewQuery < DiagnosticAggregateViewQuery
-    def specific_select_clause = "COUNT(DISTINCT CONCAT(performance.post_classroom_unit_id, ':', performance.student_id)) AS post_students_assigned"
+    def specific_select_clause = "COUNT(DISTINCT CONCAT(performance.classroom_id, ':', performance.student_id)) AS post_students_assigned"
 
     def relevant_date_column = "performance.post_assigned_at"
 

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_assigned_view_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_assigned_view_query.rb
@@ -2,7 +2,7 @@
 
 module AdminDiagnosticReports
   class PreDiagnosticAssignedViewQuery < DiagnosticAggregateViewQuery
-    def specific_select_clause = "COUNT(DISTINCT CONCAT(performance.pre_classroom_unit_id, ':', performance.student_id)) AS pre_students_assigned"
+    def specific_select_clause = "COUNT(DISTINCT CONCAT(performance.classroom_id, ':', performance.student_id)) AS pre_students_assigned"
 
     def relevant_date_column = "performance.pre_assigned_at"
 

--- a/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
+++ b/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
@@ -84,7 +84,7 @@ SELECT
         activities.name AS pre_activity_name,
         skill_groups.id AS skill_group_id,
         skill_groups.name AS skill_group_name,
-        COUNT(CASE WHEN concept_results.correct = true THEN concept_results.question_number ELSE NULL END) AS questions_correct,
+        COUNT(DISTINCT CASE WHEN concept_results.correct = true THEN concept_results.question_number ELSE NULL END) AS questions_correct,
         COUNT(DISTINCT concept_results.question_number) AS questions_total,
         classroom_units.classroom_id AS classroom_id,
         CAST(assigned_student_id AS int64) AS student_id,

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_assigned_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_assigned_view_query_spec.rb
@@ -31,7 +31,7 @@ module AdminDiagnosticReports
 
       context 'student assigned to multiple instances of the same diagnostic' do
 
-        let(:units_per_classroom) { 2 }
+        let(:classroom_count) { 2 }
 
         it { expect(results.first[:post_students_assigned]).to eq(students.length * 2) }
       end

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_assigned_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_assigned_view_query_spec.rb
@@ -29,11 +29,16 @@ module AdminDiagnosticReports
       it { expect(results.first[:aggregate_rows].map { |row| row[:name] }).to match_array(grade_names) }
       it { expect(results.first[:post_students_assigned]).to eq(students.length) }
 
-      context 'student assigned to multiple instances of the same diagnostic' do
-
+      context 'student assigned to multiple instances of the same diagnostic in different classrooms' do
         let(:classroom_count) { 2 }
 
         it { expect(results.first[:post_students_assigned]).to eq(students.length * 2) }
+      end
+
+      context 'student assigned to multiple instances of the same diagnostics in the same classroom' do
+        let(:units_per_classroom) { 2 }
+
+        it { expect(results.first[:post_students_assigned]).to eq(students.length) }
       end
 
       context 'no relevant classroom_units' do

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_completed_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_completed_view_query_spec.rb
@@ -88,6 +88,13 @@ module AdminDiagnosticReports
 
         it { expect(results.first[:overall_skill_growth]).to eq(1.0) }
       end
+
+      context 'multiple concept results for a single question' do
+        # We want to make sure that having extra concept results for a question doesn't double-count that question for scoring purposes
+        let(:post_diagnostic_concept_results) { post_diagnostic_activity_sessions.map.with_index { |activity_session, i| create_list(:concept_result, 2, activity_session:, question_number: i + 1, extra_metadata: {question_uid: post_diagnostic_question.uid}) } }
+
+        it { expect(results.first[:overall_skill_growth]).to eq(0.0) }
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/pre_diagnostic_assigned_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/pre_diagnostic_assigned_view_query_spec.rb
@@ -34,7 +34,7 @@ module AdminDiagnosticReports
       it { expect(results.first[:pre_students_assigned]).to eq(students.length) }
 
       context 'student assigned to multiple instances of the same diagnostic' do
-        let(:units_per_classroom) { 2 }
+        let(:classroom_count) { 2 }
 
         it { expect(results.first[:pre_students_assigned]).to eq(students.length * 2) }
       end

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/pre_diagnostic_assigned_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/pre_diagnostic_assigned_view_query_spec.rb
@@ -33,10 +33,16 @@ module AdminDiagnosticReports
       it { expect(results.first[:aggregate_rows].map { |row| row[:name] }).to match_array(grade_names) }
       it { expect(results.first[:pre_students_assigned]).to eq(students.length) }
 
-      context 'student assigned to multiple instances of the same diagnostic' do
+      context 'student assigned to multiple instances of the same diagnostic in different classrooms' do
         let(:classroom_count) { 2 }
 
         it { expect(results.first[:pre_students_assigned]).to eq(students.length * 2) }
+      end
+
+      context 'student assigned to multiple instances of the same diagnostics in the same classroom' do
+        let(:units_per_classroom) { 2 }
+
+        it { expect(results.first[:pre_students_assigned]).to eq(students.length) }
       end
 
       context 'no relevant classroom_units' do


### PR DESCRIPTION
## WHAT
Only count one Pre or Post assignment per classroom

NOTE: This does address one issue with the calculation of Growth Percentages that Peter S flagged, but also surfaced a more complex issue that is not addressed in this PR: https://www.notion.so/quill/ADGR-QA-February-22-bb480e0255e542909ecee020b9a97742?pvs=4#cd2f38c11c71431f8574461704187699
## WHY
Apparently it's possible to assign two instances of the Post diagnostic to a classroom even if it only has a single Pre diagnostic assigned.  Not sure how that works, but it does exist in the wild.  In cases like this, we don't want to count that as two assignments.

Also, a performance improvement we made resulted in the inclusion of multiple assignments within the same classroom for Pre diagnostics getting into the rollup view, so we need to account for that.
## HOW
Change our `DISTINCT` value from `classroom_unit_id` and `user_id` to `classroom_id` and `user_id`

### Notion Card Links
https://www.notion.so/quill/ADGR-QA-February-22-bb480e0255e542909ecee020b9a97742?pvs=4#9bed3921cb94450c9e9b6d251c1e5b34

### What have you done to QA this feature?
- Update tests
- Run query in console to confirm that the query run in the QA pass that found this error returns the correct value
- Re-test the user from the QA pass that surfaced the issue

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
