### PR TITLE
fix bug with regex pages going blank

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseList.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseList.tsx
@@ -87,14 +87,14 @@ const ResponseList = ({admin, ascending, concepts, dispatch, expand, expanded, g
   const responseListItems = responses && responses.map((resp) => {
     if (resp && resp.statusCode !== 1 && resp.statusCode !== 0 && selectedIncorrectSequences) {
       const incorrectSequences = selectedIncorrectSequences.filter(isValidAndNotEmptyRegex)
-      const anyMatches = incorrectSequences.some(inSeq => incorrectSequenceMatchHelper(resp.text, inSeq.text, inSeq.caseInsensitive))
+      const anyMatches = incorrectSequences.some(inSeq => incorrectSequenceMatchHelper(resp.text, inSeq))
       if (anyMatches) {
         return <AffectedResponse key={resp.key}>{renderResponse(resp)}</AffectedResponse>
       }
     }
     if (resp && selectedFocusPoints) {
       const focusPoints = selectedFocusPoints.filter(isValidAndNotEmptyRegex)
-      const noMatchedFocusPoints = focusPoints.every(fp => !focusPointMatchHelper(resp.text, fp.text))
+      const noMatchedFocusPoints = focusPoints.every(fp => !focusPointMatchHelper(resp.text, fp))
       if (noMatchedFocusPoints) {
         return <AffectedResponse key={resp.key}>{renderResponse(resp)}</AffectedResponse>
       }


### PR DESCRIPTION
## WHAT
Fix bug with incorrect sequence and focus point pages going blank in the diagnostic when typed in.

## WHY
We want curriculum team members to be able to use this page.

## HOW
I tracked down the bug to these lines in the code, which were rewritten two weeks ago. I confirmed that [the older version of the code](https://github.com/empirical-org/Empirical-Core/blob/0e0f6f4fa5fc4128fc50da2831a12262129f90eb/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/responseList.jsx) was closer to the change we needed, made the fix, and confirmed that it worked.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-add-regex-to-Diagnostic-focus-points-or-incorrect-sequences-f93ed4c09e8a4a02b62ac5d352e04fa5

### What have you done to QA this feature?
Loaded the page, typed in the boxes, and noted that it works now.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually testsed
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
