### PR TITLE
Combine HTML-stripping and space-adding logic

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/__tests__/__snapshots__/student_report.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/__tests__/__snapshots__/student_report.test.jsx.snap
@@ -8606,7 +8606,7 @@ exports[`StudentReport should render 1`] = `
                     </td>
                     <td />
                     <td>
-                      He can&#x27;t sing well. Still he practices every day.
+                      He can't sing well. Still he practices every day.
                     </td>
                   </tr>
                   <tr>
@@ -8890,7 +8890,7 @@ exports[`StudentReport should render 1`] = `
                     </td>
                     <td />
                     <td>
-                      Strawberries are my favorite. However I don&#x27;t eat them all the time.
+                      Strawberries are my favorite. However I don't eat them all the time.
                     </td>
                   </tr>
                   <tr>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
@@ -3,7 +3,7 @@ export const formatString = (str: string) => {
 }
 
 export const formatStringAndAddSpacesAfterPeriods = (str: string) => {
-  return stringifiedString(str).replace(/\.(?=[^ ])/g, '. ')
+  return formatString(str).replace(/\.(?=[^ ])/g, '. ')
 }
 
 export const stringifiedString = (str: string) => {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report_box.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import _ from 'underscore';
 
-import { formatString, formatStringAndAddSpacesAfterPeriods, } from './formatString';
+import { formatStringAndAddSpacesAfterPeriods, } from './formatString';
 
 import NumberSuffix from '../../modules/numberSuffixBuilder.js';
 import ScoreColor from '../../modules/score_color.js';
@@ -43,7 +43,7 @@ const StudentReportBox = ({ questionData, boxNumber, showScore, showDiff, }) => 
         <tr className={classNameAndText} key={key || ''}>
           <td>{classNameAndText}</td>
           <td />
-          <td>{formatString(directionsOrFeedback)}</td>
+          <td>{formatStringAndAddSpacesAfterPeriods(directionsOrFeedback)}</td>
         </tr>
       )
     }


### PR DESCRIPTION
## WHAT
Update logic for formatting strings while ensuring spaces after periods
## WHY
- Activities sometimes write values to ConceptResult records without spaces between the end of one sentence and start of the next.  (This looks like it usually happens when it's collapsing two paragraphs into one string.)
- While we generally strip tags from strings before displaying them, we weren't doing it everywhere, and we want to.
## HOW
Chain `formatString` and `formatStringAndAddSpacesAfterPeriods` so that when the latter is called, it also applies the formatting from the former.

### Screenshots
OLD
![Screenshot 2024-04-19 at 1 01 01 PM](https://github.com/empirical-org/Empirical-Core/assets/331565/a0237ff2-cc64-41c3-a0b6-292a44db0e45)
NEW
![Screenshot 2024-04-19 at 1 03 03 PM](https://github.com/empirical-org/Empirical-Core/assets/331565/6282d117-e273-4f13-b5c7-70fe1f183e63)

### Notion Card Links
https://www.notion.so/quill/Formatting-weirdness-in-Proofreader-teacher-reports-2be885a917794ea09f70f2749659c8b6

### What have you done to QA this feature?
Deployed to staging and loaded the report from the original Support ticket to compare formatting between production and new code to confirm that the issues flagged in the original report have been resolved.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No changes to snapshot expectations
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes