### PR TITLE
Add Concept Name to admin's concept feedback page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
@@ -31,6 +31,14 @@ class ConceptFeedback extends React.Component {
     dispatch(actions.startConceptsFeedbackEdit(conceptFeedbackID))
   }
 
+  concept = () => {
+    const { match, concepts } = this.props
+    const { params } = match
+    const { conceptFeedbackID } = params
+
+    return concepts.hasreceiveddata ? concepts.data[0].find((c) => c.uid === conceptFeedbackID) : null
+  }
+
   render() {
     const { concepts, conceptsFeedback, match } = this.props
     const { data, states } = conceptsFeedback
@@ -38,18 +46,22 @@ class ConceptFeedback extends React.Component {
     const { params } = match
     const { conceptFeedbackID } = params
 
+    const concept = this.concept()
+    const conceptName = concept ? <h4 className="title">{concept.displayName}</h4> : null
+
     if (data && data[conceptFeedbackID]) {
       const isEditing = (states[conceptFeedbackID] === C.START_CONCEPTS_FEEDBACK_EDIT);
       if (isEditing) {
         return (
           <div className="admin-container" key={conceptFeedbackID}>
-            <h4 className="title">{data[conceptFeedbackID].name}</h4>
+            {conceptName}
             <FeedbackForm {...data[conceptFeedbackID]} cancelEdit={this.cancelEdit} feedbackID={conceptFeedbackID} submitNewFeedback={this.submitNewFeedback} />
           </div>
         )
       } else {
         return (
           <div className="admin-container" key={conceptFeedbackID}>
+            {conceptName}
             <ConceptExplanation {...data[conceptFeedbackID]} />
             <p className="control">
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button> <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>


### PR DESCRIPTION
## WHAT
Add the Concept Name attribute to this page when rendering concept feedback forms.

## WHY
So admin can see the name (and parent names) of the concept that they're currently editing.

## HOW
Use the same code from Grammar to fetch the concept object and display the name in the rendered HTML blocks.

### Screenshots
![Screenshot 2024-05-13 at 1 59 20 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/a2aa68e2-ec78-4dda-bdef-e591d6679906)


### Notion Card Links
https://www.notion.so/quill/Add-Concept-Feedback-Name-to-Individual-Concept-Feedback-Pages-in-Connect-a5557d78f0394eb3a4967541a0bbb6c3?pvs=4

### What have you done to QA this feature?
Deploy to staging and verify that both the un-editing and the editing state display the correct concept name.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
