### PR TITLE
remove stripping of p tags from fill in blank questions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/editFillInBlank.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/editFillInBlank.jsx
@@ -10,7 +10,6 @@ class EditFillInBlank extends Component {
     const { params } = match
     const { questionID } = params
     let questionData = data
-    questionData.prompt = data.prompt.replace('<p>', '').replace('</p>', '')
     dispatch(fillInBlankActions.submitQuestionEdit(questionID, data));
   };
 

--- a/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
@@ -106,7 +106,6 @@ class FillInBlankForm extends Component {
       flag: flag ? flag : 'alpha',
       cuesLabel: cuesLabel
     };
-    data.prompt = data.prompt.replace('<p>', '').replace('</p>', '')
     if (this.props.new && data.prompt != '') {
       action(
         data,

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/editFillInBlank.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/editFillInBlank.jsx
@@ -10,7 +10,6 @@ class EditFillInBlank extends Component {
     const { params } = match;
     const { questionID } = params;
     const questionData = data;
-    questionData.prompt = data.prompt.replace('<p>', '').replace('</p>', '')
     dispatch(fillInBlankActions.submitQuestionEdit(questionID, data));
   };
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/newFillInBlank.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/newFillInBlank.jsx
@@ -8,7 +8,6 @@ class NewFillInBlank extends Component {
     const { dispatch } = this.props;
     if (data.prompt !== '') {
       const questionData = data
-      questionData.prompt = data.prompt.replace('<p>', '').replace('</p>', '')
       dispatch(fillInBlankActions.submitNewQuestion(
         questionData,
         {


### PR DESCRIPTION
## WHAT
Remove unnecessary stripping of `<p>` tags from fill in blank questions on create and edit, both in Connect and Diagnostic.

## WHY
This was resulting in weird behavior, where line breaks were not being saved where the curriculum team expected them to/saw in the WYSIWYG editor.

## HOW
Just removed this line of code in the relevant places. Since there is already HTML, and sometimes `<p>` tags (since the stripping only ever removed the first of each) still coming through in these prompts, this change seems low-risk.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-issue-where-fill-in-blank-line-breaks-are-not-always-saving-correctly-4d7579bcfbb34a8aa1ea42279d087b84?pvs=4

### What have you done to QA this feature?
Tested new and existing question changes on Connect and Diagnostic on staging, and asked Rachel to confirm that things are working as expected.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
