### PR TITLE
Evidence/ update profanity filter

### DIFF
--- a/services/QuillLMS/engines/evidence/config/initializers/bad_words.json
+++ b/services/QuillLMS/engines/evidence/config/initializers/bad_words.json
@@ -192,7 +192,6 @@
     "feces",
     "feg",
     "ficken",
-    "fitt*",
     "flipping the bird",
     "foreskin",
     "fuck",


### PR DESCRIPTION
## WHAT
update profanity filter for Evidence activities to remove "fitt*" from bad words list 

## WHY
we don't want the word "fitting" being flagged for profanity in responses

## HOW
just remove `fitt*` from bad words list

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Fitting-being-caught-by-the-profanity-filter-fe9b3506215d458b9c4d70fafbe31fc5

### What have you done to QA this feature?
tested on staging with several Evidence activities that I could successfully submit a response using the word "fitting" without getting a profanity flag feedback

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  small change-- manually tested
Have you deployed to Staging? | (yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
