### PR TITLE
Add LLM completion api call times

### DIFF
--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -80,13 +80,19 @@ module Evidence
         def retry_params = { llm_config_id:, llm_prompt_id:, passage_prompt_id:, num_examples: }
 
         private def create_llm_prompt_responses_feedbacks
-          passage_prompt_responses.testing_data.limit(num_examples).each do |passage_prompt_response|
-            raw_text = llm_client.run(llm_config:, prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
-            text = Resolver.run(raw_text:)
-            LLMFeedback.create!(experiment: self, raw_text:, text:, passage_prompt_response:)
-          rescue => e
-            experiment_errors << { error: e.message, passage_prompt_response_id: passage_prompt_response.id, raw_text:}.to_json
-            next
+          [].tap do |api_call_times|
+            passage_prompt_responses.testing_data.limit(num_examples).each do |passage_prompt_response|
+              api_call_start_time = Time.zone.now
+              raw_text = llm_client.run(llm_config:, prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
+              api_call_times << (Time.zone.now - api_call_start_time).round(2)
+
+              text = Resolver.run(raw_text:)
+              LLMFeedback.create!(experiment: self, raw_text:, text:, passage_prompt_response:)
+            rescue => e
+              experiment_errors << { error: e.message, passage_prompt_response_id: passage_prompt_response.id, raw_text: }.to_json
+              next
+            end
+            update_results(api_call_times:)
           end
         end
       end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/raw_text_preprocessor.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/raw_text_preprocessor.rb
@@ -4,26 +4,30 @@ module Evidence
   module Research
     module GenAI
       class RawTextPreprocessor < ApplicationService
-        attr_reader :raw_text
+        attr_reader :raw_text, :text
 
         def initialize(raw_text:)
           @raw_text = raw_text
         end
 
         def run
+          @text = remove_newlines_and_leading_and_trailing_spaces
+
           return strip_feedback_preamble if feedback_preamble?
           return strip_triple_backticks_and_json_preamble if json_preamble?
 
-          raw_text
+          text
         end
 
-        def feedback_preamble? = raw_text.start_with?('Feedback: ')
+        private def remove_newlines_and_leading_and_trailing_spaces = raw_text.gsub("\n", '').strip
 
-        def json_preamble? = raw_text.start_with?("```json\n") && raw_text.end_with?("\n```")
+        private def feedback_preamble? = text.start_with?('Feedback: ')
 
-        def strip_feedback_preamble = raw_text.sub(/^Feedback: /, '')
+        private def json_preamble? = text.start_with?("```json") && text.end_with?("```")
 
-        def strip_triple_backticks_and_json_preamble = raw_text.sub(/^```json\n/, '').sub(/\n```$/, '')
+        private def strip_feedback_preamble = text.sub(/^Feedback: /, '')
+
+        private def strip_triple_backticks_and_json_preamble = text.sub(/^```json/, '').sub(/```$/, '')
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -36,6 +36,7 @@
     <p>RougeL Sum: <%= @experiment.results.dig('misc_metrics', 'rouge', 'rougeLsum')&.round(2) %></p>
     <p>Experiment duration: <%= experiment_duration(@experiment) %></p>
     <p>Evaluation duration: <%= evaluation_duration(@experiment) %></p>
+    <p>Api call times: <%= @experiment.results['api_call_times'] %></p>
 
     <%= render 'matrix', matrix: @experiment.results['confusion_matrix'], title: 'Confusion Matrix' %>
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -81,8 +81,16 @@ module Evidence
 
               subject
             end
-          end
 
+            it 'measures and records API call times' do
+              # 2 calls for each example: one for the API call and one for the experiment_duration
+              expect(Time.zone).to receive(:now).exactly((num_examples * 2) + 2).times.and_call_original
+
+              subject
+
+              expect(experiment.reload.results['api_call_times'].size).to eq(num_examples)
+            end
+          end
 
           context 'when an error occurs during execution' do
             let(:error_message) { 'Test error' }

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/raw_text_preprocessor_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/raw_text_preprocessor_spec.rb
@@ -10,6 +10,13 @@ module Evidence
 
         let(:fixed_text) { '{"key1":"val2"}' }
 
+        context 'raw text has random newlines' do
+          let(:raw_text) { "```json\n{\"key1\":\"val2\"}\n``` \n" }
+
+          it { is_expected.to eq fixed_text }
+        end
+
+
         context 'wrapped in Feedback preamble' do
           let(:raw_text) { 'Feedback: {"key1":"val2"}' }
 


### PR DESCRIPTION
## WHAT
* Store the elapsed time for each call to the LLM
* Remove new line characters from the LLM feedback

## WHY
* It's useful to know how long the different API calls take
* They make parsing difficult and are unpredicatable

## HOW
* Calculate start and end time around the api call to the LLM client
* `raw_text.gsub("\n", '').strip`

### Screenshots
![Screenshot 2024-05-20 at 4 06 35 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/573a1f0d-5b41-4216-834b-751b1a6b4a69)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I have tested locally and I'm about test on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
