### PR TITLE
update green hues in color palette and add yellow

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/variables.scss
+++ b/services/QuillLMS/app/assets/stylesheets/variables.scss
@@ -51,13 +51,15 @@ $quill-green-transparent-10: rgba(6, 128, 107, 0.1);
 $quill-green: #06806B;
 $quill-green-50: #099A81;
 $quill-green-20: #ACD6CF;
-$quill-green-10: #D6EFEC;
+$quill-green-15: #BFE5DF;
+$quill-green-10: #D0ECE7;
 $quill-green-5: #E3F0EE;
 $quill-green-1: #F0F8F7;
 
 $quill-green-warm: #499C70;
 $quill-green-warm-50: #78BF9C;
 $quill-green-warm-20: #BEE5D2;
+$quill-green-warm-15: #D4F0E1;
 $quill-green-warm-10: #E0FAEB;
 $quill-green-warm-5: #E8F9EF;
 $quill-green-warm-1: #F3FAF6;
@@ -65,6 +67,7 @@ $quill-green-warm-1: #F3FAF6;
 $quill-green-vibrant: #2A5900;
 $quill-green-vibrant-50: #79C933;
 $quill-green-vibrant-20: #B0E185;
+$quill-green-vibrant-15: #D7F2BF;
 $quill-green-vibrant-10: #EBF8E0;
 $quill-green-vibrant-5: #FAFFF5;
 $quill-green-vibrant-1: #FAFFF6;
@@ -131,6 +134,13 @@ $quill-gold-dark-20: #E3BB7A;
 $quill-gold-dark-10: #E4D0B0;
 $quill-gold-dark-5: #F6E9D5;
 $quill-gold-dark-1: #FBF2E5;
+
+$quill-yellow: #FCE240;
+$quill-yellow-50: #F8E671;
+$quill-yellow-20: #FDF5C3;
+$quill-yellow-10: #FFFAD9;
+$quill-yellow-5: #FFFCE7;
+$quill-yellow-1: #FFFDEF;
 
 // older
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/colorPalette.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/colorPalette.tsx
@@ -139,8 +139,13 @@ const baseColorTitlesAndVariableNames = [
     title: 'Quill Gold Dark',
     variableName: "quill-gold-dark"
   },
+  {
+    title: 'Quill Yellow',
+    variableName: "quill-yellow"
+  },
 ]
 
+const greenNumbers = [null, 50, 20, 15, 10, 5, 1]
 const colorNumbers = [null, 50, 20, 10, 5, 1]
 const transparentColorNumbers = [90, 80, 70, 60, 50, 40, 30, 20, 10]
 
@@ -155,7 +160,8 @@ const renderElement =(title, variableName) => (
 
 const ColorPalette = () => {
   const colorRows = baseColorTitlesAndVariableNames.map(color => {
-    const colors = colorNumbers.map(number => {
+    const numbersArray = color.title.includes('Green') ? greenNumbers : colorNumbers
+    const colors = numbersArray.map(number => {
       let title = color.title
       let variableName = color.variableName
 

--- a/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
@@ -214,18 +214,21 @@
     quill-green: $quill-green,
     quill-green-50: $quill-green-50,
     quill-green-20: $quill-green-20,
+    quill-green-15: $quill-green-15,
     quill-green-10: $quill-green-10,
     quill-green-5: $quill-green-5,
     quill-green-1: $quill-green-1,
     quill-green-warm: $quill-green-warm,
     quill-green-warm-50: $quill-green-warm-50,
     quill-green-warm-20: $quill-green-warm-20,
+    quill-green-warm-15: $quill-green-warm-15,
     quill-green-warm-10: $quill-green-warm-10,
     quill-green-warm-5: $quill-green-warm-5,
     quill-green-warm-1: $quill-green-warm-1,
     quill-green-vibrant: $quill-green-vibrant,
     quill-green-vibrant-50: $quill-green-vibrant-50,
     quill-green-vibrant-20: $quill-green-vibrant-20,
+    quill-green-vibrant-15: $quill-green-vibrant-15,
     quill-green-vibrant-10: $quill-green-vibrant-10,
     quill-green-vibrant-5: $quill-green-vibrant-5,
     quill-green-vibrant-1: $quill-green-vibrant-1,
@@ -282,7 +285,13 @@
     quill-gold-dark-20: $quill-gold-dark-20,
     quill-gold-dark-10: $quill-gold-dark-10,
     quill-gold-dark-5: $quill-gold-dark-5,
-    quill-gold-dark-1: $quill-gold-dark-1
+    quill-gold-dark-1: $quill-gold-dark-1,
+    quill-yellow: $quill-yellow,
+    quill-yellow-50: $quill-yellow-50,
+    quill-yellow-20: $quill-yellow-20,
+    quill-yellow-10: $quill-yellow-10,
+    quill-yellow-5: $quill-yellow-5,
+    quill-yellow-1: $quill-yellow-1
   );
 
   @each $name, $color in $colors {


### PR DESCRIPTION
## WHAT
Update color palette to adjust hues for greens, including adding 15% hues, and adding yellow.

## WHY
These changes were requested by Jack.

## HOW
Just update our variables file and then the display in Backpack.

### Screenshots


### Notion Card Links
https://www.notion.so/Quill-Color-Library-Adjust-Green-Color-Ramps-3-Hues-fdb81dc565ab45c083d3d60aa7a1aaa5?pvs=4

https://www.notion.so/Quill-Color-Library-Add-New-Quill-Yellow-13e454f2a07f48e18129b99550f94fac?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
