### PR TITLE
lms/fix-snapshot-interpolation-bug

### DIFF
--- a/services/QuillLMS/app/queries/snapshots/reporting_session_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/reporting_session_query.rb
@@ -53,7 +53,7 @@ module Snapshots
       <<-SQL
         AND (
           #{reporting_sessions_view.name}.grade IN (#{grades.map { |g| "'#{g}'" }.join(',')})
-          #{'OR #{reporting_sessions_view.name}.grade IS NULL' if grades.include?('null')}
+          #{"OR #{reporting_sessions_view.name}.grade IS NULL" if grades.include?('null')}
         )
       SQL
     end


### PR DESCRIPTION
## WHAT
Use double-quotes to ensure that string interpolation works
## WHY
We don't want to pass the variable name into SQL, we want the value
## HOW
Replace `'` with `"` for strings that are intended to be interpolated

### What have you done to QA this feature?
- Deploy code to staging
- Ensure that Admin Diagnostic reports load
- Modify report filters to explicitly include "No grade set"
- Check Network tab to ensure that "null" is in the "grades" key of the request payload
- Confirm that data loads without error, and that there are no retries in the staging Sidekiq queue

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  This file does not currently have coverage, and this is a small enough fix that it didn't strike me as reasonable to build that infrastructure out for it
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
