### PR TITLE
Start caching Concepts endpoint again

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
@@ -4,6 +4,8 @@ class Api::V1::ConceptFeedbackController < Api::ApiController
   before_action :activity_type, except: [:index]
   before_action :concept_feedback_by_uid, except: [:index, :create, :update]
 
+  CACHE_EXPIRY = 24.hours
+
   def index
     render json: fetch_all_concept_feedbacks_and_cache
   end
@@ -48,7 +50,7 @@ class Api::V1::ConceptFeedbackController < Api::ApiController
   end
 
   private def fetch_all_concept_feedbacks_and_cache
-    Rails.cache.fetch("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{params[:activity_type]}") do
+    Rails.cache.fetch("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{params[:activity_type]}", expires_in: CACHE_EXPIRY) do
       ConceptFeedback
         .where(activity_type: params[:activity_type])
         .all

--- a/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
@@ -21,7 +21,8 @@ class Api::V1::ConceptsController < Api::ApiController
     #   concept_level_0: [concepts where parent id matches a level one concept]
     # }
     #
-    render json: {concepts: Concept.all_with_level}.to_json
+    concepts = fetch_all_concepts_and_cache
+    render json: concepts
   end
 
   def level_zero_concepts_with_lineage
@@ -31,5 +32,11 @@ class Api::V1::ConceptsController < Api::ApiController
 
   private def concept_params
     params.require(:concept).permit(:name, :parent_uid)
+  end
+
+  private def fetch_all_concepts_and_cache
+    Rails.cache.fetch(Concept::ALL_CONCEPTS_KEY) do
+      {concepts: Concept.all_with_level}.to_json
+    end
   end
 end

--- a/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
@@ -23,7 +23,8 @@ class Api::V1::ConceptsController < Api::ApiController
     #   concept_level_0: [concepts where parent id matches a level one concept]
     # }
     #
-    concepts = fetch_all_concepts_and_cache
+    concepts = $redis.get(Concept::ALL_CONCEPTS_KEY)
+    concepts ||= fetch_all_concepts_and_cache
     render json: concepts
   end
 
@@ -37,8 +38,8 @@ class Api::V1::ConceptsController < Api::ApiController
   end
 
   private def fetch_all_concepts_and_cache
-    Rails.cache.fetch(Concept::ALL_CONCEPTS_KEY, expires_in: CACHE_EXPIRY) do
-      {concepts: Concept.all_with_level}.to_json
-    end
+    concepts = {concepts: Concept.all_with_level}.to_json
+    $redis.set(Concept::ALL_CONCEPTS_KEY, concepts)
+    concepts
   end
 end

--- a/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concepts_controller.rb
@@ -3,6 +3,8 @@
 class Api::V1::ConceptsController < Api::ApiController
   before_action :staff!, only: [:create]
 
+  CACHE_EXPIRY = 24.hours
+
   def create
     concept = Concept.new(concept_params)
     if concept.save
@@ -35,7 +37,7 @@ class Api::V1::ConceptsController < Api::ApiController
   end
 
   private def fetch_all_concepts_and_cache
-    Rails.cache.fetch(Concept::ALL_CONCEPTS_KEY) do
+    Rails.cache.fetch(Concept::ALL_CONCEPTS_KEY, expires_in: CACHE_EXPIRY) do
       {concepts: Concept.all_with_level}.to_json
     end
   end

--- a/services/QuillLMS/app/models/concept.rb
+++ b/services/QuillLMS/app/models/concept.rb
@@ -107,6 +107,6 @@ class Concept < ApplicationRecord
   end
 
   private def clear_concept_cache
-    Rails.cache.delete("#{ALL_CONCEPTS_KEY}")
+    Rails.cache.delete(ALL_CONCEPTS_KEY.to_s)
   end
 end

--- a/services/QuillLMS/app/models/concept.rb
+++ b/services/QuillLMS/app/models/concept.rb
@@ -107,6 +107,6 @@ class Concept < ApplicationRecord
   end
 
   private def clear_concept_cache
-    Rails.cache.delete(ALL_CONCEPTS_KEY.to_s)
+    Rails.cache.delete(ALL_CONCEPTS_KEY)
   end
 end

--- a/services/QuillLMS/app/models/concept.rb
+++ b/services/QuillLMS/app/models/concept.rb
@@ -106,6 +106,6 @@ class Concept < ApplicationRecord
   end
 
   private def clear_concept_cache
-    Rails.cache.delete("#{ALL_CONCEPTS_KEY}")
+    Rails.cache.delete(ALL_CONCEPTS_KEY.to_s)
   end
 end

--- a/services/QuillLMS/app/models/concept.rb
+++ b/services/QuillLMS/app/models/concept.rb
@@ -107,6 +107,6 @@ class Concept < ApplicationRecord
   end
 
   private def clear_concept_cache
-    Rails.cache.delete(ALL_CONCEPTS_KEY)
+    $redis.del(ALL_CONCEPTS_KEY)
   end
 end

--- a/services/QuillLMS/app/models/concept.rb
+++ b/services/QuillLMS/app/models/concept.rb
@@ -22,6 +22,7 @@ class Concept < ApplicationRecord
   validates :name, presence: true
   has_many :concept_results
   has_many :change_logs, as: :changed_record
+  has_many :diagnostic_question_optimal_concepts, dependent: :destroy
 
   ALL_CONCEPTS_KEY = "all_concepts_with_level"
 
@@ -106,6 +107,6 @@ class Concept < ApplicationRecord
   end
 
   private def clear_concept_cache
-    Rails.cache.delete(ALL_CONCEPTS_KEY.to_s)
+    Rails.cache.delete("#{ALL_CONCEPTS_KEY}")
   end
 end

--- a/services/QuillLMS/app/models/concept.rb
+++ b/services/QuillLMS/app/models/concept.rb
@@ -22,7 +22,10 @@ class Concept < ApplicationRecord
   validates :name, presence: true
   has_many :concept_results
   has_many :change_logs, as: :changed_record
-  has_many :diagnostic_question_optimal_concepts, dependent: :destroy
+
+  ALL_CONCEPTS_KEY = "all_concepts_with_level"
+
+  after_commit :clear_concept_cache
 
   def lineage
     family_tree = name
@@ -100,5 +103,9 @@ class Concept < ApplicationRecord
           concepts.name
       SQL
     ).values.flatten
+  end
+
+  private def clear_concept_cache
+    Rails.cache.delete("#{ALL_CONCEPTS_KEY}")
   end
 end

--- a/services/QuillLMS/app/models/concept_feedback.rb
+++ b/services/QuillLMS/app/models/concept_feedback.rb
@@ -31,6 +31,8 @@ class ConceptFeedback < ApplicationRecord
 
   after_commit :clear_concept_feedbacks_cache
 
+  def cache_key = "#{ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}"
+
   def as_json(options=nil)
     data
   end
@@ -40,7 +42,7 @@ class ConceptFeedback < ApplicationRecord
   end
 
   private def clear_concept_feedbacks_cache
-    Rails.cache.delete("#{ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}")
+    Rails.cache.delete(cache_key)
   end
 end
 

--- a/services/QuillLMS/app/models/concept_feedback.rb
+++ b/services/QuillLMS/app/models/concept_feedback.rb
@@ -21,10 +21,15 @@ class ConceptFeedback < ApplicationRecord
     TYPE_CONNECT = 'connect',
     TYPE_GRAMMAR = 'grammar'
   ]
+
+  ALL_CONCEPT_FEEDBACKS_KEY = 'all_concept_feedbacks'
+
   validates :data, presence: true
   validates :uid, presence: true, uniqueness: { scope: :activity_type }
   validates :activity_type, presence: true, inclusion: {in: TYPES}
   validate :data_must_be_hash
+
+  after_commit :clear_concept_feedbacks_cache
 
   def as_json(options=nil)
     data
@@ -32,6 +37,10 @@ class ConceptFeedback < ApplicationRecord
 
   private def data_must_be_hash
     errors.add(:data, "must be a hash") unless data.is_a?(Hash)
+  end
+
+  private def clear_concept_feedbacks_cache
+    Rails.cache.delete("#{ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}")
   end
 end
 

--- a/services/QuillLMS/app/models/concept_feedback.rb
+++ b/services/QuillLMS/app/models/concept_feedback.rb
@@ -42,7 +42,7 @@ class ConceptFeedback < ApplicationRecord
   end
 
   private def clear_concept_feedbacks_cache
-    Rails.cache.delete(cache_key)
+    $redis.del(cache_key)
   end
 end
 

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -16,6 +16,17 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
       expect(JSON.parse(response.body).keys.first).to eq(concept_feedback.uid)
     end
+
+    it 'resets the rails cache for all concept feedbacks if not set already' do
+      Rails.cache.delete("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{concept_feedback.activity_type}")
+      get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
+      expect(JSON.parse(response.body)).to eq(
+        ConceptFeedback
+          .where(activity_type: concept_feedback.activity_type)
+          .all
+          .reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
+      )
+    end
   end
 
   describe "#show" do
@@ -39,6 +50,11 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       pre_create_count = ConceptFeedback.count
       post :create, params: { activity_type: concept_feedback.activity_type, concept_feedback: data }, as: :json
       expect(ConceptFeedback.count).to eq(pre_create_count + 1)
+    end
+
+    it "should expire the redis cache for concept feedbacks with that activity type" do
+      expect(Rails.cache).to receive(:delete).with("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{concept_feedback.activity_type}")
+      post :create, params: { activity_type: concept_feedback.activity_type, concept_feedback: {foo: "bar"} }, as: :json
     end
   end
 
@@ -70,6 +86,18 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
         as: :json
 
       expect(ConceptFeedback.find_by(uid: uid)).to be
+    end
+
+    it "should expire the redis cache for concept feedbacks with that activity type" do
+      expect(Rails.cache).to receive(:delete).with("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{concept_feedback.activity_type}")
+      data = {"foo" => "bar"}
+      put :update,
+        params: {
+          activity_type: concept_feedback.activity_type,
+          id: concept_feedback.uid,
+          concept_feedback: data
+        },
+        as: :json
     end
   end
 end

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -17,8 +17,8 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       expect(JSON.parse(response.body).keys.first).to eq(concept_feedback.uid)
     end
 
-    it 'resets the rails cache for all concept feedbacks if not set already' do
-      Rails.cache.delete(concept_feedback.cache_key)
+    it 'resets the redis cache for all concept feedbacks if not set already' do
+      $redis.del(concept_feedback.cache_key)
       get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
       expect(JSON.parse(response.body)).to eq(
         ConceptFeedback
@@ -52,8 +52,8 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       expect(ConceptFeedback.count).to eq(pre_create_count + 1)
     end
 
-    it "should expire the rails cache for concept feedbacks with that activity type" do
-      expect(Rails.cache).to receive(:delete).with(concept_feedback.cache_key)
+    it "should expire the redis cache for concept feedbacks with that activity type" do
+      expect($redis).to receive(:del).with(concept_feedback.cache_key)
       post :create, params: { activity_type: concept_feedback.activity_type, concept_feedback: {foo: "bar"} }, as: :json
     end
   end
@@ -88,8 +88,8 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       expect(ConceptFeedback.find_by(uid: uid)).to be
     end
 
-    it "should expire the rails cache for concept feedbacks with that activity type" do
-      expect(Rails.cache).to receive(:delete).with(concept_feedback.cache_key)
+    it "should expire the redis cache for concept feedbacks with that activity type" do
+      expect($redis).to receive(:del).with(concept_feedback.cache_key)
       data = {"foo" => "bar"}
       put :update,
         params: {

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -18,7 +18,7 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
     end
 
     it 'resets the rails cache for all concept feedbacks if not set already' do
-      Rails.cache.delete("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{concept_feedback.activity_type}")
+      Rails.cache.delete(concept_feedback.cache_key)
       get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
       expect(JSON.parse(response.body)).to eq(
         ConceptFeedback
@@ -52,8 +52,8 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       expect(ConceptFeedback.count).to eq(pre_create_count + 1)
     end
 
-    it "should expire the redis cache for concept feedbacks with that activity type" do
-      expect(Rails.cache).to receive(:delete).with("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{concept_feedback.activity_type}")
+    it "should expire the rails cache for concept feedbacks with that activity type" do
+      expect(Rails.cache).to receive(:delete).with(concept_feedback.cache_key)
       post :create, params: { activity_type: concept_feedback.activity_type, concept_feedback: {foo: "bar"} }, as: :json
     end
   end
@@ -88,8 +88,8 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
       expect(ConceptFeedback.find_by(uid: uid)).to be
     end
 
-    it "should expire the redis cache for concept feedbacks with that activity type" do
-      expect(Rails.cache).to receive(:delete).with("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{concept_feedback.activity_type}")
+    it "should expire the rails cache for concept feedbacks with that activity type" do
+      expect(Rails.cache).to receive(:delete).with(concept_feedback.cache_key)
       data = {"foo" => "bar"}
       put :update,
         params: {

--- a/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
@@ -31,8 +31,8 @@ describe Api::V1::ConceptsController, type: :controller do
     describe 'cache actions' do
       let(:user) { create(:staff) }
 
-      it 'expires the rails cache for all concepts, each time a new concept is created' do
-        expect(Rails.cache).to receive(:delete).with(Concept::ALL_CONCEPTS_KEY)
+      it 'expires the redis cache for all concepts, each time a new concept is created' do
+        expect($redis).to receive(:del).with(Concept::ALL_CONCEPTS_KEY)
         subject
       end
     end
@@ -50,10 +50,10 @@ describe Api::V1::ConceptsController, type: :controller do
       expect(parsed_body['concepts'].length).to eq(2)
     end
 
-    it 'sets the rails cache for all concepts if not set already' do
-      Rails.cache.delete(Concept::ALL_CONCEPTS_KEY)
+    it 'sets the redis cache for all concepts if not set already' do
+      $redis.del(Concept::ALL_CONCEPTS_KEY)
       subject
-      expect(Rails.cache.fetch(Concept::ALL_CONCEPTS_KEY)).to eq({concepts: Concept.all_with_level}.to_json)
+      expect($redis.get(Concept::ALL_CONCEPTS_KEY)).to eq({concepts: Concept.all_with_level}.to_json)
     end
   end
 

--- a/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
@@ -27,6 +27,16 @@ describe Api::V1::ConceptsController, type: :controller do
       it { expect(parsed_body['concept']['name']).to eq concept_name  }
       it { expect(parsed_body['concept']['uid']).to_not be_nil }
     end
+
+    describe 'cache actions' do
+      let(:user) { create(:staff) }
+
+      it 'expires the rails cache for all concepts, each time a new concept is created' do
+        expect(Rails.cache).to receive(:delete).with(Concept::ALL_CONCEPTS_KEY)
+        subject
+      end
+    end
+
   end
 
   context 'GET #index' do
@@ -35,10 +45,15 @@ describe Api::V1::ConceptsController, type: :controller do
     let!(:concept1) { create(:concept) }
     let!(:concept2) { create(:concept, parent: concept1) }
 
-    before { subject }
-
     it 'returns all concepts' do
+      subject
       expect(parsed_body['concepts'].length).to eq(2)
+    end
+
+    it 'sets the rails cache for all concepts if not set already' do
+      Rails.cache.delete(Concept::ALL_CONCEPTS_KEY)
+      subject
+      expect(Rails.cache.fetch(Concept::ALL_CONCEPTS_KEY)).to eq({concepts: Concept.all_with_level}.to_json)
     end
   end
 

--- a/services/QuillLMS/spec/models/concept_feedback_spec.rb
+++ b/services/QuillLMS/spec/models/concept_feedback_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ConceptFeedback, type: :model do
 
     context 'after update' do
       it 'calls Rails.cache.delete on concept feedback with activity type' do
-        expect(Rails.cache).to receive(:delete).with("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{concept_feedback.activity_type}")
+        expect(Rails.cache).to receive(:delete).with(concept_feedback.cache_key)
         concept_feedback.update(data: {test: 'test'})
       end
     end

--- a/services/QuillLMS/spec/models/concept_feedback_spec.rb
+++ b/services/QuillLMS/spec/models/concept_feedback_spec.rb
@@ -63,16 +63,16 @@ RSpec.describe ConceptFeedback, type: :model do
     let!(:concept_feedback) { create(:concept_feedback) }
 
     context 'after update' do
-      it 'calls Rails.cache.delete on concept feedback with activity type' do
-        expect(Rails.cache).to receive(:delete).with(concept_feedback.cache_key)
+      it 'calls redis cache delete on concept feedback with activity type' do
+        expect($redis).to receive(:del).with(concept_feedback.cache_key)
         concept_feedback.update(data: {test: 'test'})
       end
     end
 
     context 'after create' do
-      it 'calls Rails.cache.delete on concept feedback with activity type' do
+      it 'calls redis cache delete on concept feedback with activity type' do
         activity_type = "grammar"
-        expect(Rails.cache).to receive(:delete).with("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}")
+        expect($redis).to receive(:del).with("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}")
         ConceptFeedback.create(activity_type: activity_type, data: {test: 'test'}, uid: SecureRandom.uuid)
       end
     end

--- a/services/QuillLMS/spec/models/concept_feedback_spec.rb
+++ b/services/QuillLMS/spec/models/concept_feedback_spec.rb
@@ -58,4 +58,23 @@ RSpec.describe ConceptFeedback, type: :model do
       expect(concept_feedback.as_json).to eq(concept_feedback.data)
     end
   end
+
+  describe '#callbacks' do
+    let!(:concept_feedback) { create(:concept_feedback) }
+
+    context 'after update' do
+      it 'calls Rails.cache.delete on concept feedback with activity type' do
+        expect(Rails.cache).to receive(:delete).with("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{concept_feedback.activity_type}")
+        concept_feedback.update(data: {test: 'test'})
+      end
+    end
+
+    context 'after create' do
+      it 'calls Rails.cache.delete on concept feedback with activity type' do
+        activity_type = "grammar"
+        expect(Rails.cache).to receive(:delete).with("#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}")
+        ConceptFeedback.create(activity_type: activity_type, data: {test: 'test'}, uid: SecureRandom.uuid)
+      end
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/concept_spec.rb
+++ b/services/QuillLMS/spec/models/concept_spec.rb
@@ -30,6 +30,7 @@ describe Concept, type: :model do
 
   describe 'callbacks' do
     let!(:concept) { create(:concept, name: 'test') }
+
     context 'after update' do
       it 'calls Rails.cache.delete on all concepts key' do
         expect(Rails.cache).to receive(:delete).with(Concept::ALL_CONCEPTS_KEY)

--- a/services/QuillLMS/spec/models/concept_spec.rb
+++ b/services/QuillLMS/spec/models/concept_spec.rb
@@ -32,15 +32,15 @@ describe Concept, type: :model do
     let!(:concept) { create(:concept, name: 'test') }
 
     context 'after update' do
-      it 'calls Rails.cache.delete on all concepts key' do
-        expect(Rails.cache).to receive(:delete).with(Concept::ALL_CONCEPTS_KEY)
+      it 'calls redis cache delete on all concepts key' do
+        expect($redis).to receive(:del).with(Concept::ALL_CONCEPTS_KEY)
         concept.update(name: 'test2')
       end
     end
 
     context 'after create' do
-      it 'calls Rails.cache.delete on all concepts key' do
-        expect(Rails.cache).to receive(:delete).with(Concept::ALL_CONCEPTS_KEY)
+      it 'calls redis cache delete on all concepts key' do
+        expect($redis).to receive(:del).with(Concept::ALL_CONCEPTS_KEY)
         Concept.create(name: 'test')
       end
     end

--- a/services/QuillLMS/spec/models/concept_spec.rb
+++ b/services/QuillLMS/spec/models/concept_spec.rb
@@ -28,6 +28,23 @@ describe Concept, type: :model do
     end
   end
 
+  describe 'callbacks' do
+    let!(:concept) { create(:concept, name: 'test') }
+    context 'after update' do
+      it 'calls Rails.cache.delete on all concepts key' do
+        expect(Rails.cache).to receive(:delete).with(Concept::ALL_CONCEPTS_KEY)
+        concept.update(name: 'test2')
+      end
+    end
+
+    context 'after create' do
+      it 'calls Rails.cache.delete on all concepts key' do
+        expect(Rails.cache).to receive(:delete).with(Concept::ALL_CONCEPTS_KEY)
+        Concept.create(name: 'test')
+      end
+    end
+  end
+
   describe '.leaf_nodes' do
     let!(:root_concept) { create(:concept, name: 'root') }
     let!(:leaf1) { create(:concept, name: 'leaf1', parent: root_concept)}


### PR DESCRIPTION
## WHAT
Start caching the Concepts endpoint again because we determined the endpoint is taking up too much server traffic.

## WHY
We removed this last month because we posited that the ~1000 records being returned would not be too large a load to call uncached. However, this endpoint is called frequently enough that removing the cache did significantly increase server load, so we want to put in caching.

## HOW
Put in Rails.cache caching on Concept and ConceptFeedback indexes.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Put-Caching-back-in-place-for-Concept-endpoints-c604d9af6dfc48a0b4e6bb2c28f3e70d?pvs=4

### What have you done to QA this feature?
Deploy to staging, make sure both endpoint caches are invalidated when a new record is created, and it shows up in the index call right after creation.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
