### PR TITLE
fix spelling or grammar function and add tests

### DIFF
--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -189,7 +189,7 @@ class FeedbackHistory < ApplicationRecord
       .count > 0
   end
 
-  def spelling_or_grammar? = feedback_type.in?[GRAMMAR, RULES_BASED_THREE, SPELLING]
+  def spelling_or_grammar? = feedback_type.in?([GRAMMAR, RULES_BASED_THREE, SPELLING])
 
   private def initiate_flag_worker
     SetFeedbackHistoryFlagsWorker.perform_async(id)

--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -702,4 +702,22 @@ RSpec.describe FeedbackHistory, type: :model do
       end
     end
   end
+
+  context '#spelling_or_grammar?' do
+    it 'returns true for spelling and grammar feedback' do
+      [FeedbackHistory::SPELLING, FeedbackHistory::GRAMMAR, FeedbackHistory::RULES_BASED_THREE].each do |feedback_type|
+        feedback_history = build(:feedback_history, feedback_type: feedback_type)
+        expect(feedback_history.spelling_or_grammar?).to be true
+      end
+
+    end
+
+    it 'returns false for non-spelling or grammar feedback' do
+      FeedbackHistory::FEEDBACK_TYPES.excluding(FeedbackHistory::SPELLING, FeedbackHistory::GRAMMAR, FeedbackHistory::RULES_BASED_THREE).each do |feedback_type|
+        feedback_history = build(:feedback_history, feedback_type: feedback_type)
+        expect(feedback_history.spelling_or_grammar?).to be false
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
## WHAT
Fix an argument error in the `spelling_or_grammar?` function on feedback history.

## WHY
We want this function to work. I'd refactored it but forgotten to QA again afterwards, and the tests where it was called were stubbed.

## HOW
Find the error (`.in?` requires parentheses, apparently) and fix it. Also add actual tests.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-argument-error-on-Sentry-50b441afdb294fca960b14f7402d34ff?pvs=4

### What have you done to QA this feature?
Loaded an Evidence report locally and confirmed that it works now.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
