### PR TITLE
Cache Student Scores

### DIFF
--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -63,7 +63,7 @@ class ProfilesController < ApplicationController
 
   def student_exact_scores_data
     exact_scores_data = params[:data].map do |ua|
-      student_exact_scores(current_user, ua['activity_id'], ua['classroom_unit_id'])
+      student_exact_scores(current_user, ua)
     end
 
     render json: { exact_scores_data:}
@@ -87,7 +87,11 @@ class ProfilesController < ApplicationController
     render :staff
   end
 
-  private def student_exact_scores(user, activity_id, classroom_unit_id)
+  private def student_exact_scores(user, unit_activity_params)
+    activity_id = unit_activity_params['activity_id']
+    classroom_unit_id = unit_activity_params['classroom_unit_id']
+    ua_id = unit_activity_params['ua_id']
+
     user_id = user.id
     cache_key = "#{Student::EXACT_SCORES_CACHE_KEY}/#{user_id}/#{activity_id}/#{classroom_unit_id}"
 
@@ -105,7 +109,8 @@ class ProfilesController < ApplicationController
         'sessions' => activity_sessions.map { |as| format_activity_session_for_tooltip(as, user) },
         'completed_attempts' => activity_sessions.length,
         'activity_id' => activity_id,
-        'classroom_unit_id' => classroom_unit_id
+        'classroom_unit_id' => classroom_unit_id,
+        'ua_id' => ua_id
       }
     end
   end

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -63,19 +63,25 @@ class ProfilesController < ApplicationController
 
   def student_exact_scores_data
     exact_scores_data = params[:data].map do |ua|
-      activity_sessions = ActivitySession
-        .includes(:concept_results, :activity, :unit)
-        .where(
-          user_id: current_user.id,
-          activity_id: ua['activity_id'],
-          classroom_unit_id: ua['classroom_unit_id'],
-          state: ActivitySession::STATE_FINISHED
-        )
+      activity_id = ua['activity_id']
+      classroom_unit_id = ua['classroom_unit_id']
+      cache_key = "#{Student::EXACT_SCORES_CACHE_KEY}/#{current_user.id}/#{activity_id}/#{classroom_unit_id}"
 
-      ua['sessions'] = activity_sessions.map { |as| format_activity_session_for_tooltip(as, current_user) }
-      ua['completed_attempts'] = activity_sessions.length
+      Rails.cache.fetch(cache_key, expires_in: 8.hours) do
+        activity_sessions = ActivitySession
+          .includes(:concept_results, :activity, :unit)
+          .where(
+            user_id: current_user.id,
+            activity_id: activity_id,
+            classroom_unit_id: classroom_unit_id,
+            state: ActivitySession::STATE_FINISHED
+          )
 
-      ua
+        ua['sessions'] = activity_sessions.map { |as| format_activity_session_for_tooltip(as, current_user) }
+        ua['completed_attempts'] = activity_sessions.length
+
+        ua
+      end
     end
 
     render json: { exact_scores_data: exact_scores_data}

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -3,6 +3,8 @@
 module Student
   extend ActiveSupport::Concern
 
+  EXACT_SCORES_CACHE_KEY = 'student_exact_scores'
+
   included do
     #TODO: move these relationships into the users model
 


### PR DESCRIPTION
## WHAT
We are displaying scores to students. This is somewhat static data, but hits our two largest tables to calculate (`activity_sessions` and `concept_results`). Adding a cache to the controller endpoint and an cache.delete when a new activity is completed by a student.
## WHY
Performance reasons. This new controller endpoint is now 50% of our controller processing time.
## HOW
Cache.fetch in the controller and delete in the batch worker on activity completion.
### Screenshots
<img width="1000" alt="Screenshot 2024-03-20 at 12 14 50 PM" src="https://github.com/empirical-org/Empirical-Core/assets/1304933/521b0061-1f6b-4e93-965a-f0a15cb16502">


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Having Emilia QA this for time reasons.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
