### PR TITLE
lms/pre-diagnostic-chip-click-to-student

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/diagnosticGrowthReportsHelpers.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/diagnosticGrowthReportsHelpers.test.tsx
@@ -12,7 +12,8 @@ const mockArgs = {
   handleSetNoDiagnosticDataAvailable: jest.fn(),
   hasAdjustedFiltersFromDefault: false,
   setLoading: jest.fn(),
-  handleGrowthChipClick: jest.fn()
+  handleGrowthChipClick: jest.fn(),
+  handlePreDiagnosticChipClick: jest.fn()
 }
 
 const mockPreDiagnosticAssignedData = [{
@@ -173,7 +174,7 @@ const mockCombinedData = [{
       name: "Grade 5",
       overallSkillGrowth: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>+12%</button>,
       postDiagnosticCompleted: "51 of 52 Students",
-      preDiagnosticCompleted: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>125 of 163 Students</button>,
+      preDiagnosticCompleted: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handlePreDiagnosticChipClick} value={1663}>125 of 163 Students</button>,
       studentsCompletedPractice: "113 Students"
     },
     {
@@ -182,7 +183,7 @@ const mockCombinedData = [{
       name: "Grade 7",
       overallSkillGrowth: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>+10%</button>,
       postDiagnosticCompleted: "4 of 5 Students",
-      preDiagnosticCompleted: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>53 of 52 Students</button>,
+      preDiagnosticCompleted: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handlePreDiagnosticChipClick} value={1663}>53 of 52 Students</button>,
       studentsCompletedPractice: "46 Students"
     }
   ],
@@ -193,7 +194,7 @@ const mockCombinedData = [{
   name: "Starter Baseline Diagnostic (Pre)",
   overallSkillGrowth: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>+12%</button>,
   overallSkillGrowthSortValue: 0.11802217741935483,
-  preDiagnosticCompleted: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>178 of 215 Students</button>,
+  preDiagnosticCompleted: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handlePreDiagnosticChipClick} value={1663}>178 of 215 Students</button>,
   postDiagnosticCompleted: "55 of 215 Students",
   postStudentsCompleted: 55,
   preStudentsCompleted: 178,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/helpers.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/helpers.tsx
@@ -67,9 +67,9 @@ function processAggregateRows(aggregateRowsData, diagnosticId, rowData) {
   });
 }
 
-function preDiagnosticCompletedValue({ diagnosticId, preStudentsAssigned, preStudentsCompleted, handleGrowthChipClick }) {
+function preDiagnosticCompletedValue({ diagnosticId, preStudentsAssigned, preStudentsCompleted, handlePreDiagnosticChipClick }) {
   if(!preStudentsAssigned) { return noDataToShow }
-  return <button className="interactive-wrapper emphasized-content" onClick={handleGrowthChipClick} value={diagnosticId}>{`${preStudentsCompleted || 0} of ${preStudentsAssigned} Students`}</button>
+  return <button className="interactive-wrapper emphasized-content" onClick={handlePreDiagnosticChipClick} value={diagnosticId}>{`${preStudentsCompleted || 0} of ${preStudentsAssigned} Students`}</button>
 }
 
 function studentsCompletedPracticeValue(studentsCompletedPractice) {
@@ -93,7 +93,7 @@ function overallSkillGrowthValue({diagnosticId, overallSkillGrowth, handleGrowth
   return 'No Growth';
 }
 
-function createAggregateRowData({ aggregateRowsDataForDiagnostic, diagnosticId, handleGrowthChipClick }) {
+function createAggregateRowData({ aggregateRowsDataForDiagnostic, diagnosticId, handleGrowthChipClick, handlePreDiagnosticChipClick }) {
   return Object.keys(aggregateRowsDataForDiagnostic).map(key => {
     const data = aggregateRowsDataForDiagnostic[key];
     // we can early return if there are no students assigned to pre diagnostic
@@ -103,7 +103,7 @@ function createAggregateRowData({ aggregateRowsDataForDiagnostic, diagnosticId, 
     return {
       id: key,
       name: data.name,
-      preDiagnosticCompleted: preDiagnosticCompletedValue({ diagnosticId, preStudentsAssigned: data.pre_students_assigned, preStudentsCompleted: data.pre_students_completed, handleGrowthChipClick }),
+      preDiagnosticCompleted: preDiagnosticCompletedValue({ diagnosticId, preStudentsAssigned: data.pre_students_assigned, preStudentsCompleted: data.pre_students_completed, handlePreDiagnosticChipClick }),
       studentsCompletedPractice: studentsCompletedPracticeValue(data.students_completed_practice),
       averageActivitiesAndTimeSpent: averageActivitiesAndTimeSpentValue(data.average_practice_activities_count, data.average_time_spent_seconds),
       postDiagnosticCompleted: postDiagnosticCompleted(data.post_students_assigned, data.post_students_completed),
@@ -113,7 +113,7 @@ function createAggregateRowData({ aggregateRowsDataForDiagnostic, diagnosticId, 
 }
 
 export function aggregateOverviewData(args) {
-  const { preDiagnosticAssignedData, postDiagnosticAssignedData, preDiagnosticCompletedData, postDiagnosticCompletedData, recommendationsData, setAggregatedData, handleSetNoDiagnosticDataAvailable, hasAdjustedFiltersFromDefault, setLoading, handleGrowthChipClick } = args;
+  const { preDiagnosticAssignedData, postDiagnosticAssignedData, preDiagnosticCompletedData, postDiagnosticCompletedData, recommendationsData, setAggregatedData, handleSetNoDiagnosticDataAvailable, hasAdjustedFiltersFromDefault, setLoading, handleGrowthChipClick, handlePreDiagnosticChipClick } = args;
 
   // if there are no results for the pre diagnostic API and filters are at default, no diagnostics have been assigned
   if (!preDiagnosticAssignedData.length && !hasAdjustedFiltersFromDefault) {
@@ -197,7 +197,7 @@ export function aggregateOverviewData(args) {
     const averageActivitiesCount = recommendationsDataHash[id]?.average_practice_activities_count
     const averageTimespent = recommendationsDataHash[id]?.average_time_spent_seconds
     const aggregateRowsDataForDiagnostic = aggregateRowsData[id]
-    entry.preDiagnosticCompleted = preDiagnosticCompletedValue({ diagnosticId: id, preStudentsAssigned, preStudentsCompleted, handleGrowthChipClick })
+    entry.preDiagnosticCompleted = preDiagnosticCompletedValue({ diagnosticId: id, preStudentsAssigned, preStudentsCompleted, handlePreDiagnosticChipClick })
     entry.preStudentsCompleted = getSingleSortValue(preStudentsCompleted)
     entry.studentsCompletedPractice = studentsCompletedPracticeValue(studentsCompletedPractice)
     entry.completedPracticeCount = getSingleSortValue(studentsCompletedPractice)
@@ -207,7 +207,7 @@ export function aggregateOverviewData(args) {
     entry.postStudentsCompleted = getSingleSortValue(postStudentsCompleted)
     entry.overallSkillGrowthSortValue = getSingleSortValue(overallSkillGrowth)
     entry.overallSkillGrowth = overallSkillGrowthValue({diagnosticId: id, overallSkillGrowth, handleGrowthChipClick })
-    entry.aggregate_rows = createAggregateRowData({ aggregateRowsDataForDiagnostic, diagnosticId: id, handleGrowthChipClick})
+    entry.aggregate_rows = createAggregateRowData({ aggregateRowsDataForDiagnostic, diagnosticId: id, handleGrowthChipClick, handlePreDiagnosticChipClick })
   })
   setAggregatedData(combinedData);
   setLoading(false);

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/overviewSection.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/overviewSection.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Spinner, DataTable, noResultsMessage, DropdownInput } from '../../../Shared/index'
 import { DropdownObjectInterface } from '../../../Staff/interfaces/evidenceInterfaces'
-import { SKILL, groupByDropdownOptions, hashPayload } from '../../shared'
+import { SKILL, STUDENT, groupByDropdownOptions, hashPayload } from '../../shared'
 import { requestPost, } from '../../../../modules/request';
 import { aggregateOverviewData, averageActivitiesAndTimeSpentTooltipText, completedActivitiesTooltipText, diagnosticNameTooltipText, overallSkillGrowthTooltipText, postDiagnosticCompletedTooltipText, preDiagnosticCompletedTooltipText } from './helpers';
 
@@ -166,7 +166,8 @@ export const OverviewSection = ({
         hasAdjustedFiltersFromDefault,
         handleSetNoDiagnosticDataAvailable,
         setLoading,
-        handleGrowthChipClick
+        handleGrowthChipClick,
+        handlePreDiagnosticChipClick
       })
     }
   }, [preDiagnosticAssignedData, postDiagnosticAssignedData, preDiagnosticCompletedData, postDiagnosticCompletedData, recommendationsData])
@@ -269,6 +270,11 @@ export const OverviewSection = ({
 
   function handleFilterOptionChange(option) {
     setGroupByValue(option)
+  }
+
+  function handlePreDiagnosticChipClick(id: number) {
+    handleSetSelectedDiagnosticId(id)
+    handleTabChangeFromDataChip(STUDENT)
   }
 
   function handleGrowthChipClick(id: number) {


### PR DESCRIPTION
## WHAT
Update chip click for Pre Diagnostic column to go to student page
## WHY
That's what the spec calls for, but the current code redirects to the Skill page (duplicating the Growth chip click action)
## HOW
- write a new handler for redirecting to the Student page
- pass the new handler through to the code that builds data rows, and use it on the Pre Diagnostic chip

### Notion Card Links
https://www.notion.so/quill/ADGR-QA-February-22-bb480e0255e542909ecee020b9a97742?pvs=4#44183e17fd9d416d9ac8c7ed6e683b78

### What have you done to QA this feature?
Deploy code to staging, click on the Pre Diagnostic chip and confirm that it redirects to the Student page.  Then go back and click on a Pre Diagnostic chip for a non-Starter diagnostic to confirm that the diagnostic drop-down on  the Student page is automatically selected when the chip is clicked.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
