### PR TITLE
Add GenAI Experiment Metrics Part 2: Identical match

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -56,7 +56,7 @@ module Evidence
 
           update!(status: RUNNING)
           create_llm_prompt_responses_feedbacks(limit:)
-          update!(results: (results || {}).merge(calculated_results))
+          calculate_results
           update!(status: COMPLETED)
         rescue StandardError => e
           experiment_errors << e.message
@@ -70,8 +70,11 @@ module Evidence
           end
         end
 
+        private def calculate_results = update!(results: (results || {}).merge(calculated_results))
+
         private def calculated_results
           {
+            accuracy_identical: IdenticalResultsAccuracyCalculator.run(self),
             accuracy_optimal_sub_optimal: optimal_and_sub_optimal_results[:accuracy],
             confusion_matrix: optimal_and_sub_optimal_results[:confusion_matrix]
           }

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
@@ -29,7 +29,9 @@ module Evidence
 
         delegate :example_optimal?, :example_feedback, to: :passage_prompt_response
 
-        def example_sub_optimal? = !example_optimal?
+        def identical_feedback? = example_feedback.text == text
+
+        def optimal_or_sub_optimal_match? = example_optimal? ? optimal? : sub_optimal?
 
         def response_and_feedback = "Response: #{passage_prompt_response.response}\nFeedback: #{text}"
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
@@ -29,7 +29,7 @@ module Evidence
 
         delegate :example_optimal?, :example_feedback, to: :passage_prompt_response
 
-        def identical_feedback? = example_feedback.text == text
+        def identical_feedback? = example_feedback.text.strip == text.strip
 
         def optimal_or_sub_optimal_match? = example_optimal? ? optimal? : sub_optimal?
 

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/identical_results_accuracy_calculator.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/identical_results_accuracy_calculator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      class IdenticalResultsAccuracyCalculator < ApplicationService
+        attr_reader :experiment, :num_feedbacks
+
+        def initialize(experiment)
+          @experiment = experiment
+          @num_feedbacks = experiment.llm_feedbacks.size
+        end
+
+        def run
+          return nil if num_feedbacks.zero?
+
+          1.0 * num_identical_feedbacks / num_feedbacks
+        end
+
+        private def num_identical_feedbacks = experiment.llm_feedbacks.select(&:identical_feedback?).size
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/application/_matrix.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/application/_matrix.html.erb
@@ -1,0 +1,14 @@
+<% if matrix %>
+  <h4><%= title %></h4>
+  <table style="width: auto; table-layout: auto; border-collapse: collapse; border: 1px solid black;">
+    <% matrix.each do |row| %>
+      <tr>
+        <% row.each do |element| %>
+          <td>
+            <%= element %>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -13,31 +13,42 @@
   <p><%= @experiment.llm_prompt.description %></p>
   <p><%= simple_format(@experiment.llm_prompt.prompt) %></p>
 
+  <hr/>
   <h3>Results</h3>
-  <p><%= @experiment.results ? @experiment.results.to_json : 'No results yet' %></p>
+  <% if @experiment.results %>
+    <p>Accuracy (identical): <%= @experiment.results['accuracy_identical'] %></p>
+    <p>Accuracy (sub/optimal): <%= @experiment.results['accuracy_optimal_sub_optimal'] %></p>
 
-  <table>
-    <thead>
-      <tr>
-        <th>Eval</th>
-        <th>Prompt Response</th>
-        <th>Example Feedback</th>
-        <th>LLM Feedback</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @experiment.llm_feedbacks.each do |llm_feedback| %>
+    <%= render 'matrix', matrix: @experiment.results['confusion_matrix'], title: 'Confusion Matrix' %>
+
+    <table>
+      <thead>
         <tr>
-          <%  example_feedback = llm_feedback.example_feedback %>
-          <% status_class = llm_feedback.optimal? == example_feedback.optimal? ? 'green' : 'red' %>
-          <td class="<%= status_class %>"></td>
-          <td><%= llm_feedback.passage_prompt_response %></td>
-          <td><%= llm_feedback.text %></td>
-          <td><%= example_feedback.text %></td>
+          <th>Identical match</th>
+          <th>OptSubOpt match</th>
+          <th>Prompt Response</th>
+          <th>Example Feedback</th>
+          <th>LLM Feedback</th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <% @experiment.llm_feedbacks.each do |llm_feedback| %>
+          <tr>
+            <% example_feedback = llm_feedback.example_feedback %>
+            <td class="<%= llm_feedback.identical_feedback? ? 'green' : 'red' %>"></td>
+            <td class="<%= llm_feedback.optimal_or_sub_optimal_match? ? 'green' : 'red' %>"></td>
+            <td><%= llm_feedback.passage_prompt_response %></td>
+            <td><%= llm_feedback.text %></td>
+            <td><%= example_feedback.text %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <% else %>
+      <p>No results yet</p>
+    <% end %>
+
+
 
   <h3>Status</h3>
   <p><%= @experiment.status.capitalize %></p>

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -85,7 +85,7 @@ module Evidence
             expect { subject }
               .to change { experiment.reload.results }
               .from(nil)
-              .to(include('accuracy_optimal_sub_optimal', 'confusion_matrix'))
+              .to(include('accuracy_optimal_sub_optimal', 'confusion_matrix', 'accuracy_identical'))
           end
 
           context 'with limit provided' do

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
@@ -33,6 +33,72 @@ module Evidence
         it { expect(build(:evidence_research_gen_ai_llm_feedback)).to be_valid }
 
         it_behaves_like 'a class with optimal and sub-optimal'
+
+        describe '#optimal_or_sub_optimal_match?' do
+          subject { llm_feedback.optimal_or_sub_optimal_match? }
+
+          let(:llm_feedback) { create(:evidence_research_gen_ai_llm_feedback) }
+          let(:passage_prompt_response) { llm_feedback.passage_prompt_response }
+          let(:example_feedback) { create(:evidence_research_gen_ai_example_feedback, passage_prompt_response:) }
+
+          before do
+            allow(passage_prompt_response).to receive(:example_optimal?).and_return(example_optimal)
+            allow(llm_feedback).to receive(:optimal?).and_return(llm_optimal)
+          end
+
+          context 'when the example feedback is optimal' do
+            let(:example_optimal) { true }
+
+            context 'when the llm feedback is optimal' do
+              let(:llm_optimal) { true }
+
+              it { is_expected.to be true }
+            end
+
+            context 'when the llm feedback is sub-optimal' do
+              let(:llm_optimal) { false }
+
+              it { is_expected.to be false }
+            end
+          end
+
+          context 'when the example feedback is sub-optimal' do
+            let(:example_optimal) { false }
+
+            context 'when the llm feedback is optimal' do
+              let(:llm_optimal) { true }
+
+              it { is_expected.to be false }
+            end
+
+            context 'when the llm feedback is sub-optimal' do
+              let(:llm_optimal) { false }
+
+              it { is_expected.to be true }
+            end
+          end
+        end
+
+        describe '#identical_feedback?' do
+          subject { llm_feedback.identical_feedback? }
+
+          let(:llm_feedback) { create(:evidence_research_gen_ai_llm_feedback) }
+          let(:passage_prompt_response) { llm_feedback.passage_prompt_response }
+
+          before { create(:evidence_research_gen_ai_example_feedback, passage_prompt_response:, text:) }
+
+          context 'when the feedback is identical to the example feedback' do
+            let(:text) { llm_feedback.text }
+
+            it { expect(subject).to be true }
+          end
+
+          context 'when the feedback is not identical to the example feedback' do
+            let(:text) { 'different feedback' }
+
+            it { is_expected.to be false }
+          end
+        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
@@ -98,6 +98,12 @@ module Evidence
 
             it { is_expected.to be false }
           end
+
+          context 'when feedback is identical once stripped of leading/trailing whitespace' do
+            let(:text) { "  #{llm_feedback.text}  " }
+
+            it { is_expected.to be true }
+          end
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/identical_results_accuracy_calculator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/identical_results_accuracy_calculator_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe IdenticalResultsAccuracyCalculator, type: :service do
+        subject { described_class.run(experiment) }
+
+        let(:experiment) { create(:evidence_research_gen_ai_experiment) }
+
+        before { allow(experiment).to receive(:llm_feedbacks).and_return(llm_feedbacks) }
+
+        context 'when there are no llm feedbacks' do
+          let(:llm_feedbacks) { [] }
+
+          it { is_expected.to eq nil }
+        end
+
+        context 'with identical feedback' do
+          let(:llm_feedbacks) { [double(identical_feedback?: true)] }
+
+          it { is_expected.to eq 1.0 }
+        end
+
+        context 'with non-identical feedback' do
+          let(:llm_feedbacks) { [double(identical_feedback?: false)] }
+
+          it { is_expected.to eq 0 }
+        end
+
+        context 'with mixed feedbacks' do
+          let(:llm_feedbacks) { [double(identical_feedback?: true), double(identical_feedback?: false)] }
+
+          it { is_expected.to eq 0.5 }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add in evaluation for identical matches between llm feedback and corresponding example feedback

## WHY
It's another datapoint for evaluating accuracy of LLM feedback

## HOW
Iterate through the LLM feedback text and note how many responses have the exact same text as the training example.

### Screenshots
![Screenshot 2024-04-03 at 12 42 09 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/0db6f7e5-2f0a-4649-8119-139b78e4f5ec)


### Notion Card Links
https://www.notion.so/quill/Prompt-Engineering-Attempt-to-improve-Gemini-Performance-d2bda6915f83405791e8ff8ab4dd998e?pvs=4

### What have you done to QA this feature?
I've checked that these new calculations show up on staging experiments.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
