### PR TITLE
Fix timeframe_spec bug

### DIFF
--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -108,8 +108,8 @@ module Snapshots
 
     it_behaves_like 'snapshots period length, previous within threshold', 'this-school-year', 1
     it_behaves_like 'snapshots period length, previous within threshold', 'last-school-year', 1
-    it_behaves_like 'snapshots period length, previous within threshold', 'this-month', 1, 3
-    it_behaves_like 'snapshots period length, previous within threshold', 'last-month', 1, 3
+    it_behaves_like 'snapshots period length, previous within threshold', 'this-month', 2, 3
+    it_behaves_like 'snapshots period length, previous within threshold', 'last-month', 2, 3
 
   end
 end


### PR DESCRIPTION
## WHAT
Fix a spec [failure](https://app.circleci.com/pipelines/github/empirical-org/Empirical-Core/28241/workflows/e5c80aec-ac37-45ab-8385-377dbf3834c6) involving timeframes_spec.

## WHY
The code involving timeframes has some edge cases involving February leap years and end of the month calculation.  I think there's an off by one error here for non February, March months that hadn't manifest until April 1 occurred.

## HOW
Change the threshold value from 1 to 2.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links

### What have you done to QA this feature?
Using timecop, I tested this over different months to make sure prior months tests still work:
 
```
    before do
      travel_to 1.month.from_ago
      allow(DateTime).to receive(:current).and_return(now)
    end

    after { travel_back }
```

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
