### PR TITLE
AGDR/ expose Admin Diagnostic Report link

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/growth-diagnostic-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/growth-diagnostic-reports.scss
@@ -147,3 +147,21 @@ main {
   }
 }
 
+ @media (max-width: 725px) {
+  main {
+    .tabs-for-pages-container {
+      flex-direction: column;
+      gap: 8px;
+      .performance-type-button {
+        border-radius: 8px;
+        max-width: 250px;
+        width: 100% !important;
+        border: 1px solid $quill-grey-10;
+        &.actice {
+          border: 1px solid $quill-green;
+        }
+      }
+    }
+  }
+ }
+

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/subnav_tabs.test.tsx.snap
@@ -115,6 +115,17 @@ exports[`AdminSubnav it should render 1`] = `
           <li>
             <a
               class=""
+              href="/teachers/premium_hub/diagnostic_growth_report"
+            >
+              Diagnostic Growth Report
+            </a>
+            <div
+              class="checkmark-icon "
+            />
+          </li>
+          <li>
+            <a
+              class=""
               href="/teachers/premium_hub/data_export"
             >
               Data Export

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/subnav_tabs.tsx
@@ -54,6 +54,10 @@ const mobileTabs = {
     label: USAGE_SNAPSHOT_REPORT,
     url: '/teachers/premium_hub/usage_snapshot_report'
   },
+  [DIAGNOSTIC_GROWTH_REPORT]: {
+    label: DIAGNOSTIC_GROWTH_REPORT,
+    url: '/teachers/premium_hub/diagnostic_growth_report',
+  },
   [DATA_EXPORT]: {
     label: DATA_EXPORT,
     url: '/teachers/premium_hub/data_export'
@@ -66,12 +70,11 @@ const premiumReportDropdownItems = [
     url: '/teachers/premium_hub/usage_snapshot_report',
     new: true
   },
-  // TODO: uncomment the following two when the reports are ready for public access
-  // {
-  //   label: DIAGNOSTIC_GROWTH_REPORT,
-  //   url: '/teachers/premium_hub/diagnostic_growth_report',
-  //   new: true
-  // },
+  {
+    label: DIAGNOSTIC_GROWTH_REPORT,
+    url: '/teachers/premium_hub/diagnostic_growth_report',
+    new: true
+  },
   {
     label: DATA_EXPORT,
     url: '/teachers/premium_hub/data_export',
@@ -90,14 +93,6 @@ const premiumReportDropdownItems = [
     url: '/teachers/premium_hub/district_standards_reports'
   },
 ]
-
-const tabs = {
-  ...baseTabs,
-  [DIAGNOSTIC_GROWTH_REPORT]: {
-    label: DIAGNOSTIC_GROWTH_REPORT,
-    url: '/teachers/premium_hub/diagnostic_growth_report'
-  }
-}
 
 const PremiumReportsDropdown = ({ activeTab }) => {
   const dropdownId = "premium-reports-nav-dropdown"
@@ -197,7 +192,7 @@ export const AdminSubnav = ({ path }) => {
   function determineActiveTab() {
     const { pathname } = path;
 
-    const reportPaths = ['/district_activity_scores', '/district_concept_reports', '/district_standards_reports', '/usage_snapshot_report', '/data_export']
+    const reportPaths = ['/district_activity_scores', '/district_concept_reports', '/district_standards_reports', '/usage_snapshot_report', '/data_export', '/diagnostic_growth_report']
 
     if (reportPaths.find(path => pathname.includes(path))) {
       setActiveTab(PREMIUM_REPORTS)
@@ -205,8 +200,6 @@ export const AdminSubnav = ({ path }) => {
       setActiveTab(SUBSCRIPTIONS)
     } else if (pathname.includes('/account_management')) {
       setActiveTab(ACCOUNT_MANAGEMENT)
-    } else if (pathname.includes('/diagnostic_growth_report')) {
-      setActiveTab(DIAGNOSTIC_GROWTH_REPORT)
     } else if (pathname.includes('/integrations')) {
       setActiveTab(INTEGRATIONS)
     } else if (pathname.includes('/premium_hub')) {
@@ -224,8 +217,6 @@ export const AdminSubnav = ({ path }) => {
 
   const dropdownClass = dropdownOpen ? 'open' : '';
 
-  const tabsToShow = window.location.href.includes('diagnostic_growth_report') ? tabs : baseTabs
-
   return(
     <React.Fragment>
       <div className="tab-subnavigation-wrapper mobile class-subnav premium-hub-subnav red">
@@ -241,7 +232,7 @@ export const AdminSubnav = ({ path }) => {
       </div >
       <div className="tab-subnavigation-wrapper desktop class-subnav premium-hub-subnav">
         <div className="container">
-          {renderNavList({ tabs: tabsToShow, handleLinkClick: handleLinkClick, activeTab, childElement: <PremiumReportsDropdown activeTab={activeTab} /> })}
+          {renderNavList({ tabs: baseTabs, handleLinkClick: handleLinkClick, activeTab, childElement: <PremiumReportsDropdown activeTab={activeTab} /> })}
         </div>
       </div>
     </React.Fragment>


### PR DESCRIPTION
## WHAT
expose Admin Diagnostic Report link in dropdown menu

## WHY
this is the last step to soft launch this report

## HOW
just add it to the options array

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1407" alt="Screen Shot 2024-03-19 at 7 01 55 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/15b3d650-8c4f-47ce-8c8b-7539f11e8f45">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/ADGR-QA-February-22-bb480e0255e542909ecee020b9a97742?d=cb0dbc9ec934486a8215fd0585c610f6#0e5d8a245a5241a2914643e1aaf4e1cb

### What have you done to QA this feature?
tested locally and on staging that clicking the button navigates to the report

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes