### PR TITLE
move socket.io-redis out of devDependencies

### DIFF
--- a/services/QuillLessonsServer/package-lock.json
+++ b/services/QuillLessonsServer/package-lock.json
@@ -20,12 +20,12 @@
         "jsonwebtoken": "^8.2.1",
         "newrelic": "^6.14.0",
         "rethinkdb": "^2.3.3",
-        "socket.io": "^2.4.1"
+        "socket.io": "^2.4.1",
+        "socket.io-redis": "^5.2.0"
       },
       "devDependencies": {
         "jest": "^25.5.4",
-        "nodemon": "^1.17.3",
-        "socket.io-redis": "^5.2.0"
+        "nodemon": "^1.17.3"
       },
       "engines": {
         "node": "14.x",
@@ -4504,8 +4504,7 @@
     "node_modules/double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
-      "dev": true
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "node_modules/duplexer": {
       "version": "0.1.1",
@@ -9480,8 +9479,7 @@
     "node_modules/notepack.io": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.1.3.tgz",
-      "integrity": "sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA==",
-      "dev": true
+      "integrity": "sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA=="
     },
     "node_modules/npm-run-path": {
       "version": "2.0.2",
@@ -10222,7 +10220,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
-      "dev": true,
       "dependencies": {
         "double-ended-queue": "^2.1.0-0",
         "redis-commands": "^1.2.0",
@@ -10235,14 +10232,12 @@
     "node_modules/redis-commands": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
-      "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA==",
-      "dev": true
+      "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA=="
     },
     "node_modules/redis-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11008,7 +11003,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/socket.io-redis/-/socket.io-redis-5.2.0.tgz",
       "integrity": "sha1-j+KtlEX8UIhvtwq8dZ1nQD1Ymd8=",
-      "dev": true,
       "dependencies": {
         "debug": "~2.6.8",
         "notepack.io": "~2.1.2",
@@ -11021,7 +11015,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -11660,8 +11653,7 @@
     "node_modules/uid2": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-      "dev": true
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "node_modules/undefsafe": {
       "version": "2.0.2",
@@ -15930,8 +15922,7 @@
     "double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
-      "dev": true
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "duplexer": {
       "version": "0.1.1",
@@ -19886,8 +19877,7 @@
     "notepack.io": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.1.3.tgz",
-      "integrity": "sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA==",
-      "dev": true
+      "integrity": "sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -20466,7 +20456,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
-      "dev": true,
       "requires": {
         "double-ended-queue": "^2.1.0-0",
         "redis-commands": "^1.2.0",
@@ -20476,14 +20465,12 @@
     "redis-commands": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
-      "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA==",
-      "dev": true
+      "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA=="
     },
     "redis-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
-      "dev": true
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "regenerate": {
       "version": "1.4.0",
@@ -21136,7 +21123,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/socket.io-redis/-/socket.io-redis-5.2.0.tgz",
       "integrity": "sha1-j+KtlEX8UIhvtwq8dZ1nQD1Ymd8=",
-      "dev": true,
       "requires": {
         "debug": "~2.6.8",
         "notepack.io": "~2.1.2",
@@ -21149,7 +21135,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -21641,8 +21626,7 @@
     "uid2": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-      "dev": true
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "undefsafe": {
       "version": "2.0.2",

--- a/services/QuillLessonsServer/package.json
+++ b/services/QuillLessonsServer/package.json
@@ -24,12 +24,12 @@
     "jsonwebtoken": "^8.2.1",
     "newrelic": "^6.14.0",
     "rethinkdb": "^2.3.3",
-    "socket.io": "^2.4.1"
+    "socket.io": "^2.4.1",
+    "socket.io-redis": "^5.2.0"
   },
   "devDependencies": {
     "jest": "^25.5.4",
-    "nodemon": "^1.17.3",
-    "socket.io-redis": "^5.2.0"
+    "nodemon": "^1.17.3"
   },
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
## WHAT
- move socket.io-redis out of devDependencies into regular dependencies

## WHY
- it is a true dependency. See the [bug fix writeup](https://www.notion.so/quill/QLS-prod-not-working-after-security-patches-9ef0df6907b148cea34891dd9440899f) for why this has only recently become an issue.



### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/QLS-prod-not-working-after-security-patches-9ef0df6907b148cea34891dd9440899f

### What have you done to QA this feature?
- confirm two way websockets communication between teacher and student

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - this app currently has no running tests
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
