### PR TITLE
Add LLMPromptBuilder

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_prompt_response_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_prompt_response_feedback.rb
@@ -22,6 +22,10 @@ module Evidence
         validates :passage_prompt_response_id, presence: true
 
         attr_readonly :feedback, :label, :passage_prompt_response_id
+
+        delegate :response, to: :passage_prompt_response
+
+        def response_and_feedback = "Response: #{response}\nFeedback: #{feedback}"
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt.rb
@@ -28,6 +28,14 @@ module Evidence
           class_name: 'Evidence::Research::GenAI::PassagePromptResponse',
           dependent: :destroy
 
+        has_many :example_prompt_response_feedbacks,
+          class_name: 'Evidence::Research::GenAI::ExamplePromptResponseFeedback',
+          through: :passage_prompt_responses
+
+        has_many :llm_prompt_response_feedbacks,
+          class_name: 'Evidence::Research::GenAI::LLMPromptResponseFeedback',
+          through: :passage_prompt_responses
+
         validates :prompt, presence: true
         validates :conjunction, presence: true, inclusion: { in: CONJUNCTIONS }
         validates :instructions, presence: true

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
@@ -4,7 +4,21 @@ module Evidence
   module Research
     module GenAI
       class LLMPromptBuilder < ApplicationService
+        class InvalidLLMPromptTemplateIdError < StandardError; end
+        class InvalidPassagePromptIdError < StandardError; end
+
+        DELIMITER = "~~~"
+        OPTIONAL_COMMA_AND_DIGIT_REGEX = "(?:,(\\d+))?"
+
+        SUBSTITUTIONS = {
+          "prompt" => ->(builder, _) { builder.passage_prompt.prompt },
+          "instructions" => ->(builder, _) { builder.passage_prompt.instructions },
+          "examples" => ->(builder, limit) { builder.examples(limit) },
+        }.freeze
+
         attr_reader :llm_prompt_template_id, :passage_prompt_id
+
+        delegate :contents, to: :llm_prompt_template
 
         def initialize(llm_prompt_template_id:, passage_prompt_id:)
           @llm_prompt_template_id = llm_prompt_template_id
@@ -12,13 +26,31 @@ module Evidence
         end
 
         def run
-          LLMPrompt.create!(llm_prompt_template_id:, prompt:)
+          raise InvalidLLMPromptTemplateIdError unless llm_prompt_template_id
+          raise InvalidPassagePromptIdError unless passage_prompt_id
+
+          prompt
         end
 
-        private def llm_prompt_template = LLMPromptTemplate.find(llm_prompt_template_id)
+        def examples(limit)
+          passage_prompt
+            .example_prompt_response_feedbacks
+            .limit(limit)
+            .map(&:response_and_feedback)
+            .join("\n")
+        end
 
-        # TODO: this is a placeholder for injection
-        private def prompt = llm_prompt_template.contents
+        def passage_prompt = @passage_prompt ||= PassagePrompt.find(passage_prompt_id)
+
+        def llm_prompt_template = @llm_prompt_template ||= LLMPromptTemplate.find(llm_prompt_template_id)
+
+        private def prompt
+          SUBSTITUTIONS.reduce(contents) do |current_contents, (placeholder, replacement_proc)|
+            current_contents.gsub(/#{DELIMITER}#{placeholder}#{OPTIONAL_COMMA_AND_DIGIT_REGEX}#{DELIMITER}/) do
+              replacement_proc.call(self, Regexp.last_match(1)&.to_i)
+            end
+          end
+        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
@@ -4,8 +4,18 @@ module Evidence
   module Research
     module GenAI
       class LLMPromptBuilder < ApplicationService
-        class InvalidLLMPromptTemplateIdError < StandardError; end
-        class InvalidPassagePromptIdError < StandardError; end
+        include ActiveModel::Validations
+
+        # Sample usage of delimiter in an LLMPromptTemplate
+        # Insert prompt:
+        # ~~~prompt~~~
+        #
+        # Regexp.last_match(1)&.to_i will be nil in this case
+
+        # Insert 20 examples:
+        # ~~~examples,20~~~
+        #
+        # Regexp.last_match(1)&.to_i will be 20 in this case
 
         DELIMITER = "~~~"
         OPTIONAL_COMMA_AND_DIGIT_REGEX = "(?:,(\\d+))?"
@@ -18,18 +28,24 @@ module Evidence
 
         attr_reader :llm_prompt_template_id, :passage_prompt_id
 
+        validates :llm_prompt_template_id, presence: true
+        validates :passage_prompt_id, presence: true
+
         delegate :contents, to: :llm_prompt_template
 
         def initialize(llm_prompt_template_id:, passage_prompt_id:)
           @llm_prompt_template_id = llm_prompt_template_id
           @passage_prompt_id = passage_prompt_id
+
+          validate!
         end
 
         def run
-          raise InvalidLLMPromptTemplateIdError unless llm_prompt_template_id
-          raise InvalidPassagePromptIdError unless passage_prompt_id
-
-          prompt
+          SUBSTITUTIONS.reduce(contents) do |current_contents, (placeholder, replacement_proc)|
+            current_contents.gsub(/#{DELIMITER}#{placeholder}#{OPTIONAL_COMMA_AND_DIGIT_REGEX}#{DELIMITER}/) do
+              replacement_proc.call(self, Regexp.last_match(1)&.to_i)
+            end
+          end
         end
 
         def examples(limit)
@@ -43,14 +59,6 @@ module Evidence
         def passage_prompt = @passage_prompt ||= PassagePrompt.find(passage_prompt_id)
 
         def llm_prompt_template = @llm_prompt_template ||= LLMPromptTemplate.find(llm_prompt_template_id)
-
-        private def prompt
-          SUBSTITUTIONS.reduce(contents) do |current_contents, (placeholder, replacement_proc)|
-            current_contents.gsub(/#{DELIMITER}#{placeholder}#{OPTIONAL_COMMA_AND_DIGIT_REGEX}#{DELIMITER}/) do
-              replacement_proc.call(self, Regexp.last_match(1)&.to_i)
-            end
-          end
-        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_spec.rb
@@ -30,7 +30,18 @@ module Evidence
         it { should have_readonly_attribute(:passage_id) }
 
         it { belong_to(:passage).class_name('Evidence::Research::GenAI::Passage') }
-        it { have_many(:passage_prompt_responses).class_name('Evidence::Research::GenAI::PassagePromptResponse').dependent(:destroy) }
+
+        it do
+          have_many(:passage_prompt_responses)
+            .class_name('Evidence::Research::GenAI::PassagePromptResponse')
+            .dependent(:destroy)
+        end
+
+        it do
+          have_many(:example_prompt_response_feedbacks)
+          .class_name('Evidence::Research::GenAI::ExamplePromptResponseFeedback')
+          .through(:passage_prompt_responses)
+        end
 
         it { expect(build(:evidence_research_gen_ai_passage_prompt)).to be_valid }
       end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
@@ -20,13 +20,13 @@ module Evidence
         context 'nil llm_prompt_template_id' do
           let(:llm_prompt_template_id) { nil }
 
-          it { expect { subject.run }.to raise_error described_class::InvalidLLMPromptTemplateIdError }
+          it { expect { subject.run }.to raise_error ActiveModel::ValidationError }
         end
 
         context 'nil passage_prompt_id' do
           let(:passage_prompt_id) { nil }
 
-          it { expect { subject.run }.to raise_error described_class::InvalidPassagePromptIdError }
+          it { expect { subject.run }.to raise_error ActiveModel::ValidationError }
         end
 
         context 'contents with no substitutions' do

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe LLMPromptBuilder do
+        subject { described_class.run(llm_prompt_template_id:, passage_prompt_id:) }
+
+        let(:contents) { 'This is contents' }
+        let(:llm_prompt_template_id) { create(:evidence_research_gen_ai_llm_prompt_template, contents:).id }
+        let(:instructions) { 'These are the instructions' }
+        let(:prompt) { 'this is a prompt because' }
+        let(:passage_prompt) { create(:evidence_research_gen_ai_passage_prompt, prompt:, instructions:) }
+        let(:passage_prompt_id) { passage_prompt.id }
+
+        def delimit(placeholder) = "#{described_class::DELIMITER}#{placeholder}#{described_class::DELIMITER}"
+
+        context 'nil llm_prompt_template_id' do
+          let(:llm_prompt_template_id) { nil }
+
+          it { expect { subject.run }.to raise_error described_class::InvalidLLMPromptTemplateIdError }
+        end
+
+        context 'nil passage_prompt_id' do
+          let(:passage_prompt_id) { nil }
+
+          it { expect { subject.run }.to raise_error described_class::InvalidPassagePromptIdError }
+        end
+
+        context 'contents with no substitutions' do
+          it { is_expected.to eq contents }
+        end
+
+        context 'contents with substitutions' do
+          context 'prompt' do
+            let(:contents)  { delimit('prompt') }
+
+            it { is_expected.to eq prompt }
+          end
+
+          context 'instructions' do
+            let(:contents)  { delimit('instructions') }
+            let(:instructions) { 'these are the instructions' }
+
+            it { is_expected.to eq instructions }
+          end
+
+          context 'examples' do
+            let(:num_of_examples) { 5 }
+
+            let!(:example_prompt_response_feedbacks) do
+              create_list(
+                :evidence_research_gen_ai_example_prompt_response_feedback,
+                num_of_examples,
+                passage_prompt_response: create(:evidence_research_gen_ai_passage_prompt_response, passage_prompt:)
+              )
+            end
+
+            let(:limit) { 3 }
+            let(:contents) { delimit("examples,#{limit}") }
+
+            it { is_expected.to eq example_prompt_response_feedbacks.first(limit).map(&:response_and_feedback).join("\n") }
+          end
+
+          context 'multiple substitutions' do
+            let(:filler) { '...some filler here...'}
+            let(:contents) { "#{delimit('prompt')} #{filler} #{delimit('instructions')}" }
+
+            it { is_expected.to eq "#{prompt} #{filler} #{instructions}" }
+          end
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add `LLMPromptBuilder` service object

## WHY
The tool will create `LLMPrompt` records programmatically by transforming placeholder directives in the LLMPromptTemplate's `contents` field.  This will allow generic prompts to be written that can apply to different passages.

## HOW
For example, here is an LLMPromptTemplate's contents:
```
This is some contents.
~~~instructions~~~
Some filler
~~~examples,4~~~
```
This text contains two placeholders delimited by `instructions` and `examples,4` which are delimited by `~~~`.
The service object replaces the placeholders via with the result of proc calls defined in `SUBSTITUTIONS`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
