### PR TITLE
Integrate OpenAI completion with Experiments        

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
@@ -31,8 +31,6 @@ module Evidence
 
         def llm_client = VENDOR_MAP.fetch(vendor) { raise UnsupportedVendorError }
 
-        def model_key = version.to_sym
-
         def to_s = "#{vendor}: #{version}"
       end
     end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
@@ -17,9 +17,11 @@ module Evidence
         class UnsupportedVendorError < StandardError; end
 
         GOOGLE = 'google'
+        OPEN_AI = 'open_ai'
 
         VENDOR_MAP = {
-          GOOGLE => Evidence::Gemini::Completion
+          GOOGLE => Evidence::Gemini::Completion,
+          OPEN_AI => Evidence::OpenAI::Completion
         }.freeze
 
         validates :vendor, presence: true
@@ -28,6 +30,8 @@ module Evidence
         attr_readonly :vendor, :version
 
         def llm_client = VENDOR_MAP.fetch(vendor) { raise UnsupportedVendorError }
+
+        def model_key = version.to_sym
 
         def to_s = "#{vendor}: #{version}"
       end

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
@@ -6,33 +6,39 @@ module Evidence
       include Evidence::OpenAI::Concerns::Api
       include Evidence::OpenAI::Concerns::SentenceResults
 
-      ENDPOINT = '/completions'
+      ENDPOINT = '/chat/completions'
 
-      MAX_TOKENS = 24
+      MAX_TOKENS = 500
 
+      # rubocop:disable Naming::VariableNumber
       MODELS = {
-        ada: 'text-ada-001',
-        babbage: 'text-babbage-001',
-        curie: 'text-curie-001',
-        davinci: 'text-davinci-002',
-        turbo35_instruct: 'gpt-3.5-turbo-instruct'
+        turbo35_0125: 'gpt-3.5-turbo-0125',
+        turbo4_2024_04_09: 'gpt-4-turbo-2024-04-09'
       }
+      # rubocop:enable Naming::VariableNumber
 
       STOP_TOKENS = [". ", "; ", "? ", "! "] # max of 4 stop tokens
       MAX_COUNT = 128 # API has an undocument max of 128 for 'n'
 
       attr_accessor :prompt, :temperature, :count, :model_key, :options
 
-      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :turbo35_instruct, options: {})
+      # rubocop:disable Naming::VariableNumber
+      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :turbo35_0125, llm_config: nil, options: {})
         @prompt = prompt
         @temperature = temperature
         @count = count
-        @model_key = model_key
+        @model_key = llm_config&.model_key
         @options = options
       end
+      # rubocop:enable Naming::VariableNumber
 
-      def endpoint
-        ENDPOINT
+      def endpoint = ENDPOINT
+
+      def cleaned_results
+        response
+          .parsed_response['choices']
+          &.first
+          &.dig('message', 'content')
       end
 
       # https://beta.openai.com/docs/api-reference/completions/create
@@ -40,11 +46,13 @@ module Evidence
         # NB: 'suffix' key in documentation is not a valid key, will raise error
         {
           model: MODELS[model_key],
-          temperature: temperature,
-          prompt: prompt,
+          temperature:,
+          messages: [
+            { role: 'user', content: prompt }
+          ],
           n: [count.to_i, Evidence::OpenAI::MAX_COUNT].min,
-          max_tokens: MAX_TOKENS,
-          stop: STOP_TOKENS
+          # max_tokens: MAX_TOKENS,
+          # stop: STOP_TOKENS
         }.merge(options)
       end
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
@@ -4,33 +4,15 @@ module Evidence
   module OpenAI
     class Completion < Evidence::ApplicationService
       include Evidence::OpenAI::Concerns::Api
-      include Evidence::OpenAI::Concerns::SentenceResults
 
       ENDPOINT = '/chat/completions'
 
-      MAX_TOKENS = 500
+      attr_reader :prompt, :llm_config
 
-      # rubocop:disable Naming::VariableNumber
-      MODELS = {
-        turbo35_0125: 'gpt-3.5-turbo-0125',
-        turbo4_2024_04_09: 'gpt-4-turbo-2024-04-09'
-      }
-      # rubocop:enable Naming::VariableNumber
-
-      STOP_TOKENS = [". ", "; ", "? ", "! "] # max of 4 stop tokens
-      MAX_COUNT = 128 # API has an undocument max of 128 for 'n'
-
-      attr_accessor :prompt, :temperature, :count, :model_key, :options
-
-      # rubocop:disable Naming::VariableNumber
-      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :turbo35_0125, llm_config: nil, options: {})
+      def initialize(prompt:, llm_config:)
         @prompt = prompt
-        @temperature = temperature
-        @count = count
-        @model_key = llm_config&.model_key
-        @options = options
+        @llm_config = llm_config
       end
-      # rubocop:enable Naming::VariableNumber
 
       def endpoint = ENDPOINT
 
@@ -41,19 +23,13 @@ module Evidence
           &.dig('message', 'content')
       end
 
-      # https://beta.openai.com/docs/api-reference/completions/create
       def request_body
-        # NB: 'suffix' key in documentation is not a valid key, will raise error
         {
-          model: MODELS[model_key],
-          temperature:,
+          model: llm_config.version,
           messages: [
             { role: 'user', content: prompt }
           ],
-          n: [count.to_i, Evidence::OpenAI::MAX_COUNT].min,
-          # max_tokens: MAX_TOKENS,
-          # stop: STOP_TOKENS
-        }.merge(options)
+        }
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/sentence_completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/sentence_completion.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Evidence
+  module OpenAI
+    class SentenceCompletion < Evidence::ApplicationService
+      include Evidence::OpenAI::Concerns::Api
+      include Evidence::OpenAI::Concerns::SentenceResults
+
+      ENDPOINT = '/completions'
+
+      MAX_TOKENS = 24
+
+      MODELS = {
+        ada: 'text-ada-001',
+        babbage: 'text-babbage-001',
+        curie: 'text-curie-001',
+        davinci: 'text-davinci-002',
+        turbo35_instruct: 'gpt-3.5-turbo-instruct'
+      }
+
+      STOP_TOKENS = [". ", "; ", "? ", "! "] # max of 4 stop tokens
+      MAX_COUNT = 128 # API has an undocument max of 128 for 'n'
+
+      attr_accessor :prompt, :temperature, :count, :model_key, :options
+
+      def initialize(prompt:, temperature: 0.5, count: 1, model_key: :turbo35_instruct, options: {})
+        @prompt = prompt
+        @temperature = temperature
+        @count = count
+        @model_key = model_key
+        @options = options
+      end
+
+      def endpoint
+        ENDPOINT
+      end
+
+      # https://beta.openai.com/docs/api-reference/completions/create
+      def request_body
+        # NB: 'suffix' key in documentation is not a valid key, will raise error
+        {
+          model: MODELS[model_key],
+          temperature: temperature,
+          prompt: prompt,
+          n: [count.to_i, Evidence::OpenAI::MAX_COUNT].min,
+          max_tokens: MAX_TOKENS,
+          stop: STOP_TOKENS
+        }.merge(options)
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/lib/evidence/synthetic/generators/paraphrase.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/synthetic/generators/paraphrase.rb
@@ -38,7 +38,7 @@ module Evidence
         end
 
         private def api_results(string)
-          Evidence::OpenAI::Completion.run(
+          Evidence::OpenAI::SentenceCompletion.run(
             prompt: ml_prompt(string),
             count: COUNT,
             temperature: TEMPERATURE

--- a/services/QuillLMS/engines/evidence/lib/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/synthetic/seed_data_generator.rb
@@ -179,7 +179,7 @@ module Evidence
       end
 
       private def run_generator(generator, options: {})
-        api_results = Evidence::OpenAI::Completion.run(
+        api_results = Evidence::OpenAI::SentenceCompletion.run(
           prompt: generator.ml_prompt,
           count: generator.count,
           temperature: generator.temperature,

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_configs.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_configs.rb
@@ -17,6 +17,9 @@ module Evidence
         factory :evidence_research_gen_ai_llm_config, class: 'Evidence::Research::GenAI::LLMConfig' do
           vendor { Evidence::Research::GenAI::LLMConfig::VENDOR_MAP.keys.sample }
           version { 'v1.0' }
+
+          trait(:google) { vendor { Evidence::Research::GenAI::LLMConfig::GOOGLE } }
+          trait(:open_ai) { vendor { Evidence::Research::GenAI::LLMConfig::OPEN_AI } }
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
@@ -10,6 +10,8 @@ module Evidence
     let(:model_key) { :curie }
     let(:options) {{key: 'value'}}
     let(:endpoint) {'https://api.openai.com/v1/completions'}
+    let(:headers) { { content_type: 'application/json' } }
+    let(:llm_config) { nil }
 
     let(:sample_response_body) do
       {
@@ -29,15 +31,17 @@ module Evidence
 
     end
     # include headers in response for proper parsing by HTTParty
-    let(:sample_response) { {body: sample_response_body.to_json, headers: {content_type: 'application/json'}} }
+    let(:sample_response) { {body: sample_response_body.to_json, headers:} }
 
     let(:completion) do
       Evidence::OpenAI::Completion.new(
-          prompt: prompt,
-          temperature: temperature,
-          count: count,
-          model_key: model_key,
-          options: options)
+        prompt:,
+        temperature:,
+        count:,
+        model_key:,
+        llm_config:,
+        options:
+      )
     end
 
     describe "#new" do
@@ -47,6 +51,13 @@ module Evidence
         expect(completion.count).to eq(count)
         expect(completion.model_key).to eq(model_key)
         expect(completion.options).to eq(options)
+      end
+
+      context 'when llm_config is provided' do
+        let(:model_key) { :davinci }
+        let(:llm_config) { double('llm_config', model_key:) }
+
+        it { expect(completion.model_key).to eq model_key }
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
@@ -3,92 +3,51 @@
 require 'rails_helper'
 
 module Evidence
-  RSpec.describe(OpenAI::Completion, type: :model) do
-    let(:prompt) { 'some prompt' }
-    let(:temperature) { 0.9 }
-    let(:count) { 10 }
-    let(:model_key) { :curie }
-    let(:options) {{key: 'value'}}
-    let(:endpoint) {'https://api.openai.com/v1/completions'}
-    let(:headers) { { content_type: 'application/json' } }
-    let(:llm_config) { nil }
+  module OpenAI
+    RSpec.describe Completion do
+      %w[gpt-3.5-turbo-0125 gpt-4-turbo-2024-04-09].each do |version|
+        subject { described_class.new(prompt:, llm_config:) }
 
-    let(:sample_response_body) do
-      {
-        "id"=>"cmpl-5Yiq2oA2mneJK4GHLRBIYJ3Nm8oa2",
-        "object"=>"text_completion",
-        "created"=>1658957194,
-        "model"=>"text-ada-001",
-        "choices"=> [
-          {"text"=>"a text response",
-          "index"=>0,
-          "logprobs"=>nil,
-          "finish_reason"=>"length"},
-          {"text"=>" they value their privacy and idea of stigmaly manury", "index"=>1, "logprobs"=>nil, "finish_reason"=>"stop"},
-          {"text"=>" they are working too hard and becoming too popular", "index"=>2, "logprobs"=>nil, "finish_reason"=>"stop"}
-        ]
-      }
+        let(:prompt) { 'some prompt' }
+        let(:llm_config) { create(:evidence_research_gen_ai_llm_config, :open_ai, version:) }
 
-    end
-    # include headers in response for proper parsing by HTTParty
-    let(:sample_response) { {body: sample_response_body.to_json, headers:} }
+        context 'test endpoint', external_api: true do
+          it { expect { subject.run }.not_to raise_error }
+        end
 
-    let(:completion) do
-      Evidence::OpenAI::Completion.new(
-        prompt:,
-        temperature:,
-        count:,
-        model_key:,
-        llm_config:,
-        options:
-      )
-    end
+        context 'test request body' do
+          let(:endpoint) { 'https://api.openai.com/v1/chat/completions' }
+          let(:content) { 'a text response' }
+          let(:body) do
+            {
+              "id": "chatcmpl-123",
+              "object": "chat.completion",
+              "created": 1677652288,
+              "model": version,
+              "system_fingerprint": "fp_44709d6fcb",
+              "choices": [{
+                "index": 0,
+                "message": {
+                  "role": "assistant",
+                  "content": content
+                },
+                "logprobs": nil,
+                "finish_reason": "stop"
+              }],
+              "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 12,
+                "total_tokens": 21
+              }
+            }.to_json
+          end
 
-    describe "#new" do
-      it "should initialize as expected" do
-        expect(completion.prompt).to eq(prompt)
-        expect(completion.temperature).to eq(temperature)
-        expect(completion.count).to eq(count)
-        expect(completion.model_key).to eq(model_key)
-        expect(completion.options).to eq(options)
-      end
+          let(:headers) { { content_type: 'application/json' } }
 
-      context 'when llm_config is provided' do
-        let(:model_key) { :davinci }
-        let(:llm_config) { double('llm_config', model_key:) }
+          before { stub_request(:post, endpoint).to_return(body:, headers:) }
 
-        it { expect(completion.model_key).to eq model_key }
-      end
-    end
-
-    describe "#run" do
-      it "should post to OpenAI, populate response, and return a cleaned_response" do
-        stub_request(:post, endpoint).to_return(sample_response)
-
-        response = completion.run
-        expect(response.count).to be(3)
-        expect(response.class).to be(Array)
-        expect(response[0]).to eq("a text response")
-        expect(completion.response.class).to be(HTTParty::Response)
-
-        request_body = JSON.parse(completion.response.request.options[:body])
-        # ensure correct body was sent
-        expect(request_body['model']).to eq('text-curie-001')
-        expect(request_body['temperature']).to eq(temperature)
-        expect(request_body['prompt']).to eq(prompt)
-        expect(request_body['n']).to eq(count)
-        expect(request_body['max_tokens']).to eq(Evidence::OpenAI::Completion::MAX_TOKENS)
-        expect(request_body['stop']).to eq(Evidence::OpenAI::Completion::STOP_TOKENS)
-      end
-    end
-
-    describe "#cleaned_results" do
-      let(:response_with_chars) {["  -\n\n\n 1) Hello there[] you 2) person = \n other stuff to drop"]}
-
-      it "should strip out special characters and drop after middle newline" do
-        expect(completion).to receive(:result_texts).and_return(response_with_chars)
-
-        expect(completion.cleaned_results.first).to eq("Hello there you  person")
+          it { expect(subject.run).to eq content }
+        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/sentence_completion_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/sentence_completion_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  RSpec.describe(OpenAI::SentenceCompletion, type: :model) do
+    let(:prompt) { 'some prompt' }
+    let(:temperature) { 0.9 }
+    let(:count) { 10 }
+    let(:model_key) { :curie }
+    let(:options) {{key: 'value'}}
+    let(:endpoint) {'https://api.openai.com/v1/completions'}
+
+    let(:sample_response_body) do
+      {
+        "id"=>"cmpl-5Yiq2oA2mneJK4GHLRBIYJ3Nm8oa2",
+        "object"=>"text_completion",
+        "created"=>1658957194,
+        "model"=>"text-ada-001",
+        "choices"=> [
+          {"text"=>"a text response",
+          "index"=>0,
+          "logprobs"=>nil,
+          "finish_reason"=>"length"},
+          {"text"=>" they value their privacy and idea of stigmaly manury", "index"=>1, "logprobs"=>nil, "finish_reason"=>"stop"},
+          {"text"=>" they are working too hard and becoming too popular", "index"=>2, "logprobs"=>nil, "finish_reason"=>"stop"}
+        ]
+      }
+
+    end
+    # include headers in response for proper parsing by HTTParty
+    let(:sample_response) { {body: sample_response_body.to_json, headers: {content_type: 'application/json'}} }
+
+    let(:completion) { described_class.new(prompt:, temperature:, count:, model_key:, options:) }
+
+    describe "#new" do
+      it "should initialize as expected" do
+        expect(completion.prompt).to eq(prompt)
+        expect(completion.temperature).to eq(temperature)
+        expect(completion.count).to eq(count)
+        expect(completion.model_key).to eq(model_key)
+        expect(completion.options).to eq(options)
+      end
+    end
+
+    describe "#run" do
+      it "should post to OpenAI, populate response, and return a cleaned_response" do
+        stub_request(:post, endpoint).to_return(sample_response)
+
+        response = completion.run
+        expect(response.count).to be(3)
+        expect(response.class).to be(Array)
+        expect(response[0]).to eq("a text response")
+        expect(completion.response.class).to be(HTTParty::Response)
+
+        request_body = JSON.parse(completion.response.request.options[:body])
+        # ensure correct body was sent
+        expect(request_body['model']).to eq('text-curie-001')
+        expect(request_body['temperature']).to eq(temperature)
+        expect(request_body['prompt']).to eq(prompt)
+        expect(request_body['n']).to eq(count)
+        expect(request_body['max_tokens']).to eq(Evidence::OpenAI::SentenceCompletion::MAX_TOKENS)
+        expect(request_body['stop']).to eq(Evidence::OpenAI::SentenceCompletion::STOP_TOKENS)
+      end
+    end
+
+    describe "#cleaned_results" do
+      let(:response_with_chars) {["  -\n\n\n 1) Hello there[] you 2) person = \n other stuff to drop"]}
+
+      it "should strip out special characters and drop after middle newline" do
+        expect(completion).to receive(:result_texts).and_return(response_with_chars)
+
+        expect(completion.cleaned_results.first).to eq("Hello there you  person")
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/generators/paraphrase_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/generators/paraphrase_spec.rb
@@ -29,7 +29,7 @@ describe Evidence::Synthetic::Generators::Paraphrase do
     subject { described_class.new([text1], passage: passage).run}
 
     it 'should return paraphrases in hash format' do
-      expect(Evidence::OpenAI::Completion).to receive(:run)
+      expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
         .with(prompt: prompt, count: 4, temperature: 0.7)
         .and_return(api_results)
 
@@ -43,7 +43,7 @@ describe Evidence::Synthetic::Generators::Paraphrase do
     end
 
     it 'should lowercase result when applicable' do
-      expect(Evidence::OpenAI::Completion).to receive(:run)
+      expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
         .with(prompt: prompt, count: 4, temperature: 0.7)
         .and_return(api_result_with_uppercase)
 

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/seed_data_generator_spec.rb
@@ -86,57 +86,57 @@ module Evidence
     describe "#run" do
       it "should hit open AI for each item and store results" do
         # full - original
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: full_passage_prompt, count: 1, temperature: 1, options: {})
           .and_return(full_passage_response)
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: full_passage_prompt, count: 1, temperature: 0.9, options: {})
           .and_return(full_passage_response2)
         # full - alternate stem1
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: full_passage_prompt_alternate1, count: 1, temperature: 1, options: {})
           .and_return(full_passage_alternate1_response1)
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: full_passage_prompt_alternate1, count: 1, temperature: 0.9, options: {})
           .and_return(full_passage_alternate1_response2)
         # full - alternate stem2
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: full_passage_prompt_alternate2, count: 1, temperature: 1, options: {})
           .and_return(full_passage_alternate2_response1)
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: full_passage_prompt_alternate2, count: 1, temperature: 0.9, options: {})
           .and_return(full_passage_alternate2_response2)
         # noun
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: full_noun_prompt, count: 1, temperature: 0.8, options: {})
           .and_return(full_noun_response)
         # chunk1
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: chunk1_prompt, count: 1, temperature: 0.4, options: {})
           .and_return(chunk1_response)
         # chunk1 - alternate1
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: chunk1_prompt_alternate1, count: 1, temperature: 0.4, options: {})
           .and_return(chunk1_response)
         # chunk1 - alternate2
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: chunk1_prompt_alternate2, count: 1, temperature: 0.4, options: {})
           .and_return(chunk1_response)
         # chunk2
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: chunk2_prompt, count: 1, temperature: 0.4, options: {})
           .and_return(chunk2_response)
         # chunk2 - alternate1
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: chunk2_prompt_alternate1, count: 1, temperature: 0.4, options: {})
           .and_return(chunk2_response)
         # chunk2 - alternate2
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: chunk2_prompt_alternate2, count: 1, temperature: 0.4, options: {})
           .and_return(chunk2_response)
 
         # label example
-        expect(Evidence::OpenAI::Completion).to receive(:run)
+        expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
           .with(prompt: example_prompt, count: 1, temperature: 1, options: {max_tokens: 40})
           .and_return(example_response)
 
@@ -160,7 +160,7 @@ module Evidence
 
         it "should generate ONLY label paraphrases" do
           # label example
-          expect(Evidence::OpenAI::Completion).to receive(:run)
+          expect(Evidence::OpenAI::SentenceCompletion).to receive(:run)
             .with(prompt: example_prompt, count: 1, temperature: 1, options: {max_tokens: 40})
             .and_return(example_response)
 
@@ -180,7 +180,7 @@ module Evidence
       let(:generator) { Evidence::TextGeneration.new(ml_prompt: '', count: 1, temperature: 1) }
 
       before do
-        allow(Evidence::OpenAI::Completion).to receive(:run).and_return(response)
+        allow(Evidence::OpenAI::SentenceCompletion).to receive(:run).and_return(response)
       end
 
       subject { because.send(:run_generator, generator) }
@@ -316,7 +316,7 @@ module Evidence
       let!(:prompt) { create(:evidence_prompt, activity: activity, conjunction: "because") }
 
       before do
-        allow(Evidence::OpenAI::Completion).to receive(:run).and_return(full_passage_response)
+        allow(Evidence::OpenAI::SentenceCompletion).to receive(:run).and_return(full_passage_response)
       end
 
       subject { described_class.csvs_for_activity(activity_id: activity.id, nouns: ['hello']) }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -49,17 +49,12 @@ module Evidence
           let(:num_examples) { 4 }
           let(:passage_prompt) { experiment.passage_prompt }
           let(:llm_config) { experiment.llm_config }
+          let(:llm_prompt) { experiment.llm_prompt }
           let(:llm_client) { double(:llm_client) }
           let(:llm_feedback_text) { 'Test feedback' }
 
           let(:passage_prompt_responses) do
             create_list(:evidence_research_gen_ai_passage_prompt_response, num_examples, passage_prompt:)
-          end
-
-          let!(:example_feedbacks) do
-            passage_prompt_responses.map do |passage_prompt_response|
-              create(:evidence_research_gen_ai_example_feedback, passage_prompt_response:)
-            end
           end
 
           before do
@@ -73,12 +68,21 @@ module Evidence
             allow(CalculateResultsWorker).to receive(:perform_async).with(experiment.id)
 
             passage_prompt_responses.each do |passage_prompt_response|
-              create(:evidence_research_gen_ai_example_feedback, passage_prompt_response:)
+              create(:evidence_research_gen_ai_example_feedback, :testing, passage_prompt_response:)
             end
           end
 
           it { expect { subject }.to change { experiment.reload.status }.to(described_class::COMPLETED) }
           it { expect { subject }.to change(LLMFeedback, :count).by(num_examples) }
+
+          context 'when creating LLM prompt responses feedbacks' do
+            it 'only processes testing data responses' do
+              expect(llm_client).to receive(:run).exactly(num_examples).times
+
+              subject
+            end
+          end
+
 
           context 'when an error occurs during execution' do
             let(:error_message) { 'Test error' }


### PR DESCRIPTION
## WHAT
1.  Rename `Evidence::OpenAI::Completion` to  `Evidence::OpenAI::SentenceCompletion`
1.  Connect open ai completion wrapper to experiments framework
1.  Run experiments over testing data only

## WHY
1.  This api access uses an older endpoint and deals with a specific use case of sentence completions.
1.  Experiments should allow for different models
1.  Fine tuning and prompt engineering example data is for other use cases

## HOW
1.  Rename file and test file.
1.  Update the endpoint and add newer model keys
1.  Iterate over testing data in the `experiment#create_llm_prompt_responses_feedbacks`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Tested on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
