### PR TITLE
Match incorrect sequences in sequential order in marking logic

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/interfaces/index.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/interfaces/index.ts
@@ -71,7 +71,8 @@ export interface IncorrectSequence {
   concept_results?: Array<ConceptResult>,
   conceptResults?: Array<ConceptResult>,
   caseInsensitive?: boolean|null,
-  name?: string
+  name?: string,
+  order?: number
 }
 
 export interface FeedbackObject {

--- a/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.spec.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.spec.ts
@@ -28,43 +28,52 @@ const incorrectSequences = [
     text: 'early stage companies|||high potential companies',
     feedback: 'Inc 1',
     concept_results: [{correct: true, conceptUID: 'a'}],
-    caseInsensitive: true
+    caseInsensitive: true,
+    order: 0
   },
   {
     text: 'because|||however',
     feedback: 'Inc 2',
-    concept_results: [{correct: true, conceptUID: 'a'}]
+    concept_results: [{correct: true, conceptUID: 'a'}],
+    order: 1
   },
   {
     text: 'triangle ',
     feedback: 'Inc 3',
-    concept_results: [{correct: true, conceptUID: 'a'}]
+    concept_results: [{correct: true, conceptUID: 'a'}],
+    order: 2
   },
   {
     text: '(startups.*){2,}',
     feedback: 'Inc 4',
-    concept_results: [{correct: true, conceptUID: 'a'}]
+    concept_results: [{correct: true, conceptUID: 'a'}],
+    order: 3
   },
   {
     text: '^Emilia',
     feedback: 'Inc 5',
-    concept_results: [{correct: true, conceptUID: 'a'}]
+    concept_results: [{correct: true, conceptUID: 'a'}],
+    order: 4
   },
   {
     text: 'fun.$',
     feedback: 'Inc 6',
-    concept_results: [{correct: true, conceptUID: 'a'}]
+    concept_results: [{correct: true, conceptUID: 'a'}],
+    order: 5
   },
   {
     text: 'likes&&loves',
     feedback: 'Inc 7',
-    concept_results: [{correct: true, conceptUID: 'a'}]
+    name: 'likes and loves',
+    concept_results: [{correct: true, conceptUID: 'a'}],
+    order: 6
   },
   {
     text: '^Cissy',
     feedback: 'Inc 8',
     name: 'do not mention Cissy',
-    concept_results: [{correct: true, conceptUID: 'a'}]
+    concept_results: [{correct: true, conceptUID: 'a'}],
+    order: 7
   }
 ]
 
@@ -145,6 +154,21 @@ describe('The incorrectSequenceChecker', () => {
     const partialResponse =  {
       feedback: incorrectSequenceMatch(responseString, incorrectSequences).feedback,
       author: 'do not mention Cissy',
+      parent_id: getTopOptimalResponse(savedResponses).id,
+      concept_results: incorrectSequenceMatch(responseString, incorrectSequences).concept_results
+    }
+
+    expect(incorrectSequenceChecker(responseString, incorrectSequences, savedResponses).feedback).toEqual(partialResponse.feedback);
+    expect(incorrectSequenceChecker(responseString, incorrectSequences, savedResponses).author).toEqual(partialResponse.author);
+    expect(incorrectSequenceChecker(responseString, incorrectSequences, savedResponses).parent_id).toEqual(partialResponse.parent_id);
+    expect(incorrectSequenceChecker(responseString, incorrectSequences, savedResponses).concept_results).toEqual(partialResponse.concept_results);
+  });
+
+  it("should match incorrect sequences in sequential order, returning an earlier ordered sequence before hitting a later-ordered sequence", () => {
+    const responseString = "Cissy likes and loves some companies.";
+    const partialResponse =  {
+      feedback: incorrectSequenceMatch(responseString, incorrectSequences).feedback,
+      author: 'likes and loves',
       parent_id: getTopOptimalResponse(savedResponses).id,
       concept_results: incorrectSequenceMatch(responseString, incorrectSequences).concept_results
     }

--- a/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.ts
@@ -11,12 +11,19 @@ export function incorrectSequenceMatchHelper(responseString:string, incorrectSeq
 }
 
 export function incorrectSequenceMatch(responseString: string, incorrectSequences:Array<IncorrectSequence>):IncorrectSequence {
-  return _.find(incorrectSequences, (incSeq) => {
+  const sortedIncorrectSequences = incorrectSequences.sort((a, b) => (a.order || 0) - (b.order || 0));
+
+  for (let i = 0; i < sortedIncorrectSequences.length; i++) {
+    let incSeq = sortedIncorrectSequences[i];
     const options = incSeq.text.split('|||');
     const caseInsensitive = incSeq.caseInsensitive ? incSeq.caseInsensitive : false
     const anyMatches = _.any(options, particle => incorrectSequenceMatchHelper(responseString, particle, caseInsensitive));
-    return anyMatches;
-  });
+    if (anyMatches) {
+      return incSeq;
+    }
+  }
+
+  return null;
 }
 
 export function incorrectSequenceChecker(responseString: string, incorrectSequences:Array<IncorrectSequence>, responses:Array<Response>):PartialResponse|undefined {

--- a/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/libs/matchers/incorrect_sequence_match.ts
@@ -1,7 +1,8 @@
-import * as _ from 'underscore'
+import _ from 'lodash'
+import {stringNormalize} from 'quill-string-normalizer'
+
 import {getTopOptimalResponse} from '../sharedResponseFunctions'
 import {Response, IncorrectSequence, PartialResponse} from '../../interfaces'
-import {stringNormalize} from 'quill-string-normalizer'
 import {conceptResultTemplate} from '../helpers/concept_result_template'
 
 export function incorrectSequenceMatchHelper(responseString:string, incorrectSequenceParticle:string, caseInsensitive:boolean):boolean {
@@ -13,17 +14,12 @@ export function incorrectSequenceMatchHelper(responseString:string, incorrectSeq
 export function incorrectSequenceMatch(responseString: string, incorrectSequences:Array<IncorrectSequence>):IncorrectSequence {
   const sortedIncorrectSequences = incorrectSequences.sort((a, b) => (a.order || 0) - (b.order || 0));
 
-  for (let i = 0; i < sortedIncorrectSequences.length; i++) {
-    let incSeq = sortedIncorrectSequences[i];
+  return _.find(sortedIncorrectSequences, (incSeq) => {
     const options = incSeq.text.split('|||');
     const caseInsensitive = incSeq.caseInsensitive ? incSeq.caseInsensitive : false
-    const anyMatches = _.any(options, particle => incorrectSequenceMatchHelper(responseString, particle, caseInsensitive));
-    if (anyMatches) {
-      return incSeq;
-    }
-  }
-
-  return null;
+    const anyMatches = _.some(options, particle => incorrectSequenceMatchHelper(responseString, particle, caseInsensitive));
+    return anyMatches
+  })
 }
 
 export function incorrectSequenceChecker(responseString: string, incorrectSequences:Array<IncorrectSequence>, responses:Array<Response>):PartialResponse|undefined {


### PR DESCRIPTION
## WHAT
Now that all incorrect sequences have an "order" attribute, we want to match incorrect sequences in sequential order from lowest order to highest order, rather than just simply selecting the first incorrect sequence that matches on the response.

## WHY
Order is important when admin create incorrect sequences so we want this to be hard coded rather than depending on javascript objects' inherent ordering.

## HOW
Instead of using _.any to match incorrect sequences, sort the sequences by order, then use a for loop to check each incorrect sequence until we find one that matches on the response.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Deploy to staging and test using two incorrect sequences that both match a response in Connect, Diagnostic, and Grammar. Make sure that after reordering the incorrect sequences, the first ordered sequence always matches onto the response.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
