### PR TITLE
fix table scroll behavior on student results page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResultsTable.tsx
@@ -184,7 +184,9 @@ const StudentResultsTable = ({ isPreTest, skillGroupSummaries, studentResults, o
     onScroll()
   }, [size])
 
-  const handleScroll = React.useCallback(({ top, bottom, left, right, }) => {
+  const handleScroll = React.useCallback(() => {
+    const { top, bottom, left, } = tableRef.current.getBoundingClientRect()
+
     if (top <= 0 && bottom > 92) {
       setStickyTableStyle(oldStickyTableStyle => ({ ...oldStickyTableStyle, left: left + paddingLeft() }))
       !isSticky && setIsSticky(true);
@@ -196,7 +198,7 @@ const StudentResultsTable = ({ isPreTest, skillGroupSummaries, studentResults, o
 
   const onScroll = () => {
     if (tableRef && tableRef.current) {
-      handleScroll(tableRef.current.getBoundingClientRect());
+      handleScroll();
     }
   }
 


### PR DESCRIPTION
## WHAT
Updated scroll logic slightly so the sticky header doesn't disappear when scrolling the table horizontally.

## WHY
We want this to persist so teachers can see what column is what.

## HOW
We were passing in an argument when the page itself was scrolled that didn't get passed when the table was scrolled. By calling the `tableRef` in this function instead of passing it in, we can always access the parameters. 

### Screenshots
https://share.zight.com/WnuXnx41

### Notion Card Links
https://www.notion.so/quill/Is-is-possible-to-have-the-writing-skills-appear-when-scrolling-in-any-direction-on-the-Student-resu-af05e24c9df84b8988b0ebe9269682e9

### What have you done to QA this feature?
Just updated the code and messed around with scrolling at various screen widths to confirm that it works.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
