### PR TITLE
Banner fix/ swap color variables

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
@@ -86,8 +86,8 @@
     }
   }
   &.gold {
-    background-color: $quill-gold-dark-1;
-    border: 1px solid $quill-gold;
+    background-color: $quill-gold-1;
+    border: 1px solid $quill-gold-dark-10;
     .tag, .quill-button {
       background-color: $quill-gold-dark-50 !important;
     }
@@ -95,7 +95,7 @@
       background-color: $quill-gold-dark-20 !important;
     }
     .secondary-header {
-      color: $quill-gold-dark-50;
+      color: $quill-gold-dark;
     }
   }
   &.viridian {


### PR DESCRIPTION
## WHAT
tweak color styles for gold Banner component

## WHY
these changes were requested by Jack

## HOW
just swap color variables for border, background and secondary text

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="818" alt="Screen Shot 2024-03-20 at 1 26 28 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/1487afd0-bf4c-4796-b5cf-4c8bcfec2a18">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Banner-Components-The-Gold-Variant-needs-adjustments-5eddafacbc3b410c8055784aed46dd2f?pvs=4

### What have you done to QA this feature?
verified color changes in browser and verified with Jack that the changes look good

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | css change-- manually tested
Have you deployed to Staging? | no-- tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes