### PR TITLE
Add order to new incorrect sequences & button to save incorrect sequence order

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
@@ -27,9 +27,8 @@ class Api::V1::IncorrectSequencesController < Api::ApiController
   end
 
   def destroy
+    @question.delete_incorrect_sequence(params[:id])
     render json: {}, status: 200
-    # @question.delete_incorrect_sequence(params[:id])
-    # render(plain: 'OK')
   end
 
   def update_all

--- a/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
@@ -27,8 +27,9 @@ class Api::V1::IncorrectSequencesController < Api::ApiController
   end
 
   def destroy
-    @question.delete_incorrect_sequence(params[:id])
-    render(plain: 'OK')
+    render json: {}, status: 200
+    # @question.delete_incorrect_sequence(params[:id])
+    # render(plain: 'OK')
   end
 
   def update_all

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -83,7 +83,7 @@ class IncorrectSequencesContainer extends Component {
 
   sequencesSortedByOrder = () => {
     const { orderedIds, incorrectSequences } = this.state
-    
+
     const sequencesCollection = Array.isArray(incorrectSequences) ? incorrectSequences : hashToCollection(incorrectSequences)
 
     if (orderedIds) {
@@ -94,16 +94,29 @@ class IncorrectSequencesContainer extends Component {
   }
 
   sortCallback = sortInfo => {
-    const { actionFile } = this.state
+    const orderedIds = sortInfo.map(item => item.key);
+    this.setState({ orderedIds });
+  };
+
+  updateOrder = () => {
+    const { actionFile, orderedIds, incorrectSequences } = this.state
     const { dispatch, match } = this.props;
     const { params } = match;
     const { questionID } = params;
-    const orderedIds = sortInfo.map(item => item.key);
-    this.setState({ orderedIds, }, () => {
-      const sortedSequences = this.sequencesSortedByOrder()
-      dispatch(actionFile.updateIncorrectSequences(questionID, sortedSequences));
-    });
-  };
+    if (orderedIds) {
+      const newIncorrectSequences = []
+      const incorrectSequenceArray = hashToCollection(incorrectSequences)
+      orderedIds.forEach((id, index) => {
+        const sequence = incorrectSequenceArray.find(is => is.key === id);
+        sequence.order = index
+        newIncorrectSequences.push(sequence)
+      })
+      dispatch(actionFile.updateIncorrectSequences(questionID, newIncorrectSequences))
+      alert('Saved!')
+    } else {
+      alert('No changes to incorrect sequence order have been made.')
+    }
+  }
 
   saveSequencesAndFeedback = (key) => {
     const { actionFile } = this.state
@@ -237,6 +250,13 @@ class IncorrectSequencesContainer extends Component {
     ));
   }
 
+  renderSaveOrderButton() {
+    const { orderedIds } = this.state
+    return (
+      orderedIds ? <button className="button is-outlined is-primary" onClick={this.updateOrder} style={{ float: 'right', }}>Save Sequence Order</button> : null
+    );
+  }
+
   render() {
     const { match } = this.props
     return (
@@ -244,6 +264,7 @@ class IncorrectSequencesContainer extends Component {
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
           <a className="button is-outlined is-primary" href={`#${match.url}/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Incorrect Sequence</a>
+          {this.renderSaveOrderButton()}
         </div>
         {this.renderSequenceList()}
       </div>

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -69,7 +69,7 @@ class IncorrectSequencesContainer extends Component {
   }
 
   deleteSequence = sequenceID => {
-    const { actionFile, incorrectSequences } = this.state
+    const { actionFile, incorrectSequences, orderedIds } = this.state
     const { deleteIncorrectSequence } = actionFile
     const { dispatch, match } = this.props
     const { params } = match
@@ -77,7 +77,10 @@ class IncorrectSequencesContainer extends Component {
     if (confirm('⚠️ Are you sure you want to delete this? 😱')) {
       dispatch(deleteIncorrectSequence(questionID, sequenceID));
       delete incorrectSequences[sequenceID];
-      this.setState({incorrectSequences: incorrectSequences})
+      if (orderedIds) {
+        const newOrderedIds = orderedIds.filter(id => id != sequenceID)
+        this.setState({ orderedIds: newOrderedIds })
+      }
     }
   };
 
@@ -104,14 +107,14 @@ class IncorrectSequencesContainer extends Component {
     const { params } = match;
     const { questionID } = params;
     if (orderedIds) {
-      const newIncorrectSequences = []
+      const newIncorrectSequences = {}
       const incorrectSequenceArray = hashToCollection(incorrectSequences)
       orderedIds.forEach((id, index) => {
         const sequence = incorrectSequenceArray.find(is => is.key === id);
         sequence.order = index
-        newIncorrectSequences.push(sequence)
+        newIncorrectSequences[sequence.key] = sequence
       })
-      dispatch(actionFile.updateIncorrectSequences(questionID, newIncorrectSequences))
+      dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences))
       alert('Saved!')
     } else {
       alert('No changes to incorrect sequence order have been made.')

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/newIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/newIncorrectSequenceContainer.jsx
@@ -30,10 +30,12 @@ class NewIncorrectSequencesContainer extends Component {
   submitSequenceForm = data => {
     const { actionFile } = this.state
     const { submitNewIncorrectSequence } = actionFile
-    const { dispatch, match } = this.props
+    const { dispatch, match, generatedIncorrectSequences } = this.props
     const { params } = match
     const { questionID } = params
     delete data.conceptResults.null;
+    const usedIncorrectSequences = generatedIncorrectSequences.used[match.params.questionID];
+    data.order = _.keys(usedIncorrectSequences).length;
     dispatch(submitNewIncorrectSequence(questionID, data));
     window.history.back();
   };

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/newIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/newIncorrectSequenceContainer.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import _ from 'underscore';
 import questionActions from '../../actions/questions';
 import sentenceFragmentActions from '../../actions/sentenceFragments';
 import IncorrectSequencesInputAndConceptSelectorForm from '../shared/incorrectSequencesInputAndConceptSelectorForm.jsx';

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -162,15 +162,29 @@ class IncorrectSequencesContainer extends Component {
   }
 
   sortCallback = sortInfo => {
-    const { actionFile } = this.state
+    const orderedIds = sortInfo.map(item => item.key);
+    this.setState({ orderedIds });
+  };
+
+  updateOrder = () => {
+    const { actionFile, incorrectSequences, orderedIds } = this.state
     const { dispatch, match } = this.props;
     const { params } = match;
     const { questionID } = params;
-    const orderedIds = sortInfo.map(item => item.key);
-    this.setState({ orderedIds, }, () => {
-      dispatch(actionFile.updateIncorrectSequences(questionID, this.sequencesSortedByOrder()));
-    });
-  };
+    if (orderedIds) {
+      const newIncorrectSequences = []
+      const incorrectSequenceArray = hashToCollection(incorrectSequences)
+      orderedIds.forEach((id, index) => {
+        const sequence = incorrectSequenceArray.find(is => is.key === id);
+        sequence.order = index
+        newIncorrectSequences.push(sequence)
+      })
+      dispatch(actionFile.updateIncorrectSequences(questionID, newIncorrectSequences))
+      alert('Saved!')
+    } else {
+      alert('No changes to incorrect sequence order have been made.')
+    }
+  }
 
   renderTagsForSequence(sequenceString) {
     return sequenceString.split('|||').map((seq, index) => (<span className="tag is-medium is-light" key={`seq${index}`} style={{ margin: '3px', }}>{seq}</span>));
@@ -188,6 +202,13 @@ class IncorrectSequencesContainer extends Component {
       );
       return _.values(components);
     }
+  }
+
+  renderSaveOrderButton() {
+    const { orderedIds } = this.state
+    return (
+      orderedIds ? <button className="button is-outlined is-primary" onClick={this.updateOrder} style={{ float: 'right', }}>Save Sequence Order</button> : null
+    );
   }
 
   renderSequenceList() {
@@ -251,6 +272,7 @@ class IncorrectSequencesContainer extends Component {
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
           <a className="button is-outlined is-primary" href={`/diagnostic/#/admin/${path}/${questionID}/incorrect-sequences/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Incorrect Sequence</a>
+          {this.renderSaveOrderButton()}
         </div>
         {this.renderSequenceList()}
       </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -61,14 +61,17 @@ class IncorrectSequencesContainer extends Component {
   }
 
   deleteSequence = sequenceID => {
-    const { actionFile, incorrectSequences } = this.state
+    const { actionFile, incorrectSequences, orderedIds } = this.state
     const { dispatch, match } = this.props;
     const { params } = match;
     const { questionID } = params;
     if (confirm('⚠️ Are you sure you want to delete this? 😱')) {
       dispatch(actionFile.deleteIncorrectSequence(questionID, sequenceID));
       delete incorrectSequences[sequenceID]
-      this.setState({incorrectSequences: incorrectSequences})
+      if (orderedIds) {
+        const newOrderedIds = orderedIds.filter(id => id != sequenceID)
+        this.setState({ orderedIds: newOrderedIds })
+      }
     }
   };
 
@@ -172,14 +175,14 @@ class IncorrectSequencesContainer extends Component {
     const { params } = match;
     const { questionID } = params;
     if (orderedIds) {
-      const newIncorrectSequences = []
+      const newIncorrectSequences = {}
       const incorrectSequenceArray = hashToCollection(incorrectSequences)
       orderedIds.forEach((id, index) => {
         const sequence = incorrectSequenceArray.find(is => is.key === id);
         sequence.order = index
-        newIncorrectSequences.push(sequence)
+        newIncorrectSequences[sequence.key] = sequence
       })
-      dispatch(actionFile.updateIncorrectSequences(questionID, newIncorrectSequences))
+      dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences))
       alert('Saved!')
     } else {
       alert('No changes to incorrect sequence order have been made.')

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/newIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/newIncorrectSequenceContainer.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import _ from 'underscore';
 import { connect } from 'react-redux';
 import questionActions from '../../actions/questions';
 import sentenceFragmentActions from '../../actions/sentenceFragments.ts';

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/newIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/newIncorrectSequenceContainer.jsx
@@ -29,10 +29,12 @@ class NewIncorrectSequencesContainer extends Component {
 
   submitSequenceForm = data => {
     const { actionFile, questionTypeLink } = this.state;
-    const { dispatch, history, match } = this.props;
+    const { dispatch, history, match, generatedIncorrectSequences } = this.props;
     const { params } = match;
     const { questionID } = params;
     delete data.conceptResults.null;
+    const usedIncorrectSequences = generatedIncorrectSequences.used[match.params.questionID];
+    data.order = _.keys(usedIncorrectSequences).length;
     // TODO: fix add new incorrect sequence action to show new incorrect sequence without refreshing
     dispatch(actionFile.submitNewIncorrectSequence(questionID, data));
     history.push(`/admin/${questionTypeLink}/${questionID}/incorrect-sequences`)

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -239,10 +239,11 @@ export const deleteIncorrectSequence = (qid: string, seqid: string) => {
   };
 }
 
-export const updateIncorrectSequences = (qid: string, data: Array<IncorrectSequence>) => {
+export const updateIncorrectSequences = (qid: string, data: Array<IncorrectSequence>, callback: Function) => {
   return (dispatch: Function) => {
     IncorrectSequenceApi.updateAllForQuestion(qid, data).then(() => {
       dispatch(getQuestion(qid))
+      callback()
     }).catch((error: string) => {
       alert(`Order update failed! ${error}`);
     });

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -26,12 +26,10 @@ class IncorrectSequencesContainer extends React.Component {
     const { dispatch, match, } = this.props
     if (confirm('⚠️ Are you sure you want to delete this? 😱')) {
       dispatch(questionActions.deleteIncorrectSequence(match.params.questionID, sequenceID));
-      const newIncorrectSequences = incorrectSequences.filter(sequence => sequence.key != sequenceID)
+      delete incorrectSequences[sequenceID]
       if (orderedIds) {
         const newOrderedIds = orderedIds.filter(id => id != sequenceID)
-        this.setState({ incorrectSequences: newIncorrectSequences, orderedIds: newOrderedIds })
-      } else {
-        this.setState({ incorrectSequences: newIncorrectSequences })
+        this.setState({ orderedIds: newOrderedIds })
       }
     }
   }

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -22,12 +22,17 @@ class IncorrectSequencesContainer extends React.Component {
   }
 
   deleteSequence = (sequenceID: string) => {
-    const { incorrectSequences } = this.state
+    const { incorrectSequences, orderedIds } = this.state
     const { dispatch, match, } = this.props
     if (confirm('⚠️ Are you sure you want to delete this? 😱')) {
       dispatch(questionActions.deleteIncorrectSequence(match.params.questionID, sequenceID));
-      delete incorrectSequences[sequenceID]
-      this.setState({ incorrectSequences: incorrectSequences})
+      const newIncorrectSequences = incorrectSequences.filter(sequence => sequence.key != sequenceID)
+      if (orderedIds) {
+        const newOrderedIds = orderedIds.filter(id => id != sequenceID)
+        this.setState({ incorrectSequences: newIncorrectSequences, orderedIds: newOrderedIds })
+      } else {
+        this.setState({ incorrectSequences: newIncorrectSequences })
+      }
     }
   }
 
@@ -119,8 +124,6 @@ class IncorrectSequencesContainer extends React.Component {
       const sequencesCollection = hashToCollection(incorrectSequences)
       return orderedIds.map(id => sequencesCollection.find(s => s.key === id))
     } else {
-      console.log("sorting")
-      console.log(incorrectSequences)
       return hashToCollection(incorrectSequences).sort((a, b) => a.order - b.order);
     }
   }
@@ -183,8 +186,6 @@ class IncorrectSequencesContainer extends React.Component {
   renderSequenceList() {
     const { match } = this.props
     const components = this.sequencesSortedByOrder().map((seq) => {
-      console.log(seq)
-      console.log(seq.key)
       const onClickDelete = () => { this.handleDeleteSequence(seq.key) }
       return (
         <div className="card is-fullwidth has-bottom-margin" id={seq.key} key={seq.key}>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -119,6 +119,8 @@ class IncorrectSequencesContainer extends React.Component {
       const sequencesCollection = hashToCollection(incorrectSequences)
       return orderedIds.map(id => sequencesCollection.find(s => s.key === id))
     } else {
+      console.log("sorting")
+      console.log(incorrectSequences)
       return hashToCollection(incorrectSequences).sort((a, b) => a.order - b.order);
     }
   }
@@ -181,6 +183,8 @@ class IncorrectSequencesContainer extends React.Component {
   renderSequenceList() {
     const { match } = this.props
     const components = this.sequencesSortedByOrder().map((seq) => {
+      console.log(seq)
+      console.log(seq.key)
       const onClickDelete = () => { this.handleDeleteSequence(seq.key) }
       return (
         <div className="card is-fullwidth has-bottom-margin" id={seq.key} key={seq.key}>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -124,15 +124,30 @@ class IncorrectSequencesContainer extends React.Component {
   }
 
   sortCallback = sortInfo => {
+    const orderedIds = sortInfo.map(item => item.key);
+    this.setState({ orderedIds });
+  }
+
+  updateOrder = () => {
+    const { orderedIds, incorrectSequences } = this.state
     const { dispatch, match } = this.props;
     const { params } = match;
     const { questionID } = params;
-    const orderedIds = sortInfo.map(item => item.key);
-    this.setState({ orderedIds, }, () => {
-      dispatch(questionActions.updateIncorrectSequences(questionID, this.sequencesSortedByOrder()));
-    });
-  }
 
+    if (orderedIds) {
+      const newIncorrectSequences = []
+      const incorrectSequenceArray = hashToCollection(incorrectSequences)
+      orderedIds.forEach((id, index) => {
+        const sequence = incorrectSequenceArray.find(is => is.key === id);
+        sequence.order = index
+        newIncorrectSequences.push(sequence)
+      })
+      dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences))
+      alert('Saved!')
+    } else {
+      alert('No changes to incorrect sequence order have been made.')
+    }
+  }
 
   renderConceptResults(concepts, sequenceKey: string) {
     if (concepts) {
@@ -154,6 +169,13 @@ class IncorrectSequencesContainer extends React.Component {
     return sequenceString.split(/\|{3}(?!\|)/).map(text => (
       this.inputElement(className, text, key)
     ));
+  }
+
+  renderSaveOrderButton() {
+    const { orderedIds } = this.state
+    return (
+      orderedIds ? <button className="button is-outlined is-primary" onClick={this.updateOrder} style={{ float: 'right', }}>Save Sequence Order</button> : null
+    );
   }
 
   renderSequenceList() {
@@ -202,7 +224,8 @@ class IncorrectSequencesContainer extends React.Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
-          <a className="button is-outlined is-primary" href={`/grammar/#/admin/questions/${match.params.questionID}/incorrect-sequences/new`} rel="noopener noreferrer" style={{ float: 'right', }} target="_blank">Add Incorrect Sequence</a>
+          <a className="button is-outlined is-primary" href={`/grammar/#/admin/questions/${match.params.questionID}/incorrect-sequences/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Incorrect Sequence</a>
+          {this.renderSaveOrderButton()}
         </div>
         {this.renderSequenceList()}
         {children}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -57,8 +57,6 @@ class IncorrectSequencesContainer extends React.Component {
         sequence.order = index
         newIncorrectSequences[sequence.key] = sequence
       })
-      console.log("new array")
-      console.log(newIncorrectSequences)
 
       if (incorrectSequenceArray.length > 0) {
         dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences, this.alertDeleted))

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -140,12 +140,12 @@ class IncorrectSequencesContainer extends React.Component {
     const { questionID } = params;
 
     if (orderedIds) {
-      const newIncorrectSequences = []
+      const newIncorrectSequences = {}
       const incorrectSequenceArray = hashToCollection(incorrectSequences)
       orderedIds.forEach((id, index) => {
         const sequence = incorrectSequenceArray.find(is => is.key === id);
         sequence.order = index
-        newIncorrectSequences.push(sequence)
+        newIncorrectSequences[sequence.key] = sequence
       })
       dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences))
       alert('Saved!')

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/newIncorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/newIncorrectSequenceContainer.tsx
@@ -19,7 +19,10 @@ class NewIncorrectSequencesContainer extends React.Component {
     data.order = _.keys(usedIncorrectSequences).length;
     // the only difference in the route between this page and the one where you can see all the incorrect sequences is the `/new` at the end of the path, so removing that will send us back to the main list
     const url = match.url.replace('/new', '')
-    const callback = () => history.push(url)
+    const callback = () => {
+      history.push(url)
+      window.location.reload()
+    }
     dispatch(questionActions.submitNewIncorrectSequence(match.params.questionID, data, callback))
   }
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/newIncorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/newIncorrectSequenceContainer.tsx
@@ -13,15 +13,14 @@ class NewIncorrectSequencesContainer extends React.Component {
   }
 
   submitSequenceForm = (data) => {
-    const { dispatch, match, history, generatedIncorrectSequences } = this.props
-    const usedIncorrectSequences = generatedIncorrectSequences.used[match.params.questionID];
+    const { dispatch, match, history, questions } = this.props
+    const incorrectSequences = questions.data[match.params.questionID].incorrectSequences
     delete data.conceptResults.null;
-    data.order = _.keys(usedIncorrectSequences).length;
+    data.order = _.keys(incorrectSequences).length;
     // the only difference in the route between this page and the one where you can see all the incorrect sequences is the `/new` at the end of the path, so removing that will send us back to the main list
     const url = match.url.replace('/new', '')
     const callback = () => {
       history.push(url)
-      window.location.reload()
     }
     dispatch(questionActions.submitNewIncorrectSequence(match.params.questionID, data, callback))
   }

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/newIncorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/newIncorrectSequenceContainer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import _ from 'underscore';
 import { connect } from 'react-redux';
 import * as questionActions from '../../actions/questions';
 import IncorrectSequencesInputAndConceptSelectorForm from '../shared/incorrectSequencesInputAndConceptSelectorForm';
@@ -12,8 +13,10 @@ class NewIncorrectSequencesContainer extends React.Component {
   }
 
   submitSequenceForm = (data) => {
-    const { dispatch, match, history, } = this.props
+    const { dispatch, match, history, generatedIncorrectSequences } = this.props
+    const usedIncorrectSequences = generatedIncorrectSequences.used[match.params.questionID];
     delete data.conceptResults.null;
+    data.order = _.keys(usedIncorrectSequences).length;
     // the only difference in the route between this page and the one where you can see all the incorrect sequences is the `/new` at the end of the path, so removing that will send us back to the main list
     const url = match.url.replace('/new', '')
     const callback = () => history.push(url)

--- a/services/QuillLMS/client/app/modules/request/index.ts
+++ b/services/QuillLMS/client/app/modules/request/index.ts
@@ -19,7 +19,12 @@ async function handleFetch({ url, method, success, error, payload, }: {url: stri
   const response = await fetch(fullyQualifiedUrl(url), options)
   const textResponse = await response.clone().text()
 
-  const jsonResponse = textResponse.length ? await response.clone().json() : {};
+  let jsonResponse
+  try {
+    jsonResponse = textResponse.length ? await response.clone().json() : {};
+  } catch (err) {
+    jsonResponse = {}
+  }
 
   if (response.status === 303 && jsonResponse.redirect) {
     window.location.href = jsonResponse.redirect

--- a/services/QuillLMS/client/app/modules/request/index.ts
+++ b/services/QuillLMS/client/app/modules/request/index.ts
@@ -19,12 +19,7 @@ async function handleFetch({ url, method, success, error, payload, }: {url: stri
   const response = await fetch(fullyQualifiedUrl(url), options)
   const textResponse = await response.clone().text()
 
-  let jsonResponse
-  try {
-    jsonResponse = textResponse.length ? await response.clone().json() : {};
-  } catch (err) {
-    jsonResponse = {}
-  }
+  const jsonResponse = textResponse.length ? await response.clone().json() : {};
 
   if (response.status === 303 && jsonResponse.redirect) {
     window.location.href = jsonResponse.redirect


### PR DESCRIPTION
## WHAT
Incorrect Sequences currently aren't being saved with any order value, so the order will change around and confuse admins. We also save incorrect sequence order on every time the list order is changed, when instead we should save only when a "Save Order" button is pressed.

## WHY
This behavior was causing some bugs on admin end because they thought one order was being saved when in fact the sequences would show up in a different order. The "save on drag" behavior was also causing problems with admin because of race condition with order updates on every drag.

## HOW
Use the same behavior we currently have on focus points where we send incorrect sequences to the API with a designated "order" variable. Move ordering API calls to a button click rather than a callback on sorting.

### Screenshots
![Screenshot 2024-04-18 at 12 19 49 AM](https://github.com/empirical-org/Empirical-Core/assets/57366100/6839181f-653a-410d-ba4e-ac46813f3266)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Incorrect-Sequences-in-Grammar-currently-have-inconsistent-saving-behavior-a2308d4636244e94917cf72b907039d6?pvs=4)

### What have you done to QA this feature?
Deploy to staging and create new incorrect sequences on each type of question. Then reorder some questions and click "save" to verify saving behavior. I'm also asking Rachel to do additional QA run on all the apps to double check the behavior.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no, tested manually
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
