### PR TITLE
Preview Grammar Activity bugfix for viewing first question

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -263,7 +263,6 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         window.pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
       }
       const channel = window.pusher.subscribe(activitySessionUid);
-
       channel.bind('concept-results-saved', () => {
         document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${activitySessionUid}`;
         this.setState({ saved: true, });
@@ -340,7 +339,6 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       if ((grammarActivities.hasreceiveddata || proofreaderSessionId) && session.hasreceiveddata) {
 
         if (session.currentQuestion) {
-          console.log(session.currentQuestion)
           return (
             <QuestionComponent
               activity={grammarActivities ? grammarActivities.currentActivity : null}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -161,7 +161,6 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
     }
     if(previewMode && !introSkipped && skippedToQuestionFromIntro) {
       this.setState({ introSkipped: true });
-      this.goToNextQuestion();
     }
 
   }
@@ -264,7 +263,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         window.pusher = new Pusher(process.env.PUSHER_KEY, { cluster: process.env.PUSHER_CLUSTER });
       }
       const channel = window.pusher.subscribe(activitySessionUid);
-      
+
       channel.bind('concept-results-saved', () => {
         document.location.href = `${process.env.DEFAULT_URL}/activity_sessions/${activitySessionUid}`;
         this.setState({ saved: true, });
@@ -341,6 +340,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       if ((grammarActivities.hasreceiveddata || proofreaderSessionId) && session.hasreceiveddata) {
 
         if (session.currentQuestion) {
+          console.log(session.currentQuestion)
           return (
             <QuestionComponent
               activity={grammarActivities ? grammarActivities.currentActivity : null}


### PR DESCRIPTION
## WHAT
The first time a teacher clicks on any question in the preview Grammar Activity view, the interface skips them to the question after the desired question. This PR fixes that bug.

## WHY
This is confusing and breaking the UI for teachers, which leads to a bad experience.

## HOW
We are unnecessarily calling the function `goToNextQuestion()` here when we don't need to. Any click action on a question already calls setCurrentQuestion() and sets the UI to view that question, so when we call `goToNextQuestion()` that makes the component skip to the subsequent question instead of viewing the current one. Just remove this one line of code to fix this edge case.

### Screenshots
<img width="1362" alt="Screenshot 2024-03-30 at 1 45 51 AM" src="https://github.com/empirical-org/Empirical-Core/assets/57366100/f2a9e1d1-cf97-4d3c-b335-23412006a3ed">


### Notion Card Links
https://www.notion.so/quill/Fix-Grammar-Preview-Menu-bug-that-initially-links-to-the-wrong-question-f1ddd4d987004ab58b6d92cde7136b7e?pvs=4

### What have you done to QA this feature?
Deployed to staging. Since the code I touched only triggers when in preview mode, I went to preview a Grammar activity and clicked "Start activity" to verify that the non-skipped-intro path works. Then I played through the activity to confirm questions are loading correctly. I also clicked around to different question to confirm set_question works.

Second, I went to preview a Grammar activity and clicked the question without going through the intro. This should trigger my desired code, which loads the correct question. Follow the above steps to confirm everything is working in this flow as well.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, manually tested.
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
