### PR TITLE
improve arel, add ignore count param to session view

### DIFF
--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -332,7 +332,7 @@ class FeedbackHistory < ApplicationRecord
     query = query.having(FeedbackHistory.responses_for_scoring) if responses_for_scoring
     query = query.where("feedback_histories.activity_version = ?", activity_version) if activity_version
     result = ActiveRecord::Base.connection.execute("SELECT COUNT(*) from (#{query.to_sql}) as nickname")
-    result.first.dig('count')
+    result.first['count']
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -331,7 +331,8 @@ class FeedbackHistory < ApplicationRecord
     query = FeedbackHistory.apply_activity_session_filter(query, filter_type) if filter_type
     query = query.having(FeedbackHistory.responses_for_scoring) if responses_for_scoring
     query = query.where("feedback_histories.activity_version = ?", activity_version) if activity_version
-    query.length
+    result = ActiveRecord::Base.connection.execute("SELECT COUNT(*) from (#{query.to_sql}) as nickname")
+    result.first.dig('count')
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activitySessions/sessionsIndex.tsx
@@ -54,7 +54,7 @@ const SessionsIndex = ({ match }) => {
   });
 
   const { data: activityVersionData } = useQuery({
-    queryKey: [`change-logs-for-activity-versions-${activityId}`, activityId],
+    queryKey: [`change-logs-for-activity-versions-${activityId}`, activityId, { ignoreCount: true }],
     queryFn: fetchActivityVersions
   });
 


### PR DESCRIPTION
## WHAT
- don't return the entire result set from an AREL query when only the count is needed
- configure View Sessions to use the faster version of the `activity_versions` API

## HOW 
- wrap original AREL query in a subquery, then call it with a COUNT express.
- config change 

## WHY
- big performance gains 
- same thing we did on the Rules Analysis page, for performance gains 


### Screenshots


### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=2a3bf6bd2c8f498fb7c4335635e5d92f&pm=s

### What have you done to QA this feature?
1. Deploy to staging
2. Inspect network tab, verify that the `activity_versions` payload does not include a count
3. Confirm that the API call is faster than previous 
4. Repeat steps for the View Sessions API call: api/v1/rule_feedback_histories?activity_id=87&conjunction=because&start_date=2024-03-20t03:06:37.048z&end_date=2024-03-20t03:06:43.913z



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  tested manually. There is no new logic, so existing tests are sufficient.
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
