### PR TITLE
Fix for timeframe spec.

### DIFF
--- a/services/QuillLMS/spec/support/shared_examples/snapshots/snapshots_period_length_previous_with_threshold_rspec.rb
+++ b/services/QuillLMS/spec/support/shared_examples/snapshots/snapshots_period_length_previous_with_threshold_rspec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.shared_examples 'snapshots period length, previous within threshold' do |timeframe_key, threshold, february_threshold|
   context "'#{timeframe_key}'" do
+    let(:february_and_march_months) { [2,3] }
     let(:now) { DateTime.current }
     let(:timeframe) {described_class.calculate_timeframes(timeframe_key)}
     let(:previous_timeframe) {described_class.calculate_timeframes(timeframe_key, previous_timeframe: true)}
@@ -16,7 +17,8 @@ RSpec.shared_examples 'snapshots period length, previous within threshold' do |t
     let(:threshold_to_use) do
       return threshold if february_threshold.nil?
 
-      now.month.in?([2,3])  ? february_threshold : threshold
+      yesterday = now - 1.day
+      yesterday.month.in?(february_and_march_months) ? february_threshold : threshold
     end
 
     before do


### PR DESCRIPTION
## WHAT
Fix for timeframe spec.
## WHY
It is failing because `timeframe` uses `yesterday` to determine the timeframe, but the "threshold for months around February" logic was using `today`.
## HOW
Fix the "threshold for months around February" logic to use `yesterday`




### What have you done to QA this feature?
This is purely a test

Also borrowed Brendan's QA and did this for 12 months to double check.
```ruby
      before do
        travel_to 12.month.ago
        allow(DateTime).to receive(:current).and_return(now)
      end

      after { travel_back }
```

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
