### PR TITLE
Show custom Max Attempts Feedback for Connect fill in blank questions…

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
@@ -13,6 +13,8 @@ import {
   splitPromptForFillInBlank,
   getLatestAttempt,
   hashToCollection,
+  FinalAttemptFeedback,
+  ALLOWED_ATTEMPTS
 } from '../../../Shared/index';
 import { getGradedResponsesWithCallback } from '../../actions/responses.js';
 import { FillInBlankQuestion } from '../../interfaces/questions';
@@ -78,6 +80,23 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
     if (prevProps.question.prompt !== question.prompt) {
       this.setQuestionValues(question)
     }
+  }
+
+  correctResponse = () => {
+    const { responses } = this.state
+    const { question } = this.props
+    let text
+    if (Object.keys(responses).length) {
+      const responseArray = hashToCollection(responses).sort((a: Response, b: Response) => b.count - a.count)
+      const firstOptimalResponse = responseArray.find((r: Response) => r.optimal)
+      if (firstOptimalResponse) {
+        text = firstOptimalResponse.text
+      }
+    }
+    if (!text) {
+      text = question.answers[0].text.replace(/{|}/gm, '')
+    }
+    return text
   }
 
   setQuestionValues = (question: FillInBlankQuestion) => {
@@ -372,7 +391,17 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
     const { previewMode, question } = this.props;
     const { responses, inputErrors } = this.state
 
-    if (inputErrors && _.size(inputErrors) !== 0) {
+    const maxAttemptsSubmitted = question.attempts && question.attempts.length === ALLOWED_ATTEMPTS;
+    const latestAttempt = getLatestAttempt(question.attempts);
+
+    if (maxAttemptsSubmitted && !latestAttempt.response.optimal) {
+      return (
+        <FinalAttemptFeedback
+          correctResponse={this.correctResponse()}
+          latestAttempt={latestAttempt.response.text}
+        />
+      )
+    } else if (inputErrors && _.size(inputErrors) !== 0) {
       const blankFeedback = question.blankAllowed ? ' or leave it blank' : ''
       const feedbackText = `Choose one of the options provided${blankFeedback}. Make sure it is spelled correctly.`
       const feedback = <p>{feedbackText}</p>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/question.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/question.tsx
@@ -11,14 +11,15 @@ import {
   ProgressBar,
   TeacherPreviewMenuButton,
   getLatestAttempt,
-  hashToCollection
+  hashToCollection,
+  FinalAttemptFeedback,
+  ALLOWED_ATTEMPTS
 } from '../../../Shared/index';
 import * as responseActions from '../../actions/responses';
 import { setCurrentQuestion } from '../../actions/session';
 import { GrammarActivity } from '../../interfaces/grammarActivities';
 import { Question } from '../../interfaces/questions';
 
-const ALLOWED_ATTEMPTS = 5
 const UNANSWERED = 'unanswered'
 const CORRECTLY_ANSWERED = 'correctly answered'
 const FINAL_ATTEMPT = 'final attempt'
@@ -407,8 +408,7 @@ export class QuestionComponent extends React.Component<QuestionProps, QuestionSt
     }
 
     if (question.attempts && question.attempts.length === ALLOWED_ATTEMPTS) {
-      const finalAttemptFeedback = `<b>Good try!</b> Compare your response to the strong response, and then go on to the next question.<br><br><b>Your response</b><br>${response}<br><br><b>A strong response</b><br>${this.correctResponse()}`
-      return <Feedback feedback={<p dangerouslySetInnerHTML={{ __html: finalAttemptFeedback }} />} feedbackType="incorrect-continue" />
+      return <FinalAttemptFeedback correctResponse={this.correctResponse()} latestAttempt={response} />;
     }
     return <Feedback feedback={<p dangerouslySetInnerHTML={{ __html: latestAttempt && latestAttempt.feedback ? latestAttempt.feedback : '' }} />} feedbackType="revise-matched" />
   }

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/__tests__/__snapshots__/finalAttemptFeedback.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/__tests__/__snapshots__/finalAttemptFeedback.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FinalAttemptFeedback it should render 1`] = `
+<DocumentFragment>
+  <div
+    aria-live="assertive"
+    class="student-feedback-container revise"
+    role="status"
+  >
+    <div
+      class="feedback-row student-feedback-inner-container"
+    >
+      <img
+        alt="Next Icon"
+        class="info"
+        src="https://assets.quill.org/images/icons/continue-brown.svg"
+      />
+      <p>
+        <b>
+          Good try!
+        </b>
+         Compare your response to the strong response, and then go on to the next question.
+        <br />
+        <br />
+        <b>
+          Your response
+        </b>
+        <br />
+        This is my latest wrong response.
+        <br />
+        <br />
+        <b>
+          A strong response
+        </b>
+        <br />
+        This is the correct response.
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/__tests__/finalAttemptFeedback.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/__tests__/finalAttemptFeedback.test.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+
+import { FinalAttemptFeedback } from "../finalAttemptFeedback";
+
+const props = {
+  latestAttempt: "This is my latest wrong response.",
+  correctResponse: "This is the correct response."
+}
+
+describe('FinalAttemptFeedback', () => {
+  test('it should render', () => {
+    const { asFragment } = render(<FinalAttemptFeedback {...props} />);
+    expect(asFragment()).toMatchSnapshot();
+  })
+})

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/finalAttemptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/finalAttemptFeedback.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Feedback } from '../renderForQuestions/feedback';
+
+const FinalAttemptFeedback = ({latestAttempt, correctResponse}) => {
+  const finalAttemptFeedback = `<b>Good try!</b> Compare your response to the strong response, and then go on to the next question.<br><br><b>Your response</b><br>${latestAttempt}<br><br><b>A strong response</b><br>${correctResponse}`
+  return (
+    <Feedback
+      feedback={<p dangerouslySetInnerHTML={{ __html: finalAttemptFeedback }} />}
+      feedbackType="incorrect-continue"
+    />
+  )
+};
+
+export { FinalAttemptFeedback };

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/index.tsx
@@ -9,3 +9,7 @@ export {
 export {
   PlayTitleCard
 } from './playTitleCard'
+
+export {
+  FinalAttemptFeedback
+} from './finalAttemptFeedback'

--- a/services/QuillLMS/client/app/bundles/Shared/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/index.tsx
@@ -86,7 +86,8 @@ export {
 export {
   MultipleChoice,
   Register,
-  PlayTitleCard
+  PlayTitleCard,
+  FinalAttemptFeedback
 } from './components/studentLessons/index'
 
 export {
@@ -230,7 +231,8 @@ export {
   MAX_VIEW_WIDTH_FOR_MOBILE_NAVBAR,
   INTRODUCTION,
   CHECKLIST,
-  READ_AND_HIGHLIGHT
+  READ_AND_HIGHLIGHT,
+  ALLOWED_ATTEMPTS
 } from './utils/constants'
 
 export { DefaultReactQueryClient } from './utils/defaultReactQueryClient'

--- a/services/QuillLMS/client/app/bundles/Shared/utils/constants.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/constants.ts
@@ -47,3 +47,5 @@ export const MAX_VIEW_WIDTH_FOR_MOBILE_NAVBAR = 1150
 export const INTRODUCTION = 'introduction'
 export const CHECKLIST = 'checklist'
 export const READ_AND_HIGHLIGHT = 'read-and-highlight'
+
+export const ALLOWED_ATTEMPTS = 5


### PR DESCRIPTION
…  (#11704)

* add fill in blank max attempt feedback

* change to shared function

* change to component rather than function

* add final attempt snapshot

* linting

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
