### PR TITLE
Fix Rails Admin Slowness. (#11737)

### DIFF
--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -196,7 +196,12 @@ class ChangeLog < ApplicationRecord
     changed_record&.conjunctions if changed_record.respond_to?(:conjunctions)
   end
 
+  # TODO: Fix this overwrite of :user association
   def user
+    User.find_by(id: user_id)&.name
+  end
+
+  def user_name
     User.find_by(id: user_id)&.name
   end
 

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -25,7 +25,6 @@ module Student
 
     has_many :activity_sessions, dependent: :destroy
     has_many :assigned_activities, -> { where("students_classrooms.student_id = ANY (classroom_units.assigned_student_ids)") }, through: :classrooms, source: :activities
-    has_many :started_activities, through: :activity_sessions, source: :activity
 
     def incomplete_assigned_activities
       assigned_activities_with_activity_sessions

--- a/services/QuillLMS/app/models/locker.rb
+++ b/services/QuillLMS/app/models/locker.rb
@@ -12,7 +12,7 @@
 #  user_id     :integer
 #
 class Locker < ApplicationRecord
-  has_one :user
+  belongs_to :user
 
   validates :user_id, presence: true, uniqueness: true
   validates :label, presence: true

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -142,6 +142,8 @@ class User < ApplicationRecord
   has_many :user_subscriptions
   has_many :subscriptions, through: :user_subscriptions
   has_many :activity_sessions
+  has_many :started_activities, through: :activity_sessions, source: :activity
+
   has_one :schools_users
   has_one :sales_contact, dependent: :destroy
   has_one :school, through: :schools_users
@@ -194,7 +196,7 @@ class User < ApplicationRecord
     through: :administered_school_canvas_instance_schools,
     source: :canvas_instance
 
-  has_many :administered_school_canvas_configs, through: :administered_school_canvas_instances, source: :canvas_config
+  has_many :administered_school_canvas_configs, through: :administered_school_canvas_instances_with_canvas_configs, source: :canvas_config
 
   has_many :admin_report_filter_selections, dependent: :destroy
   has_many :pdf_subscriptions, through: :admin_report_filter_selections

--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -1,146 +1,451 @@
 # frozen_string_literal: true
 
-Rails.application.config.eager_load do
-  RailsAdmin.config do |config|
-    config.asset_source = :sprockets
+RailsAdmin.config do |config|
+  config.main_app_name = ["Quill Content Overview"]
 
-    config.authorize_with do |controller|
-      current_user = User.find_by(id: session[:user_id])
-      redirect_to main_app.root_path unless current_user&.staff?
+  config.asset_source = :sprockets
+
+  config.authorize_with do |controller|
+    current_user = User.find_by(id: session[:user_id])
+    redirect_to main_app.root_path unless current_user&.staff?
+  end
+
+  UNEDITABLE_MODELS = ['ChangeLog']
+
+  config.actions do
+    dashboard do
+      statistics false
     end
+    index                         # mandatory
+    new
+    export
+    # Turn off bulk delete, seems dangerous
+    # bulk_delete
+    show
+    edit do
+      except UNEDITABLE_MODELS
+    end
+    delete do
+      except UNEDITABLE_MODELS
+    end
+    show_in_app
 
-    config.actions do
-      dashboard do
-        statistics false
+    ## With an audit adapter, you can add:
+    # history_index
+    # history_show
+  end
+
+  config.model "ActivityCategory" do
+    list do
+      exclude_fields :activities, :activity_category_activities
+    end
+  end
+
+  config.model 'Activity' do
+    edit do
+      exclude_fields :classroom_units, :classrooms, :unit_activities, :units
+    end
+    list do
+      field :id
+      field :name do
+        searchable true
       end
-      index                         # mandatory
-      new
-      export
-      bulk_delete
-      show
-      edit
-      delete
-      show_in_app
+      field :classification
+      field :flags
+    end
+    show do
+      exclude_fields :teachers
+    end
+  end
 
-      ## With an audit adapter, you can add:
-      # history_index
-      # history_show
+  config.model 'ActivityClassification' do
+    list do
+      exclude_fields :activities
+    end
+  end
+
+  config.model 'ActivityHealth' do
+    list do
+      exclude_fields :prompt_healths
+    end
+  end
+
+  config.model 'AdminInfo' do
+    list do
+      exclude_fields :admin_approval_requests
+    end
+  end
+
+  config.model 'AdminReportFilterSelection' do
+    list do
+      exclude_fields :pdf_subscriptions
+    end
+  end
+
+  config.model 'AuthCredential' do
+    list do
+      limited_pagination true
+    end
+  end
+
+  config.model 'BlogPost' do
+    list do
+      exclude_fields :blog_post_user_ratings
+    end
+  end
+
+  config.model 'CanvasInstance' do
+    list do
+      field :id
+      field :url
+      field :created_at
+      field :updated_at
     end
 
-    config.model Concept do
-      configure :concept_results do
-        hide
-        # for list view
-        filterable false
+    show do
+      exclude_fields :canvas_accounts, :canvas_instance_auth_credentials
+    end
+  end
+
+  config.model 'ChangeLog' do
+    # TODO: this is a workaround for a bug in changelog :user being overwritten
+    field :user_name
+    include_all_fields
+    exclude_fields :user
+  end
+
+  config.model 'Classroom' do
+    list do
+      exclude_fields :classroom_units, :units, :unit_activities, :activities, :standard_levels,
+        :coteacher_classroom_invitations, :students, :students_classrooms, :classrooms_teachers, :teachers
+      limited_pagination true
+    end
+    edit do
+      configure :teachers do
+        read_only true
+      end
+      configure :students do
+        read_only true
+      end
+    end
+  end
+
+  config.model 'Concept' do
+    list do
+      exclude_fields :change_logs
+    end
+  end
+
+  config.model 'ContentPartner' do
+    list do
+      exclude_fields :activities, :content_partner_activities
+    end
+  end
+
+  config.model 'District' do
+    list do
+      exclude_fields :schools
+    end
+  end
+
+  config.model 'LearnWorldsAccount' do
+    list do
+      fields :id, :user, :last_login, :created_at, :updated_at
+    end
+  end
+
+  config.model 'Milestone' do
+    exclude_fields :users
+  end
+
+  config.model 'Objective' do
+    exclude_fields :users, :checkboxes
+  end
+
+  config.model 'Recommendation' do
+    list do
+      exclude_fields :criteria
+    end
+  end
+
+  config.model 'School' do
+    list do
+      field :zipcode do
+        searchable true
+      end
+    end
+  end
+
+  config.model 'SchoolSubscription' do
+    field :school do
+      searchable [:name, :zipcode]
+      proc { |scope|
+        scope = scope.where(role: ['teacher','admin'])
+      }
+    end
+    field :subscription do
+      searchable [:id, :account_type]
+    end
+  end
+
+  config.model 'SchoolsAdmins' do
+    field :user do
+      searchable [:email, :username]
+      sortable :email
+      proc { |scope|
+        scope = scope.where(role: ['teacher','admin'])
+      }
+    end
+    field :school do
+      searchable [:name, :zipcode]
+      proc { |scope|
+        scope = scope.where(role: ['teacher','admin'])
+      }
+    end
+  end
+
+  config.model 'Skill' do
+    field :skill_concepts do
+      eager_load skill_concepts: :concept
+    end
+    field :concepts do
+      eager_load :concepts
+    end
+    include_all_fields
+  end
+
+  config.model 'SkillGroup' do
+    list do
+      exclude_fields :skill_group_activities, :activities, :skills
+    end
+  end
+
+  config.model 'Standard' do
+    list do
+      exclude_fields :activities, :change_logs
+    end
+  end
+
+  config.model 'StandardCategory' do
+    list do
+      exclude_fields :activities, :change_logs
+      field :standards do
+        eager_load :standards
+      end
+    end
+  end
+
+  config.model 'StandardLevel' do
+    list do
+      exclude_fields :activities, :change_logs
+      field :standards do
+        eager_load :standards
+      end
+    end
+  end
+
+  config.model 'SubjectArea' do
+    list do
+      exclude_fields :teacher_info_subject_areas
+    end
+  end
+
+  config.model 'Subscription' do
+    list do
+      exclude_fields :credit_transactions, :district_subscriptions, :districts, :school_subscriptions, :schools, :user_subscriptions, :users
+    end
+  end
+
+  config.model 'Topic' do
+    list do
+      exclude_fields :activities, :activity_topics, :change_logs
+    end
+  end
+
+  config.model 'TeacherInfo' do
+    list do
+      exclude_fields :teacher_info_subject_areas, :subject_areas
+    end
+  end
+
+  config.model 'Unit' do
+    list do
+      exclude_fields :activities, :standards
+      configure :classrooms do
+        eager_load true
+      end
+      limited_pagination true
+    end
+    edit do
+      exclude_fields :user
+    end
+  end
+
+  config.model 'UnitTemplate' do
+    list do
+      exclude_fields :activities, :activities_unit_templates, :partner_contents, :units, :recommendations, :diagnostics_recommended_by
+    end
+  end
+
+  config.model 'UnitTemplateCategory' do
+    list do
+      exclude_fields :unit_templates
+    end
+  end
+
+  config.model 'User' do
+    list do
+      field :name do
+        searchable true
+      end
+      field :email do
+        searchable true
+      end
+      field :password_digest do
         searchable false
       end
+      field :created_at
+      field :account_type
+      field :role
+      limited_pagination true
     end
 
-    config.model User do
-      list do
-        field :password_digest do
-          searchable false
-        end
-        field :name do
-          searchable true
-        end
-        field :email do
-          searchable true
-          # TODO: get this displaying emails
-          # formatted_value do # used in form views
-          #
-          #   bindings[:object].email
-          # end
-          # pretty_value do # used in list view columns and show views, defaults to formatted_value for non-association fields
-          #   bindings[:object].email
-          # end
-        end
-        limited_pagination true
-      end
+    edit do
+      field :name
+      field :email
+      field :username
     end
-
-    config.model School do
-      list do
-        field :zipcode do
-          searchable true
-        end
-      end
-    end
-
-    config.model UserSubscription do
-      field :user
-      field :subscription do
-        searchable [:id, :account_type]
-      end
-    end
-
-    config.model SchoolSubscription do
-      field :school do
-        searchable [:name, :zipcode]
-        proc { |scope|
-          scope = scope.where(role: ['teacher','admin'])
-        }
-      end
-      field :subscription do
-        searchable [:id, :account_type]
-      end
-    end
-
-    config.model SchoolsAdmins do
-      field :user do
-        searchable [:email, :username]
-        sortable :email
-        proc { |scope|
-          scope = scope.where(role: ['teacher','admin'])
-        }
-      end
-      field :school do
-        searchable [:name, :zipcode]
-        proc { |scope|
-          scope = scope.where(role: ['teacher','admin'])
-        }
-      end
-    end
-
-    config.model Activity do
-      edit do
-        exclude_fields :classroom_units, :classrooms, :unit_activities, :units
-      end
-      list do
-        field :id
-        field :name do
-          searchable true
-        end
-        field :classification
-        field :flags
-      end
-    end
-
-    # Limit pagination for models with large datasets (~1M+) because of performance
-    config.model ClassroomActivity do
-      list { limited_pagination true }
-    end
-
-    config.model UnitActivity do
-      list { limited_pagination true }
-    end
-
-    config.model ClassroomUnit do
-      list { limited_pagination true }
-    end
-
-    # Exclude the models with huge datasets (~10M+) because they are performance hits
-    MODELS_TO_EXCLUDE = [
-      'ActivitySession',
-      'OldConceptResult',
-      'Notification',
-      'OauthAccessToken',
-      'OldActivitySession',
-      'StudentClassroom'
-    ]
-
-    config.excluded_models.push(*MODELS_TO_EXCLUDE)
   end
+
+  config.model 'UserSubscription' do
+    field :user
+    field :subscription do
+      searchable [:id, :account_type]
+    end
+  end
+
+  # Leaving in the models we turned off for documentation purposes
+  # e.g. this model was turned off, not forgotten
+  config.included_models = [
+    # "ActiveActivitySession",
+    'ActivitiesUnitTemplate',
+    "Activity",
+    "ActivityCategory",
+    "ActivityCategoryActivity",
+    "ActivityClassification",
+    "ActivityHealth",
+    # "ActivitySession",
+    "ActivitySurveyResponse",
+    "ActivityTopic",
+    "AdminApprovalRequest",
+    "AdminInfo",
+    "AdminReportFilterSelection",
+    "Announcement",
+    "AppSetting",
+    "AuthCredential",
+    "Author",
+    "BlogPost",
+    "BlogPostUserRating",
+    "CanvasAccount",
+    # "CanvasConfig",
+    "CanvasInstance",
+    "CanvasInstanceAuthCredential",
+    "CanvasInstanceSchool",
+    "ChangeLog",
+    "Checkbox",
+    "Classroom",
+    # "ClassroomActivity",
+    # "ClassroomUnit",
+    # "ClassroomUnitActivityState",
+    # "ClassroomsTeacher",
+    "Concept",
+    "ConceptFeedback",
+    # "ConceptResult",
+    # "ConceptResultDirections",
+    # "ConceptResultInstructions",
+    # "ConceptResultPreviousFeedback",
+    # "ConceptResultPrompt",
+    # "ConceptResultQuestionType",
+    "ContentPartner",
+    "ContentPartnerActivity",
+    "CoteacherClassroomInvitation",
+    "CreditTransaction",
+    "Criterion",
+    "CsvExport",
+    "DiagnosticQuestionSkill",
+    "District",
+    "DistrictAdmin",
+    "DistrictSubscription",
+    # "FeedbackHistory",
+    # "FeedbackHistoryFlag",
+    # "FeedbackHistoryRating",
+    # "FeedbackSession",
+    # "FirebaseApp",
+    "Image",
+    "Invitation",
+    # "IpLocation",
+    "LearnWorldsAccount",
+    "LearnWorldsAccountCourseEvent",
+    "LearnWorldsCourse",
+    "Locker",
+    "Milestone",
+    "Objective",
+    # "PackSequence",
+    # "PackSequenceItem",
+    "PartnerContent",
+    "PdfSubscription",
+    "Plan",
+    "PromptHealth",
+    "ProviderClassroom",
+    "ProviderClassroomUser",
+    "Question",
+    "RawScore",
+    "Recommendation",
+    "ReferralsUser",
+    "ReferrerUser",
+    "SalesContact",
+    "SalesFormSubmission",
+    "SalesStage",
+    "SalesStageType",
+    "School",
+    "SchoolSubscription",
+    "SchoolsAdmins",
+    "SchoolsUsers",
+    "Skill",
+    "SkillConcept",
+    "SkillGroup",
+    "SkillGroupActivity",
+    "Standard",
+    "StandardCategory",
+    "StandardLevel",
+    "StripeCheckoutSession",
+    "StripeWebhookEvent",
+    "StudentFeedbackResponse",
+    "StudentProblemReport",
+    # "StudentsClassrooms",
+    "SubjectArea",
+    "Subscription",
+    "TeacherInfo",
+    "TeacherInfoSubjectArea",
+    "TeacherNotification",
+    "TeacherNotificationSetting",
+    # "TeacherSavedActivity",
+    # "ThirdPartyUserId",
+    "TitleCard",
+    "Topic",
+    "Unit",
+    # "UnitActivity",
+    "UnitTemplate",
+    "UnitTemplateCategory",
+    "User",
+    # "UserActivityClassification",
+    "UserEmailVerification",
+    # "UserLogin",
+    # "UserMilestone",
+    # "UserPackSequenceItem",
+    "UserSubscription",
+    "ZipcodeInfo"
+  ]
 end
 
 # Monkey patch for a known issue: RailsAdmin tries to parse search strings as JSON


### PR DESCRIPTION
* Rails Admin - fix slow pages.

* Allow some of the larger tables to be visible.

* Lint catch.

* Add a few more configs from testing.

* Turn off editing of Changelog, fix broken page. Turn off bulk delete.

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
