### PR TITLE
QLS - get jests running; add CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ workflows:
             services/QuillLMS/(engines/|app/|bin/|config/|db/|lib/|Gemfile|spec/|public/|Procfile).* lms-run-evidence true
             services/QuillCMS/.* cms-run true
             services/QuillLMS/(engines/|app/|bin/|config/|db/|lib/|Gemfile|spec/|public/|Procfile).* lms-run-ruby-lint true
+            services/QuillLessonsServer/.* lessons-server-run true
           base-revision: develop
           # this is the path of the configuration we should trigger once
           # path filtering and pipeline parameter value updates are

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -260,18 +260,18 @@ jobs:
                   sudo npm install npm@8.19.2 -g
             - restore_cache:
                 keys:
-                  - npm-cache-lms-client-v8-{{ checksum "services/QuillLMS/client/package.json" }}-{{ checksum "services/QuillLMS/client/package-lock.json" }}
-                  - npm-cache-lms-client-v8-{{ checksum "services/QuillLMS/client/package.json" }}-
-                  - npm-cache-lms-client-v8-
+                  - npm-cache-lessons-server-v1-{{ checksum "services/QuillLessonsServer/package.json" }}-{{ checksum "services/QuillLessonsServer/package-lock.json" }}
+                  - npm-cache-lessons-server-v1-{{ checksum "services/QuillLessonsServer/package.json" }}-
+                  - npm-cache-lessons-server-v1-
             - run:
                 name: Install NPM dependencies
                 command: |
                   cd services/QuillLessonsServer
                   npm install --legacy-peer-deps
             - save_cache:
-                key: npm-cache-lms-client-v6-{{ checksum "services/QuillLMS/client/package.json" }}-{{ checksum "services/QuillLMS/client/package-lock.json" }}
+                key: npm-cache-lessons-server-v1-{{ checksum "services/QuillLessonsServer/package.json" }}-{{ checksum "services/QuillLessonsServer/package-lock.json" }}
                 paths:
-                  - services/QuillLMS/client/node_modules
+                  - services/QuillLessonsServer/node_modules
             - run:
                 name: Run Lessons Server Jest Tests
                 command: |

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -276,7 +276,7 @@ jobs:
                 name: Run Lessons Server Jest Tests
                 command: |
                   cd services/QuillLessonsServer
-                  node --expose-gc ./node_modules/.bin/jest **/*.test.* --maxWorkers=2 --logHeapUsage
+                  node --expose-gc ./node_modules/.bin/jest test --maxWorkers=2 --logHeapUsage
 
   lms_node_build:
     parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -240,6 +240,44 @@ jobs:
                   cd services/QuillLMS
                   TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split)
                   bin/rspec ${TESTFILES} --tag big_query_snapshot
+  lessons_server_build:
+    parameters:
+      <<: *should_run_params
+    working_directory: ~/Empirical-Core
+    parallelism: 4
+    docker:
+      - image: cimg/node:14.21
+    steps:
+      - run:
+          <<: *blank_required_step
+      - when:
+          condition: << parameters.should-run >>
+          steps:
+            - checkout
+            - run:
+                name: Install npm 8
+                command: |
+                  sudo npm install npm@8.19.2 -g
+            - restore_cache:
+                keys:
+                  - npm-cache-lms-client-v8-{{ checksum "services/QuillLMS/client/package.json" }}-{{ checksum "services/QuillLMS/client/package-lock.json" }}
+                  - npm-cache-lms-client-v8-{{ checksum "services/QuillLMS/client/package.json" }}-
+                  - npm-cache-lms-client-v8-
+            - run:
+                name: Install NPM dependencies
+                command: |
+                  cd services/QuillLessonsServer
+                  npm install --legacy-peer-deps
+            - save_cache:
+                key: npm-cache-lms-client-v6-{{ checksum "services/QuillLMS/client/package.json" }}-{{ checksum "services/QuillLMS/client/package-lock.json" }}
+                paths:
+                  - services/QuillLMS/client/node_modules
+            - run:
+                name: Run Lessons Server Jest Tests
+                command: |
+                  cd services/QuillLessonsServer
+                  node --expose-gc ./node_modules/.bin/jest **/*.test.* --maxWorkers=2 --logHeapUsage
+
   lms_node_build:
     parameters:
       <<: *should_run_params
@@ -470,6 +508,9 @@ parameters:
   lms-run-javascript:
     type: boolean
     default: false
+  lessons-server-run:
+    type: boolean
+    default: false
   lms-run-queries:
     type: boolean
     default: false
@@ -503,6 +544,9 @@ workflows:
           <<: *default_filter
       - lms_node_build:
           should-run: << pipeline.parameters.lms-run-javascript >>
+          <<: *default_filter
+      - lessons_server_build:
+          should-run: << pipeline.parameters.lessons-server-run >>
           <<: *default_filter
       - lms_big_query_build:
           should-run: << pipeline.parameters.lms-run-queries >>

--- a/services/QuillLessonsServer/test/config/rethinkdb.test.js
+++ b/services/QuillLessonsServer/test/config/rethinkdb.test.js
@@ -22,8 +22,7 @@ describe('rethinkdbConfig', () => {
     expect(config.host).toEqual('url.com');
     expect(config.port).toEqual('4321');
     expect(config.db).toEqual('quill_lessons');
-    expect(config.authKey).toEqual('1234');
-    expect(config.ssl).toHaveProperty('ca');
+    expect(config.password).toEqual('1234');
   });
 });
 

--- a/services/QuillLessonsServer/test/handlers/authorization.test.js
+++ b/services/QuillLessonsServer/test/handlers/authorization.test.js
@@ -1,0 +1,83 @@
+import * as authorization from '../../src/handlers/authorization';
+// const { _checkToken, _isRoleAuthorized, _isPreviewSession, _reportError } = require('./authorizeRole');
+
+// jest.mock('../../src/handlers/authorization', () => ({
+//   authorizeRole: {
+//     _checkToken: jest.fn(),
+//     _isRoleAuthorized: jest.fn(),
+//     _isPreviewSession: jest.fn(),
+//     _reportError: jest.fn()
+//   }
+// }));
+
+
+
+describe('authorizeRole', () => {
+  const mockCallback = jest.fn();
+  const token = { data: { role: 'user' } };
+  const data = {};
+  const client = { emit: jest.fn() };
+  const permittedRoles = ['admin', 'editor'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // it('should authorize if role is permitted', done => {
+  //   _checkToken.mockImplementationOnce((data, token, client, cb) => cb());
+  //   _isRoleAuthorized.mockReturnValueOnce(true);
+
+  //   authorizeRole(permittedRoles, data, token, client, () => {
+  //     expect(mockCallback).toHaveBeenCalled();
+  //     done();
+  //   });
+  // });
+
+  // it('should authorize if it is a preview session', done => {
+  //   _checkToken.mockImplementationOnce((data, token, client, cb) => cb());
+  //   _isRoleAuthorized.mockReturnValueOnce(false);
+  //   _isPreviewSession.mockReturnValueOnce(true);
+
+  //   authorizeRole(permittedRoles, data, token, client, () => {
+  //     expect(mockCallback).toHaveBeenCalled();
+  //     done();
+  //   });
+  // });
+
+  it('should not invoke callback when role is unuathorized', () => {
+    authorization.authorizeRole(permittedRoles, data, token, client, mockCallback);
+    expect(mockCallback).not.toHaveBeenCalled();
+  })
+
+  it('should invoke callback when role is athorized', () => {
+    jest.spyOn(authorization, '_isRoleAuthorized').mockImplementation(() => {
+      return jest.fn()
+    })
+    authorizeRole(permittedRoles, data, token, client, mockCallback);
+    expect(mockCallback).not.toHaveBeenCalled();
+  })
+
+  // it('should report error when role is not authorized and not a preview session', () => {
+  //   // _checkToken.mockImplementationOnce((data, token, client, cb) => cb());
+  //   // _isRoleAuthorized.mockReturnValueOnce(false);
+  //   // _isPreviewSession.mockReturnValueOnce(false);
+  //   jest.spyOn(authorizeRole, 'TextEditor').mockImplementation(() => {
+  //     return jest.fn()
+  //   })
+
+  //   authorizeRole(permittedRoles, data, token, client, mockCallback);
+
+  //   expect(_reportError).toHaveBeenCalledWith('unauthorizedRole', data, token, client);
+  //   expect(mockCallback).not.toHaveBeenCalled();
+  // });
+
+  // it('should process token check before deciding authorization', () => {
+  //   _checkToken.mockImplementationOnce((data, token, client, cb) => {
+  //     expect(_isRoleAuthorized).not.toHaveBeenCalled();
+  //     expect(_isPreviewSession).not.toHaveBeenCalled();
+  //     cb();
+  //   });
+
+  //   authorizeRole(permittedRoles, data, token, client, mockCallback);
+  // });
+});

--- a/services/QuillLessonsServer/test/handlers/authorization.test.js
+++ b/services/QuillLessonsServer/test/handlers/authorization.test.js
@@ -1,16 +1,4 @@
 import * as authorization from '../../src/handlers/authorization';
-// const { _checkToken, _isRoleAuthorized, _isPreviewSession, _reportError } = require('./authorizeRole');
-
-// jest.mock('../../src/handlers/authorization', () => ({
-//   authorizeRole: {
-//     _checkToken: jest.fn(),
-//     _isRoleAuthorized: jest.fn(),
-//     _isPreviewSession: jest.fn(),
-//     _reportError: jest.fn()
-//   }
-// }));
-
-
 
 describe('authorizeRole', () => {
   const mockCallback = jest.fn();
@@ -23,61 +11,15 @@ describe('authorizeRole', () => {
     jest.clearAllMocks();
   });
 
-  // it('should authorize if role is permitted', done => {
-  //   _checkToken.mockImplementationOnce((data, token, client, cb) => cb());
-  //   _isRoleAuthorized.mockReturnValueOnce(true);
-
-  //   authorizeRole(permittedRoles, data, token, client, () => {
-  //     expect(mockCallback).toHaveBeenCalled();
-  //     done();
-  //   });
-  // });
-
-  // it('should authorize if it is a preview session', done => {
-  //   _checkToken.mockImplementationOnce((data, token, client, cb) => cb());
-  //   _isRoleAuthorized.mockReturnValueOnce(false);
-  //   _isPreviewSession.mockReturnValueOnce(true);
-
-  //   authorizeRole(permittedRoles, data, token, client, () => {
-  //     expect(mockCallback).toHaveBeenCalled();
-  //     done();
-  //   });
-  // });
-
   it('should not invoke callback when role is unuathorized', () => {
     authorization.authorizeRole(permittedRoles, data, token, client, mockCallback);
     expect(mockCallback).not.toHaveBeenCalled();
   })
 
-  it('should invoke callback when role is athorized', () => {
-    jest.spyOn(authorization, '_isRoleAuthorized').mockImplementation(() => {
-      return jest.fn()
-    })
-    authorizeRole(permittedRoles, data, token, client, mockCallback);
-    expect(mockCallback).not.toHaveBeenCalled();
+  it('should invoke callback when role is authorized', () => {
+    const tokenWithRole = { data: { role: 'admin'}, isValid: true }
+    authorization.authorizeRole(['admin'], data, tokenWithRole, client, mockCallback);
+    expect(mockCallback).toHaveBeenCalled();
   })
 
-  // it('should report error when role is not authorized and not a preview session', () => {
-  //   // _checkToken.mockImplementationOnce((data, token, client, cb) => cb());
-  //   // _isRoleAuthorized.mockReturnValueOnce(false);
-  //   // _isPreviewSession.mockReturnValueOnce(false);
-  //   jest.spyOn(authorizeRole, 'TextEditor').mockImplementation(() => {
-  //     return jest.fn()
-  //   })
-
-  //   authorizeRole(permittedRoles, data, token, client, mockCallback);
-
-  //   expect(_reportError).toHaveBeenCalledWith('unauthorizedRole', data, token, client);
-  //   expect(mockCallback).not.toHaveBeenCalled();
-  // });
-
-  // it('should process token check before deciding authorization', () => {
-  //   _checkToken.mockImplementationOnce((data, token, client, cb) => {
-  //     expect(_isRoleAuthorized).not.toHaveBeenCalled();
-  //     expect(_isPreviewSession).not.toHaveBeenCalled();
-  //     cb();
-  //   });
-
-  //   authorizeRole(permittedRoles, data, token, client, mockCallback);
-  // });
 });


### PR DESCRIPTION
## WHAT
- Dan started writing some tests for QLS in 2020. I got them passing, plus added a few more. 
- Integrate QLS into CircleCI (using the orb strategy, which avoids running these tests in PRs that don't touch QLS)

## WHY
- Ideally, all production apps should have ample test coverage. This is a first start.
- ditto 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/ea241f31a84c4b79ad56e83e99f7ee93?v=388007d5669c4347b4215e24770ebbcd&p=5cbd8cf049e64745a300f05bdc15f4cc&pm=s

### What have you done to QA this feature?
n/a - tests only

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | not yet
Self-Review: Have you done an initial self-review of the code below on Github? |
