### PR TITLE
Lms/email admin diagnostic performance report

### DIFF
--- a/services/QuillLMS/app/mailers/admin_diagnostic_reports/benchmark_mailer.rb
+++ b/services/QuillLMS/app/mailers/admin_diagnostic_reports/benchmark_mailer.rb
@@ -4,7 +4,7 @@ module AdminDiagnosticReports
   class BenchmarkMailer < ::ApplicationMailer
     default from: 'hello@quill.org'
 
-    RECIPIENT_EMAIL = 'adgr-performance-benc-aaaam4wgvisxjpenaqvnndhgvy@quill.slack.com'
+    RECIPIENT_EMAIL = ENV['SLACK_ADGR_PERFORMANCE_BENCHMARKS_EMAIL']
 
     def benchmark_report(data)
       @data = data

--- a/services/QuillLMS/app/mailers/admin_diagnostic_reports/benchmark_mailer.rb
+++ b/services/QuillLMS/app/mailers/admin_diagnostic_reports/benchmark_mailer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module AdminDiagnosticReports
-  class BenchmarkMailer < ActionMailer::Base
+  class BenchmarkMailer < ::ApplicationMailer
     default from: 'hello@quill.org'
-  
+
     RECIPIENT_EMAIL = 'thomas@quill.org'
 
     def benchmark_report(data)

--- a/services/QuillLMS/app/mailers/admin_diagnostic_reports/benchmark_mailer.rb
+++ b/services/QuillLMS/app/mailers/admin_diagnostic_reports/benchmark_mailer.rb
@@ -4,7 +4,7 @@ module AdminDiagnosticReports
   class BenchmarkMailer < ::ApplicationMailer
     default from: 'hello@quill.org'
 
-    RECIPIENT_EMAIL = 'thomas@quill.org'
+    RECIPIENT_EMAIL = 'adgr-performance-benc-aaaam4wgvisxjpenaqvnndhgvy@quill.slack.com'
 
     def benchmark_report(data)
       @data = data

--- a/services/QuillLMS/app/mailers/admin_diagnostic_reports/benchmark_mailer.rb
+++ b/services/QuillLMS/app/mailers/admin_diagnostic_reports/benchmark_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module AdminDiagnosticReports
+  class BenchmarkMailer < ActionMailer::Base
+    default from: 'hello@quill.org'
+  
+    RECIPIENT_EMAIL = 'thomas@quill.org'
+
+    def benchmark_report(data)
+      @data = data
+      mail to: RECIPIENT_EMAIL, subject: 'Admin Diagnostic Report Query Runtimes'
+    end
+  end
+end

--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -12,6 +12,13 @@ class Cron
   def self.interval_1_hour
     CreditReferringAccountsWorker.perform_async
     TeacherNotifications::EnqueueUsersForRollupEmailWorker.perform_async(TeacherInfo::HOURLY_EMAIL)
+
+    # 7/8AM depending on daylight savings
+    run_at_12_hour_mark if now.hour == 12
+    # 12/1PM depending on daylight savings
+    run_at_17_hour_mark if now.hour == 17
+    # 4/5PM depending on daylight savings
+    run_at_21_hour_mark if now.hour == 21
   end
 
   # Configured in Heroku Scheduler to run every day at 07:00UTC
@@ -64,6 +71,21 @@ class Cron
   # Configured in Heroku Scheduler to run at XX:50
   def self.run_at_50_minute_mark
     ResetGhostInspectorAccountWorker.perform_async
+  end
+
+  # 7/8AM depending on daylight savings
+  def self.run_at_12_hour_mark
+    AdminDiagnosticReports::PerformanceBenchmarkWorker.perform_async
+  end
+
+  # 12/1PM depending on daylight savings
+  def self.run_at_17_hour_mark
+    AdminDiagnosticReports::PerformanceBenchmarkWorker.perform_async
+  end
+
+  # 4/5PM depending on daylight savings
+  def self.run_at_21_hour_mark
+    AdminDiagnosticReports::PerformanceBenchmarkWorker.perform_async
   end
 
   def self.run_weekday

--- a/services/QuillLMS/app/views/admin_diagnostic_reports/benchmark_mailer/benchmark_report.html.erb
+++ b/services/QuillLMS/app/views/admin_diagnostic_reports/benchmark_mailer/benchmark_report.html.erb
@@ -12,7 +12,7 @@
         <ul>
           <% benchmarks.each do |query_name, elapsed_seconds| %>
             <li>
-              <%= query_name %> - <%= elapsed_seconds %>
+              <%= query_name %> - <%= elapsed_seconds %> seconds
             </li>
           <% end %>
         </ul>

--- a/services/QuillLMS/app/views/admin_diagnostic_reports/benchmark_mailer/benchmark_report.html.erb
+++ b/services/QuillLMS/app/views/admin_diagnostic_reports/benchmark_mailer/benchmark_report.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <%= vite_stylesheet_tag 'entrypoints/snippets/rollup_email.scss', media: "all"  %>
+  </head>
+  <body class="email-body">
+    <div>
+      <% @data.each do |email, benchmarks| %>
+        <h3><%= email %></h3>
+        <ul>
+          <% benchmarks.each do |query_name, elapsed_seconds| %>
+            <li>
+              <%= query_name %> - <%= elapsed_seconds %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </div>
+  </body>
+</html>

--- a/services/QuillLMS/app/workers/admin_diagnostic_reports/performance_benchmark_worker.rb
+++ b/services/QuillLMS/app/workers/admin_diagnostic_reports/performance_benchmark_worker.rb
@@ -9,13 +9,10 @@ module AdminDiagnosticReports
     end
 
     private def query_performance_by_email
-      school_ids.to_h do |admin_email, school_ids|
-        [
-          admin_email,
-          multi_query_performance(school_ids)
-            .merge(single_query_performance(school_ids))
-            .merge(student_query_performance(school_ids))
-        ]
+      school_ids.transform_values do |school_ids|
+        multi_query_performance(school_ids)
+          .merge(single_query_performance(school_ids))
+          .merge(student_query_performance(school_ids))
       end
     end
 

--- a/services/QuillLMS/app/workers/admin_diagnostic_reports/performance_benchmark_worker.rb
+++ b/services/QuillLMS/app/workers/admin_diagnostic_reports/performance_benchmark_worker.rb
@@ -96,6 +96,8 @@ module AdminDiagnosticReports
     private def school_ids
       {
         'liz.domingue@cpsb.org' => [38811,38804,38801,38800,38779,38784,38780,38773,38765,38764],
+        'kclark@stem-prep.org' => [129038, 11117, 129037],
+        'freshteachtest@gmail.com' => [71746, 129107]
       }
     end
   end

--- a/services/QuillLMS/app/workers/admin_diagnostic_reports/performance_benchmark_worker.rb
+++ b/services/QuillLMS/app/workers/admin_diagnostic_reports/performance_benchmark_worker.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module AdminDiagnosticReports
+  class PerformanceBenchmarkWorker
+    include Sidekiq::Worker
+
+    def perform
+      BenchmarkMailer.benchmark_report(query_performance_by_email).deliver_now!
+    end
+
+    private def query_performance_by_email
+      school_ids.to_h do |admin_email, school_ids|
+        [
+          admin_email,
+          multi_query_performance(school_ids)
+            .merge(single_query_performance(school_ids))
+            .merge(student_query_performance(school_ids))
+        ]
+      end
+    end
+
+    private def multi_query_performance(school_ids)
+      multi_queries.to_h do |query_name, query|
+        start_seconds = DateTime.current.to_f
+        query.run(**multi_args(school_ids))
+        elapsed_seconds = DateTime.current.to_f - start_seconds
+        [query_name, elapsed_seconds]
+      end
+    end
+
+    private def single_query_performance(school_ids)
+      single_queries.to_h do |query_name, query|
+        start_seconds = DateTime.current.to_f
+        query.run(**single_args(school_ids))
+        elapsed_seconds = DateTime.current.to_f - start_seconds
+        [query_name, elapsed_seconds]
+      end
+    end
+
+    private def student_query_performance(school_ids)
+      student_queries.to_h do |query_name, query|
+        start_seconds = DateTime.current.to_f
+        query.run(**student_args(school_ids))
+        elapsed_seconds = DateTime.current.to_f - start_seconds
+        [query_name, elapsed_seconds]
+      end
+    end
+
+    private def now = @now ||= DateTime.current
+    private def timeframe_start = School.school_year_start(now)
+    private def timeframe_end = now
+
+    private def multi_args(school_ids)
+      {
+        timeframe_start:,
+        timeframe_end:,
+        school_ids:,
+        aggregation: 'grade'
+      }
+    end
+
+    private def single_args(school_ids)
+      multi_args(school_ids).merge({
+        diagnostic_id: 1663 # The starter pre diagnostic
+      })
+    end
+
+    private def student_args(school_ids)
+      single_args(school_ids).except(:aggregation)
+    end
+
+    private def multi_queries
+      {
+        'pre-diagnostic-assigned-view' => ::AdminDiagnosticReports::PreDiagnosticAssignedViewQuery,
+        'pre-diagnostic-completed-view' => ::AdminDiagnosticReports::PreDiagnosticCompletedViewQuery,
+        'recommendations' => ::AdminDiagnosticReports::DiagnosticRecommendationsQuery,
+        'post-diagnostic-assigned-view' => ::AdminDiagnosticReports::PostDiagnosticAssignedViewQuery,
+        'post-diagnostic-completed-view' => ::AdminDiagnosticReports::PostDiagnosticCompletedViewQuery
+      }
+    end
+
+    private def single_queries
+      {
+        'diagnostic-skills-view' => ::AdminDiagnosticReports::DiagnosticPerformanceBySkillViewQuery
+      }
+    end
+
+    private def student_queries
+      {
+        'diagnostic-students-view' => ::AdminDiagnosticReports::DiagnosticPerformanceByStudentViewQuery,
+        'student-recommendation' => ::AdminDiagnosticReports::DiagnosticRecommendationsByStudentQuery,
+        'filter-scope' => ::AdminDiagnosticReports::StudentCountByFilterScopeQuery
+      }
+    end
+
+    private def school_ids
+      {
+        'liz.domingue@cpsb.org' => [38811,38804,38801,38800,38779,38784,38780,38773,38765,38764],
+      }
+    end
+  end
+end

--- a/services/QuillLMS/spec/mailers/admin_diagnostic_reports/benchmark_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/admin_diagnostic_reports/benchmark_mailer_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 module AdminDiagnosticReports
   describe BenchmarkMailer, type: :mailer do
+    before do
+      allow_any_instance_of(ActionView::Base).to receive(:vite_stylesheet_tag)
+    end
+
     let(:email) { 'address@example.com' }
     let(:query_name) { 'sample_query' }
     let(:elapsed_time) { 1.1 }

--- a/services/QuillLMS/spec/mailers/admin_diagnostic_reports/benchmark_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/admin_diagnostic_reports/benchmark_mailer_spec.rb
@@ -16,7 +16,7 @@ module AdminDiagnosticReports
       }
     end
     let(:mail) { described_class.benchmark_report(data) }
-  
+
     it { expect(mail.subject).to eq('Admin Diagnostic Report Query Runtimes') }
     it { expect(mail.to).to eq([described_class::RECIPIENT_EMAIL]) }
     it { expect(mail.from).to eq(['hello@quill.org']) }

--- a/services/QuillLMS/spec/mailers/admin_diagnostic_reports/benchmark_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/admin_diagnostic_reports/benchmark_mailer_spec.rb
@@ -4,11 +4,8 @@ require 'rails_helper'
 
 module AdminDiagnosticReports
   describe BenchmarkMailer, type: :mailer do
-    before do
-      allow_any_instance_of(ActionView::Base).to receive(:vite_stylesheet_tag)
-    end
-
     let(:email) { 'address@example.com' }
+    let(:recipient_email) { 'recipient@example.com' }
     let(:query_name) { 'sample_query' }
     let(:elapsed_time) { 1.1 }
     let(:report_text) { "#{query_name} - #{elapsed_time} seconds" }
@@ -21,8 +18,13 @@ module AdminDiagnosticReports
     end
     let(:mail) { described_class.benchmark_report(data) }
 
+    before do
+      allow_any_instance_of(ActionView::Base).to receive(:vite_stylesheet_tag)
+      stub_const("AdminDiagnosticReports::BenchmarkMailer::RECIPIENT_EMAIL", recipient_email)
+    end
+
     it { expect(mail.subject).to eq('Admin Diagnostic Report Query Runtimes') }
-    it { expect(mail.to).to eq([described_class::RECIPIENT_EMAIL]) }
+    it { expect(mail.to).to eq([recipient_email]) }
     it { expect(mail.from).to eq(['hello@quill.org']) }
     it { expect(mail.body).to include(report_text) }
   end

--- a/services/QuillLMS/spec/mailers/admin_diagnostic_reports/benchmark_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/admin_diagnostic_reports/benchmark_mailer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AdminDiagnosticReports
+  describe BenchmarkMailer, type: :mailer do
+    let(:email) { 'address@example.com' }
+    let(:query_name) { 'sample_query' }
+    let(:elapsed_time) { 1.1 }
+    let(:report_text) { "#{query_name} - #{elapsed_time} seconds" }
+    let(:data) do
+      {
+        email => {
+          query_name => elapsed_time
+        }
+      }
+    end
+    let(:mail) { described_class.benchmark_report(data) }
+  
+    it { expect(mail.subject).to eq('Admin Diagnostic Report Query Runtimes') }
+    it { expect(mail.to).to eq([described_class::RECIPIENT_EMAIL]) }
+    it { expect(mail.from).to eq(['hello@quill.org']) }
+    it { expect(mail.body).to include(report_text) }
+  end
+end

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Cron, type: :model do
       expect(TeacherNotifications::EnqueueUsersForRollupEmailWorker).to receive(:perform_async).with(TeacherInfo::HOURLY_EMAIL)
       Cron.interval_1_hour
     end
+
+    [12, 17, 21].each do |hour|
+      it 'enqueues AdminDiagnosticReports::PerformanceBenchmarkWorker' do
+        time = Time.current.midnight + hour.hours
+        expect(Cron).to receive(:now).at_least(:thrice).and_return(time)
+        expect(AdminDiagnosticReports::PerformanceBenchmarkWorker).to receive(:perform_async)
+
+        Cron.interval_1_hour
+      end
+    end
   end
 
   describe "#interval_1_day" do

--- a/services/QuillLMS/spec/workers/admin_diagnostic_reports/performance_benchmark_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/admin_diagnostic_reports/performance_benchmark_worker_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AdminDiagnosticReports
+  describe PerformanceBenchmarkWorker, type: :worker do
+    subject { described_class.new }
+
+    let(:mailer_double) { double }
+    let(:payload) { { 'email@example.com' => { 'query' => 1.1 } } }
+
+    it do
+      expect(subject).to receive(:query_performance_by_email).and_return(payload)
+      expect(BenchmarkMailer).to receive(:benchmark_report).with(payload).and_return(mailer_double)
+      expect(mailer_double).to receive(:deliver_now!)
+
+      subject.perform
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
- Add support to our `Cron` infrastructure to trigger jobs on specific hours
- Add a new worker that benchmarks time to run all of the various Admin Diagnostic queries and send an email report of all of those values
## WHY
We want to get regular benchmarks on queries throughout the day to understand if there are performance issues and to understand how any changes we make might impact those issues.
## HOW
- Follow the pattern we used for triggering jobs during specific 10-minute intervals for triggering jobs on specific hours
- Add a worker that is configured to benchmark all queries for specific users

### Screenshots
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/4ceaeb20-7959-4ba2-8c46-a4fd059b8f54)

### Notion Card Links
https://www.notion.so/quill/Log-ADGR-performance-throughout-the-day-d1e1f3012c134d8cab42c2f02cd42c55?pvs=4

### What have you done to QA this feature?
- deployed to staging
- manually trigger the worker from a console
- confirm that email content is reasonable

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
