### PR TITLE
lms/adgr-handle-multiple-diagnostics-in-activity-pack

### DIFF
--- a/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
+++ b/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
@@ -108,7 +108,7 @@ SELECT
             AND classroom_units.id = activity_sessions.classroom_unit_id
             AND most_recent.activity_id = activity_sessions.activity_id
             AND most_recent.completed_at = activity_sessions.completed_at
-      ) AS activity_sessions ON activity_sessions.classroom_unit_id = classroom_units.id AND activity_sessions.user_id = CAST(assigned_student_id AS int64) AND activity_sessions.activity_id = activities.id AND activity_sessions.visible = true
+      ) AS activity_sessions ON activity_sessions.classroom_unit_id = classroom_units.id AND activity_sessions.user_id = CAST(assigned_student_id AS int64) AND activity_sessions.activity_id = activities.follow_up_activity_id AND activity_sessions.visible = true
       LEFT OUTER JOIN special.concept_results AS concept_results          ON activity_sessions.id = concept_results.activity_session_id
         AND concept_results.attempt_number IS NULL
       LEFT OUTER JOIN lms.questions ON STRING(PARSE_JSON(concept_results.extra_metadata).question_uid) = questions.uid

--- a/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
+++ b/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
@@ -50,7 +50,7 @@ SELECT
             AND classroom_units.id = activity_sessions.classroom_unit_id
             AND most_recent.activity_id = activity_sessions.activity_id
             AND most_recent.completed_at = activity_sessions.completed_at
-      ) AS activity_sessions ON activity_sessions.classroom_unit_id = classroom_units.id AND activity_sessions.user_id = CAST(assigned_student_id AS int64) AND activity_sessions.visible = true
+      ) AS activity_sessions ON activity_sessions.classroom_unit_id = classroom_units.id AND activity_sessions.user_id = CAST(assigned_student_id AS int64) AND activity_sessions.activity_id = activities.id AND activity_sessions.visible = true
       LEFT OUTER JOIN special.concept_results AS concept_results          ON activity_sessions.id = concept_results.activity_session_id
         AND concept_results.attempt_number IS NULL
       LEFT OUTER JOIN lms.questions ON STRING(PARSE_JSON(concept_results.extra_metadata).question_uid) = questions.uid
@@ -108,7 +108,7 @@ SELECT
             AND classroom_units.id = activity_sessions.classroom_unit_id
             AND most_recent.activity_id = activity_sessions.activity_id
             AND most_recent.completed_at = activity_sessions.completed_at
-      ) AS activity_sessions ON activity_sessions.classroom_unit_id = classroom_units.id AND activity_sessions.user_id = CAST(assigned_student_id AS int64) AND activity_sessions.visible = true
+      ) AS activity_sessions ON activity_sessions.classroom_unit_id = classroom_units.id AND activity_sessions.user_id = CAST(assigned_student_id AS int64) AND activity_sessions.activity_id = activities.id AND activity_sessions.visible = true
       LEFT OUTER JOIN special.concept_results AS concept_results          ON activity_sessions.id = concept_results.activity_session_id
         AND concept_results.attempt_number IS NULL
       LEFT OUTER JOIN lms.questions ON STRING(PARSE_JSON(concept_results.extra_metadata).question_uid) = questions.uid

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_performance_by_skill_view_query_spec.rb
@@ -7,6 +7,7 @@ module AdminDiagnosticReports
     include_context 'Admin Diagnostic Aggregate CTE'
 
     # TODO: Update these to set up the pre-conditions properly with the Pre Post view context, with the same expectations for tests
+    # TODO: A specific case that's not currently written up that we need to address is when a teacher has two different Diagnostics in the same ClassroomUnit.  We want to make sure that the data doesn't get contaminated with over-eager joins in this case
     #context 'big_query_snapshot', :big_query_snapshot do
     #  subject { results }
 


### PR DESCRIPTION
## WHAT
Make sure not to too-eagerly JOIN activity sessions
## WHY
99% of the time a Diagnostic is in its own dedicated Classroom Unit, so joining on just Classroom Unit id was reasonable, but sometimes that's not the case so we need an extra condition to make sure we don't mix data across diagnostics
## HOW
Add an extra `JOIN` condition when attaching `activity_sessions` to our rollup data to ensure that it not only matches the `classroom_units` record where the student was assigned to the diagnostic, but that it also directly matches the specific diagnostic assigned.

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.  This is one of the spec files that's commented out at the moment.  I've added a TODO for us to make sure this case gets covered in that file when we work on it again.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes