### PR TITLE
lms/fix-post-completion-aggregation

### DIFF
--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_completed_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_completed_view_query_spec.rb
@@ -95,6 +95,26 @@ module AdminDiagnosticReports
 
         it { expect(results.first[:overall_skill_growth]).to eq(0.0) }
       end
+
+      context 'aggregate row context' do
+        let(:aggregate_row_results) { results.first[:aggregate_rows] }
+
+        let(:classroom_count) { 2 }
+
+        it { expect(aggregate_row_results.map{|r| r[:aggregate_id]}).to match_array(classrooms.map(&:grade)) }
+
+        context 'aggregate by teacher' do
+          let(:aggregation_arg) { 'teacher' }
+
+          it { expect(aggregate_row_results.map{|r| r[:aggregate_id]}).to match_array(classrooms.map(&:teachers).flatten.map(&:id)) }
+        end
+
+        context 'aggregate by classroom' do
+          let(:aggregation_arg) { 'classroom' }
+
+          it { expect(aggregate_row_results.map{|r| r[:aggregate_id]}).to match_array(classrooms.map(&:id)) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix the Post diagnostic completion aggregation for teacher and grade level aggregations.  (The old code secretly always aggregated by classroom, causing unpredictable behavior when trying to aggregate by other values.)
## WHY
We want aggregation by grade and teacher to properly report the specific break-down values
## HOW
Use the pattern from Pre completion for Post completion calculation

### Screenshots
Old
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/8e2a0618-127d-4f0b-94d3-527e33a370f0)
New
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/99041535-325f-4d2d-a803-e2e52715ade6)

### Notion Card Links
https://www.notion.so/quill/ADGR-QA-February-22-bb480e0255e542909ecee020b9a97742?pvs=4#c45d960db3894247bbc973ecdd0476ee

### What have you done to QA this feature?
Using the account that surfaced the original issue, log in with the new code and change aggregation modes among Grade, Teacher, and School, confirming that the aggregation rolls up as expected and that the numbers from the top-level roll-up equal the numbers from manually summing the individual break-outs.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes