### PR TITLE
Prune devdependencies

### DIFF
--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "postinstall": "cd ./client && npm install",
-    "heroku-postbuild": "[ $RAILS_ENV = staging ] && npm prune --production",
+    "heroku-postbuild": "[ $NODE_ENV = staging ] && npm prune --production",
     "test": "npm run jest && npm run build:test && npm run lint && bundle exec rake spec",
     "lint": "cd client && npm run lint",
     "build:test": "cd client && npm run build:test",

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "postinstall": "cd ./client && npm install",
+    "heroku-postbuild": "[[ \"$NODE_ENV\" == \"staging\" ]] && npm prune --production",
     "test": "npm run jest && npm run build:test && npm run lint && bundle exec rake spec",
     "lint": "cd client && npm run lint",
     "build:test": "cd client && npm run build:test",

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "postinstall": "cd ./client && npm install",
-    "heroku-postbuild": "[[ \"$NODE_ENV\" == \"staging\" ]] && npm prune --production",
+    "heroku-postbuild": "[ $RAILS_ENV = staging ] && npm prune --production",
     "test": "npm run jest && npm run build:test && npm run lint && bundle exec rake spec",
     "lint": "cd client && npm run lint",
     "build:test": "cd client && npm run build:test",

--- a/services/QuillLessonsServer/package.json
+++ b/services/QuillLessonsServer/package.json
@@ -8,7 +8,8 @@
     "start": "npm run build && node lib/index.js",
     "serve": "node lib/index.js",
     "start:dev": "./rethink_local.sh start; PORT=3200 RETHINKDB_HOSTS=localhost:28015 nodemon src/index.js --exec babel-node src/index.js; ./rethink_local.sh stop",
-    "test": "jest test"
+    "test": "jest test",
+    "heroku-postbuild": "[ $NODE_ENV = staging ] && npm prune --production"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## WHAT
prune devDependencies when `NODE_ENV=staging`

## WHY
So that the staging build does not diverge from the production build 

## HOW
add a post-build script 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=7f05e401b4e645ea84af92749b143613&pm=s

### What have you done to QA this feature?
Ensure 'prune' step happens even when `NODE_ENV=staging` 
<img width="503" alt="Screenshot 2024-05-15 at 8 41 52 AM" src="https://github.com/empirical-org/Empirical-Core/assets/90669/087a16fb-d31d-40c4-913d-c59cf8fa6866">



PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  n/a
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
