### PR TITLE
Cache student scores at student level.

### DIFF
--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -110,7 +110,7 @@ class ProfilesController < ApplicationController
 
     data.map do |ua|
       key = [ua[ACTIVITY_ID]&.to_i, ua[CLASSROOM_UNIT_ID]&.to_i]
-      activity_sessions = activity_sessions_grouped[key]
+      activity_sessions = activity_sessions_grouped[key] || []
       student_exact_scores(user, ua, activity_sessions)
     end
   end

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -93,7 +93,6 @@ class ProfilesController < ApplicationController
     activity_id = unit_activity_params['activity_id']
     classroom_unit_id = unit_activity_params['classroom_unit_id']
     ua_id = unit_activity_params['ua_id']
-
     user_id = user.id
 
     activity_sessions = ActivitySession
@@ -112,7 +111,6 @@ class ProfilesController < ApplicationController
       'classroom_unit_id' => classroom_unit_id,
       'ua_id' => ua_id
     }
-
   end
 
   protected def user_params

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -3,6 +3,10 @@
 class ProfilesController < ApplicationController
   include PublicProgressReports
 
+  ACTIVITY_ID = 'activity_id'
+  CLASSROOM_UNIT_ID = 'classroom_unit_id'
+  UA_ID = 'ua_id'
+
   before_action :signed_in!
 
   def show
@@ -86,10 +90,6 @@ class ProfilesController < ApplicationController
   def staff
     render :staff
   end
-
-  ACTIVITY_ID = 'activity_id'
-  CLASSROOM_UNIT_ID = 'classroom_unit_id'
-  UA_ID = 'ua_id'
 
   private def student_score_cache_key = User.student_scores_cache_key(current_user.id, params[:classroom_id])
 

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -99,7 +99,7 @@ class ProfilesController < ApplicationController
     activity_id = data.map{|h| h[ACTIVITY_ID]}
 
     activity_sessions_grouped = ActivitySession
-      .includes(:concept_results, :activity, :unit)
+      .includes(:unit, concept_results: :concept, activity: :classification)
       .where(
         user_id:,
         activity_id:,

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -6,7 +6,7 @@ module Student
   EXACT_SCORES_CACHE_KEY = 'student_exact_scores_by_student'
 
   class_methods do
-    def student_scores_cache_key(user_id) = "#{EXACT_SCORES_CACHE_KEY}/#{user_id}"
+    def student_scores_cache_key(user_id, classroom_id) = "#{EXACT_SCORES_CACHE_KEY}/#{user_id}/#{classroom_id}"
   end
 
   included do

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -3,7 +3,11 @@
 module Student
   extend ActiveSupport::Concern
 
-  EXACT_SCORES_CACHE_KEY = 'student_exact_scores'
+  EXACT_SCORES_CACHE_KEY = 'student_exact_scores_by_student'
+
+  class_methods do
+    def student_scores_cache_key(user_id) = "#{EXACT_SCORES_CACHE_KEY}/#{user_id}"
+  end
 
   included do
     #TODO: move these relationships into the users model

--- a/services/QuillLMS/app/workers/batch_save_activity_session_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/batch_save_activity_session_concept_results_worker.rb
@@ -29,9 +29,9 @@ class BatchSaveActivitySessionConceptResultsWorker
   private def delete_student_score_cache(activity_session_uid)
     session = ActivitySession.find_by(uid: activity_session_uid)
 
-    return unless session
+    return unless session&.user_id
 
-    cache_key = "#{Student::EXACT_SCORES_CACHE_KEY}/#{session.user_id}/#{session.activity_id}/#{session.classroom_unit_id}"
+    cache_key = User.student_scores_cache_key(session.user_id)
 
     Rails.cache.delete(cache_key)
   end

--- a/services/QuillLMS/app/workers/batch_save_activity_session_concept_results_worker.rb
+++ b/services/QuillLMS/app/workers/batch_save_activity_session_concept_results_worker.rb
@@ -31,7 +31,9 @@ class BatchSaveActivitySessionConceptResultsWorker
 
     return unless session&.user_id
 
-    cache_key = User.student_scores_cache_key(session.user_id)
+    classroom_id = session.classroom_unit&.classroom_id
+
+    cache_key = User.student_scores_cache_key(session.user_id, classroom_id)
 
     Rails.cache.delete(cache_key)
   end

--- a/services/QuillLMS/client/app/actions/student_profile.js
+++ b/services/QuillLMS/client/app/actions/student_profile.js
@@ -22,7 +22,7 @@ export const fetchStudentProfile = (classroomId) => {
   };
 };
 
-export const fetchExactScoresData = (scores) => {
+export const fetchExactScoresData = (scores, classroomId) => {
   return (dispatch) => {
     const relevantData = scores.map(score => {
       const { ua_id, unit_id, activity_id, classroom_unit_id, } = score
@@ -32,7 +32,7 @@ export const fetchExactScoresData = (scores) => {
     // using requestPost here because params have potential to be very large
     requestPost(
       `${process.env.DEFAULT_URL}/student_exact_scores_data`,
-      { data: relevantData },
+      { data: relevantData, classroom_id: classroomId },
       body => {
         dispatch(receiveExactScoresData(body))
       }

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -81,11 +81,11 @@ class StudentProfile extends React.Component {
   }
 
   handleClickClassworkTab = (classworkTab) => {
-    const { updateActiveClassworkTab, exactScoresDataPending, fetchExactScoresData, scores, } = this.props
+    const { updateActiveClassworkTab, exactScoresDataPending, fetchExactScoresData, scores, classroomId, } = this.props
     updateActiveClassworkTab(classworkTab)
 
     if (classworkTab === COMPLETED_ACTIVITIES && exactScoresDataPending) {
-      fetchExactScoresData(scores)
+      fetchExactScoresData(scores, classroomId)
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -173,7 +173,7 @@ const mapStateToProps = state => state;
 const mapDispatchToProps = dispatch => ({
   fetchStudentProfile: (classroomId) => dispatch(fetchStudentProfile(classroomId)),
   fetchStudentsClassrooms: () => dispatch(fetchStudentsClassrooms()),
-  fetchExactScoresData: scores => dispatch(fetchExactScoresData(scores)),
+  fetchExactScoresData: (scores, classroomId) => dispatch(fetchExactScoresData(scores, classroomId)),
   handleClassroomClick: classroomId => dispatch(handleClassroomClick(classroomId)),
   updateActiveClassworkTab: tab => dispatch(updateActiveClassworkTab(tab)),
 });

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -318,7 +318,7 @@ describe ProfilesController, type: :controller do
 
       describe '#student_exact_scores_data' do
         it 'returns formatted data for activity sessions' do
-          post :student_exact_scores_data, params: { data: data_param }, as: :json
+          post :student_exact_scores_data, params: { data: data_param, classroom_id: classroom_unit.classroom_id }, as: :json
 
           expect(response).to have_http_status(:ok)
           json_response = JSON.parse(response.body)

--- a/services/QuillLMS/spec/workers/batch_save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/batch_save_activity_session_concept_results_worker_spec.rb
@@ -25,9 +25,11 @@ describe BatchSaveActivitySessionConceptResultsWorker, type: :worker do
   describe '#on_complete' do
     let(:activity_session_uid) { 'unique_id' }
     let(:options) { { 'activity_session_uid' => activity_session_uid } }
-    let(:activity_session) {create(:activity_session, uid: activity_session_uid)}
+
+    let(:classroom_unit) {create(:classroom_unit)}
+    let(:activity_session) {create(:activity_session, uid: activity_session_uid, classroom_unit: classroom_unit)}
     let(:user_id) { activity_session.user_id }
-    let(:cache_key) { User.student_scores_cache_key(user_id)}
+    let(:cache_key) { User.student_scores_cache_key(user_id, classroom_unit.classroom_id)}
 
     context 'when all jobs succeed' do
       let(:status) { double('status', failures: 0, total: 2) }

--- a/services/QuillLMS/spec/workers/batch_save_activity_session_concept_results_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/batch_save_activity_session_concept_results_worker_spec.rb
@@ -27,9 +27,7 @@ describe BatchSaveActivitySessionConceptResultsWorker, type: :worker do
     let(:options) { { 'activity_session_uid' => activity_session_uid } }
     let(:activity_session) {create(:activity_session, uid: activity_session_uid)}
     let(:user_id) { activity_session.user_id }
-    let(:activity_id) { activity_session.activity_id }
-    let(:classroom_unit_id) {activity_session.classroom_unit_id}
-    let(:cache_key) {"#{Student::EXACT_SCORES_CACHE_KEY}/#{user_id}/#{activity_id}/#{classroom_unit_id}"}
+    let(:cache_key) { User.student_scores_cache_key(user_id)}
 
     context 'when all jobs succeed' do
       let(:status) { double('status', failures: 0, total: 2) }


### PR DESCRIPTION
## WHAT
Edit: Also optimize queries to run one group query, instead of looping through many queries.
Adjust student score caching to be at the student level (not student/activity/classroom_unit level). 
## WHY
This controller action is still slow. We're spending a lot of time in Redis per controller action and making an average of 30 calls. This should reduce that time drastically and make subsequent calls faster. The downside is this cache will be flushed more often (when ever a new activity is finished, the whole cache for a student is flushed, vs. just a section of it), but I think it will be a net gain.
## HOW
Move the caching outside of the loop. Do one main query, put the results in a hash and look them up.
### Screenshots
<img width="1291" alt="Screenshot 2024-03-20 at 4 47 28 PM" src="https://github.com/empirical-org/Empirical-Core/assets/1304933/cc699d9a-2fc7-4175-a78e-aac9f380331a">


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I QA'd this feature on my staging and will ask Emilia to do a quick QA as well.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
