### PR TITLE
lms/remove-advanced-diagnostic-from-report

### DIFF
--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_aggregate_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_aggregate_query.rb
@@ -15,14 +15,9 @@ module AdminDiagnosticReports
     DIAGNOSTIC_ORDER_BY_ID = [
       1663, # Starter Baseline Diagnostic (Pre)
       1668, # Intermediate Baseline Diagnostic (Pre)
-      1678, # Advanced Baseline Diagnostic (Pre)
       1161, # ELL Starter Baseline Diagnostic (Pre)
       1568, # ELL Intermediate Baseline Diagnostic (Pre)
-      1590, # ELL Advanced Baseline Diagnostic (Pre)
-      992,  # AP Writing Skills Survey
-      1229, #  Pre-AP Writing Skills Survey 1
-      1230, # Pre-AP Writing Skills Survey 2
-      1432  # SpringBoard Writing Skills Survey
+      1590 # ELL Advanced Baseline Diagnostic (Pre)
     ]
 
     def initialize(aggregation:, **options)

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/student_count_by_filter_scope_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/student_count_by_filter_scope_query.rb
@@ -6,18 +6,7 @@ module AdminDiagnosticReports
 
     attr_reader :timeframe_start, :timeframe_end, :school_ids, :grades, :teacher_ids, :classroom_ids, :user, :additional_aggregation, :diagnostic_id
 
-    DIAGNOSTIC_ORDER_BY_ID = [
-      1663, # Starter Baseline Diagnostic (Pre)
-      1668, # Intermediate Baseline Diagnostic (Pre)
-      1678, # Advanced Baseline Diagnostic (Pre)
-      1161, # ELL Starter Baseline Diagnostic (Pre)
-      1568, # ELL Intermediate Baseline Diagnostic (Pre)
-      1590, # ELL Advanced Baseline Diagnostic (Pre)
-      992,  # AP Writing Skills Survey
-      1229, #  Pre-AP Writing Skills Survey 1
-      1230, # Pre-AP Writing Skills Survey 2
-      1432  # SpringBoard Writing Skills Survey
-    ]
+    DIAGNOSTIC_ORDER_BY_ID = DiagnosticAggregateQuery::DIAGNOSTIC_ORDER_BY_ID
 
     def initialize(timeframe_start:, timeframe_end:, diagnostic_id:, school_ids:, grades: nil, teacher_ids: nil, classroom_ids: nil, user: nil, **options) # rubocop:disable Metrics/ParameterLists
       raise InvalidDiagnosticIdError, "#{diagnostic_id} is not a valid diagnostic_id value." unless DIAGNOSTIC_ORDER_BY_ID.include?(diagnostic_id.to_i)

--- a/services/QuillLMS/client/app/bundles/PremiumHub/shared.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/shared.tsx
@@ -27,13 +27,9 @@ export const groupByDropdownOptions = [{ label: 'Grade', value: 'grade' }, { lab
 export const diagnosticTypeDropdownOptions = [
   { label: 'Starter Diagnostic', value: 1663 },
   { label: 'Intermediate Diagnostic', value: 1668 },
-  { label: 'Advanced Diagnostic', value: 1678 },
   { label: 'ELL Starter Diagnostic', value: 1161 },
   { label: 'ELL Intermediate Diagnostic', value: 1568 },
-  { label: 'ELL Advanced Diagnostic', value: 1590 },
-  { label: 'AP Writing Skills Survey', value: 992 },
-  { label: 'Pre-AP Writing Skills Survey', value: 1229 },
-  { label: 'SpringBoard Writing Skills Survey', value: 1432 }
+  { label: 'ELL Advanced Diagnostic', value: 1590 }
 ]
 
 export const premiumLockImage = <img alt="Gray lock" src={`${process.env.CDN_URL}/images/pages/administrator/premium_lock.svg`} />


### PR DESCRIPTION
## WHAT
Remove Advanced and CB-related diagnostics from the report
## WHY
This is a hopefully-temporary change while we work out a solution to accurately calculating scores for Diagnostic questions that have multiple Concepts assigned to them.  (This is also a problem with teacher diagnostic reports.)
## HOW
- Remove the IDs for the removed Diagnostics from the list of activities used by these reports
- Do a small refactor to avoid duplicating definitions of the list of activities
- Remove extra now-excluded options from the drop-down options defintion

### Screenshots
Old drop-down
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/50b31af6-bbe4-43a2-ac69-745e3a47fcf7)
New drop-down
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/a88bfb8f-e34b-4201-9a54-4b254d26c440)

### Notion Card Links
https://www.notion.so/quill/ADGR-QA-February-22-bb480e0255e542909ecee020b9a97742?pvs=4#9bed3921cb94450c9e9b6d251c1e5b34

### What have you done to QA this feature?
Deployed to staging and compared the following to production with the same admin in both environments:
- Check the Overview page to confirm that the new branch excludes the specified diagnostics from the report groupings shown on the production code
- Check thee drop down (and select each one) on staging, confirming that it only includes the new list of 5 diagnostics for both Skills and Students reports

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage for this configuration value
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes