### PR TITLE
Fix discrepancy between Teacher and Student reports

### DIFF
--- a/services/QuillLMS/app/queries/progress_reports/activities_scores_by_classroom.rb
+++ b/services/QuillLMS/app/queries/progress_reports/activities_scores_by_classroom.rb
@@ -53,8 +53,8 @@ class ProgressReports::ActivitiesScoresByClassroom
       JOIN activity_classifications
         ON activities.activity_classification_id = activity_classifications.id
       WHERE classroom_units.classroom_id IN (#{classroom_ids})
-      AND activity_sessions.is_final_score = TRUE
       AND activity_sessions.visible = true
+      AND activity_sessions.completed_at IS NOT NULL
       AND classroom_units.visible = true
       GROUP BY
         classrooms.name,

--- a/services/QuillLMS/app/queries/progress_reports/student_overview.rb
+++ b/services/QuillLMS/app/queries/progress_reports/student_overview.rb
@@ -9,6 +9,7 @@ class ProgressReports::StudentOverview
           activity_sessions.id AS activity_sessions_id,
           activities.name,
           activity_sessions.percentage,
+          activity_sessions.is_final_score,
           units.name AS unit_name,
           activities.activity_classification_id,
           cuas.completed AS is_a_completed_lesson,
@@ -20,7 +21,7 @@ class ProgressReports::StudentOverview
           ON classroom_units.id = activity_sessions.classroom_unit_id
           AND activity_sessions.user_id = #{ActiveRecord::Base.connection.quote(student_id)}
           AND activity_sessions.visible = true
-          AND activity_sessions.is_final_score = true
+          AND activity_sessions.completed_at IS NOT NULL
         JOIN units
           ON units.id = classroom_units.unit_id
         JOIN activities

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview.jsx
@@ -44,6 +44,10 @@ export default class extends React.Component {
     }
   };
 
+  filterReportData = (data) => {
+    return data.filter(activitySession => activitySession.is_final_score)
+  }
+
   calculateCountAndAverage = () => {
     const { reportData } = this.state;
     let count = 0;
@@ -198,7 +202,7 @@ export default class extends React.Component {
         {this.studentOverviewSection()}
         <StudentOveriewTable
           calculateCountAndAverage={this.calculateCountAndAverage}
-          reportData={reportData}
+          reportData={this.filterReportData(reportData)}
           studentId={studentData.id}
         />
       </div>

--- a/services/QuillLMS/spec/queries/progress_reports/activities_scores_by_classroom_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/activities_scores_by_classroom_spec.rb
@@ -32,12 +32,13 @@ describe 'ActivitiesScoresByClassroom' do
     end
   end
 
-  it 'does not return archived activity sessions' do
+  it 'does not return archived activity sessions or sessions with no completed_at date' do
     new_student = create(:student)
     create(:students_classrooms, student: new_student, classroom: classroom)
     classroom_unit = classroom.classroom_units.first
     classroom_unit.assigned_student_ids << new_student.id
     create(:activity_session, user: classroom.students.first, classroom_unit: classroom_unit, visible: false)
+    create(:activity_session, user: classroom.students.first, classroom_unit: classroom_unit, visible: true, completed_at: nil)
     results = ProgressReports::ActivitiesScoresByClassroom.results(classroom.owner.classrooms_i_teach.map(&:id))
     expect(results.pluck("name")).not_to include(new_student.name)
   end

--- a/services/QuillLMS/spec/queries/progress_reports/activities_scores_by_classroom_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/activities_scores_by_classroom_spec.rb
@@ -38,7 +38,7 @@ describe 'ActivitiesScoresByClassroom' do
     classroom_unit = classroom.classroom_units.first
     classroom_unit.assigned_student_ids << new_student.id
     create(:activity_session, user: classroom.students.first, classroom_unit: classroom_unit, visible: false)
-    create(:activity_session, user: classroom.students.first, classroom_unit: classroom_unit, visible: true, completed_at: nil)
+    create(:activity_session, user: classroom.students.first, classroom_unit: classroom_unit, visible: true, state: "unstarted", completed_at: nil)
     results = ProgressReports::ActivitiesScoresByClassroom.results(classroom.owner.classrooms_i_teach.map(&:id))
     expect(results.pluck("name")).not_to include(new_student.name)
   end


### PR DESCRIPTION
## WHAT
fix discrepancy with activity count and timespent values between the student metrics and the teacher activity scores report

## WHY
we want these values to match

## HOW
remove `is_final_score` value and add `completed_at IS NOT NULL` with queries, and filter by `is_final_score` `true` on the frontend to remove duplicate activity plays

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/A-discrepancy-between-the-Your-progress-report-in-a-student-s-account-and-the-Activity-Scores-report-9db2c1737f03477c859c53f4aceb354b

### What have you done to QA this feature?
logged into both teacher and student accounts to verify that the two values match across the reports

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
