### PR TITLE
Send optimal response concept result data with new activity creation 

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
@@ -113,7 +113,8 @@ class FillInBlankForm extends Component {
           text: newQuestionOptimalResponse.trim(),
           optimal: true,
           count: 0,
-          feedback: "That's a strong sentence!"
+          feedback: "That's a strong sentence!",
+          concept_results: [{conceptUID: conceptID, correct: true}]
         }
       );
     } else {

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
@@ -40,7 +40,7 @@ export default class extends React.Component {
       cuesLabel: this.state.cuesLabel
     }
     if (this.props.new) {
-      const optimalResponseObj = {text: this.state.optimalResponseText.trim(), optimal: true, count: 0, feedback: "That's a strong sentence!"}
+      const optimalResponseObj = {text: this.state.optimalResponseText.trim(), optimal: true, count: 0, feedback: "That's a strong sentence!", concept_results: [{conceptUID: concept, correct: true}]}
       this.props.submit(questionObj, optimalResponseObj)
     } else {
       questionObj.conceptID = this.state.concept

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -192,8 +192,6 @@ export const submitQuestionEdit = (qid: string, formContent: Question) => {
 }
 
 export const saveOptimalResponse = (qid: string, conceptUid: string, answer: {text: string}) => {
-  console.log("saving optimal")
-  console.log(answer)
   return (dispatch: Function) => {
     if (answer.text) {
       const conceptResults = [{ conceptUID: conceptUid, correct: true }]

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -157,11 +157,11 @@ export const submitNewQuestion = (content: Question) => {
       dispatch(getQuestion(question_uid))
       const action = push(`/admin/questions/${question.uid}`);
       dispatch(action);
+      content.answers.forEach(a => dispatch(saveOptimalResponse(question_uid, content.concept_uid, a)))
     }).catch((error: string) => {
       dispatch({ type: ActionTypes.RECEIVE_NEW_QUESTION_RESPONSE, });
       dispatch({ type: ActionTypes.DISPLAY_ERROR, error: `Submission failed! ${error}`, });
     });
-    content.answers.forEach(a => dispatch(saveOptimalResponse(newRef.key, content.concept_uid, a)))
   };
 }
 
@@ -192,6 +192,8 @@ export const submitQuestionEdit = (qid: string, formContent: Question) => {
 }
 
 export const saveOptimalResponse = (qid: string, conceptUid: string, answer: {text: string}) => {
+  console.log("saving optimal")
+  console.log(answer)
   return (dispatch: Function) => {
     if (answer.text) {
       const conceptResults = [{ conceptUID: conceptUid, correct: true }]


### PR DESCRIPTION
## WHAT
In Connect/Grammar, send the concept_results object with the Optimal Response payload so that new questions get created with the correct concept attached.

## WHY
Admin are confused why optimal response questions get created without the concept attached. This is expected behavior whenever they create a new prompt with an optimal response.

## HOW
For connect questions, we just weren't sending the concept_results object with the payload. For Grammar, we were sending it in the wrong place (we should send it after question creation so we can attach the newly created question_uid).

### Screenshots
<img width="1109" alt="Screenshot 2024-04-23 at 5 25 13 PM" src="https://github.com/empirical-org/Empirical-Core/assets/57366100/fb5ab153-d1ea-4a90-b5b0-037ca3b3441a">

### Notion Card Links
https://www.notion.so/quill/The-first-optimal-you-assign-when-creating-a-Connect-Grammar-or-FITB-question-displays-as-though-i-b5aef8227414431bb55fd4126f65ac32?pvs=4

### What have you done to QA this feature?
Deployed to staging and created new questions for each activity category, then verified that the prompts have concept results attached. Also asked Rachel to test this flow as well for sanity check.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, tested manually
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
