### PR TITLE
Change background color of helpful article to white

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/styles/article-spotlight.scss
+++ b/services/QuillLMS/client/app/bundles/Teacher/styles/article-spotlight.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: center;
   width: 100%;
-  background-color: $quill-grey-1;
+  background-color: $quill-white;
   padding: 0px 16px;
   .inner-container {
     max-width: 1200px;


### PR DESCRIPTION
## WHAT
Change the background color of this display element.

## WHY
So the page content looks more unified and has a clear separation from the page footer.

## HOW
Just change the background color variable.

### Screenshots
![Screenshot 2024-04-11 at 3 01 25 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/dc0f0a05-e42e-4c6e-86f2-a944f7aa8a69)


### Notion Card Links
https://www.notion.so/quill/Update-Helpful-Article-Background-Color-a22cfa4a32f9415e8fc36a001c289b0c?pvs=4

### What have you done to QA this feature?
Deploy to staging and look at all the pages where this content appears to verify the color change.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, small visual change
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
