### PR TITLE
Global Navigation UI/ update pulldown menu dropshadow

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
@@ -854,7 +854,7 @@ nav.q-navbar-home {
     width: max-content !important;
     border-radius: 5px;
     background-color: $quill-white;
-    box-shadow: 0 1px 5px 0 #c0c0c0;
+    box-shadow: 0px 0px 30px 0px rgba(0, 0, 0, 0.25);
     flex-direction: column;
     top: 40px;
     padding-top: 16px;


### PR DESCRIPTION
## WHAT
update the drop shadow for the pulldown menus of the global nav

## WHY
this change will have a better visual appearance

## HOW
tweak `drop-shadow` value for `.navbar-tooltip` class

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="655" alt="Screen Shot 2024-04-24 at 5 27 31 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/acff0755-b867-4386-a117-762a42b689dd">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Quill-Global-Navigation-UI-Updated-Drop-Shadow-Values-on-Pull-Down-Menu-9217c27041274603a81c96fd723f7e7f

### What have you done to QA this feature?
verified on staging that all of the pulldown menus have the new drop shadow effect

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | css change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
