### PR TITLE
Premium Hub/ Account Management UI fix

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/account-management.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/account-management.scss
@@ -74,6 +74,7 @@
   }
 
   .data-table-wrapper {
+    padding-bottom: 200px;
     table.data-table.reporting-format {
       overflow: visible;
       width: $sitewidepagewidth;


### PR DESCRIPTION
## WHAT
add space below the list of users in the Account Management table (seen when there is a large amount of users in the table)

## WHY
it looks to crammed with the footer

## HOW
add padding below the table

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Add-padding-below-the-admin-Account-Management-table-a7e91753d27040d4b12cf6e2438d3241?pvs=4

### What have you done to QA this feature?
tested with several different admins of large school districts

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small CSS change
Have you deployed to Staging? | no-- small change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
