### PR TITLE
AGDR/ small style fix 

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
@@ -35,6 +35,7 @@
     top: 0;
     padding: 0px;
     position: sticky;
+    z-index: 3;
     .dropdowns {
       border-radius: 8px;
       border: 1px solid $quill-grey-5;

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/filterable-reports.scss
@@ -35,7 +35,6 @@
     top: 0;
     padding: 0px;
     position: sticky;
-    z-index: 3;
     .dropdowns {
       border-radius: 8px;
       border: 1px solid $quill-grey-5;
@@ -521,7 +520,7 @@
     .filter-container {
       position: fixed;
       top: 0;
-      z-index: 2;
+      z-index: 3;
       background-color: white;
       height: 100%;
       width: 100vw;


### PR DESCRIPTION
## WHAT
fix issue where table headers were showing through filters on small screen sizes

## WHY
these should be hidden behind the breakout filters component

## HOW
just add a z-index (there is a z-index for the table headers so that the embedded table headers won't appear on top of the parent table headers when scrolling)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/ADGR-When-you-resize-the-screen-and-click-Filters-the-table-headers-show-aae8df92d3e8473fb9ee1e743e7e23e2

### What have you done to QA this feature?
tested locally and on staging that headers don't appear on top of breakout filter component

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small CSS change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
