### PR TITLE
lms/replace-coming-soon-with-link

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/overview/__tests__/__snapshots__/premiumReportsSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/overview/__tests__/__snapshots__/premiumReportsSection.test.tsx.snap
@@ -70,13 +70,12 @@ exports[`PremiumReportsSection it should render 1`] = `
           <div
             class="link-and-image"
           >
-            <button
-              class="quill-button focus-on-light outlined secondary medium disabled"
-              disabled=""
-              type="button"
+            <a
+              class="quill-button focus-on-light outlined secondary medium"
+              href="/teachers/premium_hub/diagnostic_growth_report"
             >
-              Coming soon
-            </button>
+              View report
+            </a>
             <img
               alt=""
               src="undefined/images/pages/administrator/overview/diagnostic-growth-report.svg"

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/overview/premiumReportsSection.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/overview/premiumReportsSection.tsx
@@ -50,7 +50,7 @@ export const premiumReportTiles = [
 const PremiumReportsSection = () => {
   const tiles = premiumReportTiles.map(tile => {
     const buttonClassName = "quill-button focus-on-light outlined secondary medium"
-    const button = tile.name === DIAGNOSTIC_GROWTH_REPORT ? <button className={`${buttonClassName} disabled`} disabled={true} type="button">Coming soon</button> : <Link className={buttonClassName} to={tile.link}>View report</Link>
+    const button = <Link className={buttonClassName} to={tile.link}>View report</Link>
     return (
       <div className={`tile ${tile.new ? 'new' : ''}`} key={tile.name}>
         <div>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/Overview.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/Overview.test.jsx.snap
@@ -360,13 +360,12 @@ exports[`Overview container should render with a full access type 1`] = `
               <div
                 class="link-and-image"
               >
-                <button
-                  class="quill-button focus-on-light outlined secondary medium disabled"
-                  disabled=""
-                  type="button"
+                <a
+                  class="quill-button focus-on-light outlined secondary medium"
+                  href="/teachers/premium_hub/diagnostic_growth_report"
                 >
-                  Coming soon
-                </button>
+                  View report
+                </a>
                 <img
                   alt=""
                   src="undefined/images/pages/administrator/overview/diagnostic-growth-report.svg"
@@ -978,13 +977,12 @@ exports[`Overview container should render with a limited access type 1`] = `
               <div
                 class="link-and-image"
               >
-                <button
-                  class="quill-button focus-on-light outlined secondary medium disabled"
-                  disabled=""
-                  type="button"
+                <a
+                  class="quill-button focus-on-light outlined secondary medium"
+                  href="/teachers/premium_hub/diagnostic_growth_report"
                 >
-                  Coming soon
-                </button>
+                  View report
+                </a>
                 <img
                   alt=""
                   src="undefined/images/pages/administrator/overview/diagnostic-growth-report.svg"
@@ -1567,13 +1565,12 @@ exports[`Overview container should render with a restricted access type 1`] = `
               <div
                 class="link-and-image"
               >
-                <button
-                  class="quill-button focus-on-light outlined secondary medium disabled"
-                  disabled=""
-                  type="button"
+                <a
+                  class="quill-button focus-on-light outlined secondary medium"
+                  href="/teachers/premium_hub/diagnostic_growth_report"
                 >
-                  Coming soon
-                </button>
+                  View report
+                </a>
                 <img
                   alt=""
                   src="undefined/images/pages/administrator/overview/diagnostic-growth-report.svg"


### PR DESCRIPTION
## WHAT
Replace "Coming soon" with a link to the Diagnostic Report n the admin premium landing page
## WHY
This report will be live, and we want admins to be able to take advantage of that.  (Also, it will no longer by "coming soon", so we want this to be accurate.)
## HOW
Remove the conditional logic that replaced the link button with a "Coming soon" placeholder so that the Diagnostic report behaves like all the others

### Screenshots
Old
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/b5d2037a-8469-4c04-a451-89b9ba09e905)
New
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/d50c9de2-305b-4bcc-8d26-889980568e47)

### Notion Card Links
https://www.notion.so/quill/ADGR-QA-February-22-bb480e0255e542909ecee020b9a97742?pvs=4#c7162d51f87a446d982c3919f6d24784

### What have you done to QA this feature?
- visually confirm that the button now says "View report"
- click through and confirm that it leads to the admin diagnostic overview

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes