### PR TITLE
change absolute positioning of tooltip caret

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/main.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tooltip/scorebook_and_student_profile_tooltip/main.scss
@@ -3,7 +3,7 @@
   i, svg {
     position: absolute;
     top: -20px;
-    left: 188px;
+    left: 146px;
     font-size: 34px;
     color: $quill-white;
     &.border-color {


### PR DESCRIPTION
## WHAT
Fix bug where tooltip carat wasn't pointing at the hovered item.

## WHY
We want it to be clear what the tooltip refers to.

## HOW
Just adjust the positioning.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Check both places we use this tooltip and make sure the carat is indicating the correct place at various levels of zoom.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | CSS - no tests
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
