### PR TITLE
Lms/update activity session timestamps in teacher fix

### DIFF
--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -237,17 +237,17 @@ class ActivitySession < ApplicationRecord
 
     # mark all finished anonymous sessions as final score.
     if user.nil?
-      update_columns(is_final_score: true)
+      update_columns(is_final_score: true, updated_at: DateTime.current)
       return
     end
 
     a = ActivitySession.where(classroom_unit: classroom_unit, user: user, is_final_score: true, activity: activity)
                        .where.not(id: id).first
     if a.nil?
-      update_columns is_final_score: true
+      update_columns is_final_score: true, updated_at: DateTime.current
     elsif a.percentage.nil? || percentage >= a.percentage
-      update_columns is_final_score: true
-      a.update_columns is_final_score: false
+      update_columns is_final_score: true, updated_at: DateTime.current
+      a.update_columns is_final_score: false, updated_at: DateTime.current
     end
     # return true otherwise save will be prevented
     true

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -179,7 +179,7 @@ module Student
 
     secondary_account_grouped_activity_sessions.each do |classroom_unit_id, activity_sessions|
       if classroom_unit_id
-        activity_sessions.each {|as| as.update_columns(user_id: id) }
+        activity_sessions.each {|as| as.update_columns(user_id: id, updated_at: DateTime.current) }
         if primary_account_grouped_activity_sessions[classroom_unit_id]
           hide_extra_activity_sessions(classroom_unit_id)
         else

--- a/services/QuillLMS/app/services/vitally_integration/previous_year_school_datum.rb
+++ b/services/QuillLMS/app/services/vitally_integration/previous_year_school_datum.rb
@@ -14,8 +14,8 @@ module VitallyIntegration
       school_year_end = school_year_start + 1.year
       raise "Cannot calculate data for a school year that is still ongoing." if school_year_end > Time.current
 
-      active_students_this_year = active_students_query(@school).where("activity_sessions.updated_at >= ? and activity_sessions.updated_at < ?", school_year_start, school_year_end).count
-      activities_finished_this_year = activities_finished_query(@school).where("activity_sessions.updated_at >= ? and activity_sessions.updated_at < ?", school_year_start, school_year_end).count
+      active_students_this_year = active_students_query(@school).where("activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?", school_year_start, school_year_end).count
+      activities_finished_this_year = activities_finished_query(@school).where("activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?", school_year_start, school_year_end).count
       {
         # this will not be accurate if calculated after the last day of the school year
         total_students: @school.students.where(last_sign_in: school_year_start..school_year_end).count,

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -14,9 +14,9 @@ module VitallyIntegration
       current_time = Time.current
       school_year_start = School.school_year_start(current_time)
       active_students = active_students_query(@school).count
-      active_students_this_year = active_students_query(@school).where("activity_sessions.updated_at >= ?", school_year_start).count
+      active_students_this_year = active_students_query(@school).where("activity_sessions.completed_at >= ?", school_year_start).count
       activities_finished = activities_finished_query(@school).count("DISTINCT activity_sessions.id")
-      activities_finished_this_year = activities_finished_query(@school).where("activity_sessions.updated_at >= ?", school_year_start).count("DISTINCT activity_sessions.id")
+      activities_finished_this_year = activities_finished_query(@school).where("activity_sessions.completed_at >= ?", school_year_start).count("DISTINCT activity_sessions.id")
       {
         accountId: @school.id.to_s,
         organizationId: organization_id,

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -667,7 +667,7 @@ end
   end
 
   describe '#determine_if_final_score' do
-    let!(:now) { DateTime.current }
+    let!(:now) { DateTime.current.utc }
     let!(:starting_updated_at) { now - 1.hour }
     let(:classroom) {create(:classroom)}
     let(:student) {create(:student)}
@@ -683,7 +683,7 @@ end
       new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity, updated_at: starting_updated_at)
       new_activity_session.update(completed_at: Time.current, state: 'finished', percentage: 0.95)
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
-      expect([ActivitySession.find(previous_final_score.id).reload.updated_at, ActivitySession.find(new_activity_session.id).reload.updated_at]).to eq([now, now])
+      expect([ActivitySession.find(previous_final_score.id).reload.updated_at.iso8601, ActivitySession.find(new_activity_session.id).reload.updated_at.iso8601]).to eq([now.iso8601, now.iso8601])
     end
 
     it 'updates when new activity session has equal percentage' do
@@ -691,7 +691,7 @@ end
       new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity, updated_at: starting_updated_at)
       new_activity_session.update(completed_at: Time.current, state: 'finished', percentage: previous_final_score.percentage)
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
-      expect([ActivitySession.find(previous_final_score.id).reload.updated_at, ActivitySession.find(new_activity_session.id).reload.updated_at]).to eq([now, now])
+      expect([ActivitySession.find(previous_final_score.id).reload.updated_at.iso8601, ActivitySession.find(new_activity_session.id).reload.updated_at.iso8601]).to eq([now.iso8601, now.iso8601])
     end
 
     it 'updates when new and old session percentages are nil' do
@@ -715,9 +715,9 @@ end
 
     it 'doesnt update when new activity session has lower percentage' do
       previous_final_score
-      new_activity_session = create(:activity_session, completed_at: Time.current, state: 'finished', percentage: 0.5, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session = create(:activity_session, completed_at: Time.current, state: 'finished', percentage: 0.5, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity, updated_at: now - 1.hour)
       expect([ActivitySession.find(previous_final_score.id).is_final_score, ActivitySession.find(new_activity_session.id).is_final_score]).to eq([true, false])
-      expect([ActivitySession.find(previous_final_score.id).reload.updated_at, ActivitySession.find(new_activity_session.id).reload.updated_at]).not_to eq([now, now])
+      expect([ActivitySession.find(previous_final_score.id).reload.updated_at.iso8601, ActivitySession.find(new_activity_session.id).reload.updated_at.iso8601]).not_to eq([now.iso8601, now.iso8601])
     end
 
     it 'mark finished anonymous sessions as final' do

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -667,31 +667,37 @@ end
   end
 
   describe '#determine_if_final_score' do
+    let!(:now) { DateTime.current }
+    let!(:starting_updated_at) { now - 1.hour }
     let(:classroom) {create(:classroom)}
     let(:student) {create(:student)}
     let(:activity) {create(:activity)}
 
     let(:classroom_unit)   { create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id])}
-    let(:previous_final_score) { create(:activity_session, completed_at: Time.current, percentage: 0.9, is_final_score: true, user: student, classroom_unit: classroom_unit, activity: activity)}
+    let(:previous_final_score) { create(:activity_session, completed_at: Time.current, percentage: 0.9, is_final_score: true, user: student, classroom_unit: classroom_unit, activity: activity, updated_at: starting_updated_at)}
+
+    before { allow(DateTime).to receive(:current).and_return(now) }
 
     it 'updates when new activity session has higher percentage' do
       previous_final_score
-      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity, updated_at: starting_updated_at)
       new_activity_session.update(completed_at: Time.current, state: 'finished', percentage: 0.95)
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
+      expect([ActivitySession.find(previous_final_score.id).reload.updated_at, ActivitySession.find(new_activity_session.id).reload.updated_at]).to eq([now, now])
     end
 
     it 'updates when new activity session has equal percentage' do
       previous_final_score
-      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity, updated_at: starting_updated_at)
       new_activity_session.update(completed_at: Time.current, state: 'finished', percentage: previous_final_score.percentage)
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
+      expect([ActivitySession.find(previous_final_score.id).reload.updated_at, ActivitySession.find(new_activity_session.id).reload.updated_at]).to eq([now, now])
     end
 
     it 'updates when new and old session percentages are nil' do
       previous_final_score
       previous_final_score.update(percentage: nil)
-      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
+      new_activity_session = create(:activity_session, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity, updated_at: starting_updated_at)
       new_activity_session.update(completed_at: Time.current, state: 'finished', percentage: nil)
       expect([ActivitySession.find(previous_final_score.id).reload.is_final_score, ActivitySession.find(new_activity_session.id).reload.is_final_score]).to eq([false, true])
     end
@@ -711,6 +717,7 @@ end
       previous_final_score
       new_activity_session = create(:activity_session, completed_at: Time.current, state: 'finished', percentage: 0.5, is_final_score: false, user: student, classroom_unit: classroom_unit, activity: activity)
       expect([ActivitySession.find(previous_final_score.id).is_final_score, ActivitySession.find(new_activity_session.id).is_final_score]).to eq([true, false])
+      expect([ActivitySession.find(previous_final_score.id).reload.updated_at, ActivitySession.find(new_activity_session.id).reload.updated_at]).not_to eq([now, now])
     end
 
     it 'mark finished anonymous sessions as final' do

--- a/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
@@ -65,7 +65,7 @@ describe 'Student Concern', type: :model do
   end
 
   let!(:activity_session_for_second_student1) do
-    create(:activity_session, user_id: student2.id, classroom_unit_id: classroom_unit1.id)
+    create(:activity_session, user_id: student2.id, classroom_unit_id: classroom_unit1.id, updated_at: DateTime.now - 1.hour)
   end
 
   let!(:activity_session_for_second_student2) do
@@ -239,6 +239,14 @@ describe 'Student Concern', type: :model do
         student1.merge_activity_sessions(student2)
         student2.reload
         expect(student2.activity_sessions.length).to equal(0)
+      end
+
+      it "sets updated_at on the ActivitySessions that get moved" do
+        now = DateTime.current
+        allow(DateTime).to receive(:current).and_return(now)
+
+        student1.merge_activity_sessions(student2)
+        expect(activity_session_for_second_student1.reload.updated_at).to eq(now)
       end
     end
 

--- a/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
@@ -242,11 +242,11 @@ describe 'Student Concern', type: :model do
       end
 
       it "sets updated_at on the ActivitySessions that get moved" do
-        now = DateTime.current
+        now = DateTime.current.utc
         allow(DateTime).to receive(:current).and_return(now)
 
         student1.merge_activity_sessions(student2)
-        expect(activity_session_for_second_student1.reload.updated_at).to eq(now)
+        expect(activity_session_for_second_student1.reload.updated_at.iso8601).to eq(now.iso8601)
       end
     end
 

--- a/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/student_concern_spec.rb
@@ -248,6 +248,16 @@ describe 'Student Concern', type: :model do
         student1.merge_activity_sessions(student2)
         expect(activity_session_for_second_student1.reload.updated_at.iso8601).to eq(now.iso8601)
       end
+
+      it "sets the updated_at to the same value that touch would" do
+        activity_session_for_second_student1.update_columns(updated_at: DateTime.current)
+        datetime_current_updated_at = activity_session_for_second_student1.reload.updated_at
+
+        activity_session_for_second_student1.touch
+        touch_updated_at = activity_session_for_second_student1.reload.updated_at
+
+        expect(touch_updated_at - datetime_current_updated_at).to be < 1.second
+      end
     end
 
     context "called with a teacher id" do

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -226,6 +226,7 @@ describe VitallyIntegration::SerializeVitallySalesAccount do
         user: active_old_student,
         classroom_unit: old_classroom_unit,
         state: 'finished',
+        completed_at: 2.year.ago,
         updated_at: 2.year.ago)
     end
     let!(:last_activity_session) do


### PR DESCRIPTION
## WHAT
- Find `update_columns` calls throughout our code and make sure that they also set `updated_at` so that the `updated_at` value stays accurate.  (`update_columns` calls directly to SQL, bypassing callbacks and automatic timestamps)
- Update Vitally sync logic to use `completed_at` instead of `updated_at` when determining which school year an ActivitySession counts toward
## WHY
- We want this value to be accurate, but it's also important because we use `updated_at` to keep values up to date in BigQuery, so when the values on the model change without `updated_at` changing, the changes aren't propagated through Airbyte.
- Sometimes an ActivitySession may be updated (like when we merge student accounts), and `updated_at` should change, but we shouldn't change what school year we count the activity toward.  (Note that in 99+% of cases, these two values will be the same, but we do want to handle the edge cases accurately.)
## HOW
- Just make sure to add `updated_at: DateTime.current` to `update_columns` calls throughout the codebase.
- Update query to filter on `completed_at` instead of `updated_at` and update spec conditions to test behavior properly

### Notion Card Links
https://www.notion.so/quill/Admin-Diagnostic-Growth-Report-Not-Counting-All-Completed-Diagnostics-One-School-53371cb83b4b4df2b7a12fa8939bafb6

### What have you done to QA this feature?
This can't be tested outside of production, but once this gets merged and we reset the data in BigQuery we should trigger one of these update types to make sure that the data makes it to BigQuery.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | No
Self-Review: Have you done an initial self-review of the code below on Github? | Yes