### PR TITLE
lms/fix-premium-reports-menu-z-index

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/premium-hub.scss
@@ -219,7 +219,7 @@
           min-height: min-content;
           top: 36px;
           width: 300px;
-          z-index: 2;
+          z-index: 3;
           box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.10);
           a {
             color: $quill-black;


### PR DESCRIPTION
## WHAT
Update the z-index of the menu so that it doesn't sit behind content
## WHY
We want the 
## HOW
Set `z-index` of the menu element to `3` (up from `2`).  There must already be something else on the page with `z-index` of 2, so it's falling behind that.

### Screenshots
OLD
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/14123432-57c6-4f5a-89a6-6fbd44de4045)
NEW
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/942fd2ec-c88f-4939-9d6d-4a9414f9a59b)

### What have you done to QA this feature?
Deploy to staging.  On Admin Diagnostic Report pages, make sure that the menu does not render behind the table.  Check all three tabs.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | No test coverage on styling
Self-Review: Have you done an initial self-review of the code below on Github? | Yes