### PR TITLE
GenAI Research: Enable data importing via S3

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -18,4 +18,4 @@ internalworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bund
 migrationworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q migration
 
 # Experiments
-experimentworker: MAX_THREADS=$SIDEKIQ_EXPERIMENT_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q experiment
+experimentworker: MAX_THREADS=$SIDEKIQ_EXPERIMENT_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q experiment -c 1

--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -18,4 +18,4 @@ internalworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bund
 migrationworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q migration
 
 # Experiments
-experimentworker: MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -C config/sidekiq_experiment.yml
+experimentworker: MAX_THREADS=$SIDEKIQ_EXPERIMENT_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q experiment

--- a/services/QuillLMS/config/sidekiq_experiment.yml
+++ b/services/QuillLMS/config/sidekiq_experiment.yml
@@ -1,4 +1,0 @@
----
-:concurrency: 1
-:queues:
-  - [experiment, 1]

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
@@ -4,7 +4,7 @@ module Evidence
   module Research
     module GenAI
       class ExperimentsController < ApplicationController
-        def index =  @experiments = Experiment.all.order(created_at: :asc)
+        def index =  @experiments = Experiment.all.order(created_at: :desc)
 
         def new
           @experiment = Experiment.new

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_configs_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_configs_controller.rb
@@ -12,7 +12,7 @@ module Evidence
           @llm_config = LLMConfig.new(llm_config_params)
 
           if @llm_config.save
-            redirect_to @llm_config
+            redirect_to new_research_gen_ai_experiment_path
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
@@ -12,7 +12,7 @@ module Evidence
           @llm_prompt_template = LLMPromptTemplate.new(llm_prompt_template_params)
 
           if @llm_prompt_template.save
-            redirect_to @llm_prompt_template
+            redirect_to new_research_gen_ai_experiment_path
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
@@ -14,7 +14,7 @@ module Evidence
           @passage_prompt = PassagePrompt.new(passage_prompt_params)
 
           if @passage_prompt.save
-            redirect_to @passage_prompt
+            redirect_to new_research_gen_ai_experiment_path
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -42,19 +42,19 @@ module Evidence
 
         attr_accessor :llm_prompt_template_id
 
-        def run
+        def run(limit: nil)
           return unless status == PENDING
 
           update!(status: RUNNING)
-          create_llm_prompt_responses_feedbacks
+          create_llm_prompt_responses_feedbacks(limit:)
           update!(status: COMPLETED)
         rescue StandardError => e
           experiment_errors << e.message
           update!(status: FAILED)
         end
 
-        private def create_llm_prompt_responses_feedbacks
-          passage_prompt_responses.each do |passage_prompt_response|
+        private def create_llm_prompt_responses_feedbacks(limit:)
+          passage_prompt_responses.limit(limit).each do |passage_prompt_response|
             feedback = llm_client.run(prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
             LLMFeedback.create!(text: feedback, passage_prompt_response:)
           end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -56,7 +56,7 @@ module Evidence
         private def create_llm_prompt_responses_feedbacks
           passage_prompt_responses.each do |passage_prompt_response|
             feedback = llm_client.run(prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
-            LLMPromptResponseFeedback.create!(feedback:, passage_prompt_response:)
+            LLMFeedback.create!(text: feedback, passage_prompt_response:)
           end
         end
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
@@ -16,16 +16,18 @@ module Evidence
       class LLMConfig < ApplicationRecord
         class UnsupportedVendorError < StandardError; end
 
-        VENDORS = [
-          GOOGLE = 'google'
-        ]
+        GOOGLE = 'google'
+
+        VENDOR_MAP = {
+          GOOGLE => Evidence::Gemini::Completion
+        }.freeze
 
         validates :vendor, presence: true
         validates :version, presence: true
 
         attr_readonly :vendor, :version
 
-        def llm_client = VENDORS.fetch(vendor) { raise UnsupportedVendorError }
+        def llm_client = VENDOR_MAP.fetch(vendor) { raise UnsupportedVendorError }
 
         def to_s = "#{vendor}: #{version}"
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
@@ -25,7 +25,7 @@ module Evidence
 
         attr_readonly :vendor, :version
 
-        def llm_client = VENDOR_MAP.fetch(vendor) { raise UnsupportedVendorError }
+        def llm_client = VENDORS.fetch(vendor) { raise UnsupportedVendorError }
 
         def to_s = "#{vendor}: #{version}"
       end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/data_importer.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/data_importer.rb
@@ -4,59 +4,51 @@ module Evidence
   module Research
     module GenAI
       class DataImporter < ApplicationService
+        BUCKET_NAME = ENV['AWS_S3_EVIDENCE_RESEARCH_GEN_AI_BUCKET']
         TARGET_NUM_EXAMPLES = 100
 
-        attr_reader :file_path, :file_name, :examples_path
+        attr_reader :file_name
 
-        def initialize(file_path:, file_name:, examples_path:)
-          @file_path = file_path
+        def initialize(file_name:)
           @file_name = file_name
-          @examples_path = examples_path
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
         def run
           passage_prompts.each do |passage_prompt|
             conjunction = passage_prompt.conjunction
-            training_file_name = data['files'][conjunction]['train'].split('/').last
-            validation_file_name = data['files'][conjunction]['validation'].split('/').last
+            training_file_name = data['files'][conjunction]['train']
+            validation_file_name = data['files'][conjunction]['validation']
 
             # Training and validation files are artifacts from a previous classification model
             # Here there are both drawn from to populate example feedbacks
             [training_file_name, validation_file_name].each do |examples_file_name|
               break if passage_prompt.passage_prompt_responses.count >= TARGET_NUM_EXAMPLES
 
-              examples_file_abs_path = File.join(examples_path, examples_file_name)
-              next unless File.exist?(examples_file_abs_path)
+              get_file(key: examples_file_name).each_line do |line|
+                break if passage_prompt.passage_prompt_responses.count >= TARGET_NUM_EXAMPLES
 
-              File.open(examples_file_abs_path, 'r') do |file|
-                file.each_line do |line|
-                  break if passage_prompt.passage_prompt_responses.count >= TARGET_NUM_EXAMPLES
+                example = JSON.parse(line)
+                response = example['text']
+                label = example['label']
+                feedback = data['feedback'][conjunction][label]
+                example_index = data['examples'][conjunction][label]&.index(response)
+                evaluation = example_index ? data.dig('evaluation',conjunction,label,example_index) : nil
 
-                  example = JSON.parse(line)
-                  response = example['text']
-                  label = example['label']
-                  feedback = data['feedback'][conjunction][label]
-                  example_index = data['examples'][conjunction][label]&.index(response)
-                  evaluation = example_index ? data.dig('evaluation',conjunction,label,example_index) : nil
-
-                  passage_prompt
-                    .passage_prompt_responses
-                    .find_or_create_by!(response:)
-                    .example_prompt_response_feedbacks
-                    .find_or_create_by!(label:, feedback:, evaluation:)
-                end
+                passage_prompt
+                  .passage_prompt_responses
+                  .find_or_create_by!(response:)
+                  .example_prompt_response_feedbacks
+                  .find_or_create_by!(label:, feedback:, evaluation:)
               end
             end
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
+
+        private def get_file(key:) = s3_client.get_object(bucket: BUCKET_NAME, key:).body
 
         private def data = @data ||= JSON.parse(input_file)
 
-        private def file_abs_path = File.join(file_path, file_name)
-
-        private def input_file = File.read(file_abs_path)
+        private def input_file = get_file(key: file_name).read
 
         private def name = file_name.split('.').first
 
@@ -73,6 +65,14 @@ module Evidence
                 relevant_passage: data['plagiarism'][conjunction]
               )
           end
+        end
+
+        private def s3_client
+          @s3_client ||= Aws::S3::Client.new(
+            access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+            region: ENV['AWS_REGION'],
+            secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+          )
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/data_importer.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/data_importer.rb
@@ -30,15 +30,15 @@ module Evidence
                 example = JSON.parse(line)
                 response = example['text']
                 label = example['label']
-                feedback = data['feedback'][conjunction][label]
+                text = data['feedback'][conjunction][label]
                 example_index = data['examples'][conjunction][label]&.index(response)
-                evaluation = example_index ? data.dig('evaluation',conjunction,label,example_index) : nil
+                paraphrase = example_index ? data.dig('evaluation',conjunction,label,example_index) : nil
 
                 passage_prompt
                   .passage_prompt_responses
                   .find_or_create_by!(response:)
-                  .example_prompt_response_feedbacks
-                  .find_or_create_by!(label:, feedback:, evaluation:)
+                  .example_feedbacks
+                  .find_or_create_by!(label:, text:, paraphrase:)
               end
             end
           end

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
@@ -25,3 +25,9 @@
     <%= f.submit "Run Experiment" %>
   </div>
 <% end %>
+
+
+
+
+<br/>
+<%= link_to 'Experiments', research_gen_ai_experiments_path, class: 'new-link', target: '_blank' %>

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/concerns/api.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/concerns/api.rb
@@ -12,8 +12,9 @@ module Evidence
         BASE_URI = Evidence::Gemini::BASE_URI
         BLOCK_NONE = "BLOCK_NONE"
 
-        MAX_RETRIES = 5
+        MAX_RETRIES = 10
         MAX_ATTEMPTS = 5
+        MAX_SLEEP_FOR_BACKOFF = 60.seconds
 
         SAFETY_SETTING_CATEGORIES = %w[
           HARM_CATEGORY_HARASSMENT
@@ -69,7 +70,7 @@ module Evidence
           raise "Max retries reached. Last error: #{e.message}" unless retries < MAX_RETRIES
 
           retries += 1
-          sleep 2**retries
+          sleep [2**retries, MAX_SLEEP_FOR_BACKOFF].min
           retry
         end
       end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
@@ -12,7 +12,8 @@ module Evidence
         let(:llm_prompt_template_id) { create(:evidence_research_gen_ai_llm_prompt_template, contents:).id }
         let(:instructions) { 'These are the instructions' }
         let(:prompt) { 'this is a prompt because' }
-        let(:passage_prompt) { create(:evidence_research_gen_ai_passage_prompt, prompt:, instructions:) }
+        let(:relevant_passage) { 'this is a relevant passage' }
+        let(:passage_prompt) { create(:evidence_research_gen_ai_passage_prompt, prompt:, instructions:, relevant_passage:) }
         let(:passage_prompt_id) { passage_prompt.id }
 
         def delimit(placeholder) = "#{described_class::DELIMITER}#{placeholder}#{described_class::DELIMITER}"
@@ -45,6 +46,13 @@ module Evidence
             let(:instructions) { 'these are the instructions' }
 
             it { is_expected.to eq instructions }
+          end
+
+          context 'relevant_passage' do
+            let(:contents)  { delimit('relevant_passage') }
+            let(:relevant_passage) { 'this is a relevant passage' }
+
+            it { is_expected.to eq relevant_passage }
           end
 
           context 'examples' do


### PR DESCRIPTION
## WHAT
Update the data importing script so that it uses objects on S3 instead of local data files.

Also, add some misc updates from https://github.com/empirical-org/Empirical-Core/pull/11682
  
## WHY
Since our apps don't have access to local filesystem, experiments need to import data from S3

## HOW
Use `aws-s3-sdk` to locate bucket objects and read the contents from there as opposed to `File.new` calls.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Building-Infrastructure-for-GenAI-experiments-8a5f06c5b190472bb68a831e5b6d4bbf?pvs=4

### What have you done to QA this feature?
I confirmed the service object worked through the staging console.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
