### PR TITLE
Proofreader/ grammar follow-up bug

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -166,7 +166,7 @@ export const startListeningToFollowUpQuestionsForProofreaderSession = (proofread
   }
 }
 
-const handleProofreaderSession = (proofreaderSession, state) => {
+export const handleProofreaderSession = (proofreaderSession, state) => {
   return dispatch => {
 
     // if there is no proofreader session or concept results for that session, we can't do anything here
@@ -194,7 +194,7 @@ const handleProofreaderSession = (proofreaderSession, state) => {
         concepts[cr.concept_uid] = { quantity }
       }
     })
-    debugger
+
     dispatch(saveProofreaderSessionToReducer(proofreaderSession))
     dispatch(getQuestionsForConcepts(concepts, 'production'))
   }

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -174,12 +174,19 @@ const handleProofreaderSession = (proofreaderSession, state) => {
     // that all gets processed by the normal `setSessionReducerToSavedSession` function and we don't need to set new ones
     if (!proofreaderSession || !proofreaderSession.conceptResults || proofreaderSession.answeredQuestions || state.session.proofreaderSession) { return }
 
-    const concepts: { [key: string]: { quantity: 1|2|3 } } = {}
-    const incorrectConcepts = proofreaderSession.conceptResults.filter(cr => cr.metadata.correct === 0)
+    const concepts: { [key: string]: any } = {}
+    proofreaderSession.conceptResults.map(cr => {
+      const { metadata, concept_uid } = cr
+      const { correct } = metadata
+      if (correct === 0 && !concepts[concept_uid]) {
+        concepts[concept_uid] = true
+      }
+    })
+    const incorrectConceptUIDs = Object.keys(concepts)
     let quantity = 3
-    if (incorrectConcepts.length > 9) {
+    if (incorrectConceptUIDs.length > 9) {
       quantity = 1
-    } else if (incorrectConcepts.length > 4) {
+    } else if (incorrectConceptUIDs.length > 4) {
       quantity = 2
     }
     proofreaderSession.conceptResults.forEach(cr => {
@@ -187,6 +194,7 @@ const handleProofreaderSession = (proofreaderSession, state) => {
         concepts[cr.concept_uid] = { quantity }
       }
     })
+    debugger
     dispatch(saveProofreaderSessionToReducer(proofreaderSession))
     dispatch(getQuestionsForConcepts(concepts, 'production'))
   }

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -199,7 +199,6 @@ export const handleProofreaderSession = (proofreaderSession, state) => {
         concepts[concept_uid] = { quantity }
       }
     })
-    debugger
     dispatch(saveProofreaderSessionToReducer(proofreaderSession))
     dispatch(getQuestionsForConcepts(concepts, 'production'))
   }

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/actions/session.data.js
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/actions/session.data.js
@@ -1447,4 +1447,169 @@ const mockQuestions = {
   },
 }
 
-export { denormalizedSession, normalizedSession, mockQuestions }
+const mockConceptResults1 = [
+  {
+    concept_uid: "R3sBcYAvoXP2_oNVXiA98g",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "tSSLMHqX0q-9mKTJHSyung",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "R3sBcYAvoXP2_oNVXiA98g",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "hJKqVOkQQQgfEsmzOWC1xw",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "tSSLMHqX0q-9mKTJHSyung",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "hJKqVOkQQQgfEsmzOWC1xw",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "R3sBcYAvoXP2_oNVXiA98g",
+    metadata: {
+      correct: 0
+    }
+  },
+]
+
+const mockConceptResults2 = [
+  {
+    concept_uid: "R3sBcYAvoXP2_oNVXiA98g",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "tSSLMHqX0q-9mKTJHSyung",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "hJKqVOkQQQgfEsmzOWC1xw",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "i8s7u34nksjhdninsdlkji",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "asdh783hjadkjasku3jhas",
+    metadata: {
+      correct: 0
+    }
+  }
+]
+
+const mockConceptResults3 = [
+  {
+    concept_uid: "R3sBcYAvoXP2_oNVXiA98g",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "tSSLMHqX0q-9mKTJHSyung",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "hJKqVOkQQQgfEsmzOWC1xw",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "tSSLMHqX0q-9mKTJHSyasd",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "asdh783hjadkjasku3jhas",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "9823haksjdaksjd983jkha",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "ais87h43kjasdkhj8hkass",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "ash983hjashnbasdh934hn",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "87iyhbnsdii4nskdh8ikhn",
+    metadata: {
+      correct: 0
+    }
+  },
+  {
+    concept_uid: "znbxi7erhbsj7n3unsdujn",
+    metadata: {
+      correct: 0
+    }
+  },
+]
+
+const mockProofreaderSession1 = {
+  activityUID: "asl2JCt8j1ItiGeYbOJ5tQ",
+  anonymous: false,
+  conceptResults: mockConceptResults1,
+  passage: null,
+  timeTracking: null
+}
+
+const mockProofreaderSession2 = {
+  activityUID: "asl2JCt8j1ItiGeYbOJ5tQ",
+  anonymous: false,
+  conceptResults: mockConceptResults2,
+  passage: null,
+  timeTracking: null
+}
+
+const mockProofreaderSession3 = {
+  activityUID: "asl2JCt8j1ItiGeYbOJ5tQ",
+  anonymous: false,
+  conceptResults: mockConceptResults3,
+  passage: null,
+  timeTracking: null
+}
+
+export { denormalizedSession, normalizedSession, mockQuestions, mockProofreaderSession1, mockProofreaderSession2, mockProofreaderSession3 }

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/actions/session.test.js
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/actions/session.test.js
@@ -1,15 +1,24 @@
 import 'whatwg-fetch';
-import {
-  allQuestions,
-  denormalizeSession,
-  normalizeSession,
-  populateQuestions
-} from '../../actions/session';
+
 import {
   denormalizedSession,
   mockQuestions,
   normalizedSession,
+  mockProofreaderSession1,
+  mockProofreaderSession2,
+  mockProofreaderSession3,
 } from './session.data';
+
+import {
+  allQuestions,
+  denormalizeSession,
+  normalizeSession,
+  populateQuestions,
+  handleProofreaderSession,
+  getQuestionsForConcepts
+} from '../../actions/session';
+import * as sessionActions from '../../actions/session'
+import { mockDispatch } from '../__mocks__/dispatch'
 
 // Populate our question cache to use in denormalization
 populateQuestions(mockQuestions);
@@ -76,3 +85,63 @@ describe("populate questions", () => {
     expect(allQuestions['failKey']).toEqual(undefined);
   })
 });
+
+describe("handleProofreaderSession", () => {
+  describe("no data", () => {
+    it("should not have been dispatched", () => {
+      handleProofreaderSession(null, { session: { proofreaderSession: null }})(mockDispatch)
+      expect(mockDispatch).not.toHaveBeenCalled()
+    })
+  })
+  describe("with data", () => {
+    jest.spyOn(sessionActions, 'getQuestionsForConcepts').mockImplementation(() => {
+      return {}
+    });
+    describe("4 or less incorrect concepts", () => {
+      it("should return hash with concept uids and quantity of 3", () => {
+
+        const mockState = { session: { proofreaderSession: null } }
+        const concepts = {
+          "R3sBcYAvoXP2_oNVXiA98g": { "quantity": 3 },
+          "hJKqVOkQQQgfEsmzOWC1xw": { "quantity": 3 },
+          "tSSLMHqX0q-9mKTJHSyung": { "quantity": 3 }
+        }
+        handleProofreaderSession(mockProofreaderSession1, mockState)(mockDispatch)
+        expect(getQuestionsForConcepts).toHaveBeenCalledWith(concepts, 'production')
+      })
+    })
+    describe("between 5 and 9 incorrect concepts", () => {
+      it("should return hash with concept uids and quantity of 2", () => {
+        const mockState = { session: { proofreaderSession: null } }
+        const concepts = {
+          "R3sBcYAvoXP2_oNVXiA98g": { "quantity": 2 },
+          "asdh783hjadkjasku3jhas": { "quantity": 2 },
+          "hJKqVOkQQQgfEsmzOWC1xw": { "quantity": 2 },
+          "i8s7u34nksjhdninsdlkji": { "quantity": 2 },
+          "tSSLMHqX0q-9mKTJHSyung": { "quantity": 2 }
+        }
+        handleProofreaderSession(mockProofreaderSession2, mockState)(mockDispatch)
+        expect(getQuestionsForConcepts).toHaveBeenCalledWith(concepts, 'production')
+      })
+    })
+    describe("10 or more incorrect concepts", () => {
+      it("should return hash with concept uids and quantity of 2", () => {
+        const mockState = { session: { proofreaderSession: null } }
+        const concepts = {
+          "87iyhbnsdii4nskdh8ikhn": { "quantity": 1 },
+          "9823haksjdaksjd983jkha": { "quantity": 1 },
+          "R3sBcYAvoXP2_oNVXiA98g": { "quantity": 1 },
+          "ais87h43kjasdkhj8hkass": { "quantity": 1 },
+          "asdh783hjadkjasku3jhas": { "quantity": 1 },
+          "ash983hjashnbasdh934hn": { "quantity": 1 },
+          "hJKqVOkQQQgfEsmzOWC1xw": { "quantity": 1 },
+          "tSSLMHqX0q-9mKTJHSyasd": { "quantity": 1 },
+          "tSSLMHqX0q-9mKTJHSyung": { "quantity": 1 },
+          "znbxi7erhbsj7n3unsdujn": { "quantity": 1 }
+        }
+        handleProofreaderSession(mockProofreaderSession3, mockState)(mockDispatch)
+        expect(getQuestionsForConcepts).toHaveBeenCalledWith(concepts, 'production')
+      })
+    })
+  })
+})


### PR DESCRIPTION
## WHAT
fix issue where follow up grammar activities for Proofreader sessions were not being supplied the correct amount of questions

## WHY
we want the activity to have the expected number of questions

## HOW
check by number of incorrect concepts rather than number of incorrect concept results

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Proofreader-not-linking-to-Grammar-correctly-0e7c02de2a5b4a2886bb5063526c0750?pvs=4

### What have you done to QA this feature?
I tested some activities on staging and also had Rachel verify that the number of questions matched the number of concepts

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
