### PR TITLE
Admin reports/ tweak font size for Account Management and Data Export tables

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/growth-diagnostic-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/growth-diagnostic-reports.scss
@@ -102,7 +102,6 @@ main {
         min-height: 55px !important;
         th {
           justify-content: space-between;
-          font-size: 13px !important;
           img {
             margin-right: 8px;
           }
@@ -146,7 +145,6 @@ main {
         border-right: 1px solid $quill-grey-1;
         td {
           padding: 15px 0px;
-          font-size: 13px !important;
           min-height: 81px !important;
           .emphasized-content {
             color: $quill-green;

--- a/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
@@ -203,6 +203,7 @@ table.data-table {
       th {
         color: $quill-grey-90;
         font-weight: 700;
+        font-size: 13px;
         align-items: center;
         min-height: 52px;
         max-width: 152px;
@@ -223,7 +224,7 @@ table.data-table {
           white-space: break-spaces;
           padding-right: 24px;
           margin-right: 24px !important;
-          font-size: 12px;
+          font-size: 13px;
 
           &:not(:last-child) {
             border-right: 1px solid $quill-grey-5;


### PR DESCRIPTION
## WHAT
tweak font size for Account Management and Data Export table headers and cells to 13pt

## WHY
these should match the rest of the tables formatting

## HOW
update `.reporting-format` `DataTable` class

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Investigate-Admin-Reports-Table-Font-Sizing-Data-Export-Account-Management-2775dc3827a44450b72a74bcf5d82586

### What have you done to QA this feature?
Verified on staging that all reports have size 13pt for data table headers and cell values

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | css change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
