### PR TITLE
fix tooltip copy logic

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
@@ -116,11 +116,6 @@ exports[`ScorebookTooltip component in student view should render if showExactSc
           </p>
         </div>
       </div>
-      <p
-        class="tooltip-message"
-      >
-        This type of activity is not graded.
-      </p>
     </div>
   </div>
 </DocumentFragment>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
@@ -9,7 +9,7 @@ import { getTimeSpent } from '../../../helpers/studentReports';
 import numberSuffixBuilder from '../../modules/numberSuffixBuilder';
 import PercentageDisplayer from '../../modules/percentage_displayer.jsx';
 import { proficiencyCutoffsAsPercentage } from '../../../../../modules/proficiency_cutoffs';
-import { NOT_APPLICABLE, Spinner } from '../../../../Shared'
+import { NOT_APPLICABLE, Spinner, EVIDENCE, } from '../../../../Shared'
 import useWindowSize from '../../../../Shared/hooks/useWindowSize'
 
 const ORDINAL_NUMBERS = ['Zeroth', 'First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth']
@@ -45,6 +45,7 @@ interface ScorebookTooltipData {
   locked?: Boolean;
   scheduled?: Boolean;
   marked_complete?: Boolean;
+  activity_classification_key?: string;
 }
 
 interface ScorebookTooltipProps {
@@ -97,7 +98,7 @@ export const ScorebookTooltip = ({ data, inStudentView, showExactScores, }: Scor
   }, [size]);
 
 
-  const { marked_complete, completed_attempts, locked, scheduled, sessions, started, activity, name } = data
+  const { marked_complete, completed_attempts, locked, scheduled, sessions, started, activity, name, activity_classification_key } = data
 
   function activityOverview() {
     return (
@@ -204,9 +205,16 @@ export const ScorebookTooltip = ({ data, inStudentView, showExactScores, }: Scor
   }
 
   function tooltipMessage() {
+    const isEvidenceActivity = activity_classification_key === EVIDENCE
+
+    if (inStudentView && !showExactScores && !isEvidenceActivity) { return }
+
     let text = 'Clicking on the activity icon loads the report'
-    if (inStudentView) {
-      text = showExactScores ? '*Your dashboard shows the highest score of all your attempts' : 'This type of activity is not graded.'
+
+    if (inStudentView && isEvidenceActivity) {
+      text = 'This type of activity is not graded.'
+    } else if (inStudentView && showExactScores) {
+      text = '*Your dashboard shows the highest score of all your attempts'
     }
 
     return (


### PR DESCRIPTION
## WHAT
Fix bug where all tooltips in student view with the exact scores setting turned off were showing "This activity is not graded."

## WHY
We only want to show this for Evidence activities (Diagnostic and Lessons don't show the tooltip, and other activity types are graded).

## HOW
Adjust the logic.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Just changed it and checked views with the setting both on and off to make sure that Evidence activities always show this message and the other tool types don't.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
