### PR TITLE
Lms/fix growth aggregation

### DIFF
--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_completed_view_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_completed_view_query.rb
@@ -10,7 +10,7 @@ module AdminDiagnosticReports
             aggregate_id,
             name,
             group_by,
-            COUNT(DISTINCT activity_session_id) AS post_students_completed,
+            SUM(post_students_completed) AS post_students_completed,
             AVG(growth_percentage) AS overall_skill_growth
           FROM (#{super})
           GROUP BY diagnostic_id, diagnostic_name, aggregate_id, name, group_by
@@ -25,7 +25,7 @@ module AdminDiagnosticReports
       #   NULL values are ignored when executing aggregate queries such as SUM, so rows from `performance` that have NULL "post" data will be excluded from the aggregation
       #   We subtract the pre-Diagnostic average from the post-Diagnostic average, and then use GREATEST to treat cases where post-Diagnostic scores are worse as if they were equal instead
       <<-SQL
-        performance.post_activity_session_id AS activity_session_id,
+        COUNT(DISTINCT performance.post_activity_session_id) AS post_students_completed,
         GREATEST(
           ROUND(SAFE_DIVIDE(SUM(performance.post_questions_correct), CAST(SUM(performance.post_questions_total) AS float64)), 2)
             - ROUND(SAFE_DIVIDE(SUM(CASE WHEN performance.post_activity_session_id IS NOT NULL THEN performance.pre_questions_correct ELSE NULL END),
@@ -35,7 +35,7 @@ module AdminDiagnosticReports
     end
 
     def group_by_clause
-      "#{super}, activity_session_id"
+      "#{super}, performance.skill_group_id, performance.classroom_id"
     end
 
     def relevant_date_column

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_completed_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/post_diagnostic_completed_view_query_spec.rb
@@ -115,6 +115,8 @@ module AdminDiagnosticReports
           it { expect(aggregate_row_results.map{|r| r[:aggregate_id]}).to match_array(classrooms.map(&:id)) }
         end
       end
+
+      #TODO: Write specs to cover the edge case in https://github.com/empirical-org/Empirical-Core/pull/11662
     end
   end
 end


### PR DESCRIPTION
## WHAT
Fix both growth percentage aggregation and completion count aggregation in the same query
## WHY
Data needs to be split out by skill for the weird way we calculate aggregate growth rates, but that duplicates completion counts.  This code resolves that tension, allowing both calculations to be run in the same query.
## HOW
Allow growth rate calculation to to be the primary way we organize things, then divide the duplication back out of the completion count calculation.

### What have you done to QA this feature?
Take a handful of admins, filter to a specific teacher, group by classroom.  Then log into those teachers' accounts on prod and compare the admin report values to what the teachers have in their individual reports.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | I propose to defer specs for this.  The specific pre-conditions needed to really capture this edge case in a spec are pretty involved, and given the timeline we're working on here, I'm inclined to move forward for now without them.  Open to discussion.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes