### PR TITLE
fix student metrics test

### DIFF
--- a/services/QuillLMS/spec/queries/student_dashboard_metrics_spec.rb
+++ b/services/QuillLMS/spec/queries/student_dashboard_metrics_spec.rb
@@ -4,8 +4,15 @@ require 'rails_helper'
 
 describe StudentDashboardMetrics do
   before do
-    wednesday_noon = Time.current.beginning_of_week(:wednesday).noon
-    travel_to wednesday_noon
+    now = Time.current
+    wednesday_noon = now.beginning_of_week(:wednesday).noon
+    first_of_month = now.beginning_of_month
+
+    if wednesday_noon - 7.days < first_of_month
+      travel_to wednesday_noon + 1.week
+    else
+      travel_to wednesday_noon
+    end
   end
 
   after do
@@ -40,9 +47,8 @@ describe StudentDashboardMetrics do
       expect(metrics[:day][:activities_completed]).to eq(1)
       expect(metrics[:day][:timespent]).to eq(today_timespent)
 
-      # TODO: Fix this test with time freeze in middle of month
-      # expect(metrics[:week][:activities_completed]).to eq(2)
-      # expect(metrics[:week][:timespent]).to eq(today_timespent + yesterday_timespent)
+      expect(metrics[:week][:activities_completed]).to eq(2)
+      expect(metrics[:week][:timespent]).to eq(today_timespent + yesterday_timespent)
 
       expect(metrics[:month][:activities_completed]).to eq(3)
       expect(metrics[:month][:timespent]).to eq(today_timespent + yesterday_timespent + first_of_month_timespent)


### PR DESCRIPTION
## WHAT
Fix student dashboard metrics test.

## WHY
We want tests running and passing on develop.

## HOW
Add some logic that checks to see if the time-frozen date is within the first week of the month, and if it is, go to the following Wednesday instead.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-student-dashboard-metrics-test-0ef94e153d0e42e5aa2a8f33036a9283?pvs=4

### What have you done to QA this feature?
Ran the tests.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
