### PR TITLE
Add more information to experiment results page

### DIFF
--- a/services/QuillLMS/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/config/initializers/zeitwerk.rb
@@ -14,6 +14,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_configs_controller' => 'LLMConfigsController',
     'llm_feedback' => 'LLMFeedback',
     'llm_prompt' => 'LLMPrompt',
+    'llm_prompts_controller' => 'LLMPromptsController',
     'llm_prompt_builder' => 'LLMPromptBuilder',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',

--- a/services/QuillLMS/db/migrate/20240411135759_add_durations_to_experiment.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240411135759_add_durations_to_experiment.evidence.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240411135531)
+class AddDurationsToExperiment < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_experiments, :experiment_duration, :float
+    add_column :evidence_research_gen_ai_experiments, :evaluation_duration, :float
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -145,7 +145,7 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
           item timestamp;
         BEGIN
           SELECT created_at INTO as_created_at FROM activity_sessions WHERE id = act_sess;
-          
+
           -- backward compatibility block
           IF as_created_at IS NULL OR as_created_at < timestamp '2013-08-25 00:00:00.000000' THEN
             SELECT SUM(
@@ -160,11 +160,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
                       'epoch' FROM (activity_sessions.completed_at - activity_sessions.started_at)
                     )
                 END) INTO time_spent FROM activity_sessions WHERE id = act_sess AND state='finished';
-                
+
                 RETURN COALESCE(time_spent,0);
           END IF;
-          
-          
+
+
           first_item := NULL;
           last_item := NULL;
           max_item := NULL;
@@ -188,11 +188,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
 
             END IF;
           END LOOP;
-          
+
           IF max_item IS NOT NULL AND first_item IS NOT NULL THEN
             time_spent := time_spent + EXTRACT( EPOCH FROM max_item - first_item );
           END IF;
-          
+
           RETURN time_spent;
         END;
       $$;
@@ -207,7 +207,7 @@ CREATE FUNCTION public.timespent_student(student integer) RETURNS bigint
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (
           SELECT id,timespent_activity_session(id) AS time_spent FROM activity_sessions
-          WHERE activity_sessions.user_id = student 
+          WHERE activity_sessions.user_id = student
           GROUP BY id) as as_ids;
 
       $$;
@@ -2986,7 +2986,9 @@ CREATE TABLE public.evidence_research_gen_ai_experiments (
     results jsonb,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    num_examples integer DEFAULT 0 NOT NULL
+    num_examples integer DEFAULT 0 NOT NULL,
+    experiment_duration double precision,
+    evaluation_duration double precision
 );
 
 
@@ -11351,6 +11353,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240318144601'),
 ('20240401223448'),
 ('20240403160959'),
-('20240407173007');
+('20240407173007'),
+('20240411135759');
 
 

--- a/services/QuillLMS/engines/evidence/app/assets/stylesheets/evidence/research/gen_ai/application.css
+++ b/services/QuillLMS/engines/evidence/app/assets/stylesheets/evidence/research/gen_ai/application.css
@@ -50,3 +50,31 @@ tr:nth-child(even) {
 
 .red { background-color: red; }
 .green { background-color: green; }
+
+.link-button {
+    background: none!important;
+    border: none;
+    padding: 0!important;
+    /*optional: you can also use font-family to match your link styles*/
+    font-family: inherit; /* This makes the font consistent */
+    color: #069; /* Standard link color */
+    text-decoration: underline; /* Mimics link appearance */
+    cursor: pointer;
+    display: inline;
+}
+
+.link-button:hover,
+.link-button:focus {
+    color: #01447e; /* Darker shade for hover effect  */
+    text-decoration: none; /* Differentiates it from a standard link */
+}
+
+.link-container {
+  display: flex; /* This will align children inline and manage spacing */
+  align-items: center; /* Aligns items vertically in the center */
+}
+
+.link-button, a {
+  margin-right: 10px; /* Adjust spacing between the links as needed */
+  white-space: nowrap; /* Ensures that the text does not wrap */
+}

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
@@ -30,7 +30,11 @@ module Evidence
           redirect_to research_gen_ai_experiments_path
         end
 
-        def show = @experiment = Experiment.find(params[:id])
+        def show
+          @experiment = Experiment.find(params[:id])
+          @next = Experiment.where("id > ?", @experiment.id).order(id: :asc).first
+          @previous = Experiment.where("id < ?", @experiment.id).order(id: :desc).first
+        end
 
         private def experiment_params
           params

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompts_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llm_prompts_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      class LLMPromptsController < ApplicationController
+        def show = @llm_prompt = LLMPrompt.find(params[:id])
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/helpers/evidence/research/gen_ai/experiments_helper.rb
+++ b/services/QuillLMS/engines/evidence/app/helpers/evidence/research/gen_ai/experiments_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      module ExperimentsHelper
+        def percent_complete(experiment) = (experiment.llm_feedbacks.count.to_f / experiment.num_examples * 100)&.round
+
+        def progress(experiment)
+          return '100%' if experiment.num_examples.zero?
+
+          "#{percent_complete(experiment)}% complete (#{experiment.llm_feedbacks.count}/#{experiment.num_examples})"
+        end
+
+        def evaluation_duration(experiment)
+          "#{experiment.results['evaluation_duration']&.round(2)} s"
+        end
+
+        def experiment_duration(experiment)
+          return '0 s' if experiment.results['experiment_duration'].nil? || experiment.num_examples.zero?
+
+          duration = experiment.results['experiment_duration'].round(2)
+          "#{duration} s (#{(duration / @experiment.num_examples)&.round(2)}s / example)"
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/helpers/evidence/research/gen_ai/experiments_helper.rb
+++ b/services/QuillLMS/engines/evidence/app/helpers/evidence/research/gen_ai/experiments_helper.rb
@@ -13,13 +13,13 @@ module Evidence
         end
 
         def evaluation_duration(experiment)
-          "#{experiment.results['evaluation_duration']&.round(2)} s"
+          "#{experiment.evaluation_duration&.round(2)} s"
         end
 
         def experiment_duration(experiment)
-          return '0 s' if experiment.results['experiment_duration'].nil? || experiment.num_examples.zero?
+          return '0 s' if experiment.experiment_duration.nil? || experiment.num_examples.zero?
 
-          duration = experiment.results['experiment_duration'].round(2)
+          duration = experiment.experiment_duration.round(2)
           "#{duration} s (#{(duration / @experiment.num_examples)&.round(2)}s / example)"
         end
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
@@ -29,6 +29,8 @@ module Evidence
         delegate :response, to: :passage_prompt_response
 
         def response_and_feedback = "Response: #{response}\nFeedback: #{text}"
+
+        def to_s = text
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -72,7 +72,8 @@ module Evidence
         private def create_llm_prompt_responses_feedbacks
           passage_prompt_responses.limit(num_examples).each do |passage_prompt_response|
             feedback = llm_client.run(llm_config:, prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
-            LLMFeedback.create!(experiment: self, text: feedback, passage_prompt_response:)
+            text = Resolver.run(feedback:)
+            LLMFeedback.create!(experiment: self, text:, passage_prompt_response:)
           end
         end
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -84,7 +84,7 @@ module Evidence
             feedback = llm_client.run(llm_config:, prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
             text = Resolver.run(feedback:)
             LLMFeedback.create!(experiment: self, text:, passage_prompt_response:)
-          rescue Resolver::Error => e
+          rescue Resolver::ResolverError => e
             experiment_errors << (e.message + " for response: #{passage_prompt_response.id}")
             next
           end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
@@ -34,6 +34,8 @@ module Evidence
         def optimal_or_sub_optimal_match? = example_optimal? ? optimal? : sub_optimal?
 
         def response_and_feedback = "Response: #{passage_prompt_response.response}\nFeedback: #{text}"
+
+        def to_s = text
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
@@ -6,6 +6,11 @@ module Evidence
       class Resolver < ApplicationService
         attr_reader :feedback
 
+        class ResolverError < StandardError; end
+        class NilFeedbackError < ResolverError; end
+        class EmptyFeedbackError < ResolverError; end
+        class BlankTextError < ResolverError; end
+
         FEEDBACK_MARKER = 'Feedback:'
 
         def initialize(feedback:)
@@ -13,13 +18,24 @@ module Evidence
         end
 
         def run
-          return nil if feedback.nil?
-          return feedback if feedback_index.nil?
+          raise NilFeedbackError if feedback.nil?
+          raise EmptyFeedbackError if feedback.empty?
 
-          feedback[feedback_index + FEEDBACK_MARKER.length..].strip
+          extract_feedback_content
         end
 
         private def feedback_index = feedback.index(FEEDBACK_MARKER)
+
+        private def extract_feedback_content
+          return feedback if feedback_index.nil?
+
+          content_start = feedback_index + FEEDBACK_MARKER.length
+          feedback_content = feedback[content_start..].strip
+
+          raise BlankTextError, "Feedback provided: '#{feedback}'" if feedback_content.blank?
+
+          feedback_content
+        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      class Resolver < ApplicationService
+        attr_reader :feedback
+
+        FEEDBACK_MARKER = 'Feedback:'
+
+        def initialize(feedback:)
+          @feedback = feedback
+        end
+
+        def run
+          return nil if feedback.nil?
+          return feedback if feedback_index.nil?
+
+          feedback[feedback_index + FEEDBACK_MARKER.length..].strip
+        end
+
+        private def feedback_index = feedback.index(FEEDBACK_MARKER)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/index.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/index.html.erb
@@ -2,7 +2,7 @@
   <h2>Experiments</h2>
 </header>
 <%= link_to 'New Experiment', new_research_gen_ai_experiment_path %>
-<meta http-equiv="refresh" content="5">
+<meta http-equiv="refresh" content="30">
 
 <% if @experiments.any? %>
   <table>
@@ -28,7 +28,19 @@
           <td><%= experiment.llm_prompt.description %></td>
           <td><%= experiment.num_examples %></td>
           <td><%= experiment.status %></td>
-          <td><%= link_to "View", experiment %></td>
+          <td>
+            <div class=link-container">
+              <%= link_to "View", experiment %>
+              <% if experiment.failed? %>
+                <%= button_to 'Retry',
+                      retry_research_gen_ai_experiment_path(experiment),
+                      method: :post,
+                      data: { confirm: 'Are you sure you want to retry this experiment?' },
+                      class: 'link-button'
+                %>
+              <% end %>
+            </div>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
@@ -1,3 +1,4 @@
+<%= link_to 'Experiments', research_gen_ai_experiments_path, class: 'new-link', target: '_blank' %>
 <h1>Experiment Runner</h1>
 
 <%= form_for @experiment, html: { id: 'new_experiment_form' } do |f| %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -13,6 +13,7 @@
 
 <div>
   <h2>Experiment</h2>
+  <p><%= @experiment.created_at.strftime("%B %d, %Y %H:%M") %></p>
 
   <h3>Passage</h3>
   <p><%= @experiment.passage_prompt %></p>
@@ -87,7 +88,5 @@
     </ul>
   <% end %>
 
-  <h3>Created At</h3>
-  <p><%= @experiment.created_at.strftime("%B %d, %Y %H:%M") %></p>
 </div>
 

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -1,5 +1,15 @@
 <meta http-equiv="refresh" content="5">
 
+<%= link_to 'Back', research_gen_ai_experiments_path %>
+
+<% if @previous %>
+  <%= link_to "Previous", @previous %>
+<% end %>
+
+<% if @next %>
+  <%= link_to "Next", @next %>
+<% end %>
+
 <div>
   <h2>Experiment</h2>
 
@@ -80,4 +90,3 @@
   <p><%= @experiment.created_at.strftime("%B %d, %Y %H:%M") %></p>
 </div>
 
-<%= link_to 'Back', research_gen_ai_experiments_path %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -1,6 +1,7 @@
 <meta http-equiv="refresh" content="5">
 
-<%= link_to 'Back', research_gen_ai_experiments_path %>
+<%= link_to 'Back to Experiments', research_gen_ai_experiments_path %>
+<br>
 
 <% if @previous %>
   <%= link_to "Previous", @previous %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -12,15 +12,20 @@
   <%= link_to 'LLMPromptTemplate', @experiment.llm_prompt.llm_prompt_template %>
 
   <h3>LLM Prompt</h3>
-  <p><%= @experiment.llm_prompt.description %></p>
-  <%# <p><%= simple_format(@experiment.llm_prompt.prompt) %></p>
+  <p><%= link_to @experiment.llm_prompt.description, @experiment.llm_prompt %></p>
 
   <hr/>
   <h3>Results</h3>
   <% if @experiment.results %>
     <p>Accuracy (identical): <%= @experiment.results['accuracy_identical'] %></p>
     <p>Accuracy (sub/optimal): <%= @experiment.results['accuracy_optimal_sub_optimal'] %></p>
-    <p>Misc metrics: <%= pp @experiment.results['misc_metrics'] %></p>
+    <p>Bleu: <%= @experiment.results.dig('misc_metrics', 'bleu', 'bleu')&.round(2) %></p>
+    <p>Rouge1: <%= @experiment.results.dig('misc_metrics', 'rouge', 'rouge1')&.round(2) %></p>
+    <p>Rouge2: <%= @experiment.results.dig('misc_metrics', 'rouge', 'rouge2')&.round(2) %></p>
+    <p>RougeL: <%= @experiment.results.dig('misc_metrics', 'rouge', 'rougeL')&.round(2) %></p>
+    <p>RougeL Sum: <%= @experiment.results.dig('misc_metrics', 'rouge', 'rougeLsum')&.round(2) %></p>
+    <p>Experiment duration: <%= experiment_duration(@experiment) %></p>
+    <p>Evaluation duration: <%= evaluation_duration(@experiment) %></p>
 
     <%= render 'matrix', matrix: @experiment.results['confusion_matrix'], title: 'Confusion Matrix' %>
 
@@ -29,26 +34,32 @@
         <tr>
           <th>Identical match</th>
           <th>OptSubOpt match</th>
+          <th>BertScore (F1)</th>
+          <th>BertScore (Precision)</th>
+          <th>BertScore (Recall)</th>
           <th>Prompt Response</th>
           <th>Example Feedback</th>
           <th>LLM Feedback</th>
         </tr>
       </thead>
       <tbody>
-        <% @experiment.llm_feedbacks.each do |llm_feedback| %>
+        <% @experiment.llm_feedbacks.each.with_index do |llm_feedback, index| %>
           <tr>
             <% example_feedback = llm_feedback.example_feedback %>
             <td class="<%= llm_feedback.identical_feedback? ? 'green' : 'red' %>"></td>
             <td class="<%= llm_feedback.optimal_or_sub_optimal_match? ? 'green' : 'red' %>"></td>
+            <td><%= @experiment.results.dig('misc_metrics', 'bert_score', 'f1', index)&.round(2) %></td>
+            <td><%= @experiment.results.dig('misc_metrics', 'bert_score', 'precision', index)&.round(2) %></td>
+            <td><%= @experiment.results.dig('misc_metrics', 'bert_score', 'recall', index)&.round(2) %></td>
             <td><%= llm_feedback.passage_prompt_response %></td>
-            <td><%= llm_feedback.text %></td>
-            <td><%= example_feedback.text %></td>
+            <td><%= llm_feedback.example_feedback %></td>
+            <td><%= llm_feedback  %></td>
           </tr>
         <% end %>
       </tbody>
     </table>
     <% else %>
-      <p>No results yet</p>
+      <p><%= progress(@experiment) %></p>
     <% end %>
 
 

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompts/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llm_prompts/show.html.erb
@@ -1,0 +1,12 @@
+<div>
+  <h2>LLM Prompt</h2>
+
+  <h3>Description</h3>
+  <p><%= @llm_prompt.description %></p>
+
+  <h3>Contents</h3>
+  <p><%= simple_format(@llm_prompt.prompt) %></p>
+</div>
+
+<br>
+<%= link_to 'Experiments', research_gen_ai_experiments_path %>

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/research/gen_ai/calculate_results_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/research/gen_ai/calculate_results_worker.rb
@@ -16,7 +16,7 @@ module Evidence
           experiment = Experiment.find(experiment_id)
           experiment.update_results(ResultsFetcher.run(experiment.llm_feedbacks))
         ensure
-          experiment.update!(evaluation_duration: Time.zone.now - start_time)
+          experiment&.update!(evaluation_duration: Time.zone.now - start_time)
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/research/gen_ai/calculate_results_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/research/gen_ai/calculate_results_worker.rb
@@ -16,7 +16,7 @@ module Evidence
           experiment = Experiment.find(experiment_id)
           experiment.update_results(ResultsFetcher.run(experiment.llm_feedbacks))
         ensure
-          experiment.update_results(evaluation_duration: (Time.zone.now - start_time).round(2))
+          experiment.update!(evaluation_duration: Time.zone.now - start_time)
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
@@ -10,6 +10,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_configs_controller' => 'LLMConfigsController',
     'llm_feedback' => 'LLMFeedback',
     'llm_prompt' => 'LLMPrompt',
+    'llm_prompts_controller' => 'LLMPromptsController',
     'llm_prompt_builder' => 'LLMPromptBuilder',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -43,7 +43,10 @@ Evidence::Engine.routes.draw do
 
   namespace :research do
     namespace :gen_ai do
-      resources :experiments, only: [:new, :create, :show, :index]
+      resources :experiments, only: [:new, :create, :show, :index] do
+        post :retry, on: :member
+      end
+
       resources :llm_configs, only: [:new, :create, :show, :index]
       resources :llm_prompts, only: [:show]
       resources :llm_prompt_templates, only: [:new, :create, :show, :index]

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -45,6 +45,7 @@ Evidence::Engine.routes.draw do
     namespace :gen_ai do
       resources :experiments, only: [:new, :create, :show, :index]
       resources :llm_configs, only: [:new, :create, :show, :index]
+      resources :llm_prompts, only: [:show]
       resources :llm_prompt_templates, only: [:new, :create, :show, :index]
       resources :passage_prompts, only: [:new, :create, :show, :index]
     end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240411135531_add_durations_to_experiment.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240411135531_add_durations_to_experiment.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDurationsToExperiment < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_experiments, :experiment_duration, :float
+    add_column :evidence_research_gen_ai_experiments, :evaluation_duration, :float
+  end
+end

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/concerns/api.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/concerns/api.rb
@@ -46,7 +46,6 @@ module Evidence
             raise MaxAttemptsError, e.message if num_attempts >= MAX_ATTEMPTS
 
             num_attempts += 1
-            puts "Retrying attempt #{num_attempts}"
             retry
           rescue *Evidence::HTTP_TIMEOUT_ERRORS
             []

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -944,7 +944,9 @@ CREATE TABLE public.evidence_research_gen_ai_experiments (
     results jsonb,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    num_examples integer DEFAULT 0 NOT NULL
+    num_examples integer DEFAULT 0 NOT NULL,
+    experiment_duration double precision,
+    evaluation_duration double precision
 );
 
 
@@ -2069,6 +2071,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240318143146'),
 ('20240318144447'),
 ('20240401223116'),
-('20240407172612');
+('20240407172612'),
+('20240411135531');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/experiments.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/experiments.rb
@@ -4,16 +4,18 @@
 #
 # Table name: evidence_research_gen_ai_experiments
 #
-#  id                :bigint           not null, primary key
-#  experiment_errors :text             is an Array
-#  num_examples      :integer          default(0), not null
-#  results           :jsonb
-#  status            :string           default("pending"), not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  llm_config_id     :integer          not null
-#  llm_prompt_id     :integer          not null
-#  passage_prompt_id :integer          not null
+#  id                  :bigint           not null, primary key
+#  evaluation_duration :float
+#  experiment_duration :float
+#  experiment_errors   :text             default([]), not null, is an Array
+#  num_examples        :integer          default(0), not null
+#  results             :jsonb
+#  status              :string           default("pending"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  llm_config_id       :integer          not null
+#  llm_prompt_id       :integer          not null
+#  passage_prompt_id   :integer          not null
 #
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/lib/evidence/gemini/completion_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/evidence/gemini/completion_spec.rb
@@ -11,38 +11,6 @@ module Evidence
         let(:llm_config) { create(:evidence_research_gen_ai_llm_config, version:) }
         let(:prompt) { "Write the next word after this sentence: #{Faker::Quote.mitch_hedberg}" }
 
-        describe 'response processing' do
-          subject { described_class.new(llm_config:, prompt:) }
-
-          let(:feedback_marker) { described_class::FEEDBACK_MARKER }
-          let(:feedback) { 'This is feedback.' }
-          let(:feedback_with_marker) { "Response: This is a test response. \n#{feedback_marker} #{feedback}" }
-
-          let(:parsed_response) do
-            double(
-              parsed_response: {
-                'candidates' => [
-                  { 'content' => { 'parts' => [{ 'text' => text }] } }
-                ]
-              }
-            )
-          end
-
-          before { allow(subject).to receive(:response).and_return(parsed_response) }
-
-          context 'when feedback marker is present in text' do
-            let(:text) { feedback_with_marker }
-
-            it { expect(subject.run).to eq(feedback) }
-          end
-
-          context 'when no feedback marker is present in text' do
-            let(:text) { feedback }
-
-            it { expect(subject.run).to eq(feedback) }
-          end
-        end
-
         describe 'rate limit error handling' do
           subject { described_class.new(llm_config:, prompt:) }
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -45,15 +45,15 @@ module Evidence
         describe '#run' do
           subject { experiment.run }
 
-          let(:experiment) { create(:evidence_research_gen_ai_experiment) }
+          let(:experiment) { create(:evidence_research_gen_ai_experiment, num_examples:) }
+          let(:num_examples) { 4 }
           let(:passage_prompt) { experiment.passage_prompt }
           let(:llm_config) { experiment.llm_config }
           let(:llm_client) { double(:llm_client) }
-          let(:num_passage_prompt_responses) { 4 }
           let(:llm_feedback_text) { 'Test feedback' }
 
           let(:passage_prompt_responses) do
-            create_list(:evidence_research_gen_ai_passage_prompt_response, num_passage_prompt_responses, passage_prompt:)
+            create_list(:evidence_research_gen_ai_passage_prompt_response, num_examples, passage_prompt:)
           end
 
           let!(:example_feedbacks) do
@@ -78,7 +78,7 @@ module Evidence
           end
 
           it { expect { subject }.to change { experiment.reload.status }.to(described_class::COMPLETED) }
-          it { expect { subject }.to change(LLMFeedback, :count).by(num_passage_prompt_responses) }
+          it { expect { subject }.to change(LLMFeedback, :count).by(num_examples) }
 
           context 'when an error occurs during execution' do
             let(:error_message) { 'Test error' }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -4,18 +4,19 @@
 #
 # Table name: evidence_research_gen_ai_experiments
 #
-#  id                :bigint           not null, primary key
-#  experiment_errors :text             is an Array
-#  num_examples      :integer          default(0), not null
-#  results           :jsonb
-#  status            :string           default("pending"), not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  llm_config_id     :integer          not null
-#  llm_prompt_id     :integer          not null
-#  passage_prompt_id :integer          not null
+#  id                  :bigint           not null, primary key
+#  evaluation_duration :float
+#  experiment_duration :float
+#  experiment_errors   :text             default([]), not null, is an Array
+#  num_examples        :integer          default(0), not null
+#  results             :jsonb
+#  status              :string           default("pending"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  llm_config_id       :integer          not null
+#  llm_prompt_id       :integer          not null
+#  passage_prompt_id   :integer          not null
 #
-
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe Resolver do
+        subject { described_class.run(feedback:) }
+
+        context 'when feedback is nil' do
+          let(:feedback) { nil }
+
+          it { is_expected.to eq nil }
+        end
+
+        context 'when feedback has no marker' do
+          let(:feedback) { 'This is feedback.' }
+
+          it { is_expected.to eq feedback }
+        end
+
+        context 'when feedback contains a marker' do
+          let(:marker) { described_class::FEEDBACK_MARKER }
+          let(:text) { 'This is feedback.' }
+          let(:feedback) { "Response: This is response. \n#{marker} #{text}" }
+
+          it { is_expected.to eq text }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
@@ -11,13 +11,19 @@ module Evidence
         context 'when feedback is nil' do
           let(:feedback) { nil }
 
-          it { is_expected.to eq nil }
+          it { expect { subject }.to raise_error(described_class::NilFeedbackError) }
+        end
+
+        context 'when feedback is empty' do
+          let(:feedback) { '' }
+
+          it { expect { subject }.to raise_error(described_class::EmptyFeedbackError) }
         end
 
         context 'when feedback has no marker' do
           let(:feedback) { 'This is feedback.' }
 
-          it { is_expected.to eq feedback }
+          it { expect(subject).to eq(feedback) }
         end
 
         context 'when feedback contains a marker' do
@@ -25,7 +31,13 @@ module Evidence
           let(:text) { 'This is feedback.' }
           let(:feedback) { "Response: This is response. \n#{marker} #{text}" }
 
-          it { is_expected.to eq text }
+          it { expect(subject).to eq(text) }
+        end
+
+        context 'when feedback is present but text after the marker is blank' do
+          let(:feedback) { "#{described_class::FEEDBACK_MARKER}    " }
+
+          it { expect { subject }.to raise_error(described_class::BlankTextError, "Feedback provided: '#{feedback}'") }
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/research/gen_ai/calculate_results_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/research/gen_ai/calculate_results_worker_spec.rb
@@ -39,7 +39,7 @@ module Evidence
 
           it 'merges and updates the experiment results' do
             expect(experiment).to receive(:update_results).with(fetched_results)
-            expect(experiment).to receive(:update_results).with(experiment_eval_execution_time: an_instance_of(Float))
+            expect(experiment).to receive(:update!).with(evaluation_duration: an_instance_of(Float))
             subject
           end
         end

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/research/gen_ai/calculate_results_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/research/gen_ai/calculate_results_worker_spec.rb
@@ -38,7 +38,8 @@ module Evidence
           end
 
           it 'merges and updates the experiment results' do
-            expect(experiment).to receive(:update!).with(results: fetched_results)
+            expect(experiment).to receive(:update_results).with(fetched_results)
+            expect(experiment).to receive(:update_results).with(experiment_eval_execution_time: an_instance_of(Float))
             subject
           end
         end


### PR DESCRIPTION
## WHAT
1. Add LLMPrompts#show view
1. Add `experiment_duration` and `evaluation_duration` values to experiment#show 
1. Add progress and percent complete to experiment#show
1. Add scope `order(:id)` for various has_many associations in experiment.rb
1. Correct the calculation of num_examples
1. Add BertScore columns and add RogueL and BLEU scores
1. Add `Resolver` service object
1. Add some error handling to Resolver
1. Add in Retry functionality for failed experiments

## WHY
1. It's useful to be able to see the actual LLMPrompt sent to the LLM.
1. These values will give transparency on how long these experiments take.
1. It's useful to see progress for the experiment since it regularly seems to idle.
1. When the example feedback is sent for evaluation we would like to have it sent in a consistent order
1. Before experiment records took in `nil` as a value here (since `relation.limit(nil)` will give all records).  Instead lets store the actual computed value since this can be reported in the experiments#index
1. They were previously reported in a large hash
1. Experiments are giving "Response: .... Feedback:....."  We'd like to parse out just the feedback
1. Some Resolver output is blank and we'd like to know what the input feedback and passage prompt response id.
1. Some experiments fail due to timeouts, rate limiting, etc.  Being able to retry them with the click of one button streamlines user error.

## HOW
1.  Add a LLMPromptsController and the corresponding route and template.
1.  Add migration file and update the view with these two values, leveraging `ExperimentsHelper`
1.  Leverage `ExperimentsHelper` to compute these values
1.  Add `-> { order(:id) }` to the relations 
1. Check for nil value when passed from the controller and set num_examples equal to total number of examples.  Otherwise choose the specified value.
1. Update the experiment#show template
1.  Add Resolver processing into the experiment pipeline.
1. Add some error classes and include the relevant passage_prompt_id and feedback.  Also continue the experiment since the remaining examples can still be tried.
1.  Add retry link in the experiments#index.  Only show failed experiments in the index that don't have retried experiments that have completed.

### Screenshots

Percent Progress:
<img width="301" alt="Screenshot 2024-04-11 at 12 13 40 PM" src="https://github.com/empirical-org/Empirical-Core/assets/2057805/e6f58c9e-b2cc-4ff6-8e4d-50c916e81d7f">

Various metrics
<img width="1280" alt="Screenshot 2024-04-11 at 12 14 46 PM" src="https://github.com/empirical-org/Empirical-Core/assets/2057805/54c4584f-51b7-41d5-ae8a-ca860cae97ee">


### Notion Card Links
https://www.notion.so/quill/Prompt-Engineering-Attempt-to-improve-Gemini-Performance-d2bda6915f83405791e8ff8ab4dd998e?pvs=4

### What have you done to QA this feature?
Tested on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
