### PR TITLE
Turn on spell check for all TextEditors in Connect/Grammar/Diagnostic 

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/feedbackForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/feedbackForm.jsx
@@ -52,6 +52,7 @@ export default class FeedbackForm extends React.Component {
             EditorState={EditorState}
             handleTextChange={this.handleChange.bind(null, part)}
             key={part}
+            shouldCheckSpelling={true}
             text={this.state[part]}
           />)
         ]

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/feedbackForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/feedbackForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React from 'react';
 
 import { ConceptExplanation, TextEditor } from '../../../Shared/index';
@@ -48,11 +47,8 @@ export default class FeedbackForm extends React.Component {
         return [
           (<label className="label">{part}</label>),
           (<TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={this.handleChange.bind(null, part)}
             key={part}
-            shouldCheckSpelling={true}
             text={this.state[part]}
           />)
         ]

--- a/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
@@ -157,6 +157,7 @@ class FillInBlankForm extends Component {
           ContentState={ContentState}
           EditorState={EditorState}
           handleTextChange={this.handlePromptChange}
+          shouldCheckSpelling={true}
           text={this.state.prompt}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React, { Component } from 'react';
 import { FlagDropdown, TextEditor } from '../../../Shared/index';
 import C from '../../constants.js';

--- a/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/fillInBlank/fillInBlankForm.jsx
@@ -154,10 +154,7 @@ class FillInBlankForm extends Component {
         <h6 className="control subtitle">Create a new question</h6>
         <label className="label">Prompt</label>
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={this.handlePromptChange}
-          shouldCheckSpelling={true}
           text={this.state.prompt}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';

--- a/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/focusPoints/focusPointsContainer.jsx
@@ -194,11 +194,8 @@ export class FocusPointsContainer extends Component {
           <div className="card-content">
             <label className="label" htmlFor="feedback" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, fp.key)}
               key="feedback"
-              shouldCheckSpelling={true}
               text={fp.feedback}
             />
             {this.renderConceptResults(fp.conceptResults, fp.key)}

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';

--- a/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -251,11 +251,8 @@ class IncorrectSequencesContainer extends Component {
           <div className="card-content">
             <label className="label" htmlFor="feedback" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, sequence.key)}
               key="feedback"
-              shouldCheckSpelling={true}
               text={sequence.feedback}
             />
             <br />

--- a/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessonForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessonForm.jsx
@@ -148,6 +148,7 @@ class LessonForm extends React.Component {
           ContentState={ContentState}
           EditorState={EditorState}
           handleTextChange={this.handleLPChange}
+          shouldCheckSpelling={true}
           text={this.state.landingPageHtml || ''}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessonForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessonForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React from 'react';
 import { connect } from 'react-redux';
 import SelectSearch from 'react-select-search';

--- a/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessonForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessonForm.jsx
@@ -145,10 +145,7 @@ class LessonForm extends React.Component {
           <label className="label">Landing Page Content</label>
         </p>
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={this.handleLPChange}
-          shouldCheckSpelling={true}
           text={this.state.landingPageHtml || ''}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/massEditContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/massEditContainer.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { ContentState, EditorState } from 'draft-js';
 import _ from 'underscore';
 import { requestPost, } from '../../../../modules/request/index';
 import { TextEditor } from '../../../Shared/index';

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/massEditContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/massEditContainer.jsx
@@ -185,10 +185,7 @@ class MassEditContainer extends React.Component {
               <h3>FEEDBACK</h3>
               <TextEditor
                 boilerplate={this.state.selectedMassEditBoilerplate}
-                ContentState={ContentState}
-                EditorState={EditorState}
                 handleTextChange={this.handleMassEditFeedbackTextChange}
-                shouldCheckSpelling={true}
                 text={this.state.massEditFeedback || ''}
               />
             </div>

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/massEditContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/massEditContainer.jsx
@@ -188,6 +188,7 @@ class MassEditContainer extends React.Component {
                 ContentState={ContentState}
                 EditorState={EditorState}
                 handleTextChange={this.handleMassEditFeedbackTextChange}
+                shouldCheckSpelling={true}
                 text={this.state.massEditFeedback || ''}
               />
             </div>

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React from 'react';
 import {
   FlagDropdown,

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
@@ -139,10 +139,7 @@ export default class extends React.Component {
           <h6 className="control subtitle">Create a new question</h6>
           <label className="label">Prompt</label>
           <TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={this.handlePromptChange}
-            shouldCheckSpelling={true}
             text={this.props.question.prompt || ""}
           />
           <label className="label">Instructions for student</label>

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/questionForm.jsx
@@ -142,6 +142,7 @@ export default class extends React.Component {
             ContentState={ContentState}
             EditorState={EditorState}
             handleTextChange={this.handlePromptChange}
+            shouldCheckSpelling={true}
             text={this.props.question.prompt || ""}
           />
           <label className="label">Instructions for student</label>

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import _ from 'underscore';
 

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
@@ -418,6 +418,7 @@ export default class Response extends React.Component<ResponseProps, ResponseSta
             ContentState={ContentState}
             EditorState={EditorState}
             handleTextChange={this.handleFeedbackChange}
+            shouldCheckSpelling={true}
             text={feedback || ''}
           />
 

--- a/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/questions/response.tsx
@@ -415,10 +415,7 @@ export default class Response extends React.Component<ResponseProps, ResponseSta
           <label className="label">Feedback</label>
           <TextEditor
             boilerplate={selectedBoilerplate}
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={this.handleFeedbackChange}
-            shouldCheckSpelling={true}
             text={feedback || ''}
           />
 

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -180,11 +180,8 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
-              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -184,6 +184,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
               EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
+              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React from 'react';
 import _ from 'underscore';
 import { TextEditor, isValidRegex } from '../../../Shared/index';

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -165,6 +165,7 @@ export default class extends React.Component {
               EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
+              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -161,11 +161,8 @@ export default class extends React.Component {
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
-              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React from 'react';
 import _ from 'underscore';
 import { requestPost, } from '../../../../modules/request/index';

--- a/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { TextEditor, } from '../../../Shared/index';

--- a/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
@@ -101,10 +101,7 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
           <br />
           <label className="label">Content</label>
           <TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={this.handleContentChange}
-            shouldCheckSpelling={true}
             text={content || ""}
           />
           <br />

--- a/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/titleCards/titleCardForm.tsx
@@ -104,6 +104,7 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
             ContentState={ContentState}
             EditorState={EditorState}
             handleTextChange={this.handleContentChange}
+            shouldCheckSpelling={true}
             text={content || ""}
           />
           <br />

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/feedbackForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/feedbackForm.jsx
@@ -62,6 +62,7 @@ export default class FeedbackForm extends React.Component {
               EditorState={EditorState}
               handleTextChange={(e) => this.handleChange(part, e)}
               key={part}
+              shouldCheckSpelling={true}
               text={this.state[part]}
             />
           </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/feedbackForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/feedbackForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js'
 import * as React from 'react'
 import {
   ConceptExplanation,

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/feedbackForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/feedbackForm.jsx
@@ -58,11 +58,8 @@ export default class FeedbackForm extends React.Component {
           <React.Fragment>
             <label className="label">{part}</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={(e) => this.handleChange(part, e)}
               key={part}
-              shouldCheckSpelling={true}
               text={this.state[part]}
             />
           </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankForm.jsx
@@ -121,10 +121,7 @@ class FillInBlankForm extends Component {
         <h6 className="control subtitle">Create a new question</h6>
         <label className="label">Prompt</label>
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={this.handlePromptChange}
-          shouldCheckSpelling={true}
           text={prompt}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankForm.jsx
@@ -124,6 +124,7 @@ class FillInBlankForm extends Component {
           ContentState={ContentState}
           EditorState={EditorState}
           handleTextChange={this.handlePromptChange}
+          shouldCheckSpelling={true}
           text={prompt}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React, { Component } from 'react';
 import {
   FlagDropdown,

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
@@ -194,11 +194,8 @@ export class FocusPointsContainer extends Component {
           <div className="card-content">
             <label className="label" htmlFor="feedback" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, fp.key)}
               key="feedback"
-              shouldCheckSpelling={true}
               text={fp.feedback}
             />
             {this.renderConceptResults(conceptResults, key)}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
@@ -198,6 +198,7 @@ export class FocusPointsContainer extends Component {
               EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, fp.key)}
               key="feedback"
+              shouldCheckSpelling={true}
               text={fp.feedback}
             />
             {this.renderConceptResults(conceptResults, key)}

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/focusPoints/focusPointsContainer.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import _ from 'underscore';

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -261,6 +261,7 @@ class IncorrectSequencesContainer extends Component {
               EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, seq.key)}
               key="feedback"
+              shouldCheckSpelling={true}
               text={seq.feedback}
             />
             <br />

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -257,11 +257,8 @@ class IncorrectSequencesContainer extends Component {
           <div className="card-content">
             <label className="label" htmlFor="feedback" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, seq.key)}
               key="feedback"
-              shouldCheckSpelling={true}
               text={seq.feedback}
             />
             <br />

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/incorrectSequence/incorrectSequenceContainer.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import _ from 'underscore';

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/__tests__/__snapshots__/lessonForm.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/__tests__/__snapshots__/lessonForm.test.jsx.snap
@@ -27,11 +27,8 @@ exports[`LessonForm component renderSearchBox renders a SelectSearch component w
       Landing Page Content
     </label>
     <TextEditor
-      ContentState={[Function]}
-      EditorState={[Function]}
       handleTextChange={[Function]}
       id="landing-page-content"
-      shouldCheckSpelling={true}
       text="<p>Test content</p>"
     />
   </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/__tests__/__snapshots__/lessonForm.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/__tests__/__snapshots__/lessonForm.test.jsx.snap
@@ -31,6 +31,7 @@ exports[`LessonForm component renderSearchBox renders a SelectSearch component w
       EditorState={[Function]}
       handleTextChange={[Function]}
       id="landing-page-content"
+      shouldCheckSpelling={true}
       text="<p>Test content</p>"
     />
   </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/__tests__/lessonForm.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/__tests__/lessonForm.test.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import { shallow } from 'enzyme';
 import React from 'react';
 import {
@@ -116,8 +115,6 @@ describe('LessonForm component', () => {
     expect(chooseModel.length).toEqual(1);
     expect(nameInput.props().name).toEqual('Awesome Diagnostic');
     expect(nameInput.props().onChange).toEqual(handleStateChange);
-    expect(textEditor.props().ContentState).toEqual(ContentState);
-    expect(textEditor.props().EditorState).toEqual(EditorState);
     expect(textEditor.props().handleTextChange).toEqual(onLandingPageChange);
     expect(textEditor.props().text).toEqual('<p>Test content</p>');
     expect(chooseModel.props().conceptsFeedback).toEqual(mockProps.conceptsFeedback);

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessonForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import SelectSearch from 'react-select-search';

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessonForm.tsx
@@ -217,6 +217,7 @@ export class LessonForm extends React.Component<LessonFormProps, LessonFormState
             EditorState={EditorState}
             handleTextChange={this.onLandingPageChange}
             id="landing-page-content"
+            shouldCheckSpelling={true}
             text={landingPageHtml || ''}
           />
         </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessonForm.tsx
@@ -213,11 +213,8 @@ export class LessonForm extends React.Component<LessonFormProps, LessonFormState
         <div className="control">
           <label className="label" htmlFor="landing-page-content">Landing Page Content</label>
           <TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={this.onLandingPageChange}
             id="landing-page-content"
-            shouldCheckSpelling={true}
             text={landingPageHtml || ''}
           />
         </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/massEditContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/massEditContainer.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React from 'react';
 import { connect } from 'react-redux';
 import _ from 'underscore';

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/massEditContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/massEditContainer.jsx
@@ -189,6 +189,7 @@ class MassEditContainer extends React.Component {
                 ContentState={ContentState}
                 EditorState={EditorState}
                 handleTextChange={this.handleMassEditFeedbackTextChange}
+                shouldCheckSpelling={true}
                 text={massEditFeedback || ''}
               />
             </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/massEditContainer.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/massEditContainer.jsx
@@ -186,10 +186,7 @@ class MassEditContainer extends React.Component {
               <h3>FEEDBACK</h3>
               <TextEditor
                 boilerplate={selectedMassEditBoilerplate}
-                ContentState={ContentState}
-                EditorState={EditorState}
                 handleTextChange={this.handleMassEditFeedbackTextChange}
-                shouldCheckSpelling={true}
                 text={massEditFeedback || ''}
               />
             </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/questionForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js'
 import React from 'react'
 import {
   FlagDropdown,

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/questionForm.jsx
@@ -102,10 +102,7 @@ export default class extends React.Component {
           <h6 className="control subtitle">Create a new question</h6>
           <label className="label">Prompt</label>
           <TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={this.handlePromptChange}
-            shouldCheckSpelling={true}
             text={this.props.question.prompt || ""}
           />
           <label className="label">Instructions for student</label>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/questionForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/questionForm.jsx
@@ -105,6 +105,7 @@ export default class extends React.Component {
             ContentState={ContentState}
             EditorState={EditorState}
             handleTextChange={this.handlePromptChange}
+            shouldCheckSpelling={true}
             text={this.props.question.prompt || ""}
           />
           <label className="label">Instructions for student</label>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
@@ -269,6 +269,7 @@ const Response = ({allExpanded, ascending, concepts, dispatch, expand, expanded,
             ContentState={ContentState}
             EditorState={EditorState}
             handleTextChange={handleFeedbackChange}
+            shouldCheckSpelling={true}
             text={feedback || ''}
           />
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
@@ -266,10 +266,7 @@ const Response = ({allExpanded, ascending, concepts, dispatch, expand, expanded,
           <label className="label">Feedback</label>
           <TextEditor
             boilerplate={selectedBoilerplate}
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={handleFeedbackChange}
-            shouldCheckSpelling={true}
             text={feedback || ''}
           />
 

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/questions/response.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as jsDiff from 'diff'
 
-import { ContentState, EditorState } from 'draft-js'
 import _ from 'underscore'
 
 import {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -185,6 +185,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
               EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
+              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -181,11 +181,8 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
-              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/focusPointsInputAndConceptSelectorForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React from 'react';
 import _ from 'underscore';
 import { TextEditor, isValidRegex } from '../../../Shared/index';

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -162,11 +162,8 @@ export default class extends React.Component {
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
-              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -166,6 +166,7 @@ export default class extends React.Component {
               EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
+              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/shared/incorrectSequencesInputAndConceptSelectorForm.jsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import React from 'react';
 import _ from 'underscore';
 import { TextEditor, isValidRegex } from '../../../Shared/index';

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Modal, TextEditor } from '../../../Shared/index';

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
@@ -142,10 +142,7 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
         <br />
         <label className="label">Content</label>
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={this.handleContentChange}
-          shouldCheckSpelling={true}
           text={content || ""}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/titleCards/titleCardForm.tsx
@@ -145,6 +145,7 @@ class TitleCardForm extends React.Component<TitleCardFormProps, TitleCardFormSta
           ContentState={ContentState}
           EditorState={EditorState}
           handleTextChange={this.handleContentChange}
+          shouldCheckSpelling={true}
           text={content || ""}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
@@ -133,10 +133,7 @@ class Concept extends React.Component<ConceptProps, ConceptState> {
             <h6 className="control subtitle">Create a new question</h6>
             <label className="label">Prompt</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={this.handlePromptChange}
-              shouldCheckSpelling={true}
             />
             <label className="label">Instructions for student</label>
             <p className="control">
@@ -146,10 +143,7 @@ class Concept extends React.Component<ConceptProps, ConceptState> {
             <label className="label">Rule description (optional, will overwrite the concept's description for this question if set)</label>
             <p className="control">
               <TextEditor
-                ContentState={ContentState}
-                EditorState={EditorState}
                 handleTextChange={this.handleRuleDescriptionChange}
-                shouldCheckSpelling={true}
               />
             </p>
             <label className="label">Optimal answer (you can add more later)</label>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';

--- a/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/concepts/concept.tsx
@@ -136,6 +136,7 @@ class Concept extends React.Component<ConceptProps, ConceptState> {
               ContentState={ContentState}
               EditorState={EditorState}
               handleTextChange={this.handlePromptChange}
+              shouldCheckSpelling={true}
             />
             <label className="label">Instructions for student</label>
             <p className="control">
@@ -148,6 +149,7 @@ class Concept extends React.Component<ConceptProps, ConceptState> {
                 ContentState={ContentState}
                 EditorState={EditorState}
                 handleTextChange={this.handleRuleDescriptionChange}
+                shouldCheckSpelling={true}
               />
             </p>
             <label className="label">Optimal answer (you can add more later)</label>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/feedbackForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/feedbackForm.tsx
@@ -76,6 +76,7 @@ export default class FeedbackForm extends React.Component<FeedbackFormProps, Fee
             EditorState={EditorState}
             handleTextChange={this.handleChange.bind(null, part)}
             key={part}
+            shouldCheckSpelling={true}
             text={this.state[part]}
           />)
         ]

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/feedbackForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/feedbackForm.tsx
@@ -72,11 +72,8 @@ export default class FeedbackForm extends React.Component<FeedbackFormProps, Fee
         return [
           (<label className="label">{part}</label>),
           (<TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={this.handleChange.bind(null, part)}
             key={part}
-            shouldCheckSpelling={true}
             text={this.state[part]}
           />)
         ]

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/feedbackForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/feedbackForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 
 import { ConceptExplanation, TextEditor, } from '../../../Shared/index';

--- a/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import _ from 'lodash';
 import * as React from 'react';
 import { connect } from 'react-redux';

--- a/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
@@ -214,6 +214,7 @@ class LessonForm extends React.Component<LessonFormProps, LessonFormState> {
           ContentState={ContentState}
           EditorState={EditorState}
           handleTextChange={this.handleDescriptionChange}
+          shouldCheckSpelling={true}
           text={description || ''}
         />
         <br />
@@ -224,6 +225,7 @@ class LessonForm extends React.Component<LessonFormProps, LessonFormState> {
           ContentState={ContentState}
           EditorState={EditorState}
           handleTextChange={this.handleLandingPageHTMLChange}
+          shouldCheckSpelling={true}
           text={landingPageHtml || ''}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/lessons/lessonForm.tsx
@@ -211,10 +211,7 @@ class LessonForm extends React.Component<LessonFormProps, LessonFormState> {
           <label className="label">Description</label>
         </p>
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={this.handleDescriptionChange}
-          shouldCheckSpelling={true}
           text={description || ''}
         />
         <br />
@@ -222,10 +219,7 @@ class LessonForm extends React.Component<LessonFormProps, LessonFormState> {
           <label className="label">Landing Page HTML</label>
         </p>
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={this.handleLandingPageHTMLChange}
-          shouldCheckSpelling={true}
           text={landingPageHtml || ''}
         />
         <br />

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import * as _ from 'underscore';

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
@@ -159,6 +159,7 @@ export class FocusPointsContainer extends React.Component {
               EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, fp.key)}
               key="feedback"
+              shouldCheckSpelling={true}
               text={fp.feedback}
             />
             {this.renderConceptResults(fp.conceptResults, fp.key)}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/focusPointsContainer.tsx
@@ -155,11 +155,8 @@ export class FocusPointsContainer extends React.Component {
           <div className="card-content">
             <label className="label" htmlFor="feedback" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, fp.key)}
               key="feedback"
-              shouldCheckSpelling={true}
               text={fp.feedback}
             />
             {this.renderConceptResults(fp.conceptResults, fp.key)}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -238,6 +238,7 @@ class IncorrectSequencesContainer extends React.Component {
               EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, seq.key)}
               key="feedback"
+              shouldCheckSpelling={true}
               text={seq.feedback}
             />
             <br />

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -234,11 +234,8 @@ class IncorrectSequencesContainer extends React.Component {
           <div className="card-content">
             <label className="label" htmlFor="feedback" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={(e) => this.handleFeedbackChange(e, seq.key)}
               key="feedback"
-              shouldCheckSpelling={true}
               text={seq.feedback}
             />
             <br />

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/incorrectSequenceContainer.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import _ from 'underscore';

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/massEditContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/massEditContainer.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import { Response } from '../../../Shared/quill-marking-logic/src/main';
 import * as React from 'react';
 import { connect } from 'react-redux';

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/massEditContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/massEditContainer.tsx
@@ -199,10 +199,7 @@ class MassEditContainer extends React.Component<MassEditProps, MassEditState> {
               <h3>FEEDBACK</h3>
               <TextEditor
                 boilerplate={this.state.selectedMassEditBoilerplate || ''}
-                ContentState={ContentState}
-                EditorState={EditorState}
                 handleTextChange={this.handleMassEditFeedbackTextChange}
-                shouldCheckSpelling={true}
                 text={this.state.massEditFeedback || ''}
               />
             </div>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/massEditContainer.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/massEditContainer.tsx
@@ -202,6 +202,7 @@ class MassEditContainer extends React.Component<MassEditProps, MassEditState> {
                 ContentState={ContentState}
                 EditorState={EditorState}
                 handleTextChange={this.handleMassEditFeedbackTextChange}
+                shouldCheckSpelling={true}
                 text={this.state.massEditFeedback || ''}
               />
             </div>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionForm.tsx
@@ -84,6 +84,7 @@ export default class QuestionForm extends React.Component {
             ContentState={ContentState}
             EditorState={EditorState}
             handleTextChange={this.handlePromptChange}
+            shouldCheckSpelling={true}
             text={prompt || ""}
           />
           <label className="label">Instructions for student</label>
@@ -112,6 +113,7 @@ export default class QuestionForm extends React.Component {
               ContentState={ContentState}
               EditorState={EditorState}
               handleTextChange={this.handleRuleDescriptionChange}
+              shouldCheckSpelling={true}
               text={rule_description}
             />
           </p>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionForm.tsx
@@ -81,10 +81,7 @@ export default class QuestionForm extends React.Component {
           <h6 className="control subtitle">Create a new question</h6>
           <label className="label">Prompt</label>
           <TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={this.handlePromptChange}
-            shouldCheckSpelling={true}
             text={prompt || ""}
           />
           <label className="label">Instructions for student</label>
@@ -110,10 +107,7 @@ export default class QuestionForm extends React.Component {
           <label className="label">Rule description (optional, will overwrite the concept's description for this question if set)</label>
           <p className="control">
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={this.handleRuleDescriptionChange}
-              shouldCheckSpelling={true}
               text={rule_description}
             />
           </p>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/questionForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js'
 import * as React from 'react'
 
 import { FlagDropdown, TextEditor, } from '../../../Shared/index'

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
@@ -1,5 +1,4 @@
 import * as jsDiff from 'diff';
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import * as _ from 'underscore';
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
@@ -321,10 +321,7 @@ export default class extends React.Component<ResponseProps, ResponseState> {
           <label className="label">Feedback</label>
           <TextEditor
             boilerplate={selectedBoilerplate}
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={this.handleFeedbackChange}
-            shouldCheckSpelling={true}
             text={feedback || ''}
           />
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
@@ -324,6 +324,7 @@ export default class extends React.Component<ResponseProps, ResponseState> {
             ContentState={ContentState}
             EditorState={EditorState}
             handleTextChange={this.handleFeedbackChange}
+            shouldCheckSpelling={true}
             text={feedback || ''}
           />
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import * as _ from 'underscore';
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
@@ -180,11 +180,8 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
-              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/focusPointsInputAndConceptSelectorForm.tsx
@@ -184,6 +184,7 @@ export default class FocusPointsInputAndConceptResultSelectorForm extends React.
               EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
+              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
@@ -164,6 +164,7 @@ export default class IncorrectSequencesInputAndConceptSelectorForm extends React
               EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
+              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
@@ -160,11 +160,8 @@ export default class IncorrectSequencesInputAndConceptSelectorForm extends React
             {this.renderTextInputFields()}
             <label className="label" style={{ marginTop: 10, }}>Feedback</label>
             <TextEditor
-              ContentState={ContentState}
-              EditorState={EditorState}
               handleTextChange={this.handleFeedbackChange}
               key="feedback"
-              shouldCheckSpelling={true}
               text={this.state.itemFeedback || ""}
             />
             <label className="label" style={{ marginTop: 10, }}>Concepts</label>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/shared/incorrectSequencesInputAndConceptSelectorForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import * as _ from 'underscore';
 import { isValidRegex } from '../../../Shared/index';

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/lessons/lessonForm.tsx
@@ -121,8 +121,6 @@ export class LessonForm extends React.Component<LessonFormProps, LessonFormState
         </p>
         <TextEditor
           aria-labelledby="description-label"
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={this.onHandleDescriptionChange}
           id="description"
           text={description || ''}

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/lessons/lessonForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/lessons/lessonForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import { connect } from 'react-redux';
 

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -2,6 +2,7 @@ import Editor from '@draft-js-plugins/editor';
 import { convertFromHTML, convertToHTML } from 'draft-convert';
 import * as Draft from 'draft-js';
 import {
+  ContentState,
   EditorState,
   RichUtils,
 } from 'draft-js';
@@ -43,14 +44,14 @@ class TextEditor extends React.Component <any, any> {
     const addLinkPlugin = addLinkPluginPlugin
 
     this.state = {
-      text: props.EditorState.createWithContent(this.contentState(props.text || '')),
+      text: EditorState.createWithContent(this.contentState(props.text || '')),
       richButtonsPlugin: richButtonsPlugin(),
       addLinkPlugin: addLinkPlugin,
     }
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: any) {
-    const { boilerplate, EditorState, handleTextChange, ContentState, } = this.props
+    const { boilerplate, handleTextChange } = this.props
     if (nextProps.boilerplate !== boilerplate) {
       this.setState({text: EditorState.createWithContent(ContentState.createFromBlockArray(this.contentState(nextProps.boilerplate)))},
         () => {
@@ -192,7 +193,7 @@ class TextEditor extends React.Component <any, any> {
               keyBindingFn={this.keyBindingFn}
               onChange={this.handleTextChange}
               plugins={[richButtonsPlugin, addLinkPlugin]}
-              spellCheck={!!shouldCheckSpelling}
+              spellCheck={true}
             />
           </div>
         </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/ExplanationField.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ExplanationField.tsx
@@ -43,8 +43,6 @@ export default class ExplanationField extends React.Component<any, any> {
           </div>
           <p className="concept-attribute-field-editor-subheader">Displays in Proofreader</p>
           <TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={handleChange}
             key="concept-explanation"
             text={explanation}

--- a/services/QuillLMS/client/app/bundles/Staff/components/ExplanationField.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ExplanationField.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 import { TextEditor } from '../../Shared/index';
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/RuleDescriptionField.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/RuleDescriptionField.tsx
@@ -44,8 +44,6 @@ export default class RuleDescriptionField extends React.Component<any, any> {
             {isNew ? '' : <button className="interactive-wrapper focus-on-light remove-concept-attribute-field" onClick={this.cancel} type="button"><i className="fas fa-archive" /><span>Remove</span></button>}
           </div>
           <TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             handleTextChange={handleChange}
             key="rule-description"
             text={ruleDescription}

--- a/services/QuillLMS/client/app/bundles/Staff/components/RuleDescriptionField.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/RuleDescriptionField.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 import { TextEditor } from '../../Shared/index';
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityForm.test.tsx.snap
@@ -137,10 +137,7 @@ exports[`Activity Form component should render Activities 1`] = `
                     className=""
                   >
                     <TextEditor
-                      ContentState={[Function]}
-                      EditorState={[Function]}
                       handleTextChange={[Function]}
-                      shouldCheckSpelling={true}
                       text="..."
                     />
                   </div>
@@ -327,10 +324,7 @@ exports[`Activity Form component should render Activities 1`] = `
                     Building Essential Knowledge Text
                   </p>
                   <TextEditor
-                    ContentState={[Function]}
-                    EditorState={[Function]}
                     handleTextChange={[Function]}
-                    shouldCheckSpelling={true}
                   />
                 </React.Fragment>,
               ]

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/imageSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/imageSection.test.tsx.snap
@@ -64,11 +64,8 @@ exports[`ImageSection component should render ImageSection 1`] = `
       Image Attribution Guide
     </a>
     <TextEditor
-      ContentState={[Function]}
-      EditorState={[Function]}
       handleTextChange={[MockFunction]}
       key="image-attribution"
-      shouldCheckSpelling={true}
     />
   </div>
 </Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/maxAttemptsEditor.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/maxAttemptsEditor.test.tsx.snap
@@ -8,11 +8,8 @@ exports[`MaxAttemptsEditor component should render MaxAttemptsEditor 1`] = `
      - Max Attempts Feedback - Student Did Not Reach Optimal AutoML Label
   </p>
   <TextEditor
-    ContentState={[Function]}
-    EditorState={[Function]}
     handleTextChange={[Function]}
     key="but-max-attempt-feedback"
-    shouldCheckSpelling={true}
     text="feedback"
   />
 </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleGenericAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleGenericAttributes.test.tsx.snap
@@ -103,11 +103,8 @@ exports[`RuleGenericAttributes component should render RuleGenericAttributes 1`]
     Rule Note
   </p>
   <TextEditor
-    ContentState={[Function]}
-    EditorState={[Function]}
     handleTextChange={[Function]}
     key="rule-note"
-    shouldCheckSpelling={true}
     text="test description"
   />
 </Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
@@ -38,11 +38,8 @@ exports[`RulePlagiarismAttributes component should render RulePlagiarismAttribut
     First Feedback
   </p>
   <TextEditor
-    ContentState={[Function]}
-    EditorState={[Function]}
     handleTextChange={[Function]}
     key="first-plagiarism-feedback"
-    shouldCheckSpelling={true}
     text="do not plagiarize."
   />
   <div
@@ -63,11 +60,8 @@ exports[`RulePlagiarismAttributes component should render RulePlagiarismAttribut
     Second Feedback
   </p>
   <TextEditor
-    ContentState={[Function]}
-    EditorState={[Function]}
     handleTextChange={[Function]}
     key="second-plagiarism-feedback"
-    shouldCheckSpelling={true}
     text="seriously... do not plagiarize!"
   />
   <div

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleRegexAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleRegexAttributes.test.tsx.snap
@@ -8,11 +8,8 @@ exports[`RuleRegexAttributes component should render RuleRegexAttributes 1`] = `
     Feedback
   </p>
   <TextEditor
-    ContentState={[Function]}
-    EditorState={[Function]}
     handleTextChange={[Function]}
     key="regex-feedback"
-    shouldCheckSpelling={true}
     text="test regex feedback"
   />
   <div

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleUniversalAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleUniversalAttributes.test.tsx.snap
@@ -8,11 +8,8 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
     First Layer Feedback
   </p>
   <TextEditor
-    ContentState={[Function]}
-    EditorState={[Function]}
     handleTextChange={[Function]}
     key="universal-feedback"
-    shouldCheckSpelling={true}
     text="test universal feedback"
   />
   <section
@@ -53,11 +50,8 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
       }
     />
     <TextEditor
-      ContentState={[Function]}
-      EditorState={[Function]}
       handleTextChange={[Function]}
       key="universal-feedback-highlight"
-      shouldCheckSpelling={true}
       text="prompt highlight"
     />
   </section>
@@ -99,11 +93,8 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
       }
     />
     <TextEditor
-      ContentState={[Function]}
-      EditorState={[Function]}
       handleTextChange={[Function]}
       key="universal-feedback-highlight"
-      shouldCheckSpelling={true}
       text="passage highlight"
     />
   </section>
@@ -134,11 +125,8 @@ exports[`RuleUniversalAttributes component should render RuleUniversalAttributes
     Second Layer Feedback
   </p>
   <TextEditor
-    ContentState={[Function]}
-    EditorState={[Function]}
     handleTextChange={[Function]}
     key="universal-feedback"
-    shouldCheckSpelling={true}
     text="test universal feedback"
   />
   <div

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleGenericAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleGenericAttributes.tsx
@@ -113,11 +113,8 @@ const RuleGenericAttributes = ({
       {ruleUID && renderIDorUID(ruleUID, 'Rule UID')}
       <p className="form-subsection-label">{noteLabel}</p>
       <TextEditor
-        ContentState={ContentState}
-        EditorState={EditorState}
         handleTextChange={onHandleSetRuleNote}
         key="rule-note"
-        shouldCheckSpelling={true}
         text={ruleNote}
       />
     </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleGenericAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleGenericAttributes.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 
 import { ruleOptimalOptions, ruleTypeOptions, universalRuleTypeOptions } from '../../../../../constants/evidence';

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleHint.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleHint.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 import Dropzone from 'react-dropzone';
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleHint.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleHint.tsx
@@ -48,11 +48,8 @@ const RuleHint = ({
       <input className="name-input" onChange={onHintNameChange} type="text" value={hint.name || ''} />
       <p className="form-subsection-label">Hint Explanation</p>
       <TextEditor
-        ContentState={ContentState}
-        EditorState={EditorState}
         handleTextChange={onHintExplanationChange}
         key={`hint-explanation-${hint.id}`}
-        shouldCheckSpelling={true}
         text={hint.explanation}
       />
       <p className="form-subsection-label">Hint Annotated Example</p>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 
 import { FEEDBACK, HIGHLIGHT_ADDITION, HIGHLIGHT_REMOVAL, } from '../../../../../constants/evidence';

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -117,12 +117,9 @@ const RulePlagiarismAttributes = ({
       {errors['Plagiarism Text'] && <p className="error-message">{errors['Plagiarism Text']}</p>}
       <p className="form-subsection-label">First Feedback</p>
       {plagiarismFeedbacks[0] && <TextEditor
-        ContentState={ContentState}
-        EditorState={EditorState}
         // eslint-disable-next-line
           handleTextChange={(text) => onHandleSetPlagiarismFeedback(text, 0, null, FEEDBACK)}
         key="first-plagiarism-feedback"
-        shouldCheckSpelling={true}
         text={plagiarismFeedbacks[0].text}
       />}
       {plagiarismFeedbacks[0] && plagiarismFeedbacks[0].highlights_attributes && renderHighlights(plagiarismFeedbacks[0].highlights_attributes, 0, onHandleSetPlagiarismFeedback)}
@@ -133,12 +130,9 @@ const RulePlagiarismAttributes = ({
       {errors['First Plagiarism Feedback'] && <p className="error-message">{errors['First Plagiarism Feedback']}</p>}
       <p className="form-subsection-label">Second Feedback</p>
       {plagiarismFeedbacks[1] && <TextEditor
-        ContentState={ContentState}
-        EditorState={EditorState}
         // eslint-disable-next-line
           handleTextChange={(text) => onHandleSetPlagiarismFeedback(text, 1, null, FEEDBACK)}
         key="second-plagiarism-feedback"
-        shouldCheckSpelling={true}
         text={plagiarismFeedbacks[1].text}
       />}
       {plagiarismFeedbacks[1] && plagiarismFeedbacks[1].highlights_attributes && renderHighlights(plagiarismFeedbacks[1].highlights_attributes, 1, onHandleSetPlagiarismFeedback)}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -21,11 +21,8 @@ export const PlagiarismTextEditor = ({ text, index, setPlagiarismText, }) => {
     <React.Fragment key={index}>
       <p className="form-subsection-label">Plagiarism Text - Text String {index + 1}</p>
       <TextEditor
-        ContentState={ContentState}
-        EditorState={EditorState}
         handleTextChange={onHandleSetPlagiarismText}
         key={`plagiarism-text-${index}`}
-        shouldCheckSpelling={true}
         text={text}
       />
     </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleRegexAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleRegexAttributes.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 
 import RegexRules from './regexRules';

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleRegexAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleRegexAttributes.tsx
@@ -102,12 +102,9 @@ const RuleRegexAttributes = ({
     <React.Fragment>
       <p className="form-subsection-label">Feedback</p>
       {regexFeedback[0] && <TextEditor
-        ContentState={ContentState}
-        EditorState={EditorState}
         // eslint-disable-next-line
         handleTextChange={(text) => onHandleSetRegexFeedback(text, 0, null, FEEDBACK)}
         key="regex-feedback"
-        shouldCheckSpelling={true}
         text={regexFeedback[0].text}
       />}
       {regexFeedback[0] && regexFeedback[0].highlights_attributes && renderHighlights(regexFeedback[0].highlights_attributes, 0, onHandleSetRegexFeedback)}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleUniversalAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleUniversalAttributes.tsx
@@ -88,12 +88,9 @@ const RuleAttributesSection = ({
         <React.Fragment key={i}>
           <p className="form-subsection-label">{`${numericalWordOptions[i]} Layer Feedback`}</p>
           <TextEditor
-            ContentState={ContentState}
-            EditorState={EditorState}
             // eslint-disable-next-line
             handleTextChange={(text) => onHandleSetUniversalFeedback(text, i, null, FEEDBACK)}
             key="universal-feedback"
-            shouldCheckSpelling={true}
             text={universalFeedback[i].text}
           />
           {errors['Universal Feedback'] && errors['Universal Feedback'].length && <p className="error-message">{errors['Universal Feedback'][i]}</p>}

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleUniversalAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/ruleUniversalAttributes.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 
 import { FEEDBACK, FEEDBACK_LAYER_ADDITION, FEEDBACK_LAYER_REMOVAL, HIGHLIGHT_ADDITION, HIGHLIGHT_REMOVAL, numericalWordOptions } from '../../../../../constants/evidence';

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 
 import ImageSection from "./imageSection";

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -129,11 +129,8 @@ const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormP
       </p>
       <div className={showHighlights ? '' : 'hide-highlights'}>
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={handleSetPassageText}
           key="passage-description"
-          shouldCheckSpelling={true}
           text={activityPassages[0].text}
         />
       </div>
@@ -145,11 +142,8 @@ const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormP
     <React.Fragment>
       <p className={`text-editor-label ${essentialKnowledgeStyle}`}>Building Essential Knowledge Text</p>
       <TextEditor
-        ContentState={ContentState}
-        EditorState={EditorState}
         handleTextChange={handleSetPassageEssentialKnowledgeText}
         key="essential-knowledge-text"
-        shouldCheckSpelling={true}
         text={activityPassages[0].essential_knowledge_text}
       />
     </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ContentState, EditorState } from 'draft-js';
 import Dropzone from 'react-dropzone';
 
 import { IMAGE_ALT_TEXT, IMAGE_ATTRIBUTION, IMAGE_CAPTION, IMAGE_LINK } from '../../../../../constants/evidence';

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/imageSection.tsx
@@ -69,11 +69,8 @@ export const ImageSection = ({
         <p className={`text-editor-label ${imageAttributionStyle}`} id="image-attribution-label"> Image Attribution</p>
         <a className="data-link image-attribution-guide-link" href={imageAttributionGuideLink} rel="noopener noreferrer" target="_blank">Image Attribution Guide</a>
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={handleSetImageAttribution}
           key="image-attribution"
-          shouldCheckSpelling={true}
           text={activityPassages[0].image_attribution}
         />
       </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/maxAttemptsEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/maxAttemptsEditor.tsx
@@ -22,11 +22,8 @@ export const MaxAttemptsEditor = ({ conjunction, prompt, handleSetPrompt }: MaxA
     <div>
       <p className={`text-editor-label ${maxAttemptStyle}`}>{_.capitalize(conjunction)} - Max Attempts Feedback - Student Did Not Reach Optimal AutoML Label</p>
       <TextEditor
-        ContentState={ContentState}
-        EditorState={EditorState}
         handleTextChange={handleSetActivityMaxFeedback}
         key="but-max-attempt-feedback"
-        shouldCheckSpelling={true}
         text={prompt.max_attempts_feedback || ''}
       />
     </div>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/maxAttemptsEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/maxAttemptsEditor.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as _ from 'lodash';
 import * as React from 'react';
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/model.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/model.tsx
@@ -127,12 +127,9 @@ const Model = ({ match }) => {
         />
         <p className={`text-editor-label ${modelNotesStyle}`}>Model Notes</p>
         <TextEditor
-          ContentState={ContentState}
           disabled={true}
-          EditorState={EditorState}
           handleTextChange={handleSetModelNotes}
           key="model-notes"
-          shouldCheckSpelling={true}
           text={initialNoteValue}
         />
         <DataTable

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/model.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/semanticRules/model.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 import { useQuery, useQueryClient, } from 'react-query';
 import { Link, useHistory, withRouter } from 'react-router-dom';

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from "react";
 import { stripHtml } from "string-strip-html";
 

--- a/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/helpers/evidence/ruleHelpers.tsx
@@ -208,12 +208,9 @@ export function renderHighlights(highlights, i, changeHandler) {
           value={highlightTypeValue}
         />
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           // eslint-disable-next-line
           handleTextChange={(text) => changeHandler(text, i, j, 'highlight text')}
           key="universal-feedback-highlight"
-          shouldCheckSpelling={true}
           text={highlight.text}
         />
         {passageMismatch && <p className="all-errors-message">The text of this highlight does not match with the associated activity text. This means that it will not highlight the text as intended. Please update the text above.</p>}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unitTemplate/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unitTemplate/index.tsx
@@ -238,12 +238,9 @@ export const UnitTemplate = ({ unitTemplate }) => {
       <section className="activity-pack-description-container padded-element">
         <label htmlFor="activity-pack-description">Activity Pack Description</label>
         <TextEditor
-          ContentState={ContentState}
-          EditorState={EditorState}
           handleTextChange={handlePackDescriptionChange}
           id="activity-pack-description"
           key="activity-pack-description"
-          shouldCheckSpelling={true}
           text={activityPackInfo}
         />
       </section>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unitTemplate/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unitTemplate/index.tsx
@@ -1,4 +1,3 @@
-import { ContentState, EditorState } from 'draft-js';
 import * as React from 'react';
 import Dropzone from 'react-dropzone';
 


### PR DESCRIPTION
## WHAT
Turn on spell check for the TextEditor component everywhere it appears in Connect, Diagnostic or Grammar admin panels (besides text boxes where students are typing their answer).

## WHY
So admin have an additional spell check step before they make edits to any student-facing text.

## HOW
Simply pass the shouldCheckSpelling flag to the React component when initialized.

### Screenshots
![Screenshot 2024-05-06 at 3 52 01 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/8d6b1bdf-31da-4dca-8882-612db1efc513)
![Screenshot 2024-05-06 at 3 51 50 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/959e676d-65ca-416d-ba6c-912238d7c8a7)
![Screenshot 2024-05-06 at 3 51 42 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/d93d3346-971d-4242-b436-f14ee2f283b6)
![Screenshot 2024-05-06 at 3 51 31 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/0a348b37-512f-4c53-aee6-e6ef2637847f)
![Screenshot 2024-05-06 at 3 51 22 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/1722958e-5ed7-4005-95c2-833725ea4df7)
![Screenshot 2024-05-06 at 3 51 10 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/93ca4ee0-ddb2-4fcd-99c2-1bd467e81e21)


### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Add-spell-check-to-the-Grammar-Diagnostic-and-Connect-CMSs-34aa46374067403184367163e906d3b6?pvs=4)

### What have you done to QA this feature?
Deploy to staging, go through the checklist on the Notion card and test all the flows listed, making sure that spell check is activated.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
 