### PR TITLE
fix 500 for exact scores and two small frontend bugs

### DIFF
--- a/services/QuillLMS/app/models/concerns/get_score_for_question.rb
+++ b/services/QuillLMS/app/models/concerns/get_score_for_question.rb
@@ -7,7 +7,7 @@ module GetScoreForQuestion
     if !concept_results.empty? && concept_results.first.question_score
       concept_results.first.question_score * 100
     else
-      concept_results.max_by { |cr| cr.attempt_number }&.correct ? 100 : 0
+      concept_results.max_by { |cr| cr.attempt_number || 0 }&.correct ? 100 : 0
     end
   end
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
@@ -648,17 +648,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
               class="data-table-row-section action-button-section tooltip-section"
               style="width: 88px; min-width: 88px; text-align: left;"
             >
-              <div
-                class="score-tooltip-activator"
+              <a
+                aria-label="Replay Capitalizing People, Places, & the Pronoun - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/886"
               >
-                <a
-                  aria-label="Replay Capitalizing People, Places, & the Pronoun - Mixed Topics"
-                  class="quill-button medium focus-on-light secondary outlined"
-                  href="/activity_sessions/classroom_units/8392402/activities/886"
-                >
-                  Replay
-                </a>
-              </div>
+                Replay
+              </a>
             </td>
           </tr>
           <tr
@@ -732,17 +728,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
               class="data-table-row-section action-button-section tooltip-section"
               style="width: 88px; min-width: 88px; text-align: left;"
             >
-              <div
-                class="score-tooltip-activator"
+              <a
+                aria-label="Replay Capitalizing Names of People & the Pronoun  - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/885"
               >
-                <a
-                  aria-label="Replay Capitalizing Names of People & the Pronoun  - Mixed Topics"
-                  class="quill-button medium focus-on-light secondary outlined"
-                  href="/activity_sessions/classroom_units/8392402/activities/885"
-                >
-                  Replay
-                </a>
-              </div>
+                Replay
+              </a>
             </td>
           </tr>
           <tr
@@ -816,17 +808,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
               class="data-table-row-section action-button-section tooltip-section"
               style="width: 88px; min-width: 88px; text-align: left;"
             >
-              <div
-                class="score-tooltip-activator"
+              <a
+                aria-label="Replay Capitalizing Names of People - Mixed Topics 1"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/804"
               >
-                <a
-                  aria-label="Replay Capitalizing Names of People - Mixed Topics 1"
-                  class="quill-button medium focus-on-light secondary outlined"
-                  href="/activity_sessions/classroom_units/8392402/activities/804"
-                >
-                  Replay
-                </a>
-              </div>
+                Replay
+              </a>
             </td>
           </tr>
           <tr
@@ -900,17 +888,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
               class="data-table-row-section action-button-section tooltip-section"
               style="width: 88px; min-width: 88px; text-align: left;"
             >
-              <div
-                class="score-tooltip-activator"
+              <a
+                aria-label="Replay Capitalizing Holidays, People, & Places - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/887"
               >
-                <a
-                  aria-label="Replay Capitalizing Holidays, People, & Places - Mixed Topics"
-                  class="quill-button medium focus-on-light secondary outlined"
-                  href="/activity_sessions/classroom_units/8392402/activities/887"
-                >
-                  Replay
-                </a>
-              </div>
+                Replay
+              </a>
             </td>
           </tr>
           <tr
@@ -984,17 +968,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
               class="data-table-row-section action-button-section tooltip-section"
               style="width: 88px; min-width: 88px; text-align: left;"
             >
-              <div
-                class="score-tooltip-activator"
+              <a
+                aria-label="Replay Capitalizing Dates & Holidays - Mixed Topics 1"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/801"
               >
-                <a
-                  aria-label="Replay Capitalizing Dates & Holidays - Mixed Topics 1"
-                  class="quill-button medium focus-on-light secondary outlined"
-                  href="/activity_sessions/classroom_units/8392402/activities/801"
-                >
-                  Replay
-                </a>
-              </div>
+                Replay
+              </a>
             </td>
           </tr>
           <tr
@@ -1068,17 +1048,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
               class="data-table-row-section action-button-section tooltip-section"
               style="width: 88px; min-width: 88px; text-align: left;"
             >
-              <div
-                class="score-tooltip-activator"
+              <a
+                aria-label="Replay Capitalizing Geographic Names - Mixed Topics 1"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/802"
               >
-                <a
-                  aria-label="Replay Capitalizing Geographic Names - Mixed Topics 1"
-                  class="quill-button medium focus-on-light secondary outlined"
-                  href="/activity_sessions/classroom_units/8392402/activities/802"
-                >
-                  Replay
-                </a>
-              </div>
+                Replay
+              </a>
             </td>
           </tr>
           <tr
@@ -1152,17 +1128,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
               class="data-table-row-section action-button-section tooltip-section"
               style="width: 88px; min-width: 88px; text-align: left;"
             >
-              <div
-                class="score-tooltip-activator"
+              <a
+                aria-label="Replay Capitalizing Geographic Names & Holidays - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/181"
               >
-                <a
-                  aria-label="Replay Capitalizing Geographic Names & Holidays - Mixed Topics"
-                  class="quill-button medium focus-on-light secondary outlined"
-                  href="/activity_sessions/classroom_units/8392402/activities/181"
-                >
-                  Replay
-                </a>
-              </div>
+                Replay
+              </a>
             </td>
           </tr>
         </tbody>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -236,7 +236,7 @@ export default class StudentProfileUnit extends React.Component {
       )
       const { number_of_questions, number_of_correct_questions, percentage, } = bestSession
 
-      exactScoreCopy = (<span>{number_of_correct_questions} of {number_of_questions} ({percentage * 100}%)</span>)
+      exactScoreCopy = (<span>{number_of_correct_questions} of {number_of_questions} ({Math.round(percentage * 100)}%)</span>)
     }
 
     if (maxPercentage >= FREQUENTLY_DEMONSTRATED_SKILL_CUTOFF) {
@@ -282,7 +282,7 @@ export default class StudentProfileUnit extends React.Component {
           name: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{name}</TooltipWrapper>,
           score: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{this.score(act)}</TooltipWrapper>,
           tool: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{this.toolIcon(activity_classification_key)}</TooltipWrapper>,
-          actionButton: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{this.actionButton(act, nextActivitySession)}</TooltipWrapper>,
+          actionButton: this.actionButton(act, nextActivitySession),
           dueDate: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{due_date ? formatDateTimeForDisplay(moment.utc(due_date)) : null}</TooltipWrapper>,
           completedDate: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{completed_date ? formatDateTimeForDisplay(moment.utc(completed_date)) : null}</TooltipWrapper>,
           id: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{ua_id}</TooltipWrapper>


### PR DESCRIPTION
## WHAT
Fix some bugs that popped up after launch of students seeing exact scores project.

## WHY
We want 

## HOW
Fix a 500 error that was affecting some students, and two small frontend bugs (a non-rounded percentage and a tooltip that was covering a different tooltip).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-Sentry-error-from-show_students_exact_scores-6f5fdad08149405682e7456b2613df62?pvs=4

### What have you done to QA this feature?
Logged in as an affected student locally (with staging db, which contains relevant data), confirmed that I was getting the 500, then stopped getting the 500 after the fix.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
