### PR TITLE
fix pruning heroku script

### DIFF
--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "postinstall": "cd ./client && npm install",
-    "heroku-postbuild": "[ $NODE_ENV = staging ] && npm prune --production",
+    "heroku-postbuild": "[ $NODE_ENV = blahblah ] && npm prune --production",
     "test": "npm run jest && npm run build:test && npm run lint && bundle exec rake spec",
     "lint": "cd client && npm run lint",
     "build:test": "cd client && npm run build:test",

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "postinstall": "cd ./client && npm install",
-    "heroku-postbuild": "[ $NODE_ENV = blahblah ] && npm prune --production",
+    "heroku-postbuild": "[ $NODE_ENV = blahblah ] && npm prune --production ; :",
     "test": "npm run jest && npm run build:test && npm run lint && bundle exec rake spec",
     "lint": "cd client && npm run lint",
     "build:test": "cd client && npm run build:test",

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "postinstall": "cd ./client && npm install",
-    "heroku-postbuild": "[ $NODE_ENV = blahblah ] && npm prune --production ; :",
+    "heroku-postbuild": "[ $NODE_ENV = staging ] && npm prune --production ; :",
     "test": "npm run jest && npm run build:test && npm run lint && bundle exec rake spec",
     "lint": "cd client && npm run lint",
     "build:test": "cd client && npm run build:test",


### PR DESCRIPTION
## WHAT
Fix the `heroku-postbuild` script 

## WHY
The recently introduced `heroku-postbuild` script is failing on production.  

## HOW
Always return a successful exit code, via `; :`. Heroku will fail an entire build if an npm script has a nonzero exit code. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
n/a

### What have you done to QA this feature?
Build succeeds on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  n/a
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
