### PR TITLE
Teacher Reports/ update diagnostic link for Activity Analysis

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -162,9 +162,9 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       return render json: {}, status: 404
     elsif Activity.diagnostic_activity_ids.include?(activity_id.to_i)
       activity_is_a_post_test = Activity.find_by(follow_up_activity_id: activity_id).present?
-      summary_or_growth_summary = activity_is_a_post_test ? 'growth_summary' : 'summary'
+      results_or_growth_results = activity_is_a_post_test ? 'growth_results' : 'results'
       unit_query_string = "?unit=#{unit_id}"
-      render json: { url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity_id}/classroom/#{classroom_id}/#{summary_or_growth_summary}#{unit_query_string}" }
+      render json: { url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity_id}/classroom/#{classroom_id}/#{results_or_growth_results}#{unit_query_string}" }
     else
       render json: { url: "/teachers/progress_reports/diagnostic_reports#/u/#{unit_id}/a/#{activity_id}/c/#{classroom_id}/students" }
     end

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -37,7 +37,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
         it 'responds with a summary link' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
-          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/summary?unit=#{unit.id}"}.to_json)
+          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/results?unit=#{unit.id}"}.to_json)
         end
       end
 
@@ -51,7 +51,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
         it 'responds with a summary link' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
-          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/summary?unit=#{unit.id}"}.to_json)
+          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/results?unit=#{unit.id}"}.to_json)
         end
       end
 
@@ -65,7 +65,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
         it 'responds with a growth_summary link' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
-          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/growth_summary?unit=#{unit.id}"}.to_json)
+          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/growth_results?unit=#{unit.id}"}.to_json)
         end
       end
 
@@ -78,7 +78,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
         it 'responds with a summary link that has a unit query param' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
-          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/summary?unit=#{unit.id}"}.to_json)
+          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/results?unit=#{unit.id}"}.to_json)
         end
 
       end


### PR DESCRIPTION
## WHAT
redirect to results page instead of summary page when clicking on Diagnostic on Activity Analysis page

## WHY
this is more intuitive for teachers then linking to the Summary page

## HOW
update `redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit` function to redirect to results page instead of summary

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Fix-the-diagnostic-responses-pathway-from-the-Activity-Analysis-report-6944436ee6e041bb8e419ec11d9475a6

### What have you done to QA this feature?
tested with a few different teachers with pre and post diagnostic results on the Activity Analysis page

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
