### PR TITLE
Fix vitally unlink worker

### DIFF
--- a/services/QuillLMS/app/workers/sync_vitally_worker.rb
+++ b/services/QuillLMS/app/workers/sync_vitally_worker.rb
@@ -21,7 +21,7 @@ class SyncVitallyWorker
 
   private def queue_unlink_syncs
     unlinks_to_run.each do |change_log|
-      SyncVitallyUnlinksWorker.perform_async(change_log.changed_record_id, change_log.new_value.to_i)
+      SyncVitallyUnlinksWorker.perform_async(change_log.changed_record_id, change_log.previous_value.to_i)
     end
   end
 

--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -10,7 +10,7 @@ RailsAdmin.config do |config|
     redirect_to main_app.root_path unless current_user&.staff?
   end
 
-  UNEDITABLE_MODELS = ['ChangeLog']
+  UNEDITABLE_MODELS = ['ChangeLog'].freeze unless Object.const_defined?('UNEDITABLE_MODELS')
 
   config.actions do
     dashboard do


### PR DESCRIPTION
## WHAT
Fix a bug involving vitally users not being unlinked from old schools

## WHY
A parameter passed to the worker was the wrong value

## HOW
Send the previous school_id rather than the current school_id

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Potential-Bug-in-Vitally-API-Script-that-Unlinks-Users-from-a-Previous-School-Account-21bc0a7b6c0845a3a512ff07370281c6?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
