### PR TITLE
scope activity_sessions_for_unit_activity_classroom_and_student query to finished sessions and rename

### DIFF
--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -45,7 +45,7 @@ class ActivitySessionsController < ApplicationController
 
   def student_activity_report
     @js_file = 'student'
-    @activity_sessions = activity_sessions_for_unit_activity_classroom_and_student(@activity_session.unit&.id, @activity_session.activity_id, @activity_session.classroom&.id, @activity_session.user_id)
+    @activity_sessions = finished_activity_sessions_for_unit_activity_classroom_and_student(@activity_session.unit&.id, @activity_session.activity_id, @activity_session.classroom&.id, @activity_session.user_id)
     @report_data = @activity_sessions.find { |session| session[:activity_session_id] == @activity_session.id }
   end
 

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -44,7 +44,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     render json: response
   end
 
-  def activity_sessions_for_student
+  def finished_activity_sessions_for_student
     classroom = Classroom.find(params[:classroom_id])
 
     cache_groups = {
@@ -52,8 +52,8 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
       unit_id: params[:unit_id],
       student_id: params[:student_id]
     }
-    response = current_user.classroom_cache(classroom, key: 'teachers.progress_reports.diagnostic_reports.activity_sessions_for_student', groups: cache_groups) do
-      activity_sessions_for_unit_activity_classroom_and_student(params[:unit_id], params[:activity_id], params[:classroom_id], params[:student_id])
+    response = current_user.classroom_cache(classroom, key: 'teachers.progress_reports.diagnostic_reports.finished_activity_sessions_for_student', groups: cache_groups) do
+      finished_activity_sessions_for_unit_activity_classroom_and_student(params[:unit_id], params[:activity_id], params[:classroom_id], params[:student_id])
     end
     render json: { activity_sessions: response }
   end

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -129,7 +129,7 @@ module PublicProgressReports
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
-  def activity_sessions_for_unit_activity_classroom_and_student(unit_id, activity_id, classroom_id, student_id)
+  def finished_activity_sessions_for_unit_activity_classroom_and_student(unit_id, activity_id, classroom_id, student_id)
     classroom_unit = ClassroomUnit.find_by(
       classroom_id: classroom_id,
       unit_id: unit_id
@@ -142,7 +142,9 @@ module PublicProgressReports
       .where(
         user_id: student_id,
         classroom_unit_id: classroom_unit.id,
-        activity_id: activity_id)
+        activity_id: activity_id,
+        state: ActivitySession::STATE_FINISHED_KEY
+      )
       .order('activity_sessions.completed_at')
 
     classification = Activity.find_by(id: activity_id).classification

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/student_report.tsx
@@ -87,7 +87,7 @@ const StudentReport = ({ params, studentDropdownCallback, activitySessionDropdow
   }
 
   function getActivitySessions() {
-    requestGet(`/teachers/progress_reports/activity_sessions_for_student/u/${params.unitId}/a/${params.activityId}/c/${params.classroomId}/s/${params.studentId}`, (data: { activity_sessions: Student[] }) => {
+    requestGet(`/teachers/progress_reports/finished_activity_sessions_for_student/u/${params.unitId}/a/${params.activityId}/c/${params.classroomId}/s/${params.studentId}`, (data: { activity_sessions: Student[] }) => {
       const { activity_sessions } = data;
       setActivitySessions(activity_sessions)
     });

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -334,7 +334,7 @@ EmpiricalGrammar::Application.routes.draw do
       get 'question_view/classroom/:classroom_id/activity/:activity_id' => 'diagnostic_reports#question_view'
       get 'classrooms_with_students/u/:unit_id/a/:activity_id/c/:classroom_id' => 'diagnostic_reports#classrooms_with_students'
       get 'students_by_classroom/u/:unit_id/a/:activity_id/c/:classroom_id' => 'diagnostic_reports#students_by_classroom'
-      get 'activity_sessions_for_student/u/:unit_id/a/:activity_id/c/:classroom_id/s/:student_id' => 'diagnostic_reports#activity_sessions_for_student'
+      get 'finished_activity_sessions_for_student/u/:unit_id/a/:activity_id/c/:classroom_id/s/:student_id' => 'diagnostic_reports#finished_activity_sessions_for_student'
       get 'recommendations_for_classroom/:classroom_id/activity/:activity_id' => 'diagnostic_reports#recommendations_for_classroom'
       get 'lesson_recommendations_for_classroom/:classroom_id/activity/:activity_id' => 'diagnostic_reports#lesson_recommendations_for_classroom'
       get 'diagnostic_activity_ids' => 'diagnostic_reports#diagnostic_activity_ids'

--- a/services/QuillLMS/spec/controllers/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/activity_sessions_controller_spec.rb
@@ -38,7 +38,7 @@ describe ActivitySessionsController, type: :controller do
     let(:formatted_score_obj) { { activity_session_id: activity_session.id} }
 
     before do
-      allow(controller).to receive(:activity_sessions_for_unit_activity_classroom_and_student).and_return([formatted_score_obj])
+      allow(controller).to receive(:finished_activity_sessions_for_unit_activity_classroom_and_student).and_return([formatted_score_obj])
     end
 
     it 'should set the report_data' do

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -249,7 +249,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     end
   end
 
-  describe '#activity_sessions_for_student' do
+  describe '#finished_activity_sessions_for_student' do
     let(:student) { create(:student) }
     let(:students_classroom) { create(:students_classroom, classroom: classroom, student: student) }
     let(:unit) { create(:unit) }
@@ -259,7 +259,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
     it 'returns session data for the given student, unit, and activity' do
-      get :activity_sessions_for_student, params: { classroom_id: classroom.id, unit_id: unit.id, student_id: student.id, activity_id: activity.id }
+      get :finished_activity_sessions_for_student, params: { classroom_id: classroom.id, unit_id: unit.id, student_id: student.id, activity_id: activity.id }
 
       expect(response).to have_http_status(:success)
       json_response = JSON.parse(response.body)
@@ -268,7 +268,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     end
 
     it 'returns an empty array when no sessions are available' do
-      get :activity_sessions_for_student, params: { classroom_id: classroom.id, unit_id: unit.id, student_id: 999, activity_id: activity.id } # Unmatched student ID
+      get :finished_activity_sessions_for_student, params: { classroom_id: classroom.id, unit_id: unit.id, student_id: 999, activity_id: activity.id } # Unmatched student ID
 
       expect(response).to have_http_status(:success)
       json_response = JSON.parse(response.body)
@@ -277,10 +277,10 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
     context 'with caching' do
       it 'caches the results to prevent repeated database queries' do
-        expect_any_instance_of(Teachers::ProgressReports::DiagnosticReportsController).to receive(:activity_sessions_for_unit_activity_classroom_and_student).with(any_args).once.and_call_original
+        expect_any_instance_of(Teachers::ProgressReports::DiagnosticReportsController).to receive(:finished_activity_sessions_for_unit_activity_classroom_and_student).with(any_args).once.and_call_original
 
         2.times do
-          get :activity_sessions_for_student, params: { classroom_id: classroom.id, unit_id: unit.id, student_id: student.id, activity_id: activity.id }
+          get :finished_activity_sessions_for_student, params: { classroom_id: classroom.id, unit_id: unit.id, student_id: student.id, activity_id: activity.id }
 
           expect(response).to be_successful
         end

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -555,7 +555,7 @@ describe PublicProgressReports, type: :model do
 
   end
 
-  describe '#activity_sessions_for_unit_activity_classroom_and_student' do
+  describe '#finished_activity_sessions_for_unit_activity_classroom_and_student' do
     let!(:unit) { create(:unit) }
     let!(:classroom) { create(:classroom) }
     let!(:student) { create(:user) }
@@ -564,20 +564,26 @@ describe PublicProgressReports, type: :model do
     let!(:activity_session) { create(:activity_session, user: student, classroom_unit: classroom_unit, activity: activity) }
 
     it 'returns an array of formatted activity sessions' do
-      result = FakeReports.new.activity_sessions_for_unit_activity_classroom_and_student(unit.id, activity.id, classroom.id, student.id)
+      result = FakeReports.new.finished_activity_sessions_for_unit_activity_classroom_and_student(unit.id, activity.id, classroom.id, student.id)
       expect(result).to be_an(Array)
       expect(result.first).to have_key(:activity_session_id)
     end
 
     it 'returns an empty array when no sessions are found' do
-      expect(FakeReports.new.activity_sessions_for_unit_activity_classroom_and_student(999, 999, 999, 999)).to eq([])
+      expect(FakeReports.new.finished_activity_sessions_for_unit_activity_classroom_and_student(999, 999, 999, 999)).to eq([])
     end
 
     it 'correctly orders sessions by completed_at' do
       earlier_session = create(:activity_session, completed_at: 1.day.ago, user: student, classroom_unit: classroom_unit, activity: activity)
-      result = FakeReports.new.activity_sessions_for_unit_activity_classroom_and_student(unit.id, activity.id, classroom.id, student.id)
+      result = FakeReports.new.finished_activity_sessions_for_unit_activity_classroom_and_student(unit.id, activity.id, classroom.id, student.id)
       expect(result.first[:activity_session_id]).to eq(earlier_session.id)
       expect(result.length).to eq(2)
+    end
+
+    it 'only includes finished sessions' do
+      other_session = create(:activity_session, state: ActivitySession::STATE_STARTED, user: student, classroom_unit: classroom_unit, activity: activity)
+      result = FakeReports.new.finished_activity_sessions_for_unit_activity_classroom_and_student(unit.id, activity.id, classroom.id, student.id)
+      expect(result.length).to eq(1)
     end
   end
 


### PR DESCRIPTION
## WHAT
Scope the query in`activity_sessions_for_unit_activity_classroom_and_student`, which we are using to allow teachers to select between sessions, to only return finished sessions.

## WHY
We are getting 500s when teachers attempt to view a page for a student who has in-progress sessions as well as at least one completed session.

## HOW
Just add an extra clause to the query, and rename the function and the controller action to make it clearer what it should be pulling.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://quillorg-5s.sentry.io/issues/5283157555/?project=11238&referrer=github-pr-bot

### What have you done to QA this feature?
Confirmed that looking at the activity report for a student with an in-progress session works now.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
