### PR TITLE
Bug fix/ student metrics activity total time count

### DIFF
--- a/services/QuillLMS/app/queries/student_dashboard_metrics.rb
+++ b/services/QuillLMS/app/queries/student_dashboard_metrics.rb
@@ -34,6 +34,7 @@ class StudentDashboardMetrics
         .joins(:classroom_unit)
         .where(user:, classroom_unit: {classroom_id:})
         .where.not(completed_at: nil)
+        .where(visible: true)
     end
   end
 

--- a/services/QuillLMS/spec/queries/student_dashboard_metrics_spec.rb
+++ b/services/QuillLMS/spec/queries/student_dashboard_metrics_spec.rb
@@ -64,7 +64,7 @@ describe StudentDashboardMetrics do
   describe 'completed_sessions' do
     it 'only includes sessions with completed_at not nil and visible true' do
       create(:activity_session, :started, user: student, classroom_unit:)
-      create(:activity_session, :completed, visible: false, user: student, classroom_unit:)
+      create(:activity_session, :finished, visible: false, user: student, classroom_unit:)
       metrics_instance = StudentDashboardMetrics.new(student, classroom.id)
 
       expect(metrics_instance.completed_sessions.count).to eq(activity_sessions.count)

--- a/services/QuillLMS/spec/queries/student_dashboard_metrics_spec.rb
+++ b/services/QuillLMS/spec/queries/student_dashboard_metrics_spec.rb
@@ -62,8 +62,9 @@ describe StudentDashboardMetrics do
   end
 
   describe 'completed_sessions' do
-    it 'only includes sessions with completed_at not nil' do
+    it 'only includes sessions with completed_at not nil and visible true' do
       create(:activity_session, :started, user: student, classroom_unit:)
+      create(:activity_session, :completed, visible: false, user: student, classroom_unit:)
       metrics_instance = StudentDashboardMetrics.new(student, classroom.id)
 
       expect(metrics_instance.completed_sessions.count).to eq(activity_sessions.count)


### PR DESCRIPTION
## WHAT
tweak student metrics to exclude hidden activity sessions from the total time spent calculation

## WHY
we want the time spent to match the time spent shown on the Activity Summary teacher reports

## HOW
add a where clause to the `completed_sessions` method to include `visible: true`
### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Is-a-discrepancy-between-the-Total-time-spent-on-a-student-s-Activity-Summary-report-and-the-Time-sp-bb4b8777e4784ef995d39e1b8b60abf8

### What have you done to QA this feature?
hooked into production locally to verify that both time spent counts match for these two users

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
