### PR TITLE
Bug fix/ remove banner background color applied from table hover

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/class-manager.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/class-manager.scss
@@ -1,4 +1,5 @@
 #class-manager {
+  background-color: $quill-white;
   .edit-students {
     h1 {
       font-size: 24px;


### PR DESCRIPTION
## WHAT
remove banner background color that was being applied from hovering over any cell in the Account Management table

## WHY
we don't want this being applied to the banner background

## HOW
add set background color to parent container of the page

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/The-admin-Account-Management-table-hover-state-is-incorrectly-being-applied-to-the-banner-773ef52637044f61a6273ccf5bae301a

### What have you done to QA this feature?
tested on staging that hovering over the table didn't apply the background color

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | css change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
