### PR TITLE
Update Connect and Diagnostic incorrect sequence panels to new format

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/questions.ts
@@ -176,10 +176,11 @@ function updateModelConceptUID(qid, modelConceptUID) {
   }
 }
 
-function submitNewIncorrectSequence(qid, data) {
+function submitNewIncorrectSequence(qid, data, callback) {
   return (dispatch, getState) => {
     IncorrectSequenceApi.create(qid, data).then(() => {
       dispatch(loadQuestion(qid));
+      callback();
     }, (error) => {
       alert(`Submission failed! ${error}`);
     });
@@ -206,10 +207,11 @@ function deleteIncorrectSequence(qid, seqid) {
   };
 }
 
-function updateIncorrectSequences(qid, data) {
+function updateIncorrectSequences(qid, data, callback) {
   return (dispatch, getState) => {
     IncorrectSequenceApi.updateAllForQuestion(qid, data).then(() => {
       dispatch(loadQuestion(qid));
+      callback();
     }).catch((error) => {
       alert(`Order update failed! ${error}`);
     });

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -25,17 +25,6 @@ class IncorrectSequencesContainer extends Component {
     this.state = { orderedIds: orderedIds, questionType, actionFile, questionTypeLink, incorrectSequences };
   }
 
-  // componentDidMount() {
-  //   const { actionFile } = this.state
-  //   const { getUsedSequences } = actionFile
-  //   const { dispatch, match } = this.props
-  //   const { params } = match
-  //   const { questionID } = params
-  //   if (getUsedSequences) {
-  //     dispatch(getUsedSequences(questionID))
-  //   }
-  // }
-
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { incorrectSequences } = this.state
     const { match, questions } = nextProps

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -22,7 +22,7 @@ class IncorrectSequencesContainer extends Component {
     const sequencesCollection = hashToCollection(incorrectSequences)
     const orderedIds = sequencesCollection.sort((a, b) => a.order - b.order).map(b => b.key);
 
-    this.state = { orderedIds: orderedIds, questionType, actionFile, questionTypeLink, incorrectSequences };
+    this.state = { orderedIds, questionType, actionFile, questionTypeLink, incorrectSequences };
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -17,35 +17,35 @@ class IncorrectSequencesContainer extends Component {
     const questionTypeLink = questionType === 'sentenceFragments' ? 'sentence-fragments' : 'questions'
     const actionFile = questionType === 'sentenceFragments' ? sentenceFragmentActions : questionActions
     const question = props[questionType].data[props.match.params.questionID]
-    const incorrectSequences = this.getSequences(question)
+    const incorrectSequences = question.incorrectSequences
 
-    this.state = { orderedIds: null, questionType, actionFile, questionTypeLink, incorrectSequences };
+    const sequencesCollection = hashToCollection(incorrectSequences)
+    const orderedIds = sequencesCollection.sort((a, b) => a.order - b.order).map(b => b.key);
+
+    this.state = { orderedIds: orderedIds, questionType, actionFile, questionTypeLink, incorrectSequences };
   }
 
-  componentDidMount() {
-    const { actionFile } = this.state
-    const { getUsedSequences } = actionFile
-    const { dispatch, match } = this.props
+  // componentDidMount() {
+  //   const { actionFile } = this.state
+  //   const { getUsedSequences } = actionFile
+  //   const { dispatch, match } = this.props
+  //   const { params } = match
+  //   const { questionID } = params
+  //   if (getUsedSequences) {
+  //     dispatch(getUsedSequences(questionID))
+  //   }
+  // }
+
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { incorrectSequences } = this.state
+    const { match, questions } = nextProps
     const { params } = match
-    const { questionID } = params
-    if (getUsedSequences) {
-      dispatch(getUsedSequences(questionID))
+
+    const incomingIncorrectSequences = questions.data[params.questionID].incorrectSequences
+    const incomingOrderedIds = hashToCollection(incomingIncorrectSequences).sort((a, b) => a.order - b.order).map(seq => seq.key)
+    if (!_.isEqual(incorrectSequences, incomingIncorrectSequences)) {
+      this.setState({ incorrectSequences: incomingIncorrectSequences, orderedIds: incomingOrderedIds})
     }
-  }
-
-  componentDidUpdate(previousProps, previousState) {
-    const question = this.props[this.state.questionType].data[this.props.match.params.questionID]
-    const incorrectSequences = this.getSequences(question)
-
-    if (!_.isEqual(previousState.incorrectSequences, incorrectSequences)) {
-      this.setState({ incorrectSequences, orderedIds: null });
-    };
-  }
-
-  getSequenceIndexByKey = (key) => {
-    const { incorrectSequences, } = this.state
-
-    return incorrectSequences.findIndex(is => is.key === key)
   }
 
   getSequences = (question) => {
@@ -77,10 +77,23 @@ class IncorrectSequencesContainer extends Component {
     if (confirm('⚠️ Are you sure you want to delete this? 😱')) {
       dispatch(deleteIncorrectSequence(questionID, sequenceID));
       delete incorrectSequences[sequenceID];
-      if (orderedIds) {
-        const newOrderedIds = orderedIds.filter(id => id != sequenceID)
-        this.setState({ orderedIds: newOrderedIds })
+      const newOrderedIds = orderedIds.filter(id => id !== sequenceID)
+      const incorrectSequenceArray = hashToCollection(incorrectSequences)
+
+      let newIncorrectSequences = {}
+      newOrderedIds.forEach((id, index) => {
+        const sequence = incorrectSequenceArray.find(is => is.key === id);
+        sequence.order = index
+        newIncorrectSequences[sequence.key] = sequence
+      })
+
+      if (incorrectSequenceArray.length > 0) {
+        dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences, this.alertDeleted))
+      } else {
+        this.alertDeleted()
       }
+
+      this.setState({ orderedIds: newOrderedIds, incorrectSequences: newIncorrectSequences })
     }
   };
 
@@ -89,17 +102,37 @@ class IncorrectSequencesContainer extends Component {
 
     const sequencesCollection = Array.isArray(incorrectSequences) ? incorrectSequences : hashToCollection(incorrectSequences)
 
-    if (orderedIds) {
-      return orderedIds.map(id => sequencesCollection.find(s => s.uid === id))
-    } else {
-      return sequencesCollection.sort((a, b) => a.order - b.order);
-    }
+    return orderedIds.map(id => sequencesCollection.find(s => s.key === id))
+
   }
 
   sortCallback = sortInfo => {
     const orderedIds = sortInfo.map(item => item.key);
     this.setState({ orderedIds });
   };
+
+  alertSaved = () => {
+    alert('Saved!')
+  }
+
+  alertDeleted = () => {
+    alert('Deleted!')
+  }
+
+  handleSaveAllSequences = () => {
+    const { orderedIds, incorrectSequences } = this.state
+    const { dispatch, match } = this.props;
+    const { params } = match;
+    const { questionID } = params;
+    const newIncorrectSequences = {}
+    const incorrectSequenceArray = hashToCollection(incorrectSequences)
+    orderedIds.forEach((id, index) => {
+      const sequence = incorrectSequenceArray.find(is => is.key === id);
+      sequence.order = index
+      newIncorrectSequences[sequence.key] = sequence
+    })
+    dispatch(questionActions.updateIncorrectSequences(questionID, newIncorrectSequences, this.alertSaved))
+  }
 
   updateOrder = () => {
     const { actionFile, orderedIds, incorrectSequences } = this.state
@@ -129,8 +162,7 @@ class IncorrectSequencesContainer extends Component {
     const { questionID } = params
     const { incorrectSequences } = this.state
     const filteredSequences = this.removeEmptySequences(incorrectSequences)
-    const index = this.getSequenceIndexByKey(key)
-    let data = filteredSequences[index]
+    let data = filteredSequences[key]
     delete data.conceptResults.null;
     if (data.text === '') {
       delete filteredSequences[index]
@@ -156,7 +188,7 @@ class IncorrectSequencesContainer extends Component {
     const { incorrectSequences } = this.state
     const className = `regex-${key}`
     const value = `${Array.from(document.getElementsByClassName(className)).map(i => i.value).filter(val => val !== '').join('|||')}|||`;
-    incorrectSequences[this.getSequenceIndexByKey(key)].text = value;
+    incorrectSequences[key].text = value;
     this.setState({incorrectSequences: incorrectSequences})
   }
 
@@ -169,19 +201,19 @@ class IncorrectSequencesContainer extends Component {
         return
       }
     }
-    incorrectSequences[this.getSequenceIndexByKey(key)].text = value;
+    incorrectSequences[key].text = value;
     this.setState({incorrectSequences: incorrectSequences})
   }
 
   handleNameChange = (e, key) => {
     const { incorrectSequences } = this.state
-    incorrectSequences[this.getSequenceIndexByKey(key)].name = e.target.value
+    incorrectSequences[key].name = e.target.value
     this.setState({incorrectSequences: incorrectSequences})
   }
 
   handleFeedbackChange = (e, key) => {
     const { incorrectSequences } = this.state
-    incorrectSequences[this.getSequenceIndexByKey(key)].feedback = e
+    incorrectSequences[key].feedback = e
     this.setState({incorrectSequences: incorrectSequences})
   }
 
@@ -203,12 +235,18 @@ class IncorrectSequencesContainer extends Component {
     }
   }
 
+  renderSaveButton() {
+    return (
+      <button className="button is-outlined is-primary" onClick={this.handleSaveAllSequences} style={{ float: 'right', }} type="button">Save Sequences</button>
+    );
+  }
+
   renderSequenceList = () => {
     const { match } = this.props
 
     const components = this.sequencesSortedByOrder().map((sequence) => {
       return (
-        <div className="card is-fullwidth has-bottom-margin" id={sequence.uid} key={sequence.uid} >
+        <div className="card is-fullwidth has-bottom-margin" id={sequence.key} key={sequence.key} >
           <header className="card-header">
             <input className="regex-name" onChange={(e) => this.handleNameChange(e, sequence.key)} placeholder="Name" type="text" value={sequence.name || ''} />
           </header>
@@ -237,7 +275,6 @@ class IncorrectSequencesContainer extends Component {
           <footer className="card-footer">
             <NavLink className="card-footer-item" to={`${match.url}/${sequence.key}/edit`}>Edit</NavLink>
             <a className="card-footer-item" onClick={() => this.deleteSequence(sequence.key)}>Delete</a>
-            <a className="card-footer-item" onClick={() => this.saveSequencesAndFeedback(sequence.key)}>Save</a>
           </footer>
         </div>
       )
@@ -267,7 +304,7 @@ class IncorrectSequencesContainer extends Component {
         <div className="has-top-margin">
           <h1 className="title is-3" style={{ display: 'inline-block', }}>Incorrect Sequences</h1>
           <a className="button is-outlined is-primary" href={`#${match.url}/new`} rel="noopener noreferrer" style={{ float: 'right', }}>Add Incorrect Sequence</a>
-          {this.renderSaveOrderButton()}
+          {this.renderSaveButton()}
         </div>
         {this.renderSequenceList()}
       </div>

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/newIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/newIncorrectSequenceContainer.jsx
@@ -31,14 +31,15 @@ class NewIncorrectSequencesContainer extends Component {
   submitSequenceForm = data => {
     const { actionFile } = this.state
     const { submitNewIncorrectSequence } = actionFile
-    const { dispatch, match, generatedIncorrectSequences } = this.props
-    const { params } = match
-    const { questionID } = params
+    const { dispatch, match, history, questions } = this.props
+    const incorrectSequences = questions.data[match.params.questionID].incorrectSequences
     delete data.conceptResults.null;
-    const usedIncorrectSequences = generatedIncorrectSequences.used[match.params.questionID];
-    data.order = _.keys(usedIncorrectSequences).length;
-    dispatch(submitNewIncorrectSequence(questionID, data));
-    window.history.back();
+    data.order = _.keys(incorrectSequences).length;
+    const url = match.url.replace('/new', '')
+    const callback = () => {
+      history.push(url)
+    }
+    dispatch(submitNewIncorrectSequence(match.params.questionID, data, callback));
   };
 
   render() {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/actions/questions.ts
@@ -169,10 +169,11 @@ function updateModelConceptUID(qid, modelConceptUID) {
   }
 }
 
-function submitNewIncorrectSequence(qid, data) {
+function submitNewIncorrectSequence(qid, data, callback) {
   return (dispatch, getState) => {
     IncorrectSequenceApi.create(qid, data).then(() => {
       dispatch(loadQuestion(qid));
+      callback();
     }, (error) => {
       alert(`Submission failed! ${error}`);
     });
@@ -199,10 +200,11 @@ function deleteIncorrectSequence(qid, seqid) {
   };
 }
 
-function updateIncorrectSequences(qid, data) {
+function updateIncorrectSequences(qid, data, callback) {
   return (dispatch, getState) => {
     IncorrectSequenceApi.updateAllForQuestion(qid, data).then(() => {
       dispatch(loadQuestion(qid));
+      callback();
     }).catch((error) => {
       alert(`Order update failed! ${error}`);
     });

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -20,9 +20,7 @@ class IncorrectSequencesContainer extends Component {
     const { sentenceFragments } = props
 
     const sequencesCollection = hashToCollection(incorrectSequences)
-    console.log(sequencesCollection)
     const orderedIds = sequencesCollection.sort((a, b) => a.order - b.order).map(b => b.key);
-    console.log(orderedIds)
 
     this.state = {
       orderedIds: orderedIds,
@@ -161,7 +159,6 @@ class IncorrectSequencesContainer extends Component {
   sequencesSortedByOrder = () => {
     const { orderedIds, incorrectSequences } = this.state
     const sequencesCollection = Array.isArray(incorrectSequences) ? incorrectSequences : hashToCollection(incorrectSequences)
-    console.log(orderedIds)
     return orderedIds.map(id => sequencesCollection.find(s => s.key === id))
   }
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/newIncorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/newIncorrectSequenceContainer.jsx
@@ -29,16 +29,17 @@ class NewIncorrectSequencesContainer extends Component {
   }
 
   submitSequenceForm = data => {
-    const { actionFile, questionTypeLink } = this.state;
-    const { dispatch, history, match, generatedIncorrectSequences } = this.props;
-    const { params } = match;
-    const { questionID } = params;
+    const { dispatch, history, match, questions } = this.props;
+    const { actionFile } = this.state;
+    const incorrectSequences = questions.data[match.params.questionID].incorrectSequences
+
     delete data.conceptResults.null;
-    const usedIncorrectSequences = generatedIncorrectSequences.used[match.params.questionID];
-    data.order = _.keys(usedIncorrectSequences).length;
-    // TODO: fix add new incorrect sequence action to show new incorrect sequence without refreshing
-    dispatch(actionFile.submitNewIncorrectSequence(questionID, data));
-    history.push(`/admin/${questionTypeLink}/${questionID}/incorrect-sequences`)
+    data.order = _.keys(incorrectSequences).length;
+    const url = match.url.replace('/new', '')
+    const callback = () => {
+      history.push(url)
+    }
+    dispatch(actionFile.submitNewIncorrectSequence(match.params.questionID, data, callback));
   }
 
   render() {


### PR DESCRIPTION
## WHAT
Update the Connect and Diagnostic incorrect sequence panels to use the new behavior: read incorrectSequences as objects instead of reading them as arrays and send "Save" behavior one time only instead of saving each individual sequence separately.

## WHY
This new behavior is what admins prefer and fixes some common bugs seen when using these panels.

## HOW
Update the function calls to use this new format.

### Screenshots
![Screenshot 2024-04-30 at 11 11 15 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/2c087fe2-e1be-4cf2-9253-ee28bddc2cee)


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Incorrect-Sequences-in-Grammar-currently-have-inconsistent-saving-behavior-a2308d4636244e94917cf72b907039d6?pvs=4)

### What have you done to QA this feature?
I deployed to staging and tried creating new sequences, updating them, sorting them, and using the new save all feature in both Connect and Diagnostic panels.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, no tests here.
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
