### PR TITLE
Misc GenAI experiment updates

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
@@ -84,7 +84,7 @@ module Evidence
         private def passage_prompt_ids = experiment_params[:passage_prompt_ids].reject(&:blank?).map(&:to_i)
 
         private def num_examples(passage_prompt_id)
-          max_num_examples = PassagePrompt.find(passage_prompt_id).passage_prompt_responses.count
+          max_num_examples = PassagePrompt.find(passage_prompt_id).passage_prompt_responses.testing_data.count
 
           return max_num_examples if experiment_params[:num_examples].blank?
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
@@ -36,6 +36,10 @@ module Evidence
 
         delegate :response, to: :passage_prompt_response
 
+        scope :testing_data, -> { where(data_partition: TESTING_DATA) }
+        scope :fine_tuning_data, -> { where(data_partition: FINE_TUNING_DATA) }
+        scope :prompt_engineering_data, -> { where(data_partition: PROMPT_ENGINEERING_DATA) }
+
         def response_and_feedback = { response:, feedback: text }.to_json
 
         def to_s = text

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -79,20 +79,13 @@ module Evidence
 
         def retry_params = { llm_config_id:, llm_prompt_id:, passage_prompt_id:, num_examples: }
 
-        private def testing_data_passage_prompt_responses
-          passage_prompt_responses
-            .joins(:example_feedback)
-            .where(example_feedback: { data_partition: ExampleFeedback::TESTING_DATA })
-            .limit(num_examples)
-        end
-
         private def create_llm_prompt_responses_feedbacks
-          testing_data_passage_prompt_responses.each do |passage_prompt_response|
+          passage_prompt_responses.testing_data.limit(num_examples).each do |passage_prompt_response|
             raw_text = llm_client.run(llm_config:, prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
             text = Resolver.run(raw_text:)
             LLMFeedback.create!(experiment: self, raw_text:, text:, passage_prompt_response:)
           rescue Resolver::ResolverError => e
-            experiment_errors << (e.message + " for response: #{passage_prompt_response.id}")
+            experiment_errors << { error: e.message, passage_prompt_response_id: passage_prompt_response.id, raw_text:}.to_json
             next
           end
         end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
@@ -27,7 +27,7 @@ module Evidence
         validates :passage_prompt_response_id, presence: true
         validates :experiment_id, presence: true
 
-        attr_readonly :experiment_id, :label, :passage_prompt_response_id, :text
+        attr_readonly :experiment_id, :label, :passage_prompt_response_id, :raw_text, :text
 
         delegate :example_optimal?, :example_feedback, to: :passage_prompt_response
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
@@ -24,6 +24,11 @@ module Evidence
 
         attr_readonly :response, :passage_prompt_id
 
+        def self.testing_data
+          joins(:example_feedback)
+            .where(example_feedback: { data_partition: ExampleFeedback::TESTING_DATA })
+        end
+
         def example_optimal? = example_feedback.optimal?
 
         def to_s = response

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/passage_prompt_response.rb
@@ -24,10 +24,9 @@ module Evidence
 
         attr_readonly :response, :passage_prompt_id
 
-        def self.testing_data
-          joins(:example_feedback)
-            .where(example_feedback: { data_partition: ExampleFeedback::TESTING_DATA })
-        end
+        def self.testing_data = joins(:example_feedback).merge(ExampleFeedback.testing_data)
+        def self.fine_tuning_data = joins(:example_feedback).merge(ExampleFeedback.fine_tuning_data)
+        def self.prompt_engineering_data = joins(:example_feedback).merge(ExampleFeedback.prompt_engineering_data)
 
         def example_optimal? = example_feedback.optimal?
 

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
@@ -52,6 +52,7 @@ module Evidence
         def examples(limit)
           passage_prompt
             .example_feedbacks
+            .prompt_engineering_data
             .limit(limit)
             .map(&:response_and_feedback)
             .join("\n")

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
@@ -10,8 +10,8 @@ module Evidence
         class NilFeedbackError < ResolverError; end
         class EmptyFeedbackError < ResolverError; end
         class BlankTextError < ResolverError; end
-        class InvalidJSONError < StandardError; end
-        class UnknownFeedbackStructureError < ResolverError; end
+        class InvalidJSONError < ResolverError; end
+        class UnknownJSONStructureError < ResolverError; end
 
         def initialize(raw_text:)
           @raw_text = raw_text
@@ -23,13 +23,13 @@ module Evidence
 
           return raw_text unless data.is_a?(Hash)
 
-          simple_feedback || enumerated_feedback || raise(UnknownFeedbackStructureError, "Unknown structure: '#{data}'")
+          simple_feedback || enumerated_feedback || raise(UnknownJSONStructureError)
         end
 
         private def data
           @data ||= JSON.parse(raw_text)
         rescue JSON::ParserError
-          raise InvalidJSONError, "Invalid JSON provided: '#{raw_text}'"
+          raise InvalidJSONError
         end
 
         private def simple_feedback = data['feedback']

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
@@ -11,6 +11,7 @@ module Evidence
         class EmptyFeedbackError < ResolverError; end
         class BlankTextError < ResolverError; end
         class InvalidJSONError < StandardError; end
+        class UnknownFeedbackStructureError < ResolverError; end
 
         def initialize(raw_text:)
           @raw_text = raw_text
@@ -20,7 +21,9 @@ module Evidence
           raise NilFeedbackError if raw_text.nil?
           raise EmptyFeedbackError if raw_text.empty?
 
-          simple_feedback || enumerated_feedback || raw_text
+          return raw_text unless data.is_a?(Hash)
+
+          simple_feedback || enumerated_feedback || raise(UnknownFeedbackStructureError, "Unknown structure: '#{data}'")
         end
 
         private def data
@@ -29,13 +32,9 @@ module Evidence
           raise InvalidJSONError, "Invalid JSON provided: '#{raw_text}'"
         end
 
-        private def simple_feedback
-          data['feedback']
-        end
+        private def simple_feedback = data['feedback']
 
-        private def enumerated_feedback
-          data.dig('properties', 'feedback', 'enum').join(' ')
-        end
+        private def enumerated_feedback = data.dig('properties', 'feedback', 'enum')&.join(' ')
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/resolver.rb
@@ -23,7 +23,7 @@ module Evidence
 
           return raw_text unless data.is_a?(Hash)
 
-          simple_feedback || enumerated_feedback || raise(UnknownJSONStructureError)
+          simple_feedback || enumerated_feedback || property_feedback_value || raise(UnknownJSONStructureError)
         end
 
         private def data
@@ -35,6 +35,8 @@ module Evidence
         private def simple_feedback = data['feedback']
 
         private def enumerated_feedback = data.dig('properties', 'feedback', 'enum')&.join(' ')
+
+        private def property_feedback_value = data.dig('properties', 'feedback', 'value')
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
@@ -12,8 +12,11 @@
     <%= check_box_tag 'select_all_llm_config', '', false, id: 'select_all_llm_config', class: 'check-all' %> Select all
     <br/>
     <% @llm_configs.each do |llm_config| %>
-      <%= check_box_tag 'research_gen_ai_experiment[llm_config_ids][]', llm_config.id, false, id: dom_id(llm_config), class: 'llm-config-checkbox' %>
-      <%= label_tag dom_id(llm_config), llm_config.to_s %><br/>
+      <div class="llm-config-item" style="display: flex; align-items: baseline;">
+        <%= check_box_tag 'research_gen_ai_experiment[llm_config_ids][]', llm_config.id, false, id: dom_id(llm_config), class: 'llm-config-checkbox' %>
+        <%= label_tag dom_id(llm_config), llm_config.to_s %><br/>
+        <%= link_to 'view', llm_config, class: 'new-link', style: 'margin-left: 10px;' %>
+      </div>
     <% end %>
   </div>
 
@@ -25,8 +28,11 @@
     <%= check_box_tag 'select_all_llm_prompt_template', '', false, id: 'select_all_llm_prompt_template', class: 'check-all' %> Select all
     <br/>
   <% @llm_prompt_templates.each do |llm_prompt_template| %>
-    <%= check_box_tag 'research_gen_ai_experiment[llm_prompt_template_ids][]', llm_prompt_template.id, false, id: dom_id(llm_prompt_template), class: 'llm-prompt-template-checkbox' %>
-    <%= label_tag dom_id(llm_prompt_template), llm_prompt_template.to_s %><br/>
+      <div class="llm-prompt-template-item" style="display: flex; align-items: baseline;">
+        <%= check_box_tag 'research_gen_ai_experiment[llm_prompt_template_ids][]', llm_prompt_template.id, false, id: dom_id(llm_prompt_template), class: 'llm-prompt-template-checkbox' %>
+        <%= label_tag dom_id(llm_prompt_template), llm_prompt_template.to_s %><br/>
+        <%= link_to 'view', llm_prompt_template, class: 'new-link', style: 'margin-left: 10px;' %>
+      </div>
   <% end %>
   </div>
 
@@ -37,9 +43,12 @@
     </div>
     <%= check_box_tag 'select_all_passage_prompt', '', false, id: 'select_all_passage_prompt', class: 'check-all' %> Select all
     <br/>
-    <% @passage_prompts.each do |passage_prompt, index| %>
-      <%= check_box_tag 'research_gen_ai_experiment[passage_prompt_ids][]', passage_prompt.id, false, id: dom_id(passage_prompt), class: 'passage-prompt-checkbox' %>
-      <%= label_tag dom_id(passage_prompt), passage_prompt.to_s %><br/>
+    <% @passage_prompts.each do |passage_prompt| %>
+      <div class="passage-prompt-item" style="display: flex; align-items: baseline;">
+        <%= check_box_tag 'research_gen_ai_experiment[passage_prompt_ids][]', passage_prompt.id, false, id: dom_id(passage_prompt), class: 'passage-prompt-checkbox' %>
+        <%= label_tag dom_id(passage_prompt), passage_prompt.to_s %>
+        <%= link_to 'view', passage_prompt, class: 'new-link', style: 'margin-left: 10px;' %>
+      </div>
     <% end %>
   </div>
 

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
@@ -1,4 +1,4 @@
-<%= link_to 'Experiments', research_gen_ai_experiments_path, class: 'new-link', target: '_blank' %>
+<%= link_to 'Experiments', research_gen_ai_experiments_path, class: 'new-link' %>
 <h1>Experiment Runner</h1>
 
 <%= form_for @experiment, html: { id: 'new_experiment_form' } do |f| %>
@@ -53,7 +53,7 @@
   </div>
 <% end %>
 
-<%= link_to 'Experiments', research_gen_ai_experiments_path, class: 'new-link', target: '_blank' %>
+<%= link_to 'Experiments', research_gen_ai_experiments_path, class: 'new-link' %>
 
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/example_feedback_spec.rb
@@ -32,6 +32,16 @@ module Evidence
 
         it { expect(build(:evidence_research_gen_ai_example_feedback)).to be_valid}
 
+        context 'data_partition scopes' do
+          let!(:testing_feedback) { create(:evidence_research_gen_ai_example_feedback, :testing) }
+          let!(:fine_tuning_feedback) { create(:evidence_research_gen_ai_example_feedback, :fine_tuning) }
+          let!(:prompt_engineering_feedback) { create(:evidence_research_gen_ai_example_feedback, :prompt_engineering) }
+
+          it { expect(described_class.testing_data).to eq [testing_feedback] }
+          it { expect(described_class.fine_tuning_data).to eq [fine_tuning_feedback] }
+          it { expect(described_class.prompt_engineering_data).to eq [prompt_engineering_feedback] }
+        end
+
         it_behaves_like 'a class with optimal and sub-optimal'
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -46,7 +46,7 @@ module Evidence
           subject { experiment.run }
 
           let(:experiment) { create(:evidence_research_gen_ai_experiment, num_examples:) }
-          let(:num_examples) { 4 }
+          let(:num_examples) { 3 }
           let(:passage_prompt) { experiment.passage_prompt }
           let(:llm_config) { experiment.llm_config }
           let(:llm_prompt) { experiment.llm_prompt }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_feedback_spec.rb
@@ -24,7 +24,7 @@ module Evidence
         it { should validate_presence_of(:passage_prompt_response_id)}
         it { should validate_presence_of(:experiment_id)}
 
-        # it { should have_readonly_attribute(:raw_text)}
+        it { should have_readonly_attribute(:raw_text)}
         it { should have_readonly_attribute(:text) }
         it { should have_readonly_attribute(:label) }
         it { should have_readonly_attribute(:passage_prompt_response_id) }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
@@ -28,6 +28,16 @@ module Evidence
 
         it { expect(build(:evidence_research_gen_ai_passage_prompt_response)).to be_valid }
 
+        describe '.testing_data' do
+          subject { PassagePromptResponse.testing_data }
+
+          let!(:testing_feedback) { create(:evidence_research_gen_ai_example_feedback, :testing) }
+          let!(:fine_tuning_feedback) { create(:evidence_research_gen_ai_example_feedback, :fine_tuning) }
+          let!(:prompt_engineering_feedback) { create(:evidence_research_gen_ai_example_feedback, :prompt_engineering) }
+
+          it { is_expected.to eq [testing_feedback.passage_prompt_response] }
+        end
+
         describe '#example_optimal?' do
           subject { passage_prompt_response.example_optimal? }
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/passage_prompt_response_spec.rb
@@ -28,14 +28,14 @@ module Evidence
 
         it { expect(build(:evidence_research_gen_ai_passage_prompt_response)).to be_valid }
 
-        describe '.testing_data' do
-          subject { PassagePromptResponse.testing_data }
-
+        describe 'data_partition scopes' do
           let!(:testing_feedback) { create(:evidence_research_gen_ai_example_feedback, :testing) }
           let!(:fine_tuning_feedback) { create(:evidence_research_gen_ai_example_feedback, :fine_tuning) }
           let!(:prompt_engineering_feedback) { create(:evidence_research_gen_ai_example_feedback, :prompt_engineering) }
 
-          it { is_expected.to eq [testing_feedback.passage_prompt_response] }
+          it { expect(described_class.testing_data).to eq [testing_feedback.passage_prompt_response] }
+          it { expect(described_class.fine_tuning_data).to eq [fine_tuning_feedback.passage_prompt_response] }
+          it { expect(described_class.prompt_engineering_data).to eq [prompt_engineering_feedback.passage_prompt_response] }
         end
 
         describe '#example_optimal?' do

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
@@ -62,6 +62,7 @@ module Evidence
               create_list(
                 :evidence_research_gen_ai_example_feedback,
                 num_of_examples,
+                :prompt_engineering,
                 passage_prompt_response: create(:evidence_research_gen_ai_passage_prompt_response, passage_prompt:)
               )
             end
@@ -79,7 +80,6 @@ module Evidence
             it { is_expected.to eq "#{prompt} #{filler} #{instructions}" }
           end
         end
-
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
@@ -31,7 +31,7 @@ module Evidence
           let(:feedback) { 'This is feedback' }
           let(:raw_text) { { type: 'object', properties: { feedback: { type: 'string', value: feedback } } }.to_json }
 
-          it { is_expected.to eq feedback}
+          it { is_expected.to eq feedback }
         end
 
         context 'when raw_text is an enumerated feedback' do

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
@@ -20,11 +20,18 @@ module Evidence
           it { expect { subject }.to raise_error(described_class::EmptyFeedbackError) }
         end
 
-        context 'when raw_text is a simple feedback' do
+        context 'when raw_text is a flat feedback' do
           let(:feedback) { 'This is feedback' }
           let(:raw_text) { { response: 'this is a response', feedback: }.to_json }
 
           it { is_expected.to eq feedback }
+        end
+
+        context 'when raw_text is property_feedback_value' do
+          let(:feedback) { 'This is feedback' }
+          let(:raw_text) { { type: 'object', properties: { feedback: { type: 'string', value: feedback } } }.to_json }
+
+          it { is_expected.to eq feedback}
         end
 
         context 'when raw_text is an enumerated feedback' do

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/resolver_spec.rb
@@ -42,6 +42,9 @@ module Evidence
 
           it { is_expected.to eq feedback }
         end
+
+        # TODO
+        # '{"type":"object","properties":{"feedback":{"type":"string":"You make an interesting point. Can you find any evidence in the text that suggests how driverless cars might be programmed to handle unexpected situations?"}}} '
       end
     end
   end


### PR DESCRIPTION
## WHAT
1. Change mechanism for calculating max_num_examples
1. Add scopes for testing_data, fine_tuning, and prompt_engineering
1. Change the format of experiment errors
1. Make `raw_text` attribute in `LLMFeedback` readonly
1. Restrict LLMPrompt builder examples to prompt_engineering data partition only
1. Add another structure to check for in Resolver
1. Add 'view' links next to items in Experiment#new

## WHY
1. When num_examples is left blank, our max should be only testing data, not all ExampleFeedback
1. These partitions are useful in different parts of the experiment
1. The flat strings inevitably require parsing for investigation
1. This had to be omitted during backfill migration
1. This partition is reserved for LLM Prompts
1. We'd like to get more coverage of different structures
1. Add an easy way to inspect component

## HOW
1. Calculate `max_num_examples` by scoping `testing_data`
1. Add scopes to `ExampleFeedback` and the parent object `PassagePromptResponse`
1. Store experiment errors as JSON strings rather than an unstructured one.
1. Update the `attr_readonly`
1. Add `.prompt_engineering` scope to example builder
1. dig through structure and attempt to find value.
1. `<%= link_to 'view' object ...%>`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Tested locally.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
