### PR TITLE
make sure fill in the blank inputs expand properly with capital letters

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputWidth.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputWidth.tsx
@@ -1,22 +1,32 @@
+const PADDING_WIDTH = 20
+
 export function fillInBlankInputWidth(value: string|null, cues: Array<string>) {
+  const spanForShortestCue = generateSpan(determineShortestCue(cues))
+  const spanForValue = generateSpan(value)
+
+  const shortestCueSpanWidth = spanForShortestCue.offsetWidth;
+  const valueSpanWidth = spanForValue.offsetWidth;
+
+  const elementWidth = Math.max(shortestCueSpanWidth, valueSpanWidth) + PADDING_WIDTH
+
+  document.body.removeChild(spanForShortestCue);
+  document.body.removeChild(spanForValue);
+
+  return { width: `${elementWidth}px` };
+}
+
+export function generateSpan(text) {
   const span = document.createElement('span');
 
   span.style.fontSize = '24px'; // matches the font size for the fill in the blank inputs and must be adjusted if they change
   span.style.visibility = 'hidden';
+  span.textContent = text
+
   document.body.appendChild(span);
 
-  span.textContent = determineBaseString(value, cues)
-
-  const calculatedWidth = span.offsetWidth + 20; // 20 is for padding
-
-  document.body.removeChild(span);
-
-  return { width: `${calculatedWidth}px` };
+  return span
 }
 
-export function determineBaseString(value: string|null, cues: Array<string>): string {
-  // we want the input to start at the width of the shortest cue* and then expand to fit whatever the value is
-  // * unless the shortest cue is just one or two characters, which we handle with a CSS minWidth
-  const shortestCue = cues?.length > 0 ? cues.reduce((a, b) => a.length < b.length ? a : b) : "";
-  return (value && value.length > shortestCue.length) ? value : shortestCue;
+export function determineShortestCue(cues: Array<string>): string {
+  return cues?.length > 0 ? cues.reduce((a, b) => a.length < b.length ? a : b) : ""
 }

--- a/services/QuillLMS/client/app/bundles/Shared/libs/tests/fillInBlankInputWidth.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/tests/fillInBlankInputWidth.test.tsx
@@ -1,25 +1,26 @@
-import { fillInBlankInputWidth, determineBaseString, } from '../fillInBlankInputWidth';
+import { fillInBlankInputWidth, determineShortestCue, } from '../fillInBlankInputWidth';
 
-describe('determineBaseString function', () => {
-  it('returns the value when the value is longer than the shortest cue', () => {
-    const string = determineBaseString('aaaa', ['a', 'longercue', 'muchlongercue']);
-    expect(string).toBe('aaaa');
+describe('determineShortestCue function', () => {
+  it('returns the shortest cue from a list of cues', () => {
+    const shortest = determineShortestCue(['aaa', 'a', 'aa']);
+    expect(shortest).toBe('a');
   });
 
-  it('returns the shortest cue when the shortest cue is longer than the value', () => {
-    const string = determineBaseString('a', ['aaaaaa', 'longercue', 'muchlongercue']);
-    expect(string).toBe('aaaaaa');
+  it('returns an empty string if cues array is empty', () => {
+    const shortest = determineShortestCue([]);
+    expect(shortest).toBe('');
   });
 
-  it('handles empty value and cues array by returning an empty string', () => {
-    const string = determineBaseString('', []);
-    expect(string).toBe('');
+  it('returns an empty string if cues is null', () => {
+    const shortest = determineShortestCue(null);
+    expect(shortest).toBe('');
   });
 
-  it('handles null value and cues array by returning an empty string', () => {
-    const string = determineBaseString(null, null);
-    expect(string).toBe('');
+  it('handles array with one cue', () => {
+    const shortest = determineShortestCue(['only']);
+    expect(shortest).toBe('only');
   });
+
 });
 
 


### PR DESCRIPTION
## WHAT
Make sure Fill in Blank inputs expand properly when the user is typing capital letters.

## WHY
We want this to always expand as the user types.

## HOW
The code was just taking into account the length of the string, and not how much space they actually take up. I've rewritten it to compare the actual offsetWidths of both spans so it will always fit the whole value.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/FITB-boxes-not-expanding-with-shortest-all-caps-word-e4d7a84c17b24f48b651e9623a0ef36d?pvs=4

### What have you done to QA this feature?
Tested writing in various input fields, with capitals and without, to confirm that it always behaves as expected.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
