### PR TITLE
Make sure to avoid returning more than the 500 students from spec

### DIFF
--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_student_view_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_student_view_query.rb
@@ -7,6 +7,7 @@ module AdminDiagnosticReports
     attr_reader :diagnostic_id
 
     AGGREGATE_COLUMN = :student_id
+    MAX_STUDENTS_TO_RETURN = 500
 
     def initialize(diagnostic_id:, **options)
       raise InvalidDiagnosticIdError, "#{diagnostic_id} is not a valid diagnostic_id value." unless DIAGNOSTIC_ORDER_BY_ID.include?(diagnostic_id.to_i)
@@ -95,6 +96,7 @@ module AdminDiagnosticReports
       result.group_by { |row| "#{row[:classroom_id]}:#{row[self.class::AGGREGATE_COLUMN]}" }
         .values
         .map { |group_rows| build_diagnostic_aggregates(group_rows) }
+        .slice(0, MAX_STUDENTS_TO_RETURN)
     end
 
     private def valid_aggregation_options = ['student']

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_performance_by_student_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_performance_by_student_view_query_spec.rb
@@ -7,24 +7,38 @@ module AdminDiagnosticReports
     include_context 'Admin Diagnostic Aggregate CTE'
     include_context 'Pre Post Diagnostic Skill Group Performance View'
 
+    let(:query_args) do
+      {
+        timeframe_start: timeframe_start,
+        timeframe_end: timeframe_end,
+        school_ids: school_ids,
+        grades: grades,
+        teacher_ids: teacher_ids,
+        classroom_ids: classroom_ids,
+        diagnostic_id: pre_diagnostic.id
+      }
+    end
+
+    context 'when finding more than 500 records' do
+      let(:runner_results) do
+        (described_class::MAX_STUDENTS_TO_RETURN + 1).times.map do |i|
+          {
+            :student_id => i,
+            :name => 'ROLLUP'
+          }
+        end
+      end
+      let(:runner) { double(execute: runner_results) }
+
+      it { expect(results.length).to eq(described_class::MAX_STUDENTS_TO_RETURN) }
+    end
+
     # TODO: Some of these specs fail intermittently.  In the interest of getting the code out the door, we're commenting them out, but we should come back and fix that soon
     #context 'big_query_snapshot', :big_query_snapshot do
     #  # Some of our tests include activity_sessions having NULL in its timestamps so we need a version that has timestamps with datetime data in them so that WITH in the CTE understands the data type expected
     #  let(:reference_activity_session) { create(:activity_session, :finished) }
     #  # Some of our tests expect no concept_results to exist, but BigQuery needs to know what one is shaped like in order to build temporary queries
     #  let(:reference_concept_results) { create(:concept_result, extra_metadata: {question_uid: SecureRandom.uuid}) }
-
-    #  let(:query_args) do
-    #    {
-    #      timeframe_start: timeframe_start,
-    #      timeframe_end: timeframe_end,
-    #      school_ids: school_ids,
-    #      grades: grades,
-    #      teacher_ids: teacher_ids,
-    #      classroom_ids: classroom_ids,
-    #      diagnostic_id: pre_diagnostic.id
-    #    }
-    #  end
 
     #  let(:cte_records) do
     #    [


### PR DESCRIPTION
Because of the way we do the data roll-ups with aggregate rows by skill, and with the number of skills for each diagnostic being potentially different, there's not an easy way to get this limit accurate in SQL, so we pull potentially extra records in SQL and need to cut off any extras here.

## WHAT
Make sure to avoid returning more than the 500 students from spec
## WHY
Giant tables get very unruly and unusable in a browser, so we want to set a maximum size on the table and have settled on 500 as a reasonable limit.  In an ideal world, we'd handle this limit in SQL, but the way we do aggregation (where a given student "row" may have multiple rows in the SQL data representing performance on different skills, or a student "row" may only have one row if the student has only been assigned the diagnostic but have never completed it) doesn't give us the precision we want.  We've been using `LIMIT 5000` on the SQL to make sure we don't pull way more data than we need, but this isn't sufficient to ensure only 500 records are available to the front-end.
## HOW
Add a `slice(0, 500)` call to the data after we've finished post-processing it into its final form where each record represents one student.

### Screenshots
OLD
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/325e0a4b-2f8a-4e69-9be5-453484cc498a)
NEW
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/1ef4c891-fe62-4b9f-b522-d5448e91ff89)

### Notion Card Links
https://www.notion.so/quill/ADGR-Display-a-download-link-on-the-Performance-by-Student-tab-when-an-admin-loads-the-maximum-n-838ccf65f35f4f4d9edcf17f430c5ab3

### What have you done to QA this feature?
- Log into prod and find a user who is getting more than 500 records back on the Student report
- Log in as the same user on staging with the new code
- - Confirm that the UI shows only 500 records available
- - Using the browser tools Network tab, confirm that only 500 records are coming back from the API

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes