### PR TITLE
add paragraph breaks to evidence spelling and grammar feedback

### DIFF
--- a/services/QuillLMS/client/app/constants/evidence.ts
+++ b/services/QuillLMS/client/app/constants/evidence.ts
@@ -43,7 +43,7 @@ export const FIRST_STRONG_EXAMPLE = 'first_strong_example';
 export const SECOND_STRONG_EXAMPLE = 'second_strong_example';
 
 // this constant is also used on the backend to generate hardcoded feedback for their reports (see services/QuillLMS/app/models/concerns/public_progress_reports.rb) and should be updated there if it's updated here.
-export const EVIDENCE_SUBOPTIMAL_SPELLING_OR_GRAMMAR_FINAL_ATTEMPT_FEEDBACK = "You completed four revisions!<br/>You’ve found the right piece of evidence, but there may still be spelling or grammar changes you could make to improve your sentence.<br/>Read your sentence one more time and think about what changes you could make. Then move on to the next prompt."
+export const EVIDENCE_SUBOPTIMAL_SPELLING_OR_GRAMMAR_FINAL_ATTEMPT_FEEDBACK = "You completed four revisions!<br/><br/>You’ve found the right piece of evidence, but there may still be spelling or grammar changes you could make to improve your sentence.<br/><br/>Read your sentence one more time and think about what changes you could make. Then move on to the next prompt."
 
 export const courseOptions = [
   {


### PR DESCRIPTION
## WHAT
Apply paragraph breaks to evidence spelling and grammar feedback.

## WHY
Jamie noticed this wasn't formatted correctly.

## HOW
Add two `<br>` tags.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Formatting-for-hard-coded-Evidence-spelling-grammar-final-attempt-feedback-094fc4ed26da475ab4f95b925ff02543?pvs=4

### What have you done to QA this feature?
Looked at it locally, will have Jamie double check on staging once one of my environments is free.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | Not yet - see QA section
Self-Review: Have you done an initial self-review of the code below on Github? | YES
