### PR TITLE
Activity analysis/ link fix

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -162,9 +162,8 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       return render json: {}, status: 404
     elsif Activity.diagnostic_activity_ids.include?(activity_id.to_i)
       activity_is_a_post_test = Activity.find_by(follow_up_activity_id: activity_id).present?
-      results_or_growth_results = activity_is_a_post_test ? 'growth_results' : 'results'
       unit_query_string = "?unit=#{unit_id}"
-      render json: { url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity_id}/classroom/#{classroom_id}/#{results_or_growth_results}#{unit_query_string}" }
+      render json: { url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity_id}/classroom/#{classroom_id}/responses#{unit_query_string}" }
     else
       render json: { url: "/teachers/progress_reports/diagnostic_reports#/u/#{unit_id}/a/#{activity_id}/c/#{classroom_id}/students" }
     end

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -149,7 +149,6 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     render json: { student_ids: assigned_student_ids_for_classroom_and_units(classroom, units) }
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit
     params.permit(:unit_id, :activity_id)
     unit_id = params[:unit_id]
@@ -168,7 +167,6 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       render json: { url: "/teachers/progress_reports/diagnostic_reports#/u/#{unit_id}/a/#{activity_id}/c/#{classroom_id}/students" }
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def assign_post_test
     Units::AssignmentHelpers.assign_unit_to_one_class(params[:classroom_id], params[:unit_template_id], params[:student_ids], false)

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -37,7 +37,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
         it 'responds with a summary link' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
-          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/results?unit=#{unit.id}"}.to_json)
+          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}"}.to_json)
         end
       end
 
@@ -51,7 +51,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
         it 'responds with a summary link' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
-          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/results?unit=#{unit.id}"}.to_json)
+          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}"}.to_json)
         end
       end
 
@@ -65,7 +65,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
         it 'responds with a growth_summary link' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
-          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/growth_results?unit=#{unit.id}"}.to_json)
+          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}"}.to_json)
         end
       end
 
@@ -78,7 +78,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
         it 'responds with a summary link that has a unit query param' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
-          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/results?unit=#{unit.id}"}.to_json)
+          expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}"}.to_json)
         end
 
       end

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -35,7 +35,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         let!(:unit_activity) { create(:unit_activity, unit: unit, activity: activity)}
         let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
-        it 'responds with a summary link' do
+        it 'responds with a responses link' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
           expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}"}.to_json)
         end
@@ -49,7 +49,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         let!(:unit_activity) { create(:unit_activity, unit: unit, activity: activity)}
         let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
-        it 'responds with a summary link' do
+        it 'responds with a responses link' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
           expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}"}.to_json)
         end
@@ -63,7 +63,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         let!(:unit_activity) { create(:unit_activity, unit: unit, activity: activity)}
         let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
-        it 'responds with a growth_summary link' do
+        it 'responds with a growth responses link' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
           expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}"}.to_json)
         end
@@ -76,7 +76,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         let!(:unit_activity) { create(:unit_activity, unit: unit, activity: activity)}
         let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
-        it 'responds with a summary link that has a unit query param' do
+        it 'responds with a responses link that has a unit query param' do
           get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({unit_id: unit.id, activity_id: activity.id})
           expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}"}.to_json)
         end


### PR DESCRIPTION
## WHAT
route to student responses instead of student results

## WHY
this was the preferred route

## HOW
just change link structure

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Fix-the-diagnostic-responses-pathway-from-the-Activity-Analysis-report-6944436ee6e041bb8e419ec11d9475a6?pvs=4

### What have you done to QA this feature?
tested with several users by clicking on pre and post Diagnostic activities on Activity Analysis page

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
