### PR TITLE
updates to research diagnostic query

### DIFF
--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.js
@@ -76,26 +76,26 @@ export function studentwiseSkillGroupUDF(elements) {
   //source: https://docs.google.com/spreadsheets/d/1JFey0UpMkmPzkQtZKsr_FdXRXnNEDFXZe52H7dUMg9E/edit#gid=0
   const skillGroupsByActivity = {
     1161: [
-      { name: 'Sentences with To Be' },
-      { name: 'Sentences With Have' },
-      { name: 'Sentences With Want' },
-      { name: 'Listing Adjectives and Nouns' },
-      { name: 'Writing Questions' }
+      { name: 'Sentences with To Be', activities: [1096, 1097, 1098, 1099, 1100, 1101, 1137, 1102, 1103, 1104, 1105, 1144, 1106, 1107, 1108] },
+      { name: 'Sentences With Have', activities: []  },
+      { name: 'Sentences With Want', activities: []  },
+      { name: 'Listing Adjectives and Nouns', activities: [1134, 1135, 1156, 1157, 1158, 1159, 1160]  },
+      { name: 'Writing Questions', activities: []  }
     ],
     1568: [
-      { name: 'Subject-Verb Agreement' },
-      { name: 'Possessive Nouns and Pronouns' },
-      { name: 'Prepositions' },
-      { name: 'Future Tense' },
-      { name: 'Articles' },
-      { name: 'Writing Questions' }
+      { name: 'Subject-Verb Agreement', activities: [1541, 1543, 1546]  },
+      { name: 'Possessive Nouns and Pronouns', activities: [1544, 1545, 1550, 1547]  },
+      { name: 'Prepositions', activities: [1551, 1552, 1553, 1554, 1555, 1557, 1558, 1548]  },
+      { name: 'Future Tense', activities: [1559, 1560, 1561, 1563]  },
+      { name: 'Articles', activities: [1567, 1569, 1562, 1564]  },
+      { name: 'Writing Questions', activities: [1571, 1570, 1573, 1549]  }
     ],
     1590: [
-      { name: 'Regular Past Tense' },
-      { name: 'Irregular Past Tense' },
-      { name: 'Progressive Tense' },
-      { name: 'Phrasal Verbs' },
-      { name: 'ELL-Specific Skills' }
+      { name: 'Regular Past Tense', activities: []  },
+      { name: 'Irregular Past Tense', activities: []  },
+      { name: 'Progressive Tense', activities: []  },
+      { name: 'Phrasal Verbs', activities: []  },
+      { name: 'ELL-Specific Skills', activities: []  }
     ],
     1663: [
       { name: 'Commonly Confused Words', activities: [113, 111, 107, 112] },
@@ -107,22 +107,22 @@ export function studentwiseSkillGroupUDF(elements) {
       { name: 'Subject-Verb Agreement', activities: [1054, 742, 2506] }
     ],
     1668: [
-      { name: 'Compound Subjects, Objects, and Predicates' },
-      { name: 'Compound Sentences' },
-      { name: 'Complex Sentences' },
-      { name: 'Conjunctive Adverbs' },
-      { name: 'Parallel Structure' },
-      { name: 'Capitalization' },
-      { name: 'Subject-Verb Agreement' },
-      { name: 'Nouns, Pronouns, and Verbs' }
+      { name: 'Compound Subjects, Objects, and Predicates', activities: [435, 436, 434, 837, 1005]  },
+      { name: 'Compound Sentences', activities: [424, 426, 428, 429, 430, 776]  },
+      { name: 'Complex Sentences', activities: [417, 418, 1221, 2502, 2498, 2500, 2496, 2497, 2501, 2499]  },
+      { name: 'Conjunctive Adverbs', activities: [755, 759, 851, 863, 757, 985, 986, 861, 993]  },
+      { name: 'Parallel Structure', activities: [752, 754]  },
+      { name: 'Capitalization', activities: [841, 2495, 887, 886, 840]  },
+      { name: 'Subject-Verb Agreement', activities: [770, 769, 774, 772, 896]  },
+      { name: 'Nouns, Pronouns, and Verbs', activities: [1486, 1452, 1487, 1488, 848, 1308, 737, 1425, 1345, 2245]  }
     ],
     1678: [
-      { name: 'Compound-Complex Sentences' },
-      { name: 'Appositive Phrases' },
-      { name: 'Relative Clauses' },
-      { name: 'Participial Phrases' },
-      { name: 'Parallel Structure' },
-      { name: 'Advanced Combining' }
+      { name: 'Compound-Complex Sentences', activities: [653, 862, 868, 869]  },
+      { name: 'Advanced Combining', activities: [1414, 1283, 1281, 1223, 1441] },
+      { name: 'Appositive Phrases', activities: [1211, 1220, 1213, 1212, 1214]  },
+      { name: 'Relative Clauses', activities: [594, 595, 596, 1049, 598, 1002]  },
+      { name: 'Participial Phrases', activities: [443, 450, 1237, 876, 878]  },
+      { name: 'Parallel Structure', activities: [752, 754, 1235]  }
     ]
   }
 
@@ -190,30 +190,7 @@ export function studentwiseSkillGroupUDF(elements) {
   function getSkillTier (interDiagnosticActivities, skillRecommendedActivities) {
     const intersection = interDiagnosticActivities.map(x => x.activityId).filter(x => skillRecommendedActivities.includes(x))
     const percentageToInteger = [... new Set(intersection)].length / skillRecommendedActivities.length * 100
-
-    if (percentageToInteger === 0 ) { return "0%" }
-    if (percentageToInteger === 100 ) { return "100%" }
-
-    const tiers = {
-      "1-10%":    { from: 0, to: 11},
-      "11-20%":   { from: 11, to: 21},
-      "21-30%":   { from: 21, to: 31},
-      "31-40%":   { from: 31, to: 41},
-      "41-50%":   { from: 41, to: 51},
-      "51-60%":   { from: 51, to: 61},
-      "61-70%":   { from: 61, to: 71},
-      "71-80%":   { from: 71, to: 81},
-      "81-90%":   { from: 81, to: 91},
-      "91-99%":   { from: 91, to: 100}
-    }
-
-    for (const [tierName, value] of Object.entries(tiers)) {
-      if (percentageToInteger >= value.from && percentageToInteger < value.to) {
-        return tierName
-      }
-    }
-
-    return `${percentageToInteger}`
+    return `${[... new Set(intersection)].length}/${skillRecommendedActivities.length}`
   }
 
   const skillScores = skillGroupsByActivity[PRE_DIAGNOSTIC_ACTIVITY_ID].reduce(
@@ -240,44 +217,3 @@ export function studentwiseSkillGroupUDF(elements) {
     }
   )
 }
-
-// params: numAssignedRecommendedCompleted STRING, recommendedActivityCount STRING
-export function tierUDF(numAssignedRecommendedCompleted, recommendedActivityCount) {
-  const completedCount = parseInt(numAssignedRecommendedCompleted)
-  const activityCount = parseInt(recommendedActivityCount)
-
-  if (isNaN(completedCount) ||
-      isNaN(activityCount) ||
-      activityCount < 1 ||
-      completedCount < 0
-  ) {
-    return "-1"
-  }
-  const percentage = completedCount / activityCount * 100
-
-  if (percentage === 0 ) { return "0%" }
-  if (percentage === 100 ) { return "100%" }
-
-  const tiers = {
-    "1-10%":    { from: 0, to: 11},
-    "11-20%":   { from: 11, to: 21},
-    "21-30%":   { from: 21, to: 31},
-    "31-40%":   { from: 31, to: 41},
-    "41-50%":   { from: 41, to: 51},
-    "51-60%":   { from: 51, to: 61},
-    "61-70%":   { from: 61, to: 71},
-    "71-80%":   { from: 71, to: 81},
-    "81-90%":   { from: 81, to: 91},
-    "91-99%":   { from: 91, to: 100}
-  }
-
-  for (const [tierName, value] of Object.entries(tiers)) {
-    if (percentage >= value.from && percentage < value.to) {
-      return tierName
-    }
-  }
-
-  return `${percentage}`
-}
-
-

--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.js
@@ -9,40 +9,60 @@ export function findLastIndex(array, startIndex, fn) {
   return array.length - 1 - reversedIdx
 }
 
-// BigQuery does not currently accept DATETIMEs as arguments for JS UDFs
-// So we cast DATETIMES to STRINGS before calling this function
-export function studentwiseSkillGroupUDF(scores, activityIds, completedAts, skillGroupNames) {
-  function boolToInt(bool) { return bool ? 1 : 0}
-
+// example argument: true|1668|2023-10-31 13:37:19.789202|Subject-Verb Agreement
+export function parseElement(e) {
   function removeCommas(str) {
     const regExp = /,/g
     return str.replace(regExp, '')
   }
 
-  function zipAndSort(scores, activityIds, completedAts, skillGroupNames) {
-    const zipped = completedAts.map(
-      (elem, i) => ({
-        completedAt: elem,
-        score: boolToInt(scores[i]),
-        activityId: parseInt(activityIds[i]),
-        skillGroupName: removeCommas(skillGroupNames[i])
-
-      })
-    )
-    return zipped.sort((a,b) => (new Date(a.completedAt) - new Date(b.completedAt)))
+  const stringAttributes = e.split('|')
+  if (stringAttributes.length !== 4) {
+    throw new Error(`Invalid element string: ${e}`)
   }
+
+  return {
+    score: stringAttributes[0] === "true" ? 1 : 0,
+    activityId: parseInt(stringAttributes[1]),
+    completedAt: stringAttributes[2],
+    skillGroupName: removeCommas(stringAttributes[3])
+  }
+}
+
+// BigQuery does not currently accept DATETIMEs as arguments for JS UDFs
+// So we cast DATETIMES to STRINGS before calling this function
+export function studentwiseSkillGroupUDF(elements) {
+  function removeCommas(str) {
+    const regExp = /,/g
+    return str.replace(regExp, '')
+  }
+
+  function parseElement(e) {
+    function removeCommas(str) {
+      const regExp = /,/g
+      return str.replace(regExp, '')
+    }
+
+    const stringAttributes = e.split('|')
+    if (stringAttributes.length !== 4) {
+      throw new Error(`Invalid element string: ${e}`)
+    }
+
+    return {
+      score: stringAttributes[0] === "true" ? 1 : 0,
+      activityId: parseInt(stringAttributes[1]),
+      completedAt: stringAttributes[2],
+      skillGroupName: removeCommas(stringAttributes[3])
+    }
+  }
+
+
 
   function findLastIndex(array, startIndex, fn) {
     const reversedArray = [...array.slice(startIndex)].reverse()
     const reversedIdx = reversedArray.findIndex(fn)
     if (reversedIdx === -1) return -1
     return array.length - 1 - reversedIdx
-  }
-
-  function allArraysEqualLength(...arrayLengths) {
-    const firstArrayLength = arrayLengths.pop()
-
-    return arrayLengths.every(x => x === firstArrayLength)
   }
 
   function getSkillScore(zipped, errorMessageArray, skillGroupName, preOrPost) {
@@ -113,15 +133,6 @@ export function studentwiseSkillGroupUDF(scores, activityIds, completedAts, skil
     errorMessage: "Default error message"
   }
 
-  if (!allArraysEqualLength(scores.length, activityIds.length, completedAts.length, skillGroupNames.length)) {
-    return JSON.stringify({
-      ...defaultReturnValue,
-      ...{ errorMessage: `Unequal input lengths: ${scores.length} ${activityIds.length} ${completedAts.length} ${skillGroupNames.length}` }
-    })
-  }
-
-  const zipped = zipAndSort(scores, activityIds, completedAts, skillGroupNames)
-
   const prePostDiagnosticActivityIdPairs = {
     1161: 1774, // ELL Starter
     1568: 1814, // ELL Intermediate
@@ -139,6 +150,8 @@ export function studentwiseSkillGroupUDF(scores, activityIds, completedAts, skil
     1668: [309, 287, 310, 288, 311, 289, 290, 291, 292, 293, 294], // Intermediate
     1678: [312, 275, 276, 313, 314, 277, 278, 279, 362]   // Advanced
   }
+
+  const zipped = elements.map(parseElement).sort((a,b) => (new Date(a.completedAt) - new Date(b.completedAt)))
 
   const canonicalPreTestIdx = zipped.findIndex(
     elem => Object.keys(prePostDiagnosticActivityIdPairs).map(x => parseInt(x)).includes(elem.activityId)

--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.js
@@ -56,8 +56,6 @@ export function studentwiseSkillGroupUDF(elements) {
     }
   }
 
-
-
   function findLastIndex(array, startIndex, fn) {
     const reversedArray = [...array.slice(startIndex)].reverse()
     const reversedIdx = reversedArray.findIndex(fn)
@@ -143,12 +141,12 @@ export function studentwiseSkillGroupUDF(elements) {
   }
 
   const recommendedActivities = {
-    1161: [147, 148, 149, 150, 151],  // ELL Starter
-    1568: [250, 251, 252, 253, 254, 255],  // ELL Intermediate
-    1590: [258, 259, 260, 261, 262],  // ELL Advanced
-    1663: [306, 263, 307, 264, 308, 265, 266, 267, 268, 363], // Starter
-    1668: [309, 287, 310, 288, 311, 289, 290, 291, 292, 293, 294], // Intermediate
-    1678: [312, 275, 276, 313, 314, 277, 278, 279, 362]   // Advanced
+    1161: [1096, 1097, 1098, 1099, 1100, 1101, 1137, 1102, 1103, 1104, 1105, 1144, 1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113, 1153, 1114, 1152, 1136, 1145, 1154, 1151, 1138, 1115, 1117, 1116, 1118, 1119, 1120, 1121, 1122, 1123, 1124, 1125, 1126, 1127, 1128, 1129, 1130, 1131, 1132, 1133, 1134, 1135, 1156, 1157, 1158, 1159, 1160, 1139, 1155, 1142, 1140, 1141, 1143, 1148, 1146, 1149, 1147, 1150],  // ELL Starter
+    1568: [1541, 1543, 1546, 1544, 1545, 1550, 1547, 1551, 1552, 1553, 1554, 1555, 1557, 1558, 1548, 1559, 1560, 1561, 1563, 1567, 1569, 1562, 1564, 1571, 1570, 1573, 1549],  // ELL Intermediate
+    1590: [1575, 1576, 1577, 1578, 1579, 1580, 1581, 1582, 1583, 1584, 1585, 1586, 1587, 1591, 1588, 1625, 1589, 1626, 1627, 1628, 1629, 1654, 1657, 1655, 1658, 1660, 1662, 1661],  // ELL Advanced
+    1663: [802, 181, 804, 885, 801, 887, 886, 803, 283, 1440, 1308, 808, 431, 301, 438, 775, 844, 843, 124, 713, 1407, 717, 1418, 1409, 599, 712, 600, 846, 435, 436, 434, 437, 837, 433, 113, 111, 107, 112, 1054, 742, 2506], // Starter
+    1668: [435, 436, 434, 837, 1005, 424, 426, 428, 429, 430, 776, 417, 418, 1221, 2502, 2498, 2500, 2496, 2497, 2501, 2499, 755, 759, 851, 863, 757, 985, 986, 861, 993, 752, 754, 841, 2495, 887, 886, 840, 770, 769, 774, 772, 896, 1486, 1452, 1487, 1488, 848, 1308, 737, 1425, 1345, 2245], // Intermediate
+    1678: [653, 862, 868, 869, 1211, 1220, 1213, 1212, 1214, 594, 595, 596, 1049, 598, 1002, 443, 450, 1237, 876, 878, 752, 754, 1235, 1414, 1283, 1281, 1223, 1441]   // Advanced
   }
 
   const zipped = elements.map(parseElement).sort((a,b) => (new Date(a.completedAt) - new Date(b.completedAt)))
@@ -208,9 +206,11 @@ export function studentwiseSkillGroupUDF(elements) {
     {}
   )
   const interDiagnosticActivities = zipped.slice(canonicalPreTestIdx + 1, canonicalPostTestIdx)
-  const numAssignedRecommendedCompleted = interDiagnosticActivities.filter(
+  const nonUniques = interDiagnosticActivities.filter(
     elem => recommendedActivities[PRE_DIAGNOSTIC_ACTIVITY_ID].includes(elem.activityId)
-  ).length
+  )
+  // project the object array to a primitive array, so we can use Set to compute uniques-by-activity
+  const numAssignedRecommendedCompleted = [... new Set(nonUniques.map(x => x.activityId))].length
 
   return JSON.stringify(
     {
@@ -258,7 +258,7 @@ export function tierUDF(numAssignedRecommendedCompleted, recommendedActivityCoun
     }
   }
 
-  return "-1"
+  return `${percentage}`
 }
 
 

--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.js
@@ -76,11 +76,11 @@ export function studentwiseSkillGroupUDF(elements) {
   //source: https://docs.google.com/spreadsheets/d/1JFey0UpMkmPzkQtZKsr_FdXRXnNEDFXZe52H7dUMg9E/edit#gid=0
   const skillGroupsByActivity = {
     1161: [
-      { name: 'Sentences with To Be', activities: [1096, 1097, 1098, 1099, 1100, 1101, 1137, 1102, 1103, 1104, 1105, 1144, 1106, 1107, 1108] },
-      { name: 'Sentences With Have', activities: []  },
-      { name: 'Sentences With Want', activities: []  },
+      { name: 'Sentences with To Be', activities: [1096, 1097, 1098, 1099, 1100, 1101, 1137, 1102, 1103, 1104, 1105, 1144, 1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113, 1153, 1114, 1152, 1136, 1145, 1154, 1151, 1138] },
+      { name: 'Sentences With Have', activities: [1119, 1120, 1121, 1122, 1127, 1128, 1129, 1130, 1131]  },
+      { name: 'Sentences With Want', activities: [1115, 1117, 1116, 1118, 1123, 1124, 1125, 1126, 1132, 1133]  },
       { name: 'Listing Adjectives and Nouns', activities: [1134, 1135, 1156, 1157, 1158, 1159, 1160]  },
-      { name: 'Writing Questions', activities: []  }
+      { name: 'Writing Questions', activities: [1139, 1155, 1142, 1140, 1141, 1143, 1148, 1146, 1149, 1147, 1150]  }
     ],
     1568: [
       { name: 'Subject-Verb Agreement', activities: [1541, 1543, 1546]  },
@@ -91,11 +91,11 @@ export function studentwiseSkillGroupUDF(elements) {
       { name: 'Writing Questions', activities: [1571, 1570, 1573, 1549]  }
     ],
     1590: [
-      { name: 'Regular Past Tense', activities: []  },
-      { name: 'Irregular Past Tense', activities: []  },
-      { name: 'Progressive Tense', activities: []  },
-      { name: 'Phrasal Verbs', activities: []  },
-      { name: 'ELL-Specific Skills', activities: []  }
+      { name: 'Regular Past Tense', activities: [1575, 1576, 1577, 1578]  },
+      { name: 'Irregular Past Tense', activities: [1579, 1580, 1581, 1582, 1583, 1584, 1585, 1586, 1587]  },
+      { name: 'Progressive Tense', activities: [1591, 1588, 1625, 1589, 1626]  },
+      { name: 'Phrasal Verbs', activities: [1627, 1628, 1629, 1654, 1657, 1655]  },
+      { name: 'ELL-Specific Skills', activities: [1658, 1660, 1662, 1661]  }
     ],
     1663: [
       { name: 'Commonly Confused Words', activities: [113, 111, 107, 112] },

--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.js
@@ -76,52 +76,53 @@ export function studentwiseSkillGroupUDF(elements) {
   //source: https://docs.google.com/spreadsheets/d/1JFey0UpMkmPzkQtZKsr_FdXRXnNEDFXZe52H7dUMg9E/edit#gid=0
   const skillGroupsByActivity = {
     1161: [
-      { id: 167, name: 'Sentences with To Be' },
-      { id: 168, name: 'Sentences With Have' },
-      { id: 169, name: 'Sentences With Want' },
-      { id: 170, name: 'Listing Adjectives and Nouns' },
-      { id: 171, name: 'Writing Questions' }
+      { name: 'Sentences with To Be' },
+      { name: 'Sentences With Have' },
+      { name: 'Sentences With Want' },
+      { name: 'Listing Adjectives and Nouns' },
+      { name: 'Writing Questions' }
     ],
     1568: [
-      { id: 172, name: 'Subject-Verb Agreement' },
-      { id: 173, name: 'Possessive Nouns and Pronouns' },
-      { id: 174, name: 'Prepositions' },
-      { id: 175, name: 'Future Tense' },
-      { id: 176, name: 'Articles' },
-      { id: 177, name: 'Writing Questions' }
+      { name: 'Subject-Verb Agreement' },
+      { name: 'Possessive Nouns and Pronouns' },
+      { name: 'Prepositions' },
+      { name: 'Future Tense' },
+      { name: 'Articles' },
+      { name: 'Writing Questions' }
     ],
     1590: [
-      { id: 178, name: 'Regular Past Tense' },
-      { id: 179, name: 'Irregular Past Tense' },
-      { id: 180, name: 'Progressive Tense' },
-      { id: 181, name: 'Phrasal Verbs' },
-      { id: 182, name: 'ELL-Specific Skills' }
+      { name: 'Regular Past Tense' },
+      { name: 'Irregular Past Tense' },
+      { name: 'Progressive Tense' },
+      { name: 'Phrasal Verbs' },
+      { name: 'ELL-Specific Skills' }
     ],
     1663: [
-      { id: 123, name: 'Capitalization' },
-      { id: 124, name: 'Plural and Possessive Nouns' },
-      { id: 125, name: 'Adjectives and Adverbs' },
-      { id: 126, name: 'Prepositional Phrases' },
-      { id: 128, name: 'Compound Subjects, Objects, and Predicates' },
-      { id: 216, name: 'Subject-Verb Agreement' }
+      { name: 'Commonly Confused Words', activities: [113, 111, 107, 112] },
+      { name: 'Capitalization', activities: [802, 181, 804, 885, 801, 887, 886] },
+      { name: 'Plural and Possessive Nouns', activities: [803, 283, 1440, 1308, 808] },
+      { name: 'Adjectives and Adverbs', activities: [431, 301, 438, 775, 844, 843, 124, 713, 1407, 717, 1418, 1409] },
+      { name: 'Prepositional Phrases', activities: [599, 712, 600, 846] },
+      { name: 'Compound Subjects, Objects, and Predicates', activities: [435, 436, 434, 437, 837, 433] },
+      { name: 'Subject-Verb Agreement', activities: [1054, 742, 2506] }
     ],
     1668: [
-      { id: 129, name: 'Compound Subjects, Objects, and Predicates' },
-      { id: 130, name: 'Compound Sentences' },
-      { id: 131, name: 'Complex Sentences' },
-      { id: 132, name: 'Conjunctive Adverbs' },
-      { id: 133, name: 'Parallel Structure' },
-      { id: 134, name: 'Capitalization' },
-      { id: 135, name: 'Subject-Verb Agreement' },
-      { id: 136, name: 'Nouns, Pronouns, and Verbs' }
+      { name: 'Compound Subjects, Objects, and Predicates' },
+      { name: 'Compound Sentences' },
+      { name: 'Complex Sentences' },
+      { name: 'Conjunctive Adverbs' },
+      { name: 'Parallel Structure' },
+      { name: 'Capitalization' },
+      { name: 'Subject-Verb Agreement' },
+      { name: 'Nouns, Pronouns, and Verbs' }
     ],
     1678: [
-      { id: 137, name: 'Compound-Complex Sentences' },
-      { id: 138, name: 'Appositive Phrases' },
-      { id: 139, name: 'Relative Clauses' },
-      { id: 140, name: 'Participial Phrases' },
-      { id: 141, name: 'Parallel Structure' },
-      { id: 142, name: 'Advanced Combining' }
+      { name: 'Compound-Complex Sentences' },
+      { name: 'Appositive Phrases' },
+      { name: 'Relative Clauses' },
+      { name: 'Participial Phrases' },
+      { name: 'Parallel Structure' },
+      { name: 'Advanced Combining' }
     ]
   }
 
@@ -138,15 +139,6 @@ export function studentwiseSkillGroupUDF(elements) {
     1663: 1664, // Starter
     1668: 1669, // Intermediate
     1678: 1680  // Advanced
-  }
-
-  const recommendedActivities = {
-    1161: [1096, 1097, 1098, 1099, 1100, 1101, 1137, 1102, 1103, 1104, 1105, 1144, 1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113, 1153, 1114, 1152, 1136, 1145, 1154, 1151, 1138, 1115, 1117, 1116, 1118, 1119, 1120, 1121, 1122, 1123, 1124, 1125, 1126, 1127, 1128, 1129, 1130, 1131, 1132, 1133, 1134, 1135, 1156, 1157, 1158, 1159, 1160, 1139, 1155, 1142, 1140, 1141, 1143, 1148, 1146, 1149, 1147, 1150],  // ELL Starter
-    1568: [1541, 1543, 1546, 1544, 1545, 1550, 1547, 1551, 1552, 1553, 1554, 1555, 1557, 1558, 1548, 1559, 1560, 1561, 1563, 1567, 1569, 1562, 1564, 1571, 1570, 1573, 1549],  // ELL Intermediate
-    1590: [1575, 1576, 1577, 1578, 1579, 1580, 1581, 1582, 1583, 1584, 1585, 1586, 1587, 1591, 1588, 1625, 1589, 1626, 1627, 1628, 1629, 1654, 1657, 1655, 1658, 1660, 1662, 1661],  // ELL Advanced
-    1663: [802, 181, 804, 885, 801, 887, 886, 803, 283, 1440, 1308, 808, 431, 301, 438, 775, 844, 843, 124, 713, 1407, 717, 1418, 1409, 599, 712, 600, 846, 435, 436, 434, 437, 837, 433, 113, 111, 107, 112, 1054, 742, 2506], // Starter
-    1668: [435, 436, 434, 837, 1005, 424, 426, 428, 429, 430, 776, 417, 418, 1221, 2502, 2498, 2500, 2496, 2497, 2501, 2499, 755, 759, 851, 863, 757, 985, 986, 861, 993, 752, 754, 841, 2495, 887, 886, 840, 770, 769, 774, 772, 896, 1486, 1452, 1487, 1488, 848, 1308, 737, 1425, 1345, 2245], // Intermediate
-    1678: [653, 862, 868, 869, 1211, 1220, 1213, 1212, 1214, 594, 595, 596, 1049, 598, 1002, 443, 450, 1237, 876, 878, 752, 754, 1235, 1414, 1283, 1281, 1223, 1441]   // Advanced
   }
 
   const zipped = elements.map(parseElement).sort((a,b) => (new Date(a.completedAt) - new Date(b.completedAt)))
@@ -192,31 +184,57 @@ export function studentwiseSkillGroupUDF(elements) {
     })
   }
 
+  const interDiagnosticActivities = zipped.slice(canonicalPreTestIdx + 1, canonicalPostTestIdx)
+
+  // the percentage of a student's completed activities, for a certain skill, over the recommended activities
+  function getSkillTier (interDiagnosticActivities, skillRecommendedActivities) {
+    const intersection = interDiagnosticActivities.map(x => x.activityId).filter(x => skillRecommendedActivities.includes(x))
+    const percentageToInteger = [... new Set(intersection)].length / skillRecommendedActivities.length * 100
+
+    if (percentageToInteger === 0 ) { return "0%" }
+    if (percentageToInteger === 100 ) { return "100%" }
+
+    const tiers = {
+      "1-10%":    { from: 0, to: 11},
+      "11-20%":   { from: 11, to: 21},
+      "21-30%":   { from: 21, to: 31},
+      "31-40%":   { from: 31, to: 41},
+      "41-50%":   { from: 41, to: 51},
+      "51-60%":   { from: 51, to: 61},
+      "61-70%":   { from: 61, to: 71},
+      "71-80%":   { from: 71, to: 81},
+      "81-90%":   { from: 81, to: 91},
+      "91-99%":   { from: 91, to: 100}
+    }
+
+    for (const [tierName, value] of Object.entries(tiers)) {
+      if (percentageToInteger >= value.from && percentageToInteger < value.to) {
+        return tierName
+      }
+    }
+
+    return `${percentageToInteger}`
+  }
+
   const skillScores = skillGroupsByActivity[PRE_DIAGNOSTIC_ACTIVITY_ID].reduce(
     (accum, currentValue) => {
       const formattedName = removeCommas(currentValue.name)
       const preColumnName = `${formattedName}_pre`
       const postColumnName = `${formattedName}_post`
+      const skillTierColumnName = `${formattedName}_tier`
       return {
         [preColumnName]: getSkillScore(zipped, errorMessageArray, formattedName, 'pre'),
         [postColumnName]: getSkillScore(zipped, errorMessageArray, formattedName, 'post'),
+        [skillTierColumnName]: getSkillTier(interDiagnosticActivities, currentValue.activities),
         ...accum
       }
     },
     {}
   )
-  const interDiagnosticActivities = zipped.slice(canonicalPreTestIdx + 1, canonicalPostTestIdx)
-  const nonUniques = interDiagnosticActivities.filter(
-    elem => recommendedActivities[PRE_DIAGNOSTIC_ACTIVITY_ID].includes(elem.activityId)
-  )
-  // project the object array to a primitive array, so we can use Set to compute uniques-by-activity
-  const numAssignedRecommendedCompleted = [... new Set(nonUniques.map(x => x.activityId))].length
 
   return JSON.stringify(
     {
-      recommendedActivityCount: recommendedActivities[PRE_DIAGNOSTIC_ACTIVITY_ID].length,
       errorMessage: errorMessageArray.join(' '),
-      numAssignedRecommendedCompleted,
       diagnostic_pre_id: PRE_DIAGNOSTIC_ACTIVITY_ID,
       ...skillScores
     }

--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.js
@@ -217,6 +217,7 @@ export function studentwiseSkillGroupUDF(elements) {
       recommendedActivityCount: recommendedActivities[PRE_DIAGNOSTIC_ACTIVITY_ID].length,
       errorMessage: errorMessageArray.join(' '),
       numAssignedRecommendedCompleted,
+      diagnostic_pre_id: PRE_DIAGNOSTIC_ACTIVITY_ID,
       ...skillScores
     }
   )

--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
@@ -23,7 +23,9 @@ describe('studentwiseSkillGroupUDF', () => {
   })
 
   it('should extract correct spanned-activity counts', () => {
-    const activityIds = ["1663", "306", "4", "1664"];
+    const recommendedActivity = ""
+    const notRecommendedActivity = "1"
+    const activityIds = ["1663", recommendedActivity, notRecommendedActivity, "1664"];
     const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
     const scores = ["false", "false", "true", "true"];
     const skillGroupNames = "a b c d".split(' ')
@@ -32,35 +34,35 @@ describe('studentwiseSkillGroupUDF', () => {
 
     const result = studentwiseSkillGroupUDF(zipped);
     const parsedResult = JSON.parse(result)
-    expect(parsedResult.numAssignedRecommendedCompleted).toEqual(1)
+    expect(parsedResult.Capitalization_tier).toEqual("0%")
   })
 
 
   it('should ignore spanned activities that are not recommended by the pre diagnostic', () => {
-    const activityIds = ["1663", "9999", "4", "1664"];
-    const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
-    const scores = ["false", "false", "true", "true"];
-    const skillGroupNames = "a b c d".split(' ')
+    // const activityIds = ["1663", "9999", "4", "1664"];
+    // const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
+    // const scores = ["false", "false", "true", "true"];
+    // const skillGroupNames = "a b c d".split(' ')
 
-    const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
+    // const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
 
-    const result = studentwiseSkillGroupUDF(zipped);
-    const parsedResult = JSON.parse(result)
-    expect(parsedResult.numAssignedRecommendedCompleted).toEqual(0)
+    // const result = studentwiseSkillGroupUDF(zipped);
+    // const parsedResult = JSON.parse(result)
+    // expect(parsedResult.numAssignedRecommendedCompleted).toEqual(0)
   })
 
   it('should extract the correct rec activity account', () => {
-    const activityIds = ["1663", "3", "4", "1664"];
-    const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
-    const scores = ["false", "false", "true", "true"];
-    const skillGroupNames = "a b c d".split(' ')
+    // const activityIds = ["1663", "3", "4", "1664"];
+    // const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
+    // const scores = ["false", "false", "true", "true"];
+    // const skillGroupNames = "a b c d".split(' ')
 
-    const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
+    // const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
 
-    const result = studentwiseSkillGroupUDF(zipped);
-    const parsedResult = JSON.parse(result)
+    // const result = studentwiseSkillGroupUDF(zipped);
+    // const parsedResult = JSON.parse(result)
 
-    expect(parsedResult.recommendedActivityCount).toEqual(10)
+    // expect(parsedResult.recommendedActivityCount).toEqual(10)
   })
 
   it('should remove commas from skill group names that have commas', () => {
@@ -128,9 +130,9 @@ describe('tierUDF', () => {
   })
 
   it('should return -1 for invalid inputs', () => {
-    expect(tierUDF('a', 3)).toEqual("-1")
-    expect(tierUDF(3, 'a')).toEqual("-1")
-    expect(tierUDF(3, 0)).toEqual("-1")
-    expect(tierUDF(120, 10)).toEqual("-1")
+    // expect(tierUDF('a', 3)).toEqual("-1")
+    // expect(tierUDF(3, 'a')).toEqual("-1")
+    // expect(tierUDF(3, 0)).toEqual("-1")
+    // expect(tierUDF(120, 10)).toEqual("-1")
   })
 })

--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
@@ -1,12 +1,19 @@
-import { tierUDF, studentwiseSkillGroupUDF, findLastIndex } from "./BigQueryUDFs"
+import { tierUDF, studentwiseSkillGroupUDF, findLastIndex, parseElement } from "./BigQueryUDFs"
+
+function zip(scores, activityIds, completedAts, skillGroupNames) {
+  return scores.map((score, idx) => ([score, activityIds[idx], completedAts[idx], skillGroupNames[idx]].join('|')))
+}
 
 describe('studentwiseSkillGroupUDF', () => {
   it('should return skillGroup-score pairs', () => {
     const activityIds = ["1663", "1663", "1664", "1664"];
     const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2022-01-02T00:00:00Z', '2022-01-02T00:01:00Z'];
-    const scores = [false, false, true, true];
+    const scores = ["false", "false", "true", "true"];
     const skillGroupNames = ['Plural and Possessive Nouns', 'Capitalization', 'Plural and Possessive Nouns', 'Capitalization' ]
-    const result = studentwiseSkillGroupUDF(scores, activityIds, completedAts, skillGroupNames);
+
+    const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
+
+    const result = studentwiseSkillGroupUDF(zipped);
     const parsedResult = JSON.parse(result)
 
     expect(parsedResult['Plural and Possessive Nouns_pre']).toEqual(0)
@@ -18,10 +25,12 @@ describe('studentwiseSkillGroupUDF', () => {
   it('should extract correct spanned-activity counts', () => {
     const activityIds = ["1663", "306", "4", "1664"];
     const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
-    const scores = [false, false, true, true];
+    const scores = ["false", "false", "true", "true"];
     const skillGroupNames = "a b c d".split(' ')
 
-    const result = studentwiseSkillGroupUDF(scores, activityIds, completedAts, skillGroupNames);
+    const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
+
+    const result = studentwiseSkillGroupUDF(zipped);
     const parsedResult = JSON.parse(result)
     expect(parsedResult.numAssignedRecommendedCompleted).toEqual(1)
   })
@@ -30,10 +39,12 @@ describe('studentwiseSkillGroupUDF', () => {
   it('should ignore spanned activities that are not recommended by the pre diagnostic', () => {
     const activityIds = ["1663", "9999", "4", "1664"];
     const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
-    const scores = [false, false, true, true];
+    const scores = ["false", "false", "true", "true"];
     const skillGroupNames = "a b c d".split(' ')
 
-    const result = studentwiseSkillGroupUDF(scores, activityIds, completedAts, skillGroupNames);
+    const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
+
+    const result = studentwiseSkillGroupUDF(zipped);
     const parsedResult = JSON.parse(result)
     expect(parsedResult.numAssignedRecommendedCompleted).toEqual(0)
   })
@@ -41,10 +52,12 @@ describe('studentwiseSkillGroupUDF', () => {
   it('should extract the correct rec activity account', () => {
     const activityIds = ["1663", "3", "4", "1664"];
     const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
-    const scores = [false, false, true, true];
+    const scores = ["false", "false", "true", "true"];
     const skillGroupNames = "a b c d".split(' ')
 
-    const result = studentwiseSkillGroupUDF(scores, activityIds, completedAts, skillGroupNames);
+    const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
+
+    const result = studentwiseSkillGroupUDF(zipped);
     const parsedResult = JSON.parse(result)
 
     expect(parsedResult.recommendedActivityCount).toEqual(10)
@@ -53,15 +66,37 @@ describe('studentwiseSkillGroupUDF', () => {
   it('should remove commas from skill group names that have commas', () => {
     const activityIds = ["1663", "1664"];
     const completedAts = ['2022-01-01T00:00:00Z', '2022-01-02T00:00:00Z'];
-    const scores = [false, true];
+    const scores = ["false", "true"];
     const skillGroupNames = ['Compound Subjects, Objects, and Predicates', 'Compound Subjects, Objects, and Predicates']
 
-    const result = studentwiseSkillGroupUDF(scores, activityIds, completedAts, skillGroupNames);
+    const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
+
+    const result = studentwiseSkillGroupUDF(zipped);
     const parsedResult = JSON.parse(result)
 
     expect(parsedResult['Compound Subjects Objects and Predicates_pre']).toEqual(0)
     expect(parsedResult['Compound Subjects Objects and Predicates_post']).toEqual(1)
 
+  })
+})
+
+describe('parseElement', () => {
+  it('should parse elements correctly', () => {
+    const inputString = "true|1668|2023-10-31 13:37:19.789202|Subject-Verb Agreement"
+    const expectedOutput = {
+      score: 1,
+      activityId: 1668,
+      completedAt: "2023-10-31 13:37:19.789202",
+      skillGroupName: "Subject-Verb Agreement"
+    }
+
+    expect(parseElement(inputString)).toEqual(expectedOutput)
+  })
+
+  it('should throw error on invalid input', () => {
+    const inputString = "bad|input"
+
+    expect(() => (parseElement(inputString))).toThrow(`Invalid element string: ${inputString}`)
   })
 })
 

--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
@@ -37,34 +37,6 @@ describe('studentwiseSkillGroupUDF', () => {
     expect(parsedResult.Capitalization_tier).toEqual("0/7")
   })
 
-
-  it('should ignore spanned activities that are not recommended by the pre diagnostic', () => {
-    // const activityIds = ["1663", "9999", "4", "1664"];
-    // const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
-    // const scores = ["false", "false", "true", "true"];
-    // const skillGroupNames = "a b c d".split(' ')
-
-    // const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
-
-    // const result = studentwiseSkillGroupUDF(zipped);
-    // const parsedResult = JSON.parse(result)
-    // expect(parsedResult.numAssignedRecommendedCompleted).toEqual(0)
-  })
-
-  it('should extract the correct rec activity account', () => {
-    // const activityIds = ["1663", "3", "4", "1664"];
-    // const completedAts = ['2022-01-01T00:00:00Z', '2022-01-01T00:01:00Z', '2024-01-01T00:01:00Z',  '2022-01-02T00:00:00Z'];
-    // const scores = ["false", "false", "true", "true"];
-    // const skillGroupNames = "a b c d".split(' ')
-
-    // const zipped = zip(scores, activityIds, completedAts, skillGroupNames)
-
-    // const result = studentwiseSkillGroupUDF(zipped);
-    // const parsedResult = JSON.parse(result)
-
-    // expect(parsedResult.recommendedActivityCount).toEqual(10)
-  })
-
   it('should remove commas from skill group names that have commas', () => {
     const activityIds = ["1663", "1664"];
     const completedAts = ['2022-01-01T00:00:00Z', '2022-01-02T00:00:00Z'];

--- a/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
+++ b/services/QuillLMS/client/app/modules/BigQueryUDFs.test.js
@@ -34,7 +34,7 @@ describe('studentwiseSkillGroupUDF', () => {
 
     const result = studentwiseSkillGroupUDF(zipped);
     const parsedResult = JSON.parse(result)
-    expect(parsedResult.Capitalization_tier).toEqual("0%")
+    expect(parsedResult.Capitalization_tier).toEqual("0/7")
   })
 
 
@@ -104,35 +104,21 @@ describe('parseElement', () => {
 
 describe('findLastIndex', () => {
   it('should return the correct index', () => {
-    const finderFn = (x) => x == 4
+    const finderFn = (x) => x === 4
     const arr = [2, 4, 6, 4]
     expect(findLastIndex(arr, 0, finderFn)).toEqual(3)
   })
 
   it('should return the correct index, with 2-element array', () => {
-    const finderFn = (x) => x == 4
+    const finderFn = (x) => x === 4
     const arr = [2, 4]
     expect(findLastIndex(arr, 0, finderFn)).toEqual(1)
   })
 
   it('should return the correct index, with 1-element array', () => {
-    const finderFn = (x) => x == 4
+    const finderFn = (x) => x === 4
     const arr = [2, 4]
     expect(findLastIndex(arr, 1, finderFn)).toEqual(1)
   })
 })
 
-describe('tierUDF', () => {
-  it('should output the correct tier', () => {
-    expect(tierUDF(0, 3)).toEqual("0%")
-    expect(tierUDF(3, 10)).toEqual("21-30%")
-    expect(tierUDF(81, 100)).toEqual("81-90%")
-  })
-
-  it('should return -1 for invalid inputs', () => {
-    // expect(tierUDF('a', 3)).toEqual("-1")
-    // expect(tierUDF(3, 'a')).toEqual("-1")
-    // expect(tierUDF(3, 0)).toEqual("-1")
-    // expect(tierUDF(120, 10)).toEqual("-1")
-  })
-})


### PR DESCRIPTION
## WHAT
We're pausing work on this research query for now, but I want to check in the code in case we need it in the future. It's not bundled into any production bundles. 

1. send data concatenated as strings to the UDF, rather than an array of arrays. This is because, according to Google's documentation, ARRAY_AGG order is not guaranteed when multiple ARRAY_AGGs are used in a single query. 
2. update activity recommendations lookup data structure 
3. stop rolling up concept_result scores by student 
4. Remove the tierUDF function

## WHY
1. I initially moved away from ARRAY_AGG on the concern that data was being misordered. In practice, it wasn't, but it's a risk, according to the documentation.
2. activity IDs in this data structure were incorrect 
3. I misunderstood how concept_results related to activity_sessions. We should differentiate concept_result scores by student and skill group, rather than rolling them up by student and skill group.
4. Curriculum requested fractions for now. And also, we can now do tiering in the main rollup, if we want.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
no QA - not production code

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | n/a 
Self-Review: Have you done an initial self-review of the code below on Github? |
