### PR TITLE
call for exact scores when completed tab is clicked and not before

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -80,6 +80,9 @@
     .score {
       display: flex;
       align-items: center;
+      .button-loading-spinner {
+        margin-right: 8px;
+      }
       div {
         display: inline-block;
         width: 24px;

--- a/services/QuillLMS/client/app/actions/student_profile.js
+++ b/services/QuillLMS/client/app/actions/student_profile.js
@@ -17,10 +17,6 @@ export const fetchStudentProfile = (classroomId) => {
       `${process.env.DEFAULT_URL}/student_profile_data${qs}`,
       (body) => {
         dispatch(receiveStudentProfile(body))
-
-        if (body.show_exact_scores) {
-          dispatch(fetchExactScoresData(body.scores))
-        }
       }
     );
   };

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
@@ -495,7 +495,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
 </DocumentFragment>
 `;
 
-exports[`StudentProfileUnit component should render completed activities when showExactScores is true 1`] = `
+exports[`StudentProfileUnit component should render completed activities when showExactScores is true and the data is present 1`] = `
 <DocumentFragment>
   <div
     class="student-profile-unit undefined"
@@ -1123,6 +1123,578 @@ exports[`StudentProfileUnit component should render completed activities when sh
               >
                 Feb 22, 1:59pm
               </div>
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Geographic Names & Holidays - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/181"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`StudentProfileUnit component should render completed activities when showExactScores is true but the data is pending 1`] = `
+<DocumentFragment>
+  <div
+    class="student-profile-unit undefined"
+  >
+    <div
+      class="unit-name-and-staggered-release-status"
+    >
+      <h2
+        class="unit-name"
+      >
+        Unit
+      </h2>
+      <span />
+    </div>
+    <div
+      class="activities-container completed-activities"
+    >
+      <table
+        class="data-table undefined"
+      >
+        <thead>
+          <tr
+            class="data-table-headers"
+          >
+            <th
+              class="data-table-header name-section"
+              scope="col"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              <span>
+                Activity
+              </span>
+            </th>
+            <th
+              class="data-table-header score-section tooltip-section"
+              scope="col"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <span>
+                Score
+              </span>
+            </th>
+            <th
+              class="data-table-header tool-icon-section"
+              scope="col"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <span>
+                Tool
+              </span>
+            </th>
+            <th
+              class="data-table-header completed-due-date-section"
+              scope="col"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <span>
+                Due date
+              </span>
+            </th>
+            <th
+              class="data-table-header completed-date-section"
+              scope="col"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              <span>
+                Completed date
+              </span>
+            </th>
+            <th
+              class="data-table-header action-button-section tooltip-section"
+              scope="col"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <span />
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="data-table-body"
+        >
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing People, Places, & the Pronoun - Mixed Topics
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="frequently-demonstrated-skill"
+                />
+                <span>
+                  <span>
+                    <span
+                      class="button-loading-spinner-container"
+                    >
+                      <img
+                        alt="spinning circle to indicate loading"
+                        class="button-loading-spinner"
+                        src="undefined/images/shared/indeterminate_spinner_dark@2x.png"
+                      />
+                    </span>
+                     (100%)
+                  </span>
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing People, Places, & the Pronoun - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/886"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Names of People & the Pronoun  - Mixed Topics
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="frequently-demonstrated-skill"
+                />
+                <span>
+                  <span>
+                    <span
+                      class="button-loading-spinner-container"
+                    >
+                      <img
+                        alt="spinning circle to indicate loading"
+                        class="button-loading-spinner"
+                        src="undefined/images/shared/indeterminate_spinner_dark@2x.png"
+                      />
+                    </span>
+                     (100%)
+                  </span>
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Names of People & the Pronoun  - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/885"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Names of People - Mixed Topics 1
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="frequently-demonstrated-skill"
+                />
+                <span>
+                  <span>
+                    <span
+                      class="button-loading-spinner-container"
+                    >
+                      <img
+                        alt="spinning circle to indicate loading"
+                        class="button-loading-spinner"
+                        src="undefined/images/shared/indeterminate_spinner_dark@2x.png"
+                      />
+                    </span>
+                     (100%)
+                  </span>
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Names of People - Mixed Topics 1"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/804"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Holidays, People, & Places - Mixed Topics
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="frequently-demonstrated-skill"
+                />
+                <span>
+                  <span>
+                    <span
+                      class="button-loading-spinner-container"
+                    >
+                      <img
+                        alt="spinning circle to indicate loading"
+                        class="button-loading-spinner"
+                        src="undefined/images/shared/indeterminate_spinner_dark@2x.png"
+                      />
+                    </span>
+                     (90%)
+                  </span>
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Holidays, People, & Places - Mixed Topics"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/887"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Dates & Holidays - Mixed Topics 1
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="sometimes-demonstrated-skill"
+                />
+                <span>
+                  <span>
+                    <span
+                      class="button-loading-spinner-container"
+                    >
+                      <img
+                        alt="spinning circle to indicate loading"
+                        class="button-loading-spinner"
+                        src="undefined/images/shared/indeterminate_spinner_dark@2x.png"
+                      />
+                    </span>
+                     (40%)
+                  </span>
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Dates & Holidays - Mixed Topics 1"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/801"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Geographic Names - Mixed Topics 1
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="sometimes-demonstrated-skill"
+                />
+                <span>
+                  <span>
+                    <span
+                      class="button-loading-spinner-container"
+                    >
+                      <img
+                        alt="spinning circle to indicate loading"
+                        class="button-loading-spinner"
+                        src="undefined/images/shared/indeterminate_spinner_dark@2x.png"
+                      />
+                    </span>
+                     (40%)
+                  </span>
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
+            </td>
+            <td
+              class="data-table-row-section action-button-section tooltip-section"
+              style="width: 88px; min-width: 88px; text-align: left;"
+            >
+              <a
+                aria-label="Replay Capitalizing Geographic Names - Mixed Topics 1"
+                class="quill-button medium focus-on-light secondary outlined"
+                href="/activity_sessions/classroom_units/8392402/activities/802"
+              >
+                Replay
+              </a>
+            </td>
+          </tr>
+          <tr
+            class="data-table-row  "
+          >
+            <td
+              class="data-table-row-section name-section tooltip-section"
+              style="width: 474px; min-width: 474px; text-align: left;"
+            >
+              Capitalizing Geographic Names & Holidays - Mixed Topics
+            </td>
+            <td
+              class="data-table-row-section score-section tooltip-section"
+              style="width: 230px; min-width: 230px; text-align: left;"
+            >
+              <div
+                class="score"
+              >
+                <div
+                  class="rarely-demonstrated-skill"
+                />
+                <span>
+                  <span>
+                    <span
+                      class="button-loading-spinner-container"
+                    >
+                      <img
+                        alt="spinning circle to indicate loading"
+                        class="button-loading-spinner"
+                        src="undefined/images/shared/indeterminate_spinner_dark@2x.png"
+                      />
+                    </span>
+                     (22%)
+                  </span>
+                </span>
+              </div>
+            </td>
+            <td
+              class="data-table-row-section tool-icon-section tooltip-section"
+              style="width: 24px; min-width: 24px; text-align: left;"
+            >
+              <img
+                alt="Puzzle piece representing Quill Grammar"
+                src="undefined/images/icons/tool-grammar-gray.svg"
+              />
+            </td>
+            <td
+              class="data-table-row-section completed-due-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Mar 27, 5am
+            </td>
+            <td
+              class="data-table-row-section completed-date-section tooltip-section"
+              style="width: 110px; min-width: 110px; text-align: left;"
+            >
+              Feb 22, 1:59pm
             </td>
             <td
               class="data-table-row-section action-button-section tooltip-section"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/student_profile_unit.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/student_profile_unit.test.jsx
@@ -30,11 +30,25 @@ describe('StudentProfileUnit component', () => {
     expect(asFragment()).toMatchSnapshot()
   });
 
-  it('should render completed activities when showExactScores is true', () => {
+  it('should render completed activities when showExactScores is true but the data is pending', () => {
     const { asFragment, } = render(
       <StudentProfileUnit
         data={completeCategorizedActivities}
         exactScoresData={exactScoresData}
+        exactScoresDataPending={true}
+        showExactScores={true}
+        unitName="Unit"
+      />
+    );
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should render completed activities when showExactScores is true and the data is present', () => {
+    const { asFragment, } = render(
+      <StudentProfileUnit
+        data={completeCategorizedActivities}
+        exactScoresData={exactScoresData}
+        exactScoresDataPending={false}
         showExactScores={true}
         unitName="Unit"
       />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -7,6 +7,7 @@ import {
   closedLockIcon,
   onMobile,
   openLockIcon,
+  DarkButtonLoadingSpinner,
 } from '../../../Shared/index';
 import { formatDateTimeForDisplay, } from '../../helpers/unitActivityDates';
 import activityLaunchLink from '../modules/generate_activity_launch_link.js';
@@ -207,7 +208,7 @@ export default class StudentProfileUnit extends React.Component {
   }
 
   score = (act) => {
-    const { exactScoresData, showExactScores, } = this.props
+    const { exactScoresData, showExactScores, exactScoresDataPending, } = this.props
     const { activity_classification_key, max_percentage, ua_id, classroom_unit_id, } = act
     const maxPercentage = Number(max_percentage)
 
@@ -227,7 +228,9 @@ export default class StudentProfileUnit extends React.Component {
 
     let exactScoreCopy
 
-    if (showExactScores) {
+    if (showExactScores && exactScoresDataPending) {
+      exactScoreCopy = (<span><DarkButtonLoadingSpinner /> ({Math.round(max_percentage * 100)}%)</span>)
+    } else if (showExactScores) {
       const relevantExactScore = exactScoresData.find(es => es.ua_id === ua_id && es.classroom_unit_id === classroom_unit_id)
       const bestSession = relevantExactScore.sessions.reduce(
         (a, b) => {
@@ -271,13 +274,13 @@ export default class StudentProfileUnit extends React.Component {
   }
 
   renderCompletedActivities = () => {
-    const { data, nextActivitySession, showExactScores, exactScoresData, } = this.props
+    const { data, nextActivitySession, showExactScores, exactScoresData, exactScoresDataPending, } = this.props
     if (!(data.complete && data.complete.length)) { return null}
 
     const rows = data.complete.map(act => {
       const { name, activity_classification_key, ua_id, due_date, completed_date, } = act
 
-      if (showExactScores && !UNGRADED_ACTIVITY_CLASSIFICATIONS.includes(activity_classification_key)) {
+      if (showExactScores && !UNGRADED_ACTIVITY_CLASSIFICATIONS.includes(activity_classification_key) && !exactScoresDataPending) {
         return {
           name: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{name}</TooltipWrapper>,
           score: <TooltipWrapper activity={act} exactScoresData={exactScoresData}>{this.score(act)}</TooltipWrapper>,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_units.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_units.jsx
@@ -94,7 +94,7 @@ export default class StudentProfileUnits extends React.Component {
   }
 
   renderContent = () => {
-    const { loading, nextActivitySession, isBeingPreviewed, selectedUnitId, exactScoresData, showExactScores, } = this.props
+    const { loading, nextActivitySession, isBeingPreviewed, selectedUnitId, exactScoresData, showExactScores, exactScoresDataPending, } = this.props
     if (loading) { return <LoadingIndicator /> }
 
     const content = this.displayedUnits().map(unit => {
@@ -103,6 +103,7 @@ export default class StudentProfileUnits extends React.Component {
         <StudentProfileUnit
           data={unit}
           exactScoresData={exactScoresData}
+          exactScoresDataPending={exactScoresDataPending}
           id={unit_id}
           isBeingPreviewed={isBeingPreviewed}
           isSelectedUnit={String(unit_id) === selectedUnitId}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -127,8 +127,6 @@ class StudentProfile extends React.Component {
 
     if (loading) { return <LoadingIndicator /> }
 
-    if (activeClassworkTab === COMPLETED_ACTIVITIES && exactScoresDataPending)  { return <LoadingIndicator /> }
-
     if (!selectedClassroomId) { return (<SelectAClassroom classrooms={classrooms} isBeingPreviewed={isBeingPreviewed} onClickCard={this.handleClassroomTabClick} />)}
 
     return (
@@ -157,6 +155,7 @@ class StudentProfile extends React.Component {
             activeClassworkTab={activeClassworkTab}
             data={scores}
             exactScoresData={exactScoresData}
+            exactScoresDataPending={exactScoresDataPending}
             isBeingPreviewed={isBeingPreviewed}
             loading={loading}
             nextActivitySession={nextActivitySession}

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import {
   fetchStudentProfile,
   fetchStudentsClassrooms,
+  fetchExactScoresData,
   handleClassroomClick,
   updateActiveClassworkTab,
 } from '../../../actions/student_profile';
@@ -80,8 +81,12 @@ class StudentProfile extends React.Component {
   }
 
   handleClickClassworkTab = (classworkTab) => {
-    const { updateActiveClassworkTab, } = this.props
+    const { updateActiveClassworkTab, exactScoresDataPending, fetchExactScoresData, scores, } = this.props
     updateActiveClassworkTab(classworkTab)
+
+    if (classworkTab === COMPLETED_ACTIVITIES && exactScoresDataPending) {
+      fetchExactScoresData(scores)
+    }
   }
 
   initializePusher = (nextProps) => {
@@ -115,14 +120,14 @@ class StudentProfile extends React.Component {
       isBeingPreviewed,
       history,
       metrics,
-      loadingExactScoresData,
+      exactScoresDataPending,
       exactScoresData,
       showExactScores,
     } = this.props;
 
     if (loading) { return <LoadingIndicator /> }
 
-    if (activeClassworkTab === COMPLETED_ACTIVITIES && loadingExactScoresData)  { return <LoadingIndicator /> }
+    if (activeClassworkTab === COMPLETED_ACTIVITIES && exactScoresDataPending)  { return <LoadingIndicator /> }
 
     if (!selectedClassroomId) { return (<SelectAClassroom classrooms={classrooms} isBeingPreviewed={isBeingPreviewed} onClickCard={this.handleClassroomTabClick} />)}
 
@@ -169,8 +174,9 @@ const mapStateToProps = state => state;
 const mapDispatchToProps = dispatch => ({
   fetchStudentProfile: (classroomId) => dispatch(fetchStudentProfile(classroomId)),
   fetchStudentsClassrooms: () => dispatch(fetchStudentsClassrooms()),
+  fetchExactScoresData: scores => dispatch(fetchExactScoresData(scores)),
   handleClassroomClick: classroomId => dispatch(handleClassroomClick(classroomId)),
-  updateActiveClassworkTab: tab => dispatch(updateActiveClassworkTab(tab))
+  updateActiveClassworkTab: tab => dispatch(updateActiveClassworkTab(tab)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(StudentProfile);

--- a/services/QuillLMS/client/app/reducers/student_profile.js
+++ b/services/QuillLMS/client/app/reducers/student_profile.js
@@ -11,7 +11,7 @@ const initialState = {
   student: null,
   nextActivitySession: null,
   activeClassworkTab: TO_DO_ACTIVITIES,
-  loadingExactScoresData: false
+  exactScoresDataPending: false
 };
 
 export default (state, action) => {
@@ -21,7 +21,7 @@ export default (state, action) => {
     case 'HANDLE_CLASSROOM_CLICK':
       return Object.assign({}, state, {
         loading: true,
-        loadingExactScoresData: false,
+        exactScoresDataPending: false,
         selectedClassroomId: action.selectedClassroomId
       });
     case 'RECEIVE_STUDENTS_CLASSROOMS':
@@ -35,11 +35,11 @@ export default (state, action) => {
         selectedClassroomId: action.data.classroom_id,
         metrics: action.data.metrics,
         showExactScores: action.data.show_exact_scores,
-        loadingExactScoresData: action.data.show_exact_scores // if this value is true, we set off another request to get this data, so it is now loading
+        exactScoresDataPending: action.data.show_exact_scores // if this value is true, when we switch to the completed tab we will fire a request to get the relevant data
       });
     case 'RECEIVE_EXACT_SCORES_DATA': {
       return Object.assign({}, state, {
-        loadingExactScoresData: false,
+        exactScoresDataPending: false,
         exactScoresData: action.data.exact_scores_data
       })
     }


### PR DESCRIPTION
## WHAT
Call for exact scores when the "Completed" tab is clicked, and not before. Also update the page so that the loading spinner does not take over the page, but shows up in individual rows next to the percentage until all the data is loaded.

Note: we are planning to wait to see if caching helps significantly reduce our load, and if not, deploy after that.

## WHY
This endpoint is slow so it's adding a lot of load to the site. Students are visiting the "To-do activities" tab more than the "Completed activities" tab, so we're currently hitting it more than is necessary. I did this initially to reduce visible load time for users, but we don't want that to make the site slower for everyone.

## HOW
Wait til the user actually clicks the "Completed activities" tab to load the exact score data.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Tested out the page to ensure that loading a) waits until you actually click "Completed activities" but then b) successfully completes once that happens.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
