### PR TITLE
Bug fix/ Activity Analysis reports prompt value

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/formatString.ts
@@ -3,6 +3,8 @@ export const formatString = (str: string) => {
 }
 
 export const formatStringAndAddSpacesAfterPeriods = (str: string) => {
+  // some concept results don't have a concept result prompt so we early return to prevent the page from crashing
+  if (!str) { return }
   return formatString(str).replace(/\.(?=[^ ])/g, '. ')
 }
 


### PR DESCRIPTION
## WHAT
fix issue where nil prompt values were causing the student activity analysis page to crash

## WHY
we want this page to load for users

## HOW
add early return if `str` value is `null`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Students-Activity-Analysis-reports-for-the-activity-Proofreading-Coordinate-Adjectives-Visiting--c42889d717564536b063e6caacfee33f

### What have you done to QA this feature?
tested on staging that the student views for this activity load as expected

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | no-- small change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
