### PR TITLE
lms/increase-adgr-worker-priority

### DIFF
--- a/services/QuillLMS/app/workers/admin_diagnostic_reports/diagnostic_overview_worker.rb
+++ b/services/QuillLMS/app/workers/admin_diagnostic_reports/diagnostic_overview_worker.rb
@@ -4,6 +4,8 @@ module AdminDiagnosticReports
   class DiagnosticOverviewWorker
     include Sidekiq::Worker
 
+    sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
     PUSHER_EVENT = 'admin-diagnostic-overview-cached'
     TOO_SLOW_THRESHOLD = 20
 

--- a/services/QuillLMS/app/workers/admin_diagnostic_reports/diagnostic_skills_worker.rb
+++ b/services/QuillLMS/app/workers/admin_diagnostic_reports/diagnostic_skills_worker.rb
@@ -4,6 +4,8 @@ module AdminDiagnosticReports
   class DiagnosticSkillsWorker
     include Sidekiq::Worker
 
+    sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
     PUSHER_EVENT = 'admin-diagnostic-skills-cached'
     TOO_SLOW_THRESHOLD = 20
 

--- a/services/QuillLMS/app/workers/admin_diagnostic_reports/diagnostic_students_worker.rb
+++ b/services/QuillLMS/app/workers/admin_diagnostic_reports/diagnostic_students_worker.rb
@@ -4,6 +4,8 @@ module AdminDiagnosticReports
   class DiagnosticStudentsWorker
     include Sidekiq::Worker
 
+    sidekiq_options queue: SidekiqQueue::CRITICAL_EXTERNAL
+
     PUSHER_EVENT = 'admin-diagnostic-students-cached'
     TOO_SLOW_THRESHOLD = 20
 


### PR DESCRIPTION
## WHAT
Put Admin Diagnostic cache workers into the CRITICAL_EXTERNAL queue
## WHY
So that they don't get trapped behind other lower-priority jobs in the DEFAULT queue
## HOW
Set the `queue` Sidekiq option in the job classes

### What have you done to QA this feature?
I don't see an obvious way of proving that this will improve experienced performance without worker traffic like we have in production.  Open to suggestions.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No tests on config values
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes