### PR TITLE
Turn off integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ workflows:
             services/QuillLMS/(app/|bin/|config/|db/|lib/|Gemfile|spec/|public/|Procfile).* lms-run-backend true
             services/QuillLMS/client/.* lms-run-javascript true
             services/QuillLMS/app/queries/.* lms-run-queries true
-            services/QuillLMS/(app/|bin/|config/|db/|lib/|Gemfile|spec/|public/|Procfile|client/).* lms-run-integration true
             services/QuillLMS/(engines/|app/|bin/|config/|db/|lib/|Gemfile|spec/|public/|Procfile).* lms-run-evidence true
             services/QuillCMS/.* cms-run true
             packages/quill-marking-logic/.* marking-logic-run true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -496,9 +496,6 @@ parameters:
   lms-run-queries:
     type: boolean
     default: false
-  lms-run-integration:
-    type: boolean
-    default: false
   lms-run-evidence:
     type: boolean
     default: false
@@ -532,9 +529,6 @@ workflows:
           <<: *default_filter
       - lms_big_query_build:
           should-run: << pipeline.parameters.lms-run-queries >>
-          <<: *default_filter
-      - lms_integration_build:
-          should-run: << pipeline.parameters.lms-run-integration >>
           <<: *default_filter
       - evidence_rails_build:
           should-run: << pipeline.parameters.lms-run-evidence >>


### PR DESCRIPTION
## WHAT
These have been off since the summer (since the Ruby 3) upgrade. Turning them off again.
## WHY
My old PR brought them back in by accident. They don't run properly.
## HOW
rm config for the lms-integration


### What have you done to QA this feature?
No QA, but I watched the integration tests not pass in another branch.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'NO', config change.
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
