### PR TITLE
Admin reports/ classrooms filter bug

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/filters.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/__tests__/filters.test.tsx
@@ -13,6 +13,7 @@ describe('Filters component', () => {
     availableGrades: grades,
     availableTeachers: teachers,
     availableClassrooms: classrooms,
+    originalAllClassrooms: classrooms,
     applyFilters: jest.fn(),
     clearFilters: jest.fn(),
     selectedGrades: grades,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
@@ -13,6 +13,7 @@ const Filters = ({
   availableGrades,
   availableTeachers,
   availableClassrooms,
+  originalAllClassrooms,
   applyFilters,
   clearFilters,
   selectedGrades,
@@ -55,7 +56,9 @@ const Filters = ({
 
   function effectiveSelectedClassrooms() {
     // this accounts for a weird edge case documented in this card: https://www.notion.so/quill/Address-issue-in-the-admin-report-filters-causing-the-Classroom-filter-to-sometimes-end-up-in-an-u-b10b51c217114e67ae937120be73ecfd
-    if(selectedTeachers.length === availableTeachers.length) { return availableClassrooms }
+    if(selectedTeachers.length === availableTeachers.length) {
+      setSelectedClassrooms(originalAllClassrooms)
+    }
     return selectedClassrooms.filter(c => availableClassrooms.find(ac => ac.id === c.id))
   }
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/usage_snapshots/filters.tsx
@@ -54,6 +54,8 @@ const Filters = ({
   }
 
   function effectiveSelectedClassrooms() {
+    // this accounts for a weird edge case documented in this card: https://www.notion.so/quill/Address-issue-in-the-admin-report-filters-causing-the-Classroom-filter-to-sometimes-end-up-in-an-u-b10b51c217114e67ae937120be73ecfd
+    if(selectedTeachers.length === availableTeachers.length) { return availableClassrooms }
     return selectedClassrooms.filter(c => availableClassrooms.find(ac => ac.id === c.id))
   }
 

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/PremiumFilterableReportsContainer.tsx
@@ -343,6 +343,7 @@ export const PremiumFilterableReportsContainer = ({ accessType, adminInfo, }) =>
     availableGrades,
     availableTeachers,
     availableClassrooms: availableClassroomsToPass,
+    originalAllClassrooms,
     applyFilters,
     clearFilters,
     selectedGrades,


### PR DESCRIPTION
## WHAT
fix edge case bug related to classroom filters with the following steps:
- selects a specific teacher and classroom
- removes the classroom and clicks apply
- removes the teacher
the result is that all of the previously selected teacher's classrooms will be selected, rather than the filters reverting to "All classrooms selected"

## WHY
we want the filters to behave as expected

## HOW
add a check when rendering classroom filter selections that checks for the selected teachers array length matching the length of the available teachers array; if so, set selected classrooms to `allOriginalClassrooms`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Address-issue-in-the-admin-report-filters-causing-the-Classroom-filter-to-sometimes-end-up-in-an-u-b10b51c217114e67ae937120be73ecfd

### What have you done to QA this feature?
on staging, reproduced the above actions with several users to ensure that the classroom filter would revert back to "All classrooms selected"

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
