### PR TITLE
Add data_partition to example feedback

### DIFF
--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-
 RailsAdmin.config do |config|
-  uneditable_models = ['ChangeLog']
-
   config.main_app_name = ["Quill Content Overview"]
 
   config.asset_source = :sprockets
@@ -12,6 +9,8 @@ RailsAdmin.config do |config|
     current_user = User.find_by(id: session[:user_id])
     redirect_to main_app.root_path unless current_user&.staff?
   end
+
+  UNEDITABLE_MODELS = ['ChangeLog']
 
   config.actions do
     dashboard do
@@ -23,8 +22,12 @@ RailsAdmin.config do |config|
     # Turn off bulk delete, seems dangerous
     # bulk_delete
     show
-    edit { except uneditable_models }
-    delete { except uneditable_models }
+    edit do
+      except UNEDITABLE_MODELS
+    end
+    delete do
+      except UNEDITABLE_MODELS
+    end
     show_in_app
 
     ## With an audit adapter, you can add:

--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+
 RailsAdmin.config do |config|
+  uneditable_models = ['ChangeLog']
+
   config.main_app_name = ["Quill Content Overview"]
 
   config.asset_source = :sprockets
@@ -9,8 +12,6 @@ RailsAdmin.config do |config|
     current_user = User.find_by(id: session[:user_id])
     redirect_to main_app.root_path unless current_user&.staff?
   end
-
-  UNEDITABLE_MODELS = ['ChangeLog']
 
   config.actions do
     dashboard do
@@ -22,12 +23,8 @@ RailsAdmin.config do |config|
     # Turn off bulk delete, seems dangerous
     # bulk_delete
     show
-    edit do
-      except UNEDITABLE_MODELS
-    end
-    delete do
-      except UNEDITABLE_MODELS
-    end
+    edit { except uneditable_models }
+    delete { except uneditable_models }
     show_in_app
 
     ## With an audit adapter, you can add:

--- a/services/QuillLMS/db/migrate/20240425125302_add_data_partition_to_example_feedbacks.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240425125302_add_data_partition_to_example_feedbacks.evidence.rb
@@ -7,6 +7,6 @@ class AddDataPartitionToExampleFeedbacks < ActiveRecord::Migration[7.0]
       :data_partition,
       :string,
       null: false,
-      default: Evidence::Research::GenAI::ExampleFeedback::TEST_DATA
+      default: Evidence::Research::GenAI::ExampleFeedback::TESTING_DATA
   end
 end

--- a/services/QuillLMS/db/migrate/20240425125302_add_data_partition_to_example_feedbacks.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240425125302_add_data_partition_to_example_feedbacks.evidence.rb
@@ -3,10 +3,6 @@
 # This migration comes from evidence (originally 20240425125151)
 class AddDataPartitionToExampleFeedbacks < ActiveRecord::Migration[7.0]
   def change
-    add_column :evidence_research_gen_ai_example_feedbacks,
-      :data_partition,
-      :string,
-      null: false,
-      default: Evidence::Research::GenAI::ExampleFeedback::TESTING_DATA
+    add_column :evidence_research_gen_ai_example_feedbacks, :data_partition, :string
   end
 end

--- a/services/QuillLMS/db/migrate/20240425125302_add_data_partition_to_example_feedbacks.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240425125302_add_data_partition_to_example_feedbacks.evidence.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240425125151)
+class AddDataPartitionToExampleFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_example_feedbacks,
+      :data_partition,
+      :string,
+      null: false,
+      default: Evidence::Research::GenAI::ExampleFeedback::TEST_DATA
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2950,7 +2950,7 @@ CREATE TABLE public.evidence_research_gen_ai_example_feedbacks (
     paraphrase text,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    data_partition character varying DEFAULT 'testing'::character varying NOT NULL
+    data_partition character varying
 );
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2950,7 +2950,7 @@ CREATE TABLE public.evidence_research_gen_ai_example_feedbacks (
     paraphrase text,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    data_partition character varying DEFAULT 'test'::character varying NOT NULL
+    data_partition character varying DEFAULT 'testing'::character varying NOT NULL
 );
 
 

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -145,7 +145,7 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
           item timestamp;
         BEGIN
           SELECT created_at INTO as_created_at FROM activity_sessions WHERE id = act_sess;
-
+          
           -- backward compatibility block
           IF as_created_at IS NULL OR as_created_at < timestamp '2013-08-25 00:00:00.000000' THEN
             SELECT SUM(
@@ -160,11 +160,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
                       'epoch' FROM (activity_sessions.completed_at - activity_sessions.started_at)
                     )
                 END) INTO time_spent FROM activity_sessions WHERE id = act_sess AND state='finished';
-
+                
                 RETURN COALESCE(time_spent,0);
           END IF;
-
-
+          
+          
           first_item := NULL;
           last_item := NULL;
           max_item := NULL;
@@ -188,11 +188,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
 
             END IF;
           END LOOP;
-
+          
           IF max_item IS NOT NULL AND first_item IS NOT NULL THEN
             time_spent := time_spent + EXTRACT( EPOCH FROM max_item - first_item );
           END IF;
-
+          
           RETURN time_spent;
         END;
       $$;
@@ -207,7 +207,7 @@ CREATE FUNCTION public.timespent_student(student integer) RETURNS bigint
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (
           SELECT id,timespent_activity_session(id) AS time_spent FROM activity_sessions
-          WHERE activity_sessions.user_id = student
+          WHERE activity_sessions.user_id = student 
           GROUP BY id) as as_ids;
 
       $$;
@@ -2949,7 +2949,8 @@ CREATE TABLE public.evidence_research_gen_ai_example_feedbacks (
     label character varying NOT NULL,
     paraphrase text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    data_partition character varying DEFAULT 'test'::character varying NOT NULL
 );
 
 
@@ -11354,6 +11355,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240401223448'),
 ('20240403160959'),
 ('20240407173007'),
-('20240411135759');
+('20240411135759'),
+('20240425125302');
 
 

--- a/services/QuillLMS/engines/evidence/app/assets/stylesheets/evidence/research/gen_ai/application.css
+++ b/services/QuillLMS/engines/evidence/app/assets/stylesheets/evidence/research/gen_ai/application.css
@@ -36,6 +36,10 @@ tr:nth-child(even) {
   background-color: #f2f2f2; /* Zebra striping for rows */
 }
 
+.feedback-column {
+  width: 20%;
+}
+
 .actions-link {
   padding: 4px 8px;
   background-color: #007bff; /* Blue background */

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
@@ -16,6 +16,8 @@ module Evidence
           if @passage_prompt.save
             redirect_to new_research_gen_ai_experiment_path
           else
+            @passages = Passage.all
+            @conjunctions = PassagePrompt::CONJUNCTIONS
             render :new
           end
         end
@@ -25,7 +27,7 @@ module Evidence
         private def passage_prompt_params
           params
             .require(:research_gen_ai_passage_prompt)
-            .permit(:conjunction, :instructions, :prompt, :passage_id)
+            .permit(:conjunction, :instructions, :prompt, :passage_id, :relevant_passage)
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passage_prompts_controller.rb
@@ -16,8 +16,6 @@ module Evidence
           if @passage_prompt.save
             redirect_to new_research_gen_ai_experiment_path
           else
-            @passages = Passage.all
-            @conjunctions = PassagePrompt::CONJUNCTIONS
             render :new
           end
         end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passages_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passages_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      class PassagesController < ApplicationController
+        def new
+          @passage = Passage.new
+        end
+
+        def create
+          @passage = Passage.new(passage_params)
+
+          if @passage.save
+            redirect_to new_research_gen_ai_experiment_path
+          else
+            render :new
+          end
+        end
+
+        def show = @passage = Prompt.find(params[:id])
+
+        private def passage_params
+          params
+            .require(:research_gen_ai_passage)
+            .permit(:name, :contents)
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passages_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/passages_controller.rb
@@ -18,7 +18,7 @@ module Evidence
           end
         end
 
-        def show = @passage = Prompt.find(params[:id])
+        def show = @passage = Passage.find(params[:id])
 
         private def passage_params
           params

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
+#  data_partition             :string           default("test"), not null
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null
@@ -18,11 +19,18 @@ module Evidence
       class ExampleFeedback < ApplicationRecord
         include HasOptimalAndSubOptimal
 
+        DATA_PARTITIONS = [
+          PROMPT_ENGINEERING_DATA = 'prompt_engineering',
+          FINE_TUNING_DATA = 'fine_tuning',
+          TEST_DATA = 'test'
+        ].freeze
+
         belongs_to :passage_prompt_response, class_name: 'Evidence::Research::GenAI::PassagePromptResponse'
 
         validates :text, presence: true
         validates :label, presence: true
         validates :passage_prompt_response_id, presence: true
+        validates :data_partition, presence: true, inclusion: { in: DATA_PARTITIONS }
 
         attr_readonly :text, :label, :passage_prompt_response_id
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
@@ -5,7 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
-#  data_partition             :string           default("testing"), not null
+#  data_partition             :string
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null
@@ -30,7 +30,7 @@ module Evidence
         validates :text, presence: true
         validates :label, presence: true
         validates :passage_prompt_response_id, presence: true
-        validates :data_partition, presence: true, inclusion: { in: DATA_PARTITIONS }
+        validates :data_partition, inclusion: { in: DATA_PARTITIONS }, allow_nil: true
 
         attr_readonly :text, :label, :passage_prompt_response_id
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
@@ -5,7 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
-#  data_partition             :string           default("test"), not null
+#  data_partition             :string           default("testing"), not null
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null
@@ -22,7 +22,7 @@ module Evidence
         DATA_PARTITIONS = [
           PROMPT_ENGINEERING_DATA = 'prompt_engineering',
           FINE_TUNING_DATA = 'fine_tuning',
-          TEST_DATA = 'testing'
+          TESTING_DATA = 'testing'
         ].freeze
 
         belongs_to :passage_prompt_response, class_name: 'Evidence::Research::GenAI::PassagePromptResponse'

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
@@ -22,7 +22,7 @@ module Evidence
         DATA_PARTITIONS = [
           PROMPT_ENGINEERING_DATA = 'prompt_engineering',
           FINE_TUNING_DATA = 'fine_tuning',
-          TEST_DATA = 'test'
+          TEST_DATA = 'testing'
         ].freeze
 
         belongs_to :passage_prompt_response, class_name: 'Evidence::Research::GenAI::PassagePromptResponse'

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/index.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/index.html.erb
@@ -1,8 +1,8 @@
 <header>
   <h2>Experiments</h2>
 </header>
+
 <%= link_to 'New Experiment', new_research_gen_ai_experiment_path %>
-<meta http-equiv="refresh" content="30">
 
 <% if @experiments.any? %>
   <table>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -1,5 +1,3 @@
-<meta http-equiv="refresh" content="5">
-
 <%= link_to 'Back to Experiments', research_gen_ai_experiments_path %>
 <br>
 

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -16,7 +16,7 @@
   <p><%= @experiment.created_at.strftime("%B %d, %Y %H:%M") %></p>
 
   <h3>Passage</h3>
-  <p><%= @experiment.passage_prompt %></p>
+  <p><%= link_to @experiment.passage_prompt, @experiment.passage_prompt %></p>
 
   <h3>LLM</h3>
   <p><%= @experiment.llm_config %></p>
@@ -50,8 +50,8 @@
           <th>BertScore (Precision)</th>
           <th>BertScore (Recall)</th>
           <th>Prompt Response</th>
-          <th>Example Feedback</th>
-          <th>LLM Feedback</th>
+          <th class='feedback-column'>Example Feedback</th>
+          <th class='feedback-column'>LLM Feedback</th>
         </tr>
       </thead>
       <tbody>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/new.html.erb
@@ -1,4 +1,3 @@
-<% binding.pry %>
 <h1>New Passage Prompt</h1>
 
 <%= form_for @passage_prompt do |f| %>
@@ -6,14 +5,13 @@
 
   <div class="field-spacing">
     <%= f.label :passage_id, "Passage:" %>
-    <%= f.collection_select :passage_id, @passages, :id, :to_s, { required: true } %>
+    <%= f.collection_select :passage_id, @passages, :id, :name, { required: true } %>
+    <%= link_to 'new', new_research_gen_ai_passage_path, class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
   </div>
-
-  <%# <%= link_to 'new', new_research_gen_ai_passage_path, class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %> %>
 
   <div class="field-spacing">
     <%= f.label :conjunction, "Conjunction:" %>
-    <%= select_tag :conjunction, options_for_select(@conjunctions), { required: true } %>
+    <%= f.select :conjunction, options_for_select(@conjunctions), { required: true } %>
   </div>
 
   <div class="field-spacing">

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/new.html.erb
@@ -1,3 +1,4 @@
+<% binding.pry %>
 <h1>New Passage Prompt</h1>
 
 <%= form_for @passage_prompt do |f| %>
@@ -5,8 +6,10 @@
 
   <div class="field-spacing">
     <%= f.label :passage_id, "Passage:" %>
-    <%= f.collection_select :passage, @passages, :id, :to_s, { required: true } %>
+    <%= f.collection_select :passage_id, @passages, :id, :to_s, { required: true } %>
   </div>
+
+  <%# <%= link_to 'new', new_research_gen_ai_passage_path, class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %> %>
 
   <div class="field-spacing">
     <%= f.label :conjunction, "Conjunction:" %>
@@ -20,7 +23,12 @@
 
   <div class="field-spacing">
     <%= f.label :instructions %><br>
-    <%= f.text_area :instructions, cols: 100, rows: 50, required: true %>
+    <%= f.text_area :instructions, cols: 100, rows: 25, required: true %>
+  </div>
+
+  <div class="field-spacing">
+    <%= f.label :relevant_passage  %><br>
+    <%= f.text_area :relevant_passage, cols: 100, rows: 25, required: true %>
   </div>
 
   <div class="actions">

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/show.html.erb
@@ -1,0 +1,24 @@
+<div>
+  <h2>Passage Prompt</h2>
+
+  <h3>Name</h3>
+  <p><%= @passage_prompt.name %></p>
+
+  <h3>Conjunction</h3>
+  <p><%= @passage_prompt.conjunction %></p>
+
+  <h3>Prompt</h3>
+  <p><%= simple_format(@passage_prompt.prompt) %></p>
+
+  <h3>Instructions</h3>
+  <p><%= simple_format(@passage_prompt.instructions) %></p>
+
+  <h3>Relevant Passage</h3>
+  <p><%= simple_format(@passage_prompt.relevant_passage) %></p>
+</div>
+
+<br>
+<%= link_to 'New Experiment', new_research_gen_ai_experiment_path %>
+<br>
+<br>
+<%= link_to 'Experiments', research_gen_ai_experiments_path %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passage_prompts/show.html.erb
@@ -2,7 +2,7 @@
   <h2>Passage Prompt</h2>
 
   <h3>Name</h3>
-  <p><%= @passage_prompt.name %></p>
+  <p><%= link_to @passage_prompt.name, @passage_prompt.passage %></p>
 
   <h3>Conjunction</h3>
   <p><%= @passage_prompt.conjunction %></p>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passages/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passages/new.html.erb
@@ -1,0 +1,19 @@
+<h1>New Passage</h1>
+
+<%= form_for @passage do |f| %>
+  <%= render 'errors', object: @passage %>
+
+  <div class="field-spacing">
+    <%= f.label :name %><br>
+    <%= f.text_field :name, size: 100, required: true %>
+  </div>
+
+  <div class="field-spacing">
+    <%= f.label :contents %><br>
+    <%= f.text_area :contents, cols: 100, rows: 50, required: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Create" %>
+  </div>
+<% end %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passages/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/passages/show.html.erb
@@ -1,0 +1,15 @@
+<div>
+  <h2>Passage</h2>
+
+  <h3>Name</h3>
+  <p><%= @passage.name %></p>
+
+  <h3>Contents</h3>
+  <p><%= simple_format(@passage.contents) %></p>
+</div>
+
+<br>
+<%= link_to 'New Experiment', new_research_gen_ai_experiment_path %>
+<br>
+<br>
+<%= link_to 'Experiments', research_gen_ai_experiments_path %>

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -51,6 +51,7 @@ Evidence::Engine.routes.draw do
       resources :llm_prompts, only: [:show]
       resources :llm_prompt_templates, only: [:new, :create, :show, :index]
       resources :passage_prompts, only: [:new, :create, :show, :index]
+      resources :passages, only: [:new, :create, :show]
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240425125151_add_data_partition_to_example_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240425125151_add_data_partition_to_example_feedbacks.rb
@@ -6,6 +6,6 @@ class AddDataPartitionToExampleFeedbacks < ActiveRecord::Migration[7.0]
       :data_partition,
       :string,
       null: false,
-      default: Evidence::Research::GenAI::ExampleFeedback::TEST_DATA
+      default: Evidence::Research::GenAI::ExampleFeedback::TESTING_DATA
   end
 end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240425125151_add_data_partition_to_example_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240425125151_add_data_partition_to_example_feedbacks.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDataPartitionToExampleFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_example_feedbacks,
+      :data_partition,
+      :string,
+      null: false,
+      default: Evidence::Research::GenAI::ExampleFeedback::TEST_DATA
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240425125151_add_data_partition_to_example_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240425125151_add_data_partition_to_example_feedbacks.rb
@@ -2,10 +2,6 @@
 
 class AddDataPartitionToExampleFeedbacks < ActiveRecord::Migration[7.0]
   def change
-    add_column :evidence_research_gen_ai_example_feedbacks,
-      :data_partition,
-      :string,
-      null: false,
-      default: Evidence::Research::GenAI::ExampleFeedback::TESTING_DATA
+    add_column :evidence_research_gen_ai_example_feedbacks, :data_partition, :string
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -907,7 +907,8 @@ CREATE TABLE public.evidence_research_gen_ai_example_feedbacks (
     label character varying NOT NULL,
     paraphrase text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    data_partition character varying DEFAULT 'test'::character varying NOT NULL
 );
 
 
@@ -2072,6 +2073,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240318144447'),
 ('20240401223116'),
 ('20240407172612'),
-('20240411135531');
+('20240411135531'),
+('20240425125151');
 
 

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -908,7 +908,7 @@ CREATE TABLE public.evidence_research_gen_ai_example_feedbacks (
     paraphrase text,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    data_partition character varying DEFAULT 'testing'::character varying NOT NULL
+    data_partition character varying
 );
 
 

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -908,7 +908,7 @@ CREATE TABLE public.evidence_research_gen_ai_example_feedbacks (
     paraphrase text,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    data_partition character varying DEFAULT 'test'::character varying NOT NULL
+    data_partition character varying DEFAULT 'testing'::character varying NOT NULL
 );
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/example_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/example_feedbacks.rb
@@ -5,7 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
-#  data_partition             :string           default("test"), not null
+#  data_partition             :string
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null
@@ -21,6 +21,10 @@ module Evidence
           passage_prompt_response { association :evidence_research_gen_ai_passage_prompt_response }
           text { 'This is the feedback' }
           label { 'Optimal_1' }
+
+          trait(:testing) { data_partition { Evidence::Research::GenAI::ExampleFeedback::TESTING_DATA } }
+          trait(:fine_tuning) { data_partition { Evidence::Research::GenAI::ExampleFeedback::FINE_TUNING_DATA } }
+          trait(:prompt_engineering) { data_partition { Evidence::Research::GenAI::ExampleFeedback::PROMPT_ENGINEERING_DATA } }
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/example_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/example_feedbacks.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
+#  data_partition             :string           default("test"), not null
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_feedback_spec.rb
@@ -5,7 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
-#  data_partition             :string           default("test"), not null
+#  data_partition             :string
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null
@@ -22,7 +22,6 @@ module Evidence
         it { should validate_presence_of(:text) }
         it { should validate_presence_of(:label) }
         it { should validate_presence_of(:passage_prompt_response_id)}
-        it { should validate_presence_of(:data_partition) }
         it { should validate_inclusion_of(:data_partition).in_array(ExampleFeedback::DATA_PARTITIONS) }
 
         it { should have_readonly_attribute(:text) }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_feedback_spec.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_example_feedbacks
 #
 #  id                         :bigint           not null, primary key
+#  data_partition             :string           default("test"), not null
 #  label                      :string           not null
 #  paraphrase                 :text
 #  text                       :text             not null
@@ -21,6 +22,8 @@ module Evidence
         it { should validate_presence_of(:text) }
         it { should validate_presence_of(:label) }
         it { should validate_presence_of(:passage_prompt_response_id)}
+        it { should validate_presence_of(:data_partition) }
+        it { should validate_inclusion_of(:data_partition).in_array(ExampleFeedback::DATA_PARTITIONS) }
 
         it { should have_readonly_attribute(:text) }
         it { should have_readonly_attribute(:label) }


### PR DESCRIPTION
## WHAT
1.  Add `data_partition` field to `ExampleFeedback`
1.  Add passages controller, views, routes
1.  Move data_importer code to automl_data_importer
1.  Add new data_importer code

## WHY
1.  The experiment runner needs to know what examples are for prompt_engineering, fine_tuning and testing.
1.  It's easier to add new passages in than command line
1.  The old data_importer code was for our automl experiments
1.  The format of new passage data is in CSV and requires different parameters

## HOW
1.  Add migration file and model validations for `data_partition` attribute
1.  Use same pattern as passage_prompt, llm_config, etc.
1.  Rename file.
1.  Since the CSV sheets are per passage and conjunction, update data importer to take in passage_prompt_id parameter.  The rest of the data importing is simplified from the automl datasets. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Separate-Test-Data-from-Example-data-1d373fd2d8e5461a9a2403438d2a9676?pvs=4

### What have you done to QA this feature?
I've tested locally and on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
