### PR TITLE
show best attempt, not worst attempt on student completed page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
@@ -18,7 +18,7 @@
     -o-font-smoothing: antialiased;
     margin: auto;
     position: relative;
-    padding-bottom: 54px;
+    padding-bottom: 200px;
 
     section {
       border-bottom: none;

--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -5,6 +5,7 @@
   margin-bottom: 24px;
   .score-tooltip-activator {
     position: relative;
+    white-space: normal;
   }
   &.selected-unit {
     .unit-name-and-staggered-release-status {
@@ -56,7 +57,9 @@
         cursor: text;
       }
       .data-table-row {
-        height: 72px;
+        min-height: 72px;
+        height: min-content;
+        padding: 18px 0px;
         &:hover {
           background-color: transparent;
         }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -231,7 +231,7 @@ export default class StudentProfileUnit extends React.Component {
       const relevantExactScore = exactScoresData.find(es => es.ua_id === ua_id && es.classroom_unit_id === classroom_unit_id)
       const bestSession = relevantExactScore.sessions.reduce(
         (a, b) => {
-          return a.percentage < b.percentage ? a : b
+          return a.percentage > b.percentage ? a : b
         }
       )
       const { number_of_questions, number_of_correct_questions, percentage, } = bestSession


### PR DESCRIPTION
## WHAT
Fix student completed view so that highest score shows when they've completed multiple attempts at the same activity.

## WHY
We want students to see their best attempt.

## HOW
Flip percentage sort logic.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Confirmed that the highest-scoring attempt is now showing.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
