### PR TITLE
Add Chain-of-Thought to Example Feedback

### DIFF
--- a/services/QuillLMS/Procfile.dev
+++ b/services/QuillLMS/Procfile.dev
@@ -3,7 +3,7 @@ rails: rails s -b 0.0.0.0
 
 worker: bundle exec sidekiq -v -q default -q critical
 reportworker: bundle exec sidekiq -v -q low
-experimentworker: bundle exec sidekiq -C config/sidekiq_experiment.yml
+experimentworker: bundle exec sidekiq -c 1
 
 redis-sidekiq: redis-server --port 6379
 

--- a/services/QuillLMS/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/config/initializers/zeitwerk.rb
@@ -17,6 +17,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_prompt_builder' => 'LLMPromptBuilder',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',
+    'llm_prompts_controller' => 'LLMPromptsController',
     'open_ai' => 'OpenAI',
     'pusher_csv_export_completed' => 'PusherCSVExportCompleted',
     'report_demo_ap_creator' => 'ReportDemoAPCreator',

--- a/services/QuillLMS/db/migrate/20240328124800_add_chain_of_thought_to_evidence_research_gen_ai_example_feedback.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240328124800_add_chain_of_thought_to_evidence_research_gen_ai_example_feedback.evidence.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240328124638)
+class AddChainOfThoughtToEvidenceResearchGenAIExampleFeedback < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_example_feedbacks, :chain_of_thought, :text
+  end
+end

--- a/services/QuillLMS/db/migrate/20240328190319_add_coda_to_evidence_research_gen_ai_llm_prompt_templates.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240328190319_add_coda_to_evidence_research_gen_ai_llm_prompt_templates.evidence.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240328185342)
+class AddCodaToEvidenceResearchGenAILLMPromptTemplates < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_llm_prompt_templates,
+      :coda,
+      :string,
+      null: false,
+      default: Evidence::Research::GenAI::LLMPromptTemplate::FEEDBACK_CODA
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2917,7 +2917,8 @@ CREATE TABLE public.evidence_research_gen_ai_example_feedbacks (
     label character varying NOT NULL,
     paraphrase text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    chain_of_thought text
 );
 
 
@@ -11292,6 +11293,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240318141154'),
 ('20240318142126'),
 ('20240318143324'),
-('20240318144601');
+('20240318144601'),
+('20240328124800');
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3051,7 +3051,8 @@ CREATE TABLE public.evidence_research_gen_ai_llm_prompt_templates (
     description text NOT NULL,
     contents text NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    coda character varying DEFAULT 'feedback'::character varying NOT NULL
 );
 
 
@@ -11294,6 +11295,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240318142126'),
 ('20240318143324'),
 ('20240318144601'),
-('20240328124800');
+('20240328124800'),
+('20240328190319');
 
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/example_feedbacks_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/example_feedbacks_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      class ExampleFeedbacksController < ApplicationController
+        before_action :example_feedback, only: %i[show update]
+
+        def show = example_feedback
+
+        def edit = example_feedback
+
+        def update
+          if example_feedback.update(edit_example_feedback_params)
+            redirect_to example_feedback
+          else
+            render :edit
+          end
+        end
+
+        private def example_feedback = @example_feedback ||= ExampleFeedback.find(params[:id])
+
+        private def example_feedback_params = params.require(:research_gen_ai_example_feedback)
+        private def edit_example_feedback_params = example_feedback_params.permit(:chain_of_thought, :paraphrase)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
@@ -6,6 +6,7 @@ module Evidence
       class LLMPromptTemplatesController < ApplicationController
         def new
           @llm_prompt_template = LLMPromptTemplate.new
+          @codas = LLMPromptTemplate::CODAS
         end
 
         def create

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompt_templates_controller.rb
@@ -12,7 +12,7 @@ module Evidence
           @llm_prompt_template = LLMPromptTemplate.new(llm_prompt_template_params)
 
           if @llm_prompt_template.save
-            redirect_to new_research_gen_ai_experiment_path
+            redirect_to @llm_prompt_template
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompts_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompts_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      class LLMPromptsController < ApplicationController
+        def show = @llm_prompt = LLMPrompt.find(params[:id])
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
+#  chain_of_thought           :text
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null
@@ -27,6 +28,10 @@ module Evidence
         delegate :response, to: :passage_prompt_response
 
         def response_and_feedback = "Response: #{response}\nFeedback: #{text}"
+
+        def response_chain_of_thought_and_feedback
+          "Response: #{response}\nChain-of-Thought: #{chain_of_thought}\nFeedback: #{text}"
+        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -33,12 +33,22 @@ module Evidence
           class_name: 'Evidence::Research::GenAI::PassagePromptResponse',
           through: :passage_prompt
 
+        has_many :llm_feedbacks,
+          class_name: 'Evidence::Research::GenAI::LLMPromptFeedback',
+          through: :passage_prompt_responses
+
+        has_many :example_feedbacks,
+          class_name: 'Evidence::Research::GenAI::ExampleFeedback',
+          through: :passage_prompt_responses
+
         validates :llm_config_id, :llm_prompt_id, :passage_prompt_id, presence: true
         validates :status, presence: true, inclusion: { in: STATUSES }
 
         delegate :conjunction, :name, to: :passage_prompt
         delegate :llm_client, to: :llm_config
         delegate :vendor, :version, to: :llm_config
+
+        attr_readonly :llm_config_id, :llm_prompt_id, :passage_prompt_id
 
         attr_accessor :llm_prompt_template_id
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -65,7 +65,7 @@ module Evidence
 
         private def create_llm_prompt_responses_feedbacks(limit:)
           passage_prompt_responses.limit(limit).each do |passage_prompt_response|
-            feedback = llm_client.run(prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
+            feedback = llm_client.run(prompt: llm_prompt.prompt_response_coda(passage_prompt_response.response))
             LLMFeedback.create!(text: feedback, passage_prompt_response:)
           end
         end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
@@ -32,6 +32,8 @@ module Evidence
 
         def feedback_prompt(response) = "#{prompt}\n\nResponse: #{response}\nFeedback:"
         def evaluation_prompt(response) = "#{prompt}\n\nResponse: #{response}\nParaphrase:"
+
+        def to_s = prompt
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
@@ -21,7 +21,7 @@ module Evidence
 
         attr_readonly :prompt, :llm_prompt_template_id
 
-        delegate :description, to: :llm_prompt_template
+        delegate :coda, :description, to: :llm_prompt_template
 
         def self.create_from_template!(llm_prompt_template_id:, passage_prompt_id:)
           create!(
@@ -30,8 +30,7 @@ module Evidence
            )
         end
 
-        def feedback_prompt(response) = "#{prompt}\n\nResponse: #{response}\nFeedback:"
-        def evaluation_prompt(response) = "#{prompt}\n\nResponse: #{response}\nParaphrase:"
+        def prompt_response_coda(response) = "#{prompt}\n\nResponse: #{response}\n#{coda}:"
 
         def to_s = prompt
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_template.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_template.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_llm_prompt_templates
 #
 #  id          :bigint           not null, primary key
+#  coda        :string           default("feedback"), not null
 #  contents    :text             not null
 #  description :text             not null
 #  created_at  :datetime         not null
@@ -14,14 +15,29 @@ module Evidence
   module Research
     module GenAI
       class LLMPromptTemplate < ApplicationRecord
-        validates :description, presence: true
-        validates :contents, presence: true
+        CODAS = [
+          FEEDBACK_CODA = 'feedback',
+          CHAIN_OF_THOUGHT_CODA = 'chain_of_thought',
+          EVALUATION_CODA = 'evaluation'
+        ].freeze
 
-        attr_readonly :description, :contents
+        DISPLAY_CODA = {
+          CHAIN_OF_THOUGHT_CODA => 'Chain-of-Thought',
+          EVALUATION_CODA => 'Evaluation',
+          FEEDBACK_CODA => 'Feedback'
+        }.freeze
+
+        validates :coda, presence: true, inclusion: { in: CODAS }
+        validates :contents, presence: true
+        validates :description, presence: true
+
+        attr_readonly :coda, :contents, :description
 
         has_many :llm_prompts,
           class_name: 'Evidence::Research::GenAI::LLMPrompt',
           dependent: :destroy
+
+        def display_coda = DISPLAY_CODA[coda]
 
         def to_s = description
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
@@ -23,6 +23,8 @@ module Evidence
         validates :passage_prompt_id, presence: true
 
         attr_readonly :response, :passage_prompt_id
+
+        def to_s = response
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
@@ -21,10 +21,12 @@ module Evidence
         OPTIONAL_COMMA_AND_DIGIT_REGEX = "(?:,(\\d+))?"
 
         SUBSTITUTIONS = {
-          "prompt" => ->(builder, _) { builder.passage_prompt.prompt },
-          "instructions" => ->(builder, _) { builder.passage_prompt.instructions },
-          "relevant_passage" => ->(builder, _) { builder.passage_prompt.relevant_passage },
           "examples" => ->(builder, limit) { builder.examples(limit) },
+          "examples_chain_of_thought" => ->(builder, limit) { builder.examples_chain_of_thought(limit) },
+          "instructions" => ->(builder, _) { builder.passage_prompt.instructions },
+          "passage" => ->(builder, _) { builder.passage_prompt.passage.contents },
+          "prompt" => ->(builder, _) { builder.passage_prompt.prompt },
+          "relevant_passage" => ->(builder, _) { builder.passage_prompt.relevant_passage },
         }.freeze
 
         attr_reader :llm_prompt_template_id, :passage_prompt_id
@@ -54,6 +56,15 @@ module Evidence
             .example_feedbacks
             .limit(limit)
             .map(&:response_and_feedback)
+            .join("\n")
+        end
+
+        def examples_chain_of_thought(limit)
+          passage_prompt
+            .example_feedbacks
+            .where.not(chain_of_thought: nil)
+            .limit(limit)
+            .map(&:response_chain_of_thought_and_feedback)
             .join("\n")
         end
 

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/example_feedbacks/edit.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/example_feedbacks/edit.html.erb
@@ -1,0 +1,36 @@
+<h1>Edit Example Feedback</h1>
+
+<div class="field-spacing">
+  <h3>Response</h3>
+  <p><%= @example_feedback.passage_prompt_response %></p>
+</div>
+
+<div class="field-spacing">
+  <h3>Feedback</h3>
+  <p><%= @example_feedback.text %></p>
+</div>
+
+<div class="field-spacing">
+  <h3>Label</h3>
+  <p><%= @example_feedback.label %></p>
+</div>
+
+<%= form_for @example_feedback do |f| %>
+  <%= render 'errors', object: @example_feedback %>
+
+  <hr/>
+  <h2>Editable Fields</h2>
+  <div class="field-spacing">
+    <%= f.label :chain_of_thought %><br>
+    <%= f.text_area :chain_of_thought, cols: 100, rows: 5 %>
+  </div>
+
+  <div class="field-spacing">
+    <%= f.label :paraphrase %><br>
+    <%= f.text_area :paraphrase, cols: 100, rows: 5 %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/example_feedbacks/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/example_feedbacks/show.html.erb
@@ -1,0 +1,28 @@
+<div>
+  <h2>Example Feedback</h2>
+
+  <h3>Response</h3>
+  <p><%= @example_feedback.passage_prompt_response %></p>
+
+  <h3>Feedback</h3>
+  <p><%= @example_feedback.text %></p>
+
+  <h3>Label</h3>
+  <p><%= @example_feedback.label %></p>
+
+  <% if @example_feedback.paraphrase %>
+    <h3>Paraphrase</h3>
+    <p><%= @example_feedback.paraphrase %></p>
+  <% end %>
+
+  <% if @example_feedback.chain_of_thought %>
+    <h3>Chain-of-Thought</h3>
+    <p><%= @example_feedback.chain_of_thought %></p>
+  <% end %>
+</div>
+
+<br>
+<%= link_to 'Edit Example Feedback', [:edit, @example_feedback] %>
+<br>
+<br>
+<%= link_to 'Experiments', research_gen_ai_experiments_path %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/index.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/index.html.erb
@@ -7,9 +7,10 @@
     <thead>
       <tr>
         <th>ID</th>
-        <th>Status</th>
         <th>Passage</th>
         <th>Conjunction</th>
+        <th>Status</th>
+        <th>LLM Prompt Description</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -20,6 +21,7 @@
           <td><%= experiment.passage_prompt.name %></td>
           <td><%= experiment.conjunction %></td>
           <td><%= experiment.status %></td>
+          <td><%= experiment.llm_prompt.description %></td>
           <td><%= link_to "View", experiment %></td>
         </tr>
       <% end %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -2,16 +2,13 @@
   <h2>Experiment</h2>
 
   <h3>Passage</h3>
-  <p><%= @experiment.passage_prompt %></p>
+  <p><%= link_to @experiment.passage_prompt, @experiment.passage_prompt %></p>
 
   <h3>LLM</h3>
   <p><%= @experiment.llm_config %></p>
 
-  <%= link_to 'LLMPromptTemplate', @experiment.llm_prompt.llm_prompt_template %>
-
   <h3>LLM Prompt</h3>
-  <p><%= @experiment.llm_prompt.description %></p>
-  <p><%= simple_format(@experiment.llm_prompt.prompt) %></p>
+  <p><%= link_to @experiment.llm_prompt.description, @experiment.llm_prompt %></p>
 
   <h3>Results</h3>
   <p><%= @experiment.results ? @experiment.results.to_json : 'No results yet' %></p>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -7,6 +7,8 @@
   <h3>LLM</h3>
   <p><%= @experiment.llm_config %></p>
 
+  <%= link_to 'LLMPromptTemplate', @experiment.llm_prompt.llm_prompt_template %>
+
   <h3>LLM Prompt</h3>
   <p><%= @experiment.llm_prompt.description %></p>
   <p><%= simple_format(@experiment.llm_prompt.prompt) %></p>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompt_templates/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompt_templates/new.html.erb
@@ -8,6 +8,11 @@
   </div>
 
   <div class="field-spacing">
+    <%= f.label :coda, "Coda:" %>
+    <%= select_tag :coda, options_for_select(@codas), { required: true } %>
+  </div>
+
+  <div class="field-spacing">
     <%= f.label :contents %><br>
     <%= f.text_area :contents, cols: 100, rows: 50, required: true %>
   </div>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompt_templates/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompt_templates/show.html.erb
@@ -1,0 +1,15 @@
+<div>
+  <h2>LLM Prompt Template</h2>
+
+  <h3>Description</h3>
+  <p><%= @llm_prompt_template.description %></p>
+
+  <h3>Contents</h3>
+  <p><%= simple_format(@llm_prompt_template.contents) %></p>
+</div>
+
+<br>
+<%= link_to 'New Experiment', new_research_gen_ai_experiment_path %>
+<br>
+<br>
+<%= link_to 'Experiments', research_gen_ai_experiments_path %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompt_templates/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompt_templates/show.html.erb
@@ -4,6 +4,9 @@
   <h3>Description</h3>
   <p><%= @llm_prompt_template.description %></p>
 
+  <h3>Coda</h3>
+  <p><%= @llm_prompt_template.coda %></p>
+
   <h3>Contents</h3>
   <p><%= simple_format(@llm_prompt_template.contents) %></p>
 </div>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompts/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompts/show.html.erb
@@ -1,0 +1,11 @@
+<div>
+  <h2>LLM Prompt</h2>
+
+  <h3>Description</h3>
+  <p><%= link_to @llm_prompt.description, @llm_prompt.llm_prompt_template %><p>
+
+  <h3>Prompt</h3>
+  <p><%= simple_format(@llm_prompt.prompt) %></p>
+</div>
+
+<%= link_to 'Back', research_gen_ai_experiments_path %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/show.html.erb
@@ -1,0 +1,31 @@
+<div>
+  <h2>Passage Prompt</h2>
+  <p><%= @passage_prompt  %></p>
+
+  <% if @passage_prompt.example_feedbacks.any? %>
+    <h3>Example Feedback</h3>
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>Response</th>
+          <th>Example Feedback</th>
+          <th>Chain of Thought</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @passage_prompt.example_feedbacks.each do |example_feedback| %>
+          <tr>
+            <td><%= link_to "Edit", [:edit, example_feedback] %></td>
+            <td><%= example_feedback.passage_prompt_response.response %></td>
+            <td><%= example_feedback.text %></td>
+            <td><%= example_feedback.chain_of_thought %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>No example feedback found.</p>
+  <% end %>
+</div>
+<%= link_to 'Back', research_gen_ai_experiments_path %>

--- a/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
@@ -13,6 +13,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_prompt_builder' => 'LLMPromptBuilder',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',
+    'llm_prompts_controller' => 'LLMPromptsController',
     'open_ai' => 'OpenAI',
     'vertex_ai' => 'VertexAI'
   )

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -43,9 +43,11 @@ Evidence::Engine.routes.draw do
 
   namespace :research do
     namespace :gen_ai do
+      resources :example_feedbacks, only: [:show, :edit, :update]
       resources :experiments, only: [:new, :create, :show, :index]
       resources :llm_configs, only: [:new, :create, :show, :index]
       resources :llm_prompt_templates, only: [:new, :create, :show, :index]
+      resources :llm_prompts, only: [:show]
       resources :passage_prompts, only: [:new, :create, :show, :index]
     end
   end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240328124638_add_chain_of_thought_to_evidence_research_gen_ai_example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240328124638_add_chain_of_thought_to_evidence_research_gen_ai_example_feedback.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddChainOfThoughtToEvidenceResearchGenAIExampleFeedback < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_example_feedbacks, :chain_of_thought, :text
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240328185342_add_coda_to_evidence_research_gen_ai_llm_prompt_templates.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240328185342_add_coda_to_evidence_research_gen_ai_llm_prompt_templates.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddCodaToEvidenceResearchGenAILLMPromptTemplates < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_llm_prompt_templates,
+      :coda,
+      :string,
+      null: false,
+      default: Evidence::Research::GenAI::LLMPromptTemplate::FEEDBACK_CODA
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1041,7 +1041,8 @@ CREATE TABLE public.evidence_research_gen_ai_llm_prompt_templates (
     description text NOT NULL,
     contents text NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    coda character varying DEFAULT 'feedback'::character varying NOT NULL
 );
 
 
@@ -2067,6 +2068,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240318141942'),
 ('20240318143146'),
 ('20240318144447'),
-('20240328124638');
+('20240328124638'),
+('20240328185342');
 
 

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -907,7 +907,8 @@ CREATE TABLE public.evidence_research_gen_ai_example_feedbacks (
     label character varying NOT NULL,
     paraphrase text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    chain_of_thought text
 );
 
 
@@ -2065,6 +2066,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240318140506'),
 ('20240318141942'),
 ('20240318143146'),
-('20240318144447');
+('20240318144447'),
+('20240328124638');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/example_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/example_feedbacks.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
+#  chain_of_thought           :text
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_templates.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_templates.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_llm_prompt_templates
 #
 #  id          :bigint           not null, primary key
+#  coda        :string           default("feedback"), not null
 #  contents    :text             not null
 #  description :text             not null
 #  created_at  :datetime         not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_feedback_spec.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
+#  chain_of_thought           :text
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -26,6 +26,9 @@ module Evidence
         it { should validate_presence_of(:llm_prompt_id) }
         it { should validate_presence_of(:passage_prompt_id) }
         it { should validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+        it { should have_readonly_attribute(:llm_config_id) }
+        it { should have_readonly_attribute(:llm_prompt_id) }
+        it { should have_readonly_attribute(:passage_prompt_id) }
 
         it { belong_to(:llm_config).class_name('Evidence::Research::GenAI::LLMConfig') }
         it { belong_to(:llm_prompt).class_name('Evidence::Research::GenAI::LLMPrompt') }
@@ -35,6 +38,18 @@ module Evidence
           have_many(:passage_prompt_responses)
             .class_name('Evidence::Research::GenAI::PassagePromptResponse')
             .through(:passage_prompt)
+        end
+
+        it do
+          have_many(:llm_feedbacks)
+            .class_name('Evidence::Research::GenAI::LLMPromptFeedback')
+            .through(:passage_prompt_responses)
+        end
+
+        it do
+          have_many(:example_feedbacks)
+            .class_name('Evidence::Research::GenAI::ExampleFeedback')
+            .through(:passage_prompt_responses)
         end
 
         it { expect(build(:evidence_research_gen_ai_experiment)).to be_valid }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_template_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_template_spec.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_llm_prompt_templates
 #
 #  id          :bigint           not null, primary key
+#  coda        :string           default("feedback"), not null
 #  contents    :text             not null
 #  description :text             not null
 #  created_at  :datetime         not null
@@ -18,10 +19,13 @@ module Evidence
       RSpec.describe LLMPromptTemplate, type: :model do
         it { should validate_presence_of(:description) }
         it { should validate_presence_of(:contents) }
+        it { should validate_presence_of(:coda) }
+        it { should validate_inclusion_of(:coda).in_array(LLMPromptTemplate::CODAS) }
         it { should have_readonly_attribute(:description) }
         it { should have_readonly_attribute(:contents) }
+        it { should have_readonly_attribute(:coda) }
 
-        it { should have_many(:llm_prompts).class_name('Evidence::Research::GenAI::LLMPrompt').dependent(:destroy) }
+        it { should have_many(:llm_prompts).dependent(:destroy) }
 
         it { expect(FactoryBot.build(:evidence_research_gen_ai_llm_prompt_template)).to be_valid }
       end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
@@ -55,6 +55,13 @@ module Evidence
             it { is_expected.to eq relevant_passage }
           end
 
+          context 'passage' do
+            let(:contents) { delimit('passage') }
+            let(:passage_contents) { passage_prompt.passage.contents }
+
+            it { is_expected.to eq passage_contents }
+          end
+
           context 'examples' do
             let(:num_of_examples) { 5 }
 
@@ -70,6 +77,24 @@ module Evidence
             let(:contents) { delimit("examples,#{limit}") }
 
             it { is_expected.to eq example_feedbacks.first(limit).map(&:response_and_feedback).join("\n") }
+          end
+
+          context 'examples_chain_of_thought' do
+            let(:num_of_examples) { 5 }
+
+            let!(:example_feedbacks) do
+              create_list(
+                :evidence_research_gen_ai_example_feedback,
+                num_of_examples,
+                chain_of_thought: 'this is a chain of thought',
+                passage_prompt_response: create(:evidence_research_gen_ai_passage_prompt_response, passage_prompt:)
+              )
+            end
+
+            let(:limit) { 3 }
+            let(:contents) { delimit("examples_chain_of_thought,#{limit}") }
+
+            it { is_expected.to eq example_feedbacks.first(limit).map(&:response_chain_of_thought_and_feedback).join("\n") }
           end
 
           context 'multiple substitutions' do


### PR DESCRIPTION
## WHAT
1.  Add `chain_of_thought` (i.e. CoT) attribute to `Evidence::Research::GenAI::ExampleFeedback`
1.  Currently, the end of our LLMPrompt contain a label (e.g. `Feedback:` or `Evaluation`).  Let's parameterize this label as `coda` and add it as an attribute on `LLMPromptTemplate`

## WHY
1.  We'd like to run experiments to see if CoT helps with accuracy.
1.   The use of CoT is related to the coda we want to make this dependency explicit.

## HOW
1.  Add a migration with the field and then update the PromptBuilder substitution to encode `examples_chain_of_thought`
1.  Add a migration with the field and then update the Experiment#run method to use the `prompt_response_coda` method.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Prompt-Engineering-Attempt-to-improve-Gemini-Performance-d2bda6915f83405791e8ff8ab4dd998e?pvs=4

### What have you done to QA this feature?
Tested out some creation via the UI on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
