### PR TITLE
Airbyte conceptresult migration

### DIFF
--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_completed_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_completed_query.rb
@@ -30,7 +30,7 @@ module AdminDiagnosticReports
         JOIN lms.activity_sessions
           ON classroom_units.id = activity_sessions.classroom_unit_id
             AND activity_sessions.visible = true
-        JOIN special.concept_results
+        JOIN lms.concept_results
           ON activity_sessions.id = concept_results.activity_session_id
         JOIN lms.activities
           ON activity_sessions.activity_id = activities.id

--- a/services/QuillLMS/app/queries/progress_reports/district_concept_reports.rb
+++ b/services/QuillLMS/app/queries/progress_reports/district_concept_reports.rb
@@ -44,7 +44,7 @@ class ProgressReports::DistrictConceptReports
           ON activity_sessions.classroom_unit_id = classroom_units.id
         JOIN lms.users AS students
           ON students.id = activity_sessions.user_id
-        JOIN special.concept_results
+        JOIN lms.concept_results
           ON concept_results.activity_session_id = activity_sessions.id
         WHERE schools_admins.user_id = #{admin_id}
         GROUP BY

--- a/services/QuillLMS/bin/dev/airbyte
+++ b/services/QuillLMS/bin/dev/airbyte
@@ -5,7 +5,7 @@ INSTANCES = {
   1 => {
     name: 'airbyte2',
     port: 8001,
-    tables: "concept_results",
+    tables: "concept_results (prefix: special)",
   },
   2 => {
     name: 'airbyte-pink',
@@ -16,6 +16,11 @@ INSTANCES = {
     name: 'airbyte-0-43-0',
     port: 8003,
     tables: "all_other_tables"
+  },
+  4 => {
+    name: 'airbyte-celadon',
+    port: 8004,
+    tables: "concept_results (prefix: lms)"
   }
 }
 
@@ -39,7 +44,7 @@ Step = Struct.new(:prompt, :valid?, :current_value)
 
 MACHINE = {
   0 => Step.new(prompt0, ->(input){ [1,2].include?(input.to_i)}, nil),
-  1 => Step.new(prompt1, ->(input){ [1,2,3].include?(input.to_i)}, nil)
+  1 => Step.new(prompt1, ->(input){ INSTANCES.keys.include?(input.to_i)}, nil)
 }
 
 SSH_SUBCOMMAND = '2'

--- a/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
+++ b/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
@@ -60,7 +60,7 @@ SELECT
               COUNT(diagnostic_question_optimal_concepts.id) > 0 AND
               LOGICAL_AND(CASE WHEN diagnostic_question_optimal_concepts.id IS NOT NULL THEN concept_results.correct END)
             ) AS correct
-          FROM special.concept_results AS concept_results
+          FROM lms.concept_results AS concept_results
           LEFT OUTER JOIN lms.diagnostic_question_optimal_concepts ON STRING(PARSE_JSON(concept_results.extra_metadata).question_uid) = diagnostic_question_optimal_concepts.question_uid AND concept_results.concept_id = diagnostic_question_optimal_concepts.concept_id
         WHERE concept_results.attempt_number IS NULL
         GROUP BY concept_results.activity_session_id, concept_results.extra_metadata, concept_results.question_number
@@ -130,7 +130,7 @@ SELECT
               COUNT(diagnostic_question_optimal_concepts.id) > 0 AND
               LOGICAL_AND(CASE WHEN diagnostic_question_optimal_concepts.id IS NOT NULL THEN concept_results.correct END)
             ) AS correct
-          FROM special.concept_results AS concept_results
+          FROM lms.concept_results AS concept_results
           LEFT OUTER JOIN lms.diagnostic_question_optimal_concepts ON STRING(PARSE_JSON(concept_results.extra_metadata).question_uid) = diagnostic_question_optimal_concepts.question_uid AND concept_results.concept_id = diagnostic_question_optimal_concepts.concept_id
         WHERE concept_results.attempt_number IS NULL
         GROUP BY concept_results.activity_session_id, concept_results.extra_metadata, concept_results.question_number

--- a/services/QuillLMS/lib/query_examples/admin_diagnostics/diagnostic-skills.sql
+++ b/services/QuillLMS/lib/query_examples/admin_diagnostics/diagnostic-skills.sql
@@ -41,15 +41,15 @@
                 WHERE
           pre_activity_sessions.completed_at BETWEEN '2023-08-01 00:00:00' AND '2023-12-01 00:00:00'
           AND schools.id IN (38811,38804,38801,38800,38779,38784,38780,38773,38765,38764)
-          
-          
-          
+
+
+
           AND classrooms_teachers.role = 'owner'
           AND activities.id = 1663
 
         GROUP BY aggregate_id, classrooms.name, student_id
-        
-        
+
+
 ),
 pre_questions_correct AS (        SELECT
           student_id,
@@ -61,7 +61,7 @@ pre_questions_correct AS (        SELECT
           most_recent_activity_sessions.name,
           most_recent_activity_sessions.group_by
         FROM most_recent_activity_sessions
-        JOIN special.concept_results AS pre_concept_results
+        JOIN lms.concept_results AS pre_concept_results
           ON most_recent_activity_sessions.pre_activity_session_id = pre_concept_results.activity_session_id
         GROUP BY student_id, pre_activity_session_id, post_activity_session_id, pre_concept_results.question_number, aggregate_id, name, group_by
 ),
@@ -94,7 +94,7 @@ post_questions_correct AS (        SELECT
           most_recent_activity_sessions.name,
           most_recent_activity_sessions.group_by
         FROM most_recent_activity_sessions
-        JOIN special.concept_results AS post_concept_results
+        JOIN lms.concept_results AS post_concept_results
           ON most_recent_activity_sessions.post_activity_session_id = post_concept_results.activity_session_id
         GROUP BY student_id, pre_activity_session_id, post_activity_session_id, post_concept_results.question_number, aggregate_id, name, group_by
 ),

--- a/services/QuillLMS/lib/query_examples/admin_diagnostics/post-diagnostic-completed.sql
+++ b/services/QuillLMS/lib/query_examples/admin_diagnostics/post-diagnostic-completed.sql
@@ -5,7 +5,7 @@
            Total Slot Time:         4216190 ms
            BI Engine Mode Used:     BI_ENGINE_DISABLED
              BI Engine Code:          INPUT_TOO_LARGE
-             BI Engine Message:       Input table special.concept_results has 5639 files, which exceeds the limit of 5000 files.
+             BI Engine Message:       Input table lms.concept_results has 5639 files, which exceeds the limit of 5000 files.
         */
         WITH aggregate_rows AS (        SELECT
             diagnostic_id,
@@ -40,7 +40,7 @@
         JOIN lms.activity_sessions
           ON classroom_units.id = activity_sessions.classroom_unit_id
             AND activity_sessions.visible = true
-        JOIN special.concept_results
+        JOIN lms.concept_results
           ON activity_sessions.id = concept_results.activity_session_id
         JOIN lms.activities AS post_activities
           ON activity_sessions.activity_id = post_activities.id
@@ -50,15 +50,15 @@
                 WHERE
           activity_sessions.completed_at BETWEEN '2023-08-01 00:00:00' AND '2023-12-01 00:00:00'
           AND schools.id IN (38811,38804,38801,38800,38779,38784,38780,38773,38765,38764)
-          
-          
-          
+
+
+
           AND classrooms_teachers.role = 'owner'
           AND activities.id IN (1663,1668,1678,1161,1568,1590,992,1229,1230,1432)
 
         GROUP BY activities.id, activities.name, aggregate_id, classrooms.name, activity_sessions.id, concept_results.question_number
-        
-        
+
+
 )
           GROUP BY diagnostic_id, diagnostic_name, aggregate_id, name, group_by
 )

--- a/services/QuillLMS/lib/query_examples/admin_diagnostics/pre-diagnostic-completed.sql
+++ b/services/QuillLMS/lib/query_examples/admin_diagnostics/pre-diagnostic-completed.sql
@@ -5,7 +5,7 @@
            Total Slot Time:         5385229 ms
            BI Engine Mode Used:     BI_ENGINE_DISABLED
              BI Engine Code:          INPUT_TOO_LARGE
-             BI Engine Message:       Input table special.concept_results has 5921 files, which exceeds the limit of 5000 files.
+             BI Engine Message:       Input table lms.concept_results has 5921 files, which exceeds the limit of 5000 files.
         */
         WITH aggregate_rows AS (        SELECT
             diagnostic_id,
@@ -40,7 +40,7 @@
         JOIN lms.activity_sessions
           ON classroom_units.id = activity_sessions.classroom_unit_id
             AND activity_sessions.visible = true
-        JOIN special.concept_results
+        JOIN lms.concept_results
           ON activity_sessions.id = concept_results.activity_session_id
         JOIN lms.activities
           ON activity_sessions.activity_id = activities.id
@@ -48,15 +48,15 @@
                 WHERE
           activity_sessions.completed_at BETWEEN '2023-08-01 00:00:00' AND '2023-11-30 23:59:59'
           AND schools.id IN (38811,38804,38801,38800,38779,38784,38780,38773,38765,38764)
-          
-          
-          
+
+
+
           AND classrooms_teachers.role = 'owner'
           AND activities.id IN (1663,1668,1678,1161,1568,1590,992,1229,1230,1432)
 
         GROUP BY activities.id, activities.name, aggregate_id, classrooms.name, activity_sessions.id, concept_results.question_number
-        
-        
+
+
 )
           GROUP BY diagnostic_id, diagnostic_name, aggregate_id, name, group_by
 )


### PR DESCRIPTION
## WHAT
1. Updates airbyte CLI with latest instance
2. switches all BQ concept_results references to use the `lms` namespace
## WHY
1. We want to easily access the new airbyte instance
2. So that we can start using the new airbyte instance, which is cold-startable. 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=aee98ceae39447bba7f83a4917e1a06c&pm=s

### What have you done to QA this feature?
- run the `ProgressReports::DistrictConceptReports` on this branch with a fixed time window, and ensure that the results are identical to the results on `develop`

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - no logic change
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
