### PR TITLE
Add order to new incorrect sequences & button to save incorrect seque…

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/incorrect_sequences_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::IncorrectSequencesController < Api::ApiController
 
   def destroy
     @question.delete_incorrect_sequence(params[:id])
-    render(plain: 'OK')
+    render json: {}, status: 200
   end
 
   def update_all

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/newIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/newIncorrectSequenceContainer.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import _ from 'underscore';
 import questionActions from '../../actions/questions';
 import sentenceFragmentActions from '../../actions/sentenceFragments';
 import IncorrectSequencesInputAndConceptSelectorForm from '../shared/incorrectSequencesInputAndConceptSelectorForm.jsx';
@@ -30,10 +31,12 @@ class NewIncorrectSequencesContainer extends Component {
   submitSequenceForm = data => {
     const { actionFile } = this.state
     const { submitNewIncorrectSequence } = actionFile
-    const { dispatch, match } = this.props
+    const { dispatch, match, generatedIncorrectSequences } = this.props
     const { params } = match
     const { questionID } = params
     delete data.conceptResults.null;
+    const usedIncorrectSequences = generatedIncorrectSequences.used[match.params.questionID];
+    data.order = _.keys(usedIncorrectSequences).length;
     dispatch(submitNewIncorrectSequence(questionID, data));
     window.history.back();
   };

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -61,14 +61,17 @@ class IncorrectSequencesContainer extends Component {
   }
 
   deleteSequence = sequenceID => {
-    const { actionFile, incorrectSequences } = this.state
+    const { actionFile, incorrectSequences, orderedIds } = this.state
     const { dispatch, match } = this.props;
     const { params } = match;
     const { questionID } = params;
     if (confirm('⚠️ Are you sure you want to delete this? 😱')) {
       dispatch(actionFile.deleteIncorrectSequence(questionID, sequenceID));
       delete incorrectSequences[sequenceID]
-      this.setState({incorrectSequences: incorrectSequences})
+      if (orderedIds) {
+        const newOrderedIds = orderedIds.filter(id => id != sequenceID)
+        this.setState({ orderedIds: newOrderedIds })
+      }
     }
   };
 
@@ -162,15 +165,29 @@ class IncorrectSequencesContainer extends Component {
   }
 
   sortCallback = sortInfo => {
-    const { actionFile } = this.state
+    const orderedIds = sortInfo.map(item => item.key);
+    this.setState({ orderedIds });
+  };
+
+  updateOrder = () => {
+    const { actionFile, incorrectSequences, orderedIds } = this.state
     const { dispatch, match } = this.props;
     const { params } = match;
     const { questionID } = params;
-    const orderedIds = sortInfo.map(item => item.key);
-    this.setState({ orderedIds, }, () => {
-      dispatch(actionFile.updateIncorrectSequences(questionID, this.sequencesSortedByOrder()));
-    });
-  };
+    if (orderedIds) {
+      const newIncorrectSequences = {}
+      const incorrectSequenceArray = hashToCollection(incorrectSequences)
+      orderedIds.forEach((id, index) => {
+        const sequence = incorrectSequenceArray.find(is => is.key === id);
+        sequence.order = index
+        newIncorrectSequences[sequence.key] = sequence
+      })
+      dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences))
+      alert('Saved!')
+    } else {
+      alert('No changes to incorrect sequence order have been made.')
+    }
+  }
 
   renderTagsForSequence(sequenceString) {
     return sequenceString.split('|||').map((seq, index) => (<span className="tag is-medium is-light" key={`seq${index}`} style={{ margin: '3px', }}>{seq}</span>));
@@ -188,6 +205,13 @@ class IncorrectSequencesContainer extends Component {
       );
       return _.values(components);
     }
+  }
+
+  renderSaveOrderButton() {
+    const { orderedIds } = this.state
+    return (
+      orderedIds ? <button className="button is-outlined is-primary" onClick={this.updateOrder} style={{ float: 'right', }}>Save Sequence Order</button> : null
+    );
   }
 
   renderSequenceList() {
@@ -251,6 +275,7 @@ class IncorrectSequencesContainer extends Component {
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
           <a className="button is-outlined is-primary" href={`/diagnostic/#/admin/${path}/${questionID}/incorrect-sequences/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Incorrect Sequence</a>
+          {this.renderSaveOrderButton()}
         </div>
         {this.renderSequenceList()}
       </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/newIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/newIncorrectSequenceContainer.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import _ from 'underscore';
 import { connect } from 'react-redux';
 import questionActions from '../../actions/questions';
 import sentenceFragmentActions from '../../actions/sentenceFragments.ts';
@@ -29,10 +30,12 @@ class NewIncorrectSequencesContainer extends Component {
 
   submitSequenceForm = data => {
     const { actionFile, questionTypeLink } = this.state;
-    const { dispatch, history, match } = this.props;
+    const { dispatch, history, match, generatedIncorrectSequences } = this.props;
     const { params } = match;
     const { questionID } = params;
     delete data.conceptResults.null;
+    const usedIncorrectSequences = generatedIncorrectSequences.used[match.params.questionID];
+    data.order = _.keys(usedIncorrectSequences).length;
     // TODO: fix add new incorrect sequence action to show new incorrect sequence without refreshing
     dispatch(actionFile.submitNewIncorrectSequence(questionID, data));
     history.push(`/admin/${questionTypeLink}/${questionID}/incorrect-sequences`)

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -239,10 +239,11 @@ export const deleteIncorrectSequence = (qid: string, seqid: string) => {
   };
 }
 
-export const updateIncorrectSequences = (qid: string, data: Array<IncorrectSequence>) => {
+export const updateIncorrectSequences = (qid: string, data: Array<IncorrectSequence>, callback: Function) => {
   return (dispatch: Function) => {
     IncorrectSequenceApi.updateAllForQuestion(qid, data).then(() => {
       dispatch(getQuestion(qid))
+      callback()
     }).catch((error: string) => {
       alert(`Order update failed! ${error}`);
     });

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -11,9 +11,15 @@ class IncorrectSequencesContainer extends React.Component {
 
   constructor(props) {
     super(props);
+    const { questions, match } = this.props
 
-    const question = this.props.questions.data[this.props.match.params.questionID]
-    this.state = { orderedIds: null, incorrectSequences: question.incorrectSequences, }
+    const question = questions.data[match.params.questionID]
+    const incorrectSequences = question.incorrectSequences
+
+    const sequencesCollection = hashToCollection(incorrectSequences)
+    const orderedIds = sequencesCollection.sort((a, b) => a.order - b.order).map(b => b.key);
+
+    this.state = { orderedIds: orderedIds, incorrectSequences: incorrectSequences, }
   }
 
   UNSAFE_componentWillMount() {
@@ -21,13 +27,44 @@ class IncorrectSequencesContainer extends React.Component {
     dispatch(questionActions.getUsedSequences(match.params.questionID))
   }
 
-  deleteSequence = (sequenceID: string) => {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { incorrectSequences } = this.state
+    const { match, questions } = nextProps
+    const { params } = match
+
+    const incomingIncorrectSequences = questions.data[params.questionID].incorrectSequences
+    const incomingOrderedIds = hashToCollection(incomingIncorrectSequences).sort((a, b) => a.order - b.order).map(seq => seq.key)
+    if (!_.isEqual(incorrectSequences, incomingIncorrectSequences)) {
+      this.setState({ incorrectSequences: incomingIncorrectSequences, orderedIds: incomingOrderedIds})
+    }
+  }
+
+  deleteSequence = (sequenceID: string) => {
+    const { incorrectSequences, orderedIds } = this.state
     const { dispatch, match, } = this.props
+    const { params } = match;
+    const { questionID } = params;
+
     if (confirm('⚠️ Are you sure you want to delete this? 😱')) {
       dispatch(questionActions.deleteIncorrectSequence(match.params.questionID, sequenceID));
       delete incorrectSequences[sequenceID]
-      this.setState({ incorrectSequences: incorrectSequences})
+      const newOrderedIds = orderedIds.filter(id => id !== sequenceID)
+      const incorrectSequenceArray = hashToCollection(incorrectSequences)
+
+      let newIncorrectSequences = {}
+      newOrderedIds.forEach((id, index) => {
+        const sequence = incorrectSequenceArray.find(is => is.key === id);
+        sequence.order = index
+        newIncorrectSequences[sequence.key] = sequence
+      })
+
+      if (incorrectSequenceArray.length > 0) {
+        dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences, this.alertDeleted))
+      } else {
+        this.alertDeleted()
+      }
+
+      this.setState({ orderedIds: newOrderedIds, incorrectSequences: newIncorrectSequences })
     }
   }
 
@@ -115,24 +152,38 @@ class IncorrectSequencesContainer extends React.Component {
 
   sequencesSortedByOrder = () => {
     const { orderedIds, incorrectSequences } = this.state
-    if (orderedIds) {
-      const sequencesCollection = hashToCollection(incorrectSequences)
-      return orderedIds.map(id => sequencesCollection.find(s => s.key === id))
-    } else {
-      return hashToCollection(incorrectSequences).sort((a, b) => a.order - b.order);
-    }
+
+    const sequencesCollection = hashToCollection(incorrectSequences)
+    return orderedIds.map(id => sequencesCollection.find(s => s.key === id))
   }
 
   sortCallback = sortInfo => {
+    const orderedIds = sortInfo.map(item => item.key);
+    this.setState({ orderedIds });
+  }
+
+  alertSaved = () => {
+    alert('Saved!')
+  }
+
+  alertDeleted = () => {
+    alert('Deleted!')
+  }
+
+  handleSaveAllSequences = () => {
+    const { orderedIds, incorrectSequences } = this.state
     const { dispatch, match } = this.props;
     const { params } = match;
     const { questionID } = params;
-    const orderedIds = sortInfo.map(item => item.key);
-    this.setState({ orderedIds, }, () => {
-      dispatch(questionActions.updateIncorrectSequences(questionID, this.sequencesSortedByOrder()));
-    });
+    const newIncorrectSequences = {}
+    const incorrectSequenceArray = hashToCollection(incorrectSequences)
+    orderedIds.forEach((id, index) => {
+      const sequence = incorrectSequenceArray.find(is => is.key === id);
+      sequence.order = index
+      newIncorrectSequences[sequence.key] = sequence
+    })
+    dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences, this.alertSaved))
   }
-
 
   renderConceptResults(concepts, sequenceKey: string) {
     if (concepts) {
@@ -154,6 +205,12 @@ class IncorrectSequencesContainer extends React.Component {
     return sequenceString.split(/\|{3}(?!\|)/).map(text => (
       this.inputElement(className, text, key)
     ));
+  }
+
+  renderSaveButton() {
+    return (
+      <button className="button is-outlined is-primary" onClick={this.handleSaveAllSequences} style={{ float: 'right', }} type="button">Save Sequences</button>
+    );
   }
 
   renderSequenceList() {
@@ -189,7 +246,6 @@ class IncorrectSequencesContainer extends React.Component {
           <footer className="card-footer">
             <a className="card-footer-item" href={`/grammar/#/admin/questions/${match.params.questionID}/incorrect-sequences/${seq.key}/edit`}>Edit</a>
             <button className="card-footer-item" onClick={onClickDelete} type="button">Delete</button>
-            <a className="card-footer-item" onClick={() => this.saveSequencesAndFeedback(seq.key)}>Save</a>
           </footer>
         </div>
       )});
@@ -202,7 +258,8 @@ class IncorrectSequencesContainer extends React.Component {
       <div>
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
-          <a className="button is-outlined is-primary" href={`/grammar/#/admin/questions/${match.params.questionID}/incorrect-sequences/new`} rel="noopener noreferrer" style={{ float: 'right', }} target="_blank">Add Incorrect Sequence</a>
+          <a className="button is-outlined is-primary" href={`/grammar/#/admin/questions/${match.params.questionID}/incorrect-sequences/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Incorrect Sequence</a>
+          {this.renderSaveButton()}
         </div>
         {this.renderSequenceList()}
         {children}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/newIncorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/newIncorrectSequenceContainer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import _ from 'underscore';
 import { connect } from 'react-redux';
 import * as questionActions from '../../actions/questions';
 import IncorrectSequencesInputAndConceptSelectorForm from '../shared/incorrectSequencesInputAndConceptSelectorForm';
@@ -12,11 +13,15 @@ class NewIncorrectSequencesContainer extends React.Component {
   }
 
   submitSequenceForm = (data) => {
-    const { dispatch, match, history, } = this.props
+    const { dispatch, match, history, questions } = this.props
+    const incorrectSequences = questions.data[match.params.questionID].incorrectSequences
     delete data.conceptResults.null;
+    data.order = _.keys(incorrectSequences).length;
     // the only difference in the route between this page and the one where you can see all the incorrect sequences is the `/new` at the end of the path, so removing that will send us back to the main list
     const url = match.url.replace('/new', '')
-    const callback = () => history.push(url)
+    const callback = () => {
+      history.push(url)
+    }
     dispatch(questionActions.submitNewIncorrectSequence(match.params.questionID, data, callback))
   }
 


### PR DESCRIPTION
…nce order (#11753)

* add order variable to new incorrect sequences on all apps

* save incorrect sequence order button on grammar

* update connect and grammar

* error catching for handlefetch

* render correct json object in controller

* for testing

* set ordered ids on delete

* make sort send a json object instead of an array

* fix delete

* debug to connect and grammar

* delete order handling

* linting

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
