### PR TITLE
Lms/another pre diagnostic chip fix

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/index.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/index.tsx
@@ -109,6 +109,9 @@ export const DiagnosticGrowthReportsContainer = ({
   }
 
   function handleSetSelectedDiagnosticId(e) {
+    console.log('handleSetSelectedDiagnosticId')
+    console.log(e)
+    console.log(e.target.value)
     setSelectedDiagnosticId(Number(e.target.value))
   }
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/index.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/index.tsx
@@ -110,9 +110,6 @@ export const DiagnosticGrowthReportsContainer = ({
   }
 
   function handleSetSelectedDiagnosticId(e) {
-    console.log('handleSetSelectedDiagnosticId')
-    console.log(e)
-    console.log(e.target.value)
     setSelectedDiagnosticId(Number(e.target.value))
   }
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/index.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/index.tsx
@@ -91,6 +91,7 @@ export const DiagnosticGrowthReportsContainer = ({
 
   const studentSectionProps = {
     ...sharedProps,
+    selectedDiagnosticId,
     passedStudentData: null,
     passedRecommendationsData: null,
     passedVisibleData: null

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/studentSection.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/studentSection.tsx
@@ -108,11 +108,12 @@ export const StudentSection = ({
   selectedTimeframe,
   pusherChannel,
   handleSetDiagnosticIdForStudentCount,
+  selectedDiagnosticId,
   passedStudentData,
   passedRecommendationsData,
   passedVisibleData
 }) => {
-  const [diagnosticTypeValue, setDiagnosticTypeValue] = React.useState<DropdownObjectInterface>(diagnosticTypeDropdownOptions[0])
+  const [diagnosticTypeValue, setDiagnosticTypeValue] = React.useState<DropdownObjectInterface>(getInitialDiagnosticType())
   const [pusherMessage, setPusherMessage] = React.useState<string>(null)
   const [recommendationsData, setRecommendationsData] = React.useState<any>(passedRecommendationsData || null);
   const [studentData, setStudentData] = React.useState<any>(passedStudentData || null);
@@ -249,6 +250,13 @@ export const StudentSection = ({
 
   function handleDiagnosticTypeOptionChange(option) {
     setDiagnosticTypeValue(option)
+  }
+
+  function getInitialDiagnosticType() {
+    if(selectedDiagnosticId) {
+      return diagnosticTypeDropdownOptions.filter(diagnosticType => diagnosticType.value === selectedDiagnosticId)[0]
+    }
+    return diagnosticTypeDropdownOptions[0]
   }
 
   function loadMoreRows() {


### PR DESCRIPTION
## WHAT
Update Student report tab to respect the ability to set the selected diagnostic when coming from a different tab
## WHY
We want users who navigate to the Student tab by clicking on the Pre Diagnostic chip to arrive on the same diagnostic that they were clicking on
## HOW
Copy the logic used in the Skills tab code: pass a selected-diagnostic-id into the component, and use that id (when present) to set the value inside the component.

### Notion Card Links
https://www.notion.so/quill/ADGR-QA-February-22-bb480e0255e542909ecee020b9a97742?pvs=4#89c0e303f3934c60b130c7f6764b8e74

### What have you done to QA this feature?
Open the Overview page, click on the Pre Diagnostic chip for a non-starter diagnostic row, ensure that we A) land on the Student tab, and B) the Diagnostic drop-down has pre-selected the non-starter diagnostic we selected on the Overview page

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  We don't have any existing test coverage for this chip-clicking behavior, and given our current timeline, I'm inclined to avoid creating it from scratch.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes