### PR TITLE
Remove psych from Gemfile

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -163,8 +163,6 @@ gem 'capitalize-names', require: 'capitalize_names'
 
 gem 'rexml'
 
-gem 'psych', '< 4'
-
 group :production, :staging do
   gem 'rails-autoscale-web'
   gem 'rails-autoscale-sidekiq'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -327,12 +327,12 @@ GEM
       gapic-common (>= 0.20.0, < 2.a)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.1)
-    google-protobuf (3.24.3)
+    google-protobuf (3.25.3)
     googleapis-common-protos (1.4.0)
       google-protobuf (~> 3.14)
       googleapis-common-protos-types (~> 1.2)
       grpc (~> 1.27)
-    googleapis-common-protos-types (1.9.0)
+    googleapis-common-protos-types (1.14.0)
       google-protobuf (~> 3.18)
     googleauth (1.8.0)
       faraday (>= 0.17.3, < 3.a)
@@ -347,8 +347,8 @@ GEM
     grover (1.1.5)
       combine_pdf (~> 1.0)
       nokogiri (~> 1.0)
-    grpc (1.58.0)
-      google-protobuf (~> 3.23)
+    grpc (1.63.0)
+      google-protobuf (~> 3.25)
       googleapis-common-protos-types (~> 1.0)
     grpc-google-iam-v1 (1.3.0)
       google-protobuf (~> 3.18)
@@ -531,7 +531,6 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    psych (3.3.4)
     public_suffix (5.0.3)
     puma (5.6.8)
       nio4r (~> 2.0)
@@ -914,7 +913,6 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-rails
-  psych (< 4)
   puma (~> 5.6.8)
   puma_worker_killer
   pusher (~> 2.0.3)

--- a/services/QuillLMS/app/services/demo/session_data.rb
+++ b/services/QuillLMS/app/services/demo/session_data.rb
@@ -18,6 +18,8 @@ module Demo
 
     REPLAYED_PAIR = [Demo::ReportDemoCreator::REPLAYED_ACTIVITY_ID, Demo::ReportDemoCreator::REPLAYED_SAMPLE_USER_ID]
 
+    SAFE_LOAD_CLASSES = [ActivitySession, ConceptResult, ConceptResultQuestionType]
+
     ACTIVITY_USER_PAIRS = Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES
       .map {|hash| hash[:activity_sessions].map(&:to_a)}
       .flatten(2)
@@ -44,7 +46,7 @@ module Demo
     end
 
     private def load_file(file)
-      YAML.load_file(FILE_DIRECTORY + file)
+      YAML.safe_load(FILE_DIRECTORY + file, SAFE_LOAD_CLASSES)
     end
 
     # Important! This only needs to be run if there is a change to:

--- a/services/QuillLMS/app/services/demo/session_data.rb
+++ b/services/QuillLMS/app/services/demo/session_data.rb
@@ -18,7 +18,14 @@ module Demo
 
     REPLAYED_PAIR = [Demo::ReportDemoCreator::REPLAYED_ACTIVITY_ID, Demo::ReportDemoCreator::REPLAYED_SAMPLE_USER_ID]
 
-    SAFE_LOAD_CLASSES = [ActivitySession, ConceptResult, ConceptResultQuestionType]
+    SAFE_LOAD_CLASSES = [
+      ActiveModel::Attribute.const_get(:FromDatabase),
+      Symbol,
+      Time,
+      ActivitySession,
+      ConceptResult,
+      ConceptResultQuestionType
+    ]
 
     ACTIVITY_USER_PAIRS = Demo::ReportDemoCreator::ACTIVITY_PACKS_TEMPLATES
       .map {|hash| hash[:activity_sessions].map(&:to_a)}
@@ -46,7 +53,9 @@ module Demo
     end
 
     private def load_file(file)
-      YAML.safe_load(FILE_DIRECTORY + file, SAFE_LOAD_CLASSES)
+      file_path = FILE_DIRECTORY + file
+      file_content = File.read(file_path)
+      YAML.safe_load(file_content, permitted_classes: SAFE_LOAD_CLASSES)
     end
 
     # Important! This only needs to be run if there is a change to:

--- a/services/QuillLMS/config/application.rb
+++ b/services/QuillLMS/config/application.rb
@@ -75,5 +75,16 @@ module EmpiricalGrammar
     config.active_record.encryption.primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
     config.active_record.encryption.deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
     config.active_record.encryption.key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
+
+    config.active_record.yaml_column_permitted_classes = [
+      Symbol,
+      Hash,
+      Array,
+      ActiveSupport::TimeWithZone,
+      ActiveSupport::TimeZone,
+      ActiveSupport::HashWithIndifferentAccess,
+      ActiveModel::Attribute.const_get(:FromDatabase),
+      Time
+    ]
   end
 end

--- a/services/QuillLMS/config/application.rb
+++ b/services/QuillLMS/config/application.rb
@@ -75,16 +75,5 @@ module EmpiricalGrammar
     config.active_record.encryption.primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
     config.active_record.encryption.deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
     config.active_record.encryption.key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
-
-    config.active_record.yaml_column_permitted_classes = [
-      Symbol,
-      Hash,
-      Array,
-      ActiveSupport::TimeWithZone,
-      ActiveSupport::TimeZone,
-      ActiveSupport::HashWithIndifferentAccess,
-      ActiveModel::Attribute.const_get(:FromDatabase),
-      Time
-    ]
   end
 end


### PR DESCRIPTION
## WHAT
Remove `psych` gem

## WHY
An older version of gem was pinned in this [PR](https://github.com/empirical-org/Empirical-Core/pull/11045/files) due to an [issue](https://www.ctrl.blog/entry/ruby-psych4.html) with loading of YAML files with newer version of psych.

It's also [conflicting](https://github.com/Shopify/ruby-lsp/blob/main/Gemfile.lock#L7) with my local configuration.

## HOW
Remove the gem and then change the loading of yaml files in session data to use safe_load along with permitted classes. (see https://github.com/rails/rails/issues/49977) 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I ran `Demo::ReportDemoCreator.create_demo` in the staging console and then clicked around the demo account.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No. Configuration change.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
