### PR TITLE
Update GenAI Experiment Prompt Builder

### DIFF
--- a/services/QuillLMS/Procfile
+++ b/services/QuillLMS/Procfile
@@ -18,4 +18,4 @@ internalworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bund
 migrationworker: MAX_THREADS=$SIDEKIQ_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q migration
 
 # Experiments
-experimentworker: MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -C config/sidekiq_experiment.yml
+experimentworker: MAX_THREADS=$SIDEKIQ_EXPERIMENT_PROCESS_MAX_THREADS MALLOC_ARENA_MAX=2 bundle exec sidekiq -q experiment

--- a/services/QuillLMS/config/sidekiq_experiment.yml
+++ b/services/QuillLMS/config/sidekiq_experiment.yml
@@ -1,4 +1,0 @@
----
-:concurrency: 1
-:queues:
-  - [experiment, 1]

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_configs_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_configs_controller.rb
@@ -12,7 +12,7 @@ module Evidence
           @llm_config = LLMConfig.new(llm_config_params)
 
           if @llm_config.save
-            redirect_to @llm_config
+            redirect_to research_gen_ai_experiments_path
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_configs_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_configs_controller.rb
@@ -12,7 +12,7 @@ module Evidence
           @llm_config = LLMConfig.new(llm_config_params)
 
           if @llm_config.save
-            redirect_to research_gen_ai_experiments_path
+            redirect_to new_research_gen_ai_experiment_path
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
@@ -12,7 +12,7 @@ module Evidence
           @llm_prompt_template = LLMPromptTemplate.new(llm_prompt_template_params)
 
           if @llm_prompt_template.save
-            redirect_to @llm_prompt_template
+            redirect_to research_gen_ai_experiment_path
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
@@ -12,7 +12,7 @@ module Evidence
           @llm_prompt_template = LLMPromptTemplate.new(llm_prompt_template_params)
 
           if @llm_prompt_template.save
-            redirect_to research_gen_ai_experiment_path
+            redirect_to new_research_gen_ai_experiment_path
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
@@ -14,7 +14,7 @@ module Evidence
           @passage_prompt = PassagePrompt.new(passage_prompt_params)
 
           if @passage_prompt.save
-            redirect_to research_gen_ai_experiments_path
+            redirect_to new_research_gen_ai_experiment_path
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
@@ -14,7 +14,7 @@ module Evidence
           @passage_prompt = PassagePrompt.new(passage_prompt_params)
 
           if @passage_prompt.save
-            redirect_to @passage_prompt
+            redirect_to research_gen_ai_experiments_path
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
@@ -25,7 +25,7 @@ module Evidence
 
         attr_readonly :vendor, :version
 
-        def llm_client = VENDOR_MAP.fetch(vendor) { raise UnsupportedVendorError }
+        def llm_client = VENDORS.fetch(vendor) { raise UnsupportedVendorError }
 
         def to_s = "#{vendor}: #{version}"
       end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/data_importer.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/data_importer.rb
@@ -30,15 +30,15 @@ module Evidence
                 example = JSON.parse(line)
                 response = example['text']
                 label = example['label']
-                feedback = data['feedback'][conjunction][label]
+                text = data['feedback'][conjunction][label]
                 example_index = data['examples'][conjunction][label]&.index(response)
-                evaluation = example_index ? data.dig('evaluation',conjunction,label,example_index) : nil
+                paraphrase = example_index ? data.dig('evaluation',conjunction,label,example_index) : nil
 
                 passage_prompt
                   .passage_prompt_responses
                   .find_or_create_by!(response:)
-                  .example_prompt_response_feedbacks
-                  .find_or_create_by!(label:, feedback:, evaluation:)
+                  .example_feedbacks
+                  .find_or_create_by!(label:, text:, paraphrase:)
               end
             end
           end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
@@ -12,7 +12,8 @@ module Evidence
         let(:llm_prompt_template_id) { create(:evidence_research_gen_ai_llm_prompt_template, contents:).id }
         let(:instructions) { 'These are the instructions' }
         let(:prompt) { 'this is a prompt because' }
-        let(:passage_prompt) { create(:evidence_research_gen_ai_passage_prompt, prompt:, instructions:) }
+        let(:relevant_passage) { 'this is a relevant passage' }
+        let(:passage_prompt) { create(:evidence_research_gen_ai_passage_prompt, prompt:, instructions:, relevant_passage:) }
         let(:passage_prompt_id) { passage_prompt.id }
 
         def delimit(placeholder) = "#{described_class::DELIMITER}#{placeholder}#{described_class::DELIMITER}"
@@ -45,6 +46,13 @@ module Evidence
             let(:instructions) { 'these are the instructions' }
 
             it { is_expected.to eq instructions }
+          end
+
+          context 'relevant_passage' do
+            let(:contents)  { delimit('relevant_passage') }
+            let(:relevant_passage) { 'this is a relevant passage' }
+
+            it { is_expected.to eq relevant_passage }
           end
 
           context 'examples' do


### PR DESCRIPTION
## WHAT
1. Add relevant_passage substitution
1. Fix experiment queue
1. Fix redirects
1. Fix data importing

## WHY
1.  Relevant_passage can be used in prompt engineering rather than the whole passage
1.  Jobs are currently stuck enqueued
1.  Redirects for the crud apps do not work
1.  Some tables were renamed upstream and import code needs to reflect that

## HOW
1.  Add to SUBSTITUTIONS map in prompt builder
1.  Update the Procfile configuration to use existing pattern
1.  Redirect to new experiments path for now
1.  Use example_feedbacks instead of example_prompt_response_feedbacks

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Tried on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
