### PR TITLE
Fix syntax error in delete concept results

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/response.tsx
@@ -208,9 +208,9 @@ export default class extends React.Component<ResponseProps, ResponseState> {
   deleteConceptResult = (crid) => {
     const { conceptResults } = this.state
     if (confirm('Are you sure?')) {
-      const conceptResults = Object.assign({}, conceptResults || {});
-      delete conceptResults[crid];
-      this.setState({conceptResults})
+      const newConceptResults = Object.assign({}, conceptResults || {});
+      delete newConceptResults[crid];
+      this.setState({conceptResults: newConceptResults})
     }
   }
 


### PR DESCRIPTION
## WHAT
Fix a syntax error that was preventing conceptResults from being deleted from responses in Grammar admin panel.

## WHY
So admin can delete concept results where appropriate.

## HOW
We were setting the same variable name, "conceptResults", twice in the same function. Change the name of the second variable so it can be correctly called.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Make-it-possible-to-remove-Concept-Results-from-Responses-in-Grammar-2772be1129cd4903ad962a63e41e7cf4?pvs=4

### What have you done to QA this feature?
Deploy to staging and test out deleting a concept result from a response, confirm it is saved correctly after updating.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no, small change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
