### PR TITLE
apply key commands to rich utils

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/__tests__/__snapshots__/lessonForm.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/__tests__/__snapshots__/lessonForm.test.jsx.snap
@@ -25,14 +25,14 @@ exports[`LessonForm component renderSearchBox renders a SelectSearch component w
       htmlFor="landing-page-content"
     >
       Landing Page Content
-      <TextEditor
-        ContentState={[Function]}
-        EditorState={[Function]}
-        handleTextChange={[Function]}
-        id="landing-page-content"
-        text="<p>Test content</p>"
-      />
     </label>
+    <TextEditor
+      ContentState={[Function]}
+      EditorState={[Function]}
+      handleTextChange={[Function]}
+      id="landing-page-content"
+      text="<p>Test content</p>"
+    />
   </div>
   <br />
   <p

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessonForm.tsx
@@ -211,16 +211,14 @@ export class LessonForm extends React.Component<LessonFormProps, LessonFormState
           <NameInput name={name} onChange={this.handleStateChange} />
         </p>
         <div className="control">
-          <label className="label" htmlFor="landing-page-content">
-            Landing Page Content
-            <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
-              handleTextChange={this.onLandingPageChange}
-              id="landing-page-content"
-              text={landingPageHtml || ''}
-            />
-          </label>
+          <label className="label" htmlFor="landing-page-content">Landing Page Content</label>
+          <TextEditor
+            ContentState={ContentState}
+            EditorState={EditorState}
+            handleTextChange={this.onLandingPageChange}
+            id="landing-page-content"
+            text={landingPageHtml || ''}
+          />
         </div>
         <br />
         <p className="control">

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -113,11 +113,14 @@ class TextEditor extends React.Component <any, any> {
   // command: string returned from this.keyBidingFn(event)
   // if this function returns 'handled' string, all ends here.
   // if it return 'not-handled', handling of :command will be delegated to Editor's default handling.
-  onKeyCommand = (command) => {
+  onKeyCommand = (command, editorState) => {
     const { text, } = this.state
     let newState;
+
     if (command === HIGHLIGHT) {
       newState = Draft.RichUtils.toggleInlineStyle(text, HIGHLIGHTABLE);
+    } else {
+      newState = Draft.RichUtils.handleKeyCommand(editorState, command);
     }
 
     if (newState) {
@@ -200,4 +203,3 @@ class TextEditor extends React.Component <any, any> {
 }
 
 export { TextEditor };
-


### PR DESCRIPTION
## WHAT
Apply key commands to rich utils so the curriculum team can use CMD + B for bolding, CMD + I for italics, etc.

## WHY
To speed up the content development process.

## HOW
DraftJS makes this super easy -- I just did what their docs outlined [here](https://draftjs.org/docs/quickstart-rich-styling/#:~:text=RichUtils%20and%20Key%20Commands,or%20remove%20the%20desired%20style.).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/RFC-for-de-duplicating-question-uids-9045f1870e80455ab132f8c93649fc37?pvs=4

### What have you done to QA this feature?
Tested locally, will put on staging and have Jamie/Rachel QA once one of my staging envs is free (both currently in use for design review).

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | Not yet - see QA section
Self-Review: Have you done an initial self-review of the code below on Github? | YES
