### PR TITLE
fix learn more link

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/__tests__/__snapshots__/teacher_student_dashboard_settings.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/__tests__/__snapshots__/teacher_student_dashboard_settings.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`TeacherStudentDashboardSettings component should render 1`] = `
     >
       Control what your classes see on their dashboard. 
       <a
-        href=""
+        href="https://support.quill.org/en/articles/9034576-how-do-students-see-their-scores-and-time-spent"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_student_dashboard_settings.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/accounts/edit/teacher_student_dashboard_settings.tsx
@@ -75,7 +75,7 @@ const TeacherStudentDashboardSettings = ({ activateSection, active, deactivateSe
   return (
     <section className="user-account-section student-dashboard-settings-section">
       <h1>Student dashboard</h1>
-      <p className="student-dashboard-settings-description">Control what your classes see on their dashboard. <a href="" rel="noopener noreferrer" target="_blank">Learn more.</a></p>
+      <p className="student-dashboard-settings-description">Control what your classes see on their dashboard. <a href="https://support.quill.org/en/articles/9034576-how-do-students-see-their-scores-and-time-spent" rel="noopener noreferrer" target="_blank">Learn more.</a></p>
       <form acceptCharset="UTF-8" onSubmit={handleSubmit} >
         <div className="fields" onClick={activateSection} onKeyDown={activateSection}>
           {renderCheckbox()}


### PR DESCRIPTION
## WHAT
Fix the "Learn more" link on the teacher account page.

## WHY
We want this to go to the support article.

## HOW
Add the href.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Loaded the page and clicked the link.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
