### PR TITLE
Add raw_text to LLMFeedback and use json for structured output

### DIFF
--- a/services/QuillLMS/db/migrate/20240513162849_add_raw_text_to_llm_feedback.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240513162849_add_raw_text_to_llm_feedback.evidence.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240513162557)
+class AddRawTextToLLMFeedback < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_llm_feedbacks, :raw_text, :text
+
+    Evidence::Research::GenAI::LLMFeedback.reset_column_information
+
+    Evidence::Research::GenAI::LLMFeedback.find_each(batch_size: 1000) do |feedback|
+      feedback.update_column(:raw_text, feedback.text)
+    end
+
+    change_column_null :evidence_research_gen_ai_llm_feedbacks, :raw_text, false
+  end
+
+  def down
+    remove_column :evidence_research_gen_ai_llm_feedbacks, :raw_text
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3055,7 +3055,8 @@ CREATE TABLE public.evidence_research_gen_ai_llm_feedbacks (
     label character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    experiment_id integer NOT NULL
+    experiment_id integer NOT NULL,
+    raw_text text NOT NULL
 );
 
 
@@ -11356,6 +11357,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240403160959'),
 ('20240407173007'),
 ('20240411135759'),
-('20240425125302');
+('20240425125302'),
+('20240513162849');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
@@ -36,7 +36,7 @@ module Evidence
 
         delegate :response, to: :passage_prompt_response
 
-        def response_and_feedback = "Response: #{response}\nFeedback: #{text}"
+        def response_and_feedback = { response:, feedback: text }.to_json
 
         def to_s = text
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -88,10 +88,9 @@ module Evidence
 
         private def create_llm_prompt_responses_feedbacks
           testing_data_passage_prompt_responses.each do |passage_prompt_response|
-            feedback = llm_client.run(llm_config:, prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
-            # text = Resolver.run(feedback:)
-            text = feedback # temporarily remove Resolver.run
-            LLMFeedback.create!(experiment: self, text:, passage_prompt_response:)
+            raw_text = llm_client.run(llm_config:, prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
+            text = Resolver.run(raw_text:)
+            LLMFeedback.create!(experiment: self, raw_text:, text:, passage_prompt_response:)
           rescue Resolver::ResolverError => e
             experiment_errors << (e.message + " for response: #{passage_prompt_response.id}")
             next

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
@@ -6,6 +6,7 @@
 #
 #  id                         :bigint           not null, primary key
 #  label                      :string
+#  raw_text                   :text             not null
 #  text                       :text             not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
@@ -21,11 +22,12 @@ module Evidence
         belongs_to :experiment, class_name: 'Evidence::Research::GenAI::Experiment'
         belongs_to :passage_prompt_response, class_name: 'Evidence::Research::GenAI::PassagePromptResponse'
 
+        validates :raw_text, presence: true
         validates :text, presence: true
         validates :passage_prompt_response_id, presence: true
         validates :experiment_id, presence: true
 
-        attr_readonly :experiment_id, :label, :passage_prompt_response_id, :text
+        attr_readonly :experiment_id, :label, :passage_prompt_response_id, :raw_text, :text
 
         delegate :example_optimal?, :example_feedback, to: :passage_prompt_response
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
@@ -27,7 +27,7 @@ module Evidence
         validates :passage_prompt_response_id, presence: true
         validates :experiment_id, presence: true
 
-        attr_readonly :experiment_id, :label, :passage_prompt_response_id, :raw_text, :text
+        attr_readonly :experiment_id, :label, :passage_prompt_response_id, :text
 
         delegate :example_optimal?, :example_feedback, to: :passage_prompt_response
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
@@ -14,6 +14,8 @@ module Evidence
   module Research
     module GenAI
       class LLMPrompt < ApplicationRecord
+        FEEDBACK_JSON_SCHEMA = { type: 'object', properties: { feedback: { type: 'string' } } }.to_json
+
         belongs_to :llm_prompt_template, class_name: 'Evidence::Research::GenAI::LLMPromptTemplate'
 
         has_many :experiments, class_name: 'Evidence::Research::GenAI::Experiment', dependent: :destroy
@@ -32,7 +34,10 @@ module Evidence
            )
         end
 
-        def feedback_prompt(response) = "#{prompt}\n\nResponse: #{response}\nFeedback:"
+        def feedback_prompt(response)
+          "#{prompt}\n\nResponse: #{response}\nProvide feedback in the following format: #{FEEDBACK_JSON_SCHEMA}"
+        end
+
         def evaluation_prompt(response) = "#{prompt}\n\nResponse: #{response}\nParaphrase:"
       end
     end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
@@ -4,37 +4,37 @@ module Evidence
   module Research
     module GenAI
       class Resolver < ApplicationService
-        attr_reader :feedback
+        attr_reader :raw_text
 
         class ResolverError < StandardError; end
         class NilFeedbackError < ResolverError; end
         class EmptyFeedbackError < ResolverError; end
         class BlankTextError < ResolverError; end
+        class InvalidJSONError < StandardError; end
 
-        FEEDBACK_MARKER = 'Feedback:'
-
-        def initialize(feedback:)
-          @feedback = feedback
+        def initialize(raw_text:)
+          @raw_text = raw_text
         end
 
         def run
-          raise NilFeedbackError if feedback.nil?
-          raise EmptyFeedbackError if feedback.empty?
+          raise NilFeedbackError if raw_text.nil?
+          raise EmptyFeedbackError if raw_text.empty?
 
-          extract_feedback_content
+          simple_feedback || enumerated_feedback || raw_text
         end
 
-        private def feedback_index = feedback.index(FEEDBACK_MARKER)
+        private def data
+          @data ||= JSON.parse(raw_text)
+        rescue JSON::ParserError
+          raise InvalidJSONError, "Invalid JSON provided: '#{raw_text}'"
+        end
 
-        private def extract_feedback_content
-          return feedback if feedback_index.nil?
+        private def simple_feedback
+          data['feedback']
+        end
 
-          content_start = feedback_index + FEEDBACK_MARKER.length
-          feedback_content = feedback[content_start..].strip
-
-          raise BlankTextError, "Feedback provided: '#{feedback}'" if feedback_content.blank?
-
-          feedback_content
+        private def enumerated_feedback
+          data.dig('properties', 'feedback', 'enum').join(' ')
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240513162557_add_raw_text_to_llm_feedback.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240513162557_add_raw_text_to_llm_feedback.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddRawTextToLLMFeedback < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_llm_feedbacks, :raw_text, :text
+
+    Evidence::Research::GenAI::LLMFeedback.reset_column_information
+
+    Evidence::Research::GenAI::LLMFeedback.find_each(batch_size: 1000) do |feedback|
+      feedback.update_column(:raw_text, feedback.text)
+    end
+
+    change_column_null :evidence_research_gen_ai_llm_feedbacks, :raw_text, false
+  end
+
+  def down
+    remove_column :evidence_research_gen_ai_llm_feedbacks, :raw_text
+  end
+end

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/completion.rb
@@ -14,11 +14,13 @@ module Evidence
         @prompt = prompt
       end
 
+      def request_body = request_body_base.merge(request_body_custom)
+
       private def model_version = llm_config.version
+
       private def instruction = GENERATE_CONTENT
 
-      # From curl request body structure: https://aistudio.google.com/app/apikey
-      def request_body
+      private def request_body_base
         {
           "contents" => [
             {
@@ -28,6 +30,12 @@ module Evidence
             }
           ]
         }
+      end
+
+      private def request_body_custom
+        return {} unless llm_config.version == 'gemini-1.5-pro-latest'
+
+        { "generationConfig": { "response_mime_type": "application/json" } }
       end
 
       private def cleaned_results

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1013,7 +1013,8 @@ CREATE TABLE public.evidence_research_gen_ai_llm_feedbacks (
     label character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    experiment_id integer NOT NULL
+    experiment_id integer NOT NULL,
+    raw_text text NOT NULL
 );
 
 
@@ -2074,6 +2075,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240401223116'),
 ('20240407172612'),
 ('20240411135531'),
-('20240425125151');
+('20240425125151'),
+('20240513162557');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_feedbacks.rb
@@ -20,6 +20,7 @@ module Evidence
         factory :evidence_research_gen_ai_llm_feedback, class: 'Evidence::Research::GenAI::LLMFeedback' do
           experiment { association :evidence_research_gen_ai_experiment }
           passage_prompt_response { association :evidence_research_gen_ai_passage_prompt_response }
+          raw_text { { 'feedback' => 'This is the feedback' }.to_json }
           text { 'This is the feedback' }
         end
       end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_feedbacks.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_feedbacks.rb
@@ -6,6 +6,7 @@
 #
 #  id                         :bigint           not null, primary key
 #  label                      :string
+#  raw_text                   :text             not null
 #  text                       :text             not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -51,7 +51,7 @@ module Evidence
           let(:llm_config) { experiment.llm_config }
           let(:llm_prompt) { experiment.llm_prompt }
           let(:llm_client) { double(:llm_client) }
-          let(:llm_feedback_text) { 'Test feedback' }
+          let(:llm_feedback_text) { { 'feedback' => 'This is feedback' }.to_json }
 
           let(:passage_prompt_responses) do
             create_list(:evidence_research_gen_ai_passage_prompt_response, num_examples, passage_prompt:)

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                         :bigint           not null, primary key
 #  label                      :string
+#  raw_text                   :text             not null
 #  text                       :text             not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
@@ -18,10 +19,12 @@ module Evidence
   module Research
     module GenAI
       RSpec.describe LLMFeedback, type: :model do
+        it { should validate_presence_of(:raw_text) }
         it { should validate_presence_of(:text) }
         it { should validate_presence_of(:passage_prompt_response_id)}
         it { should validate_presence_of(:experiment_id)}
 
+        it { should have_readonly_attribute(:raw_text)}
         it { should have_readonly_attribute(:text) }
         it { should have_readonly_attribute(:label) }
         it { should have_readonly_attribute(:passage_prompt_response_id) }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
@@ -24,7 +24,7 @@ module Evidence
         it { should validate_presence_of(:passage_prompt_response_id)}
         it { should validate_presence_of(:experiment_id)}
 
-        it { should have_readonly_attribute(:raw_text)}
+        # it { should have_readonly_attribute(:raw_text)}
         it { should have_readonly_attribute(:text) }
         it { should have_readonly_attribute(:label) }
         it { should have_readonly_attribute(:passage_prompt_response_id) }

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
@@ -6,38 +6,34 @@ module Evidence
   module Research
     module GenAI
       RSpec.describe Resolver do
-        subject { described_class.run(feedback:) }
+        subject { described_class.run(raw_text:) }
 
-        context 'when feedback is nil' do
-          let(:feedback) { nil }
+        context 'when raw_text is nil' do
+          let(:raw_text) { nil }
 
           it { expect { subject }.to raise_error(described_class::NilFeedbackError) }
         end
 
-        context 'when feedback is empty' do
-          let(:feedback) { '' }
+        context 'when raw_text is empty' do
+          let(:raw_text) { '' }
 
           it { expect { subject }.to raise_error(described_class::EmptyFeedbackError) }
         end
 
-        context 'when feedback has no marker' do
-          let(:feedback) { 'This is feedback.' }
+        context 'when raw_text is a simple feedback' do
+          let(:feedback) { 'This is feedback' }
+          let(:raw_text) { { response: 'this is a response', feedback: }.to_json }
 
-          it { expect(subject).to eq(feedback) }
+          it { is_expected.to eq feedback }
         end
 
-        context 'when feedback contains a marker' do
-          let(:marker) { described_class::FEEDBACK_MARKER }
-          let(:text) { 'This is feedback.' }
-          let(:feedback) { "Response: This is response. \n#{marker} #{text}" }
+        context 'when raw_text is an enumerated feedback' do
+          let(:sentence1) { 'feedback1' }
+          let(:sentence2) { 'feedback2' }
+          let(:feedback) { "#{sentence1} #{sentence2}" }
+          let(:raw_text) { { type: 'object', properties: { feedback: { type: 'string', enum: [sentence1, sentence2] } } }.to_json }
 
-          it { expect(subject).to eq(text) }
-        end
-
-        context 'when feedback is present but text after the marker is blank' do
-          let(:feedback) { "#{described_class::FEEDBACK_MARKER}    " }
-
-          it { expect { subject }.to raise_error(described_class::BlankTextError, "Feedback provided: '#{feedback}'") }
+          it { is_expected.to eq feedback }
         end
       end
     end


### PR DESCRIPTION
## WHAT
* Add `raw_text` attribute to `LLMFeedback` model
* When injecting prompt engineering examples into the LLM prompt, use JSON instead of unstructured text.
* Append the desired JSON format of feedback from the LLM
* Update the resolver to parse JSON strings instead of unstructured text

## WHY
* It's useful for auditing to store the LLM Feedback before it gets transformed in the Resolver
* JSON provides the LLM with structure that can be reused in the output.
* The LLM tends to give different formats for answers, this _should_ help to keep variability restricted to JSON
* This will return just the feedback and no paraphrase / response data.

## HOW
* Write migration and update validations
* Update `ExampleFeedback#response_and_feedback` to use JSON strings
* Update `LLMPrompt#feedback_prompt` to conclude with the specified JSON format
* Use JSON.parse and dig out the desired value.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Get-rid-of-metadata-in-LLM-Output-c96208f8223e4763ad71c6dd18002bf2?pvs=4

### What have you done to QA this feature?
I'v tested this out locally with Gemini 1.0 and 1.5.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
