### PR TITLE
AGDR/ display download link for Student section

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/growth-diagnostic-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/growth-diagnostic-reports.scss
@@ -308,8 +308,18 @@ main {
     flex-direction: column;
     align-items: center;
     margin-top: 48px;
-    p {
-      font-size: 12px;
+    .text-container {
+      display: flex;
+      p {
+        font-size: 12px;
+      }
+      p:first-of-type {
+        margin-right: 3px;
+      }
+      a {
+        font-weight: 700;
+        color: $quill-green;
+      }
     }
     button {
       margin-top: 16px;

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/studentSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/studentSection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`StudentSection loaded state clicking toggle button should expand aggregate rows for skill 1`] = `
 <DocumentFragment>
   <div
-    class="dropdown-container input-container inactive   diagnostic-type-dropdown searchable "
+    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
     role="button"
     tabindex="0"
   >
@@ -27,19 +27,19 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
         class="dropdown__control css-13cymwt-control"
       >
         <div
-          class="dropdown__value-container css-1fdsijx-ValueContainer"
+          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
         >
           <div
-            class="dropdown__placeholder css-1jqq78o-placeholder"
-            id="react-select-6-placeholder"
-          />
+            class="dropdown__single-value css-1dimb5e-singleValue"
+          >
+            Starter Diagnostic
+          </div>
           <div
             class="dropdown__input-container css-qbdosj-Input"
             data-value=""
           >
             <input
               aria-autocomplete="list"
-              aria-describedby="react-select-6-placeholder"
               aria-expanded="false"
               aria-haspopup="true"
               autocapitalize="none"
@@ -742,7 +742,7 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
 exports[`StudentSection loaded state it should render the expected data when data is present 1`] = `
 <DocumentFragment>
   <div
-    class="dropdown-container input-container inactive   diagnostic-type-dropdown searchable "
+    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
     role="button"
     tabindex="0"
   >
@@ -766,19 +766,19 @@ exports[`StudentSection loaded state it should render the expected data when dat
         class="dropdown__control css-13cymwt-control"
       >
         <div
-          class="dropdown__value-container css-1fdsijx-ValueContainer"
+          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
         >
           <div
-            class="dropdown__placeholder css-1jqq78o-placeholder"
-            id="react-select-5-placeholder"
-          />
+            class="dropdown__single-value css-1dimb5e-singleValue"
+          >
+            Starter Diagnostic
+          </div>
           <div
             class="dropdown__input-container css-qbdosj-Input"
             data-value=""
           >
             <input
               aria-autocomplete="list"
-              aria-describedby="react-select-5-placeholder"
               aria-expanded="false"
               aria-haspopup="true"
               autocapitalize="none"
@@ -1362,7 +1362,7 @@ exports[`StudentSection loaded state it should render the expected data when dat
 exports[`StudentSection loaded state it should render the expected empty state message 1`] = `
 <DocumentFragment>
   <div
-    class="dropdown-container input-container inactive   diagnostic-type-dropdown searchable "
+    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
     role="button"
     tabindex="0"
   >
@@ -1386,19 +1386,19 @@ exports[`StudentSection loaded state it should render the expected empty state m
         class="dropdown__control css-13cymwt-control"
       >
         <div
-          class="dropdown__value-container css-1fdsijx-ValueContainer"
+          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
         >
           <div
-            class="dropdown__placeholder css-1jqq78o-placeholder"
-            id="react-select-4-placeholder"
-          />
+            class="dropdown__single-value css-1dimb5e-singleValue"
+          >
+            Starter Diagnostic
+          </div>
           <div
             class="dropdown__input-container css-qbdosj-Input"
             data-value=""
           >
             <input
               aria-autocomplete="list"
-              aria-describedby="react-select-4-placeholder"
               aria-expanded="false"
               aria-haspopup="true"
               autocapitalize="none"
@@ -1824,7 +1824,7 @@ exports[`StudentSection loaded state it should render the expected empty state m
 exports[`StudentSection loaded state it should render the expected header components 1`] = `
 <DocumentFragment>
   <div
-    class="dropdown-container input-container inactive   diagnostic-type-dropdown searchable "
+    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
     role="button"
     tabindex="0"
   >
@@ -1848,19 +1848,19 @@ exports[`StudentSection loaded state it should render the expected header compon
         class="dropdown__control css-13cymwt-control"
       >
         <div
-          class="dropdown__value-container css-1fdsijx-ValueContainer"
+          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
         >
           <div
-            class="dropdown__placeholder css-1jqq78o-placeholder"
-            id="react-select-3-placeholder"
-          />
+            class="dropdown__single-value css-1dimb5e-singleValue"
+          >
+            Starter Diagnostic
+          </div>
           <div
             class="dropdown__input-container css-qbdosj-Input"
             data-value=""
           >
             <input
               aria-autocomplete="list"
-              aria-describedby="react-select-3-placeholder"
               aria-expanded="false"
               aria-haspopup="true"
               autocapitalize="none"
@@ -2278,6 +2278,105 @@ exports[`StudentSection loaded state it should render the expected header compon
       >
         Load more
       </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`StudentSection loading state it should render loading spinner 1`] = `
+<DocumentFragment>
+  <div
+    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
+    role="button"
+    tabindex="0"
+  >
+    <label>
+      Diagnostic:
+    </label>
+    <div
+      class="dropdown css-b62m3t-container"
+    >
+      <span
+        class="css-1f43avz-a11yText-A11yText"
+        id="react-select-2-live-region"
+      />
+      <span
+        aria-atomic="false"
+        aria-live="polite"
+        aria-relevant="additions text"
+        class="css-1f43avz-a11yText-A11yText"
+      />
+      <div
+        class="dropdown__control css-13cymwt-control"
+      >
+        <div
+          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
+        >
+          <div
+            class="dropdown__single-value css-1dimb5e-singleValue"
+          >
+            Starter Diagnostic
+          </div>
+          <div
+            class="dropdown__input-container css-qbdosj-Input"
+            data-value=""
+          >
+            <input
+              aria-autocomplete="list"
+              aria-expanded="false"
+              aria-haspopup="true"
+              autocapitalize="none"
+              autocomplete="off"
+              autocorrect="off"
+              class="dropdown__input"
+              id="react-select-2-input"
+              role="combobox"
+              spellcheck="false"
+              style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+              tabindex="0"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="dropdown__indicators css-1hb7zxy-IndicatorsContainer"
+        >
+          <span
+            class="dropdown__indicator-separator css-1u9des2-indicatorSeparator"
+          />
+          <div
+            aria-hidden="true"
+            class="dropdown__indicator dropdown__dropdown-indicator css-1xc3v61-indicatorContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="css-tj5bde-Svg"
+              focusable="false"
+              height="20"
+              viewBox="0 0 20 20"
+              width="20"
+            >
+              <path
+                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="loading-spinner"
+  >
+    <div
+      class="spinner-container"
+    >
+      <img
+        alt="Loading spinner"
+        class="spinner"
+        src="https://assets.quill.org/images/icons/loader_still.svg"
+      />
     </div>
   </div>
 </DocumentFragment>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/studentSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/studentSection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`StudentSection loaded state clicking toggle button should expand aggregate rows for skill 1`] = `
 <DocumentFragment>
   <div
-    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
+    class="dropdown-container input-container inactive   diagnostic-type-dropdown searchable "
     role="button"
     tabindex="0"
   >
@@ -27,19 +27,19 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
         class="dropdown__control css-13cymwt-control"
       >
         <div
-          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
+          class="dropdown__value-container css-1fdsijx-ValueContainer"
         >
           <div
-            class="dropdown__single-value css-1dimb5e-singleValue"
-          >
-            Starter Diagnostic
-          </div>
+            class="dropdown__placeholder css-1jqq78o-placeholder"
+            id="react-select-6-placeholder"
+          />
           <div
             class="dropdown__input-container css-qbdosj-Input"
             data-value=""
           >
             <input
               aria-autocomplete="list"
+              aria-describedby="react-select-6-placeholder"
               aria-expanded="false"
               aria-haspopup="true"
               autocapitalize="none"
@@ -719,13 +719,17 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
   <div
     class="load-more-button-container"
   >
-    <p>
-      Displaying 
-      <strong>
-        50 of 2
-      </strong>
-       students
-    </p>
+    <div
+      class="text-container"
+    >
+      <p>
+        Displaying 
+        <strong>
+          50 of null
+        </strong>
+         students
+      </p>
+    </div>
     <button
       class="quill-button small secondary focus-on-light outlined"
     >
@@ -738,7 +742,7 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
 exports[`StudentSection loaded state it should render the expected data when data is present 1`] = `
 <DocumentFragment>
   <div
-    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
+    class="dropdown-container input-container inactive   diagnostic-type-dropdown searchable "
     role="button"
     tabindex="0"
   >
@@ -762,19 +766,19 @@ exports[`StudentSection loaded state it should render the expected data when dat
         class="dropdown__control css-13cymwt-control"
       >
         <div
-          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
+          class="dropdown__value-container css-1fdsijx-ValueContainer"
         >
           <div
-            class="dropdown__single-value css-1dimb5e-singleValue"
-          >
-            Starter Diagnostic
-          </div>
+            class="dropdown__placeholder css-1jqq78o-placeholder"
+            id="react-select-5-placeholder"
+          />
           <div
             class="dropdown__input-container css-qbdosj-Input"
             data-value=""
           >
             <input
               aria-autocomplete="list"
+              aria-describedby="react-select-5-placeholder"
               aria-expanded="false"
               aria-haspopup="true"
               autocapitalize="none"
@@ -1334,13 +1338,17 @@ exports[`StudentSection loaded state it should render the expected data when dat
     <div
       class="load-more-button-container"
     >
-      <p>
-        Displaying 
-        <strong>
-          50 of 2
-        </strong>
-         students
-      </p>
+      <div
+        class="text-container"
+      >
+        <p>
+          Displaying 
+          <strong>
+            50 of null
+          </strong>
+           students
+        </p>
+      </div>
       <button
         class="quill-button small secondary focus-on-light outlined"
       >
@@ -1354,7 +1362,7 @@ exports[`StudentSection loaded state it should render the expected data when dat
 exports[`StudentSection loaded state it should render the expected empty state message 1`] = `
 <DocumentFragment>
   <div
-    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
+    class="dropdown-container input-container inactive   diagnostic-type-dropdown searchable "
     role="button"
     tabindex="0"
   >
@@ -1378,19 +1386,19 @@ exports[`StudentSection loaded state it should render the expected empty state m
         class="dropdown__control css-13cymwt-control"
       >
         <div
-          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
+          class="dropdown__value-container css-1fdsijx-ValueContainer"
         >
           <div
-            class="dropdown__single-value css-1dimb5e-singleValue"
-          >
-            Starter Diagnostic
-          </div>
+            class="dropdown__placeholder css-1jqq78o-placeholder"
+            id="react-select-4-placeholder"
+          />
           <div
             class="dropdown__input-container css-qbdosj-Input"
             data-value=""
           >
             <input
               aria-autocomplete="list"
+              aria-describedby="react-select-4-placeholder"
               aria-expanded="false"
               aria-haspopup="true"
               autocapitalize="none"
@@ -1792,13 +1800,17 @@ exports[`StudentSection loaded state it should render the expected empty state m
     <div
       class="load-more-button-container"
     >
-      <p>
-        Displaying 
-        <strong>
-          50 of 0
-        </strong>
-         students
-      </p>
+      <div
+        class="text-container"
+      >
+        <p>
+          Displaying 
+          <strong>
+            50 of null
+          </strong>
+           students
+        </p>
+      </div>
       <button
         class="quill-button small secondary focus-on-light outlined"
       >
@@ -1812,7 +1824,7 @@ exports[`StudentSection loaded state it should render the expected empty state m
 exports[`StudentSection loaded state it should render the expected header components 1`] = `
 <DocumentFragment>
   <div
-    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
+    class="dropdown-container input-container inactive   diagnostic-type-dropdown searchable "
     role="button"
     tabindex="0"
   >
@@ -1836,19 +1848,19 @@ exports[`StudentSection loaded state it should render the expected header compon
         class="dropdown__control css-13cymwt-control"
       >
         <div
-          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
+          class="dropdown__value-container css-1fdsijx-ValueContainer"
         >
           <div
-            class="dropdown__single-value css-1dimb5e-singleValue"
-          >
-            Starter Diagnostic
-          </div>
+            class="dropdown__placeholder css-1jqq78o-placeholder"
+            id="react-select-3-placeholder"
+          />
           <div
             class="dropdown__input-container css-qbdosj-Input"
             data-value=""
           >
             <input
               aria-autocomplete="list"
+              aria-describedby="react-select-3-placeholder"
               aria-expanded="false"
               aria-haspopup="true"
               autocapitalize="none"
@@ -2250,117 +2262,22 @@ exports[`StudentSection loaded state it should render the expected header compon
     <div
       class="load-more-button-container"
     >
-      <p>
-        Displaying 
-        <strong>
-          50 of 0
-        </strong>
-         students
-      </p>
+      <div
+        class="text-container"
+      >
+        <p>
+          Displaying 
+          <strong>
+            50 of null
+          </strong>
+           students
+        </p>
+      </div>
       <button
         class="quill-button small secondary focus-on-light outlined"
       >
         Load more
       </button>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`StudentSection loading state it should render loading spinner 1`] = `
-<DocumentFragment>
-  <div
-    class="dropdown-container input-container inactive has-text  diagnostic-type-dropdown searchable "
-    role="button"
-    tabindex="0"
-  >
-    <label>
-      Diagnostic:
-    </label>
-    <div
-      class="dropdown css-b62m3t-container"
-    >
-      <span
-        class="css-1f43avz-a11yText-A11yText"
-        id="react-select-2-live-region"
-      />
-      <span
-        aria-atomic="false"
-        aria-live="polite"
-        aria-relevant="additions text"
-        class="css-1f43avz-a11yText-A11yText"
-      />
-      <div
-        class="dropdown__control css-13cymwt-control"
-      >
-        <div
-          class="dropdown__value-container dropdown__value-container--has-value css-1fdsijx-ValueContainer"
-        >
-          <div
-            class="dropdown__single-value css-1dimb5e-singleValue"
-          >
-            Starter Diagnostic
-          </div>
-          <div
-            class="dropdown__input-container css-qbdosj-Input"
-            data-value=""
-          >
-            <input
-              aria-autocomplete="list"
-              aria-expanded="false"
-              aria-haspopup="true"
-              autocapitalize="none"
-              autocomplete="off"
-              autocorrect="off"
-              class="dropdown__input"
-              id="react-select-2-input"
-              role="combobox"
-              spellcheck="false"
-              style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-              tabindex="0"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <div
-          class="dropdown__indicators css-1hb7zxy-IndicatorsContainer"
-        >
-          <span
-            class="dropdown__indicator-separator css-1u9des2-indicatorSeparator"
-          />
-          <div
-            aria-hidden="true"
-            class="dropdown__indicator dropdown__dropdown-indicator css-1xc3v61-indicatorContainer"
-          >
-            <svg
-              aria-hidden="true"
-              class="css-tj5bde-Svg"
-              focusable="false"
-              height="20"
-              viewBox="0 0 20 20"
-              width="20"
-            >
-              <path
-                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="loading-spinner"
-  >
-    <div
-      class="spinner-container"
-    >
-      <img
-        alt="Loading spinner"
-        class="spinner"
-        src="https://assets.quill.org/images/icons/loader_still.svg"
-      />
     </div>
   </div>
 </DocumentFragment>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/studentSection.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/studentSection.test.tsx
@@ -13,6 +13,7 @@ const props = {
   selectedTeacherIds: [],
   selectedClassroomIds: [],
   selectedTimeframe: "This school year",
+  selectedDiagnosticId: '1664',
   pusherChannel: null,
   handleSetDiagnosticIdForStudentCount: jest.fn(),
   passedStudentData: null,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/studentSection.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/studentSection.test.tsx
@@ -13,7 +13,7 @@ const props = {
   selectedTeacherIds: [],
   selectedClassroomIds: [],
   selectedTimeframe: "This school year",
-  selectedDiagnosticId: '1664',
+  selectedDiagnosticId: 1663,
   pusherChannel: null,
   handleSetDiagnosticIdForStudentCount: jest.fn(),
   passedStudentData: null,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/studentSection.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/studentSection.tsx
@@ -13,6 +13,7 @@ const FILTER_SCOPE_QUERY_KEY = 'filter-scope'
 const PUSHER_EVENT_KEY = "admin-diagnostic-students-cached";
 const DEFAULT_WIDTH = "138px"
 const BATCH_SIZE = 50
+const MAX_ROW_COUNT = 500
 
 const headers = [
   {
@@ -292,11 +293,12 @@ export const StudentSection = ({
   function renderButtonContent() {
     const disabled = rowsToShow === studentData.length
     const disabledClass = disabled ? 'disabled contained' : 'outlined'
+    const showDownloadLink = rowsToShow === MAX_ROW_COUNT
     return(
       <div className="load-more-button-container">
         <div className="text-container">
           <p>Displaying <strong>{`${rowsToShow} of ${totalStudents}`}</strong> students</p>
-          {disabled && <p> • Please <a href="" rel="noopener noreferrer" target="_blank">download this report</a> to view more than 500 results.</p>}
+          {showDownloadLink && <p> • Please <a href="" rel="noopener noreferrer" target="_blank">download this report</a> to view more than 500 results.</p>}
         </div>
         <button className={`quill-button small secondary focus-on-light ${disabledClass}`} disabled={disabled} onClick={loadMoreRows}>Load more</button>
       </div>


### PR DESCRIPTION
## WHAT
display download link for Student section after 500 records have been reached

## WHY
we limit the amount of records returned to 500 for performance reasons, so we want to give users with larger data sets to download the full report

## HOW
add `filter_scope` query to `Student Section` to get total student count and conditionally render download link after 500 records have been loaded

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1064" alt="Screen Shot 2024-04-24 at 2 05 51 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/82b761aa-b38b-4790-b5a6-a31965724fc9">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/ADGR-Display-a-download-link-on-the-Performance-by-Student-tab-when-an-admin-loads-the-maximum-n-838ccf65f35f4f4d9edcf17f430c5ab3

### What have you done to QA this feature?
Tested on staging with several users that the following behavior occurs:
- the Load more button disables after the total number of records has been reached (regardless if it's 500 or more records)
- display download report link if 500 records have been loaded and total student count is more than 500
- total student count matches the total student matches count in Filter component

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
