### PR TITLE
Various CSS styling tweaks

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/about-us-pages.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/about-us-pages.scss
@@ -6,10 +6,6 @@
   align-items: center;
   max-width: 980px;
 
-  iframe {
-    margin-top: 64px;
-  }
-
   h2 {
     font-size: 24px;
     font-weight: bold;
@@ -23,7 +19,6 @@
   }
 
   .header {
-    margin-top: 16px;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/services/QuillLMS/app/assets/stylesheets/pages/contact.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/contact.scss
@@ -45,7 +45,7 @@
 .contact-page {
   display: flex;
   flex-direction: row;
-  padding: 64px 0px;
+  padding: 0px;
   justify-content: center;
   align-items: flex-start;
   .vertical-divider {

--- a/services/QuillLMS/app/assets/stylesheets/pages/misc-pages.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/misc-pages.scss
@@ -2,10 +2,6 @@
 	padding-right: 20%;
 	padding-bottom: 10%;
 
-	iframe {   // for impact page
-		margin-top: 5%;
-	}
-
 	h4, h3, h2 {
 		margin-top: 5%;
 	}
@@ -148,6 +144,10 @@
 
 .white-page {
 	background-color: $quill-white;
+}
+
+.about-the-org-page {
+	margin-top: 80px;
 }
 
 .pages-faq {

--- a/services/QuillLMS/app/assets/stylesheets/pages/pathways.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/pathways.scss
@@ -2,7 +2,6 @@
   max-width: 950px;
   .header {
     max-width: 656px;
-    padding-top: 32px;
     h1 {
       text-align: center;
       margin-bottom: 16px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/press.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/press.scss
@@ -1,5 +1,5 @@
 .press-page {
-  padding: 121px 0px;
+  padding: 0px;
 
   .hidden {
     display: none;

--- a/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/navbar.scss
@@ -352,6 +352,7 @@
   }
   .user-dropdown-button {
     border-radius: 6px;
+    border: 1px solid $quill-green-15;
     float: right;
     height: 30px;
     align-items: center;

--- a/services/QuillLMS/app/views/pages/about.html.erb
+++ b/services/QuillLMS/app/views/pages/about.html.erb
@@ -6,7 +6,7 @@
 <% expand_icon_url = "#{base_image_url}/expand.svg" %>
 
 <div class="white-background">
-  <div class="container pages-container white-page about-page about-us-page" id="careers">
+  <div class="container pages-container white-page about-page about-us-page about-the-org-page" id="careers">
 
     <iframe src="https://www.youtube.com/embed/dcjHca0bpCc?si=GtJxwDzrD57HSdkP" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 

--- a/services/QuillLMS/app/views/pages/careers.html.erb
+++ b/services/QuillLMS/app/views/pages/careers.html.erb
@@ -6,7 +6,7 @@
 <% expand_icon_url = "#{base_image_url}/expand.svg" %>
 
 <div class="white-background">
-  <div class="container pages-container white-page careers-page about-us-page" id="careers">
+  <div class="container pages-container white-page careers-page about-us-page about-the-org-page" id="careers">
 
     <div class="header">
       <h1>Join our team</h1>

--- a/services/QuillLMS/app/views/pages/contact.html.erb
+++ b/services/QuillLMS/app/views/pages/contact.html.erb
@@ -5,7 +5,7 @@
 
 <%= render partial: 'pages/shared/our_story_navbar', active_tab: @active_tab, title: @title %>
 <div class="white-background">
-  <div class="container contact-page">
+  <div class="container contact-page about-the-org-page">
     <div class="contact-container">
       <img src="https://quill-cdn.s3.amazonaws.com/images/icons/email.svg" />
       <h1>Sales</h1>

--- a/services/QuillLMS/app/views/pages/impact.html.erb
+++ b/services/QuillLMS/app/views/pages/impact.html.erb
@@ -5,7 +5,7 @@
 <% base_image_url = "#{ENV['CDN_URL']}/images/impact" %>
 
 <div class="white-background">
-  <div class="container about-us-page impact-page">
+  <div class="container about-us-page impact-page about-the-org-page">
     <div class="header">
       <h1>No hype machine. Real data. Real impact.</h1>
       <p class="hide-mobile">Humility, transparency, and education technology are concepts rarely found in the same sentence. We want to change that. We’re candid about who uses Quill and how much so everyone can gauge how we’re doing and what our users are learning. Our goal is to be helpful to teachers and the students they serve—and we can only do that by keeping it real.</p>

--- a/services/QuillLMS/app/views/pages/pathways.html.erb
+++ b/services/QuillLMS/app/views/pages/pathways.html.erb
@@ -4,7 +4,7 @@
 <%= render partial: 'pages/shared/our_story_navbar', active_tab: @active_tab, title: @title, image_link:  @image_link %>
 
 <div class="white-background">
-  <div class="container about-us-page pathways-page">
+  <div class="container about-us-page pathways-page about-the-org-page">
     <div class="header">
       <h1>How can educators most effectively approach teaching writing?</h1>
       <p><b>Quill.org partners with Teaching Lab for a research project to investigate writing.</b></p>

--- a/services/QuillLMS/app/views/pages/press.html.erb
+++ b/services/QuillLMS/app/views/pages/press.html.erb
@@ -5,7 +5,7 @@
 
 <%= render partial: 'pages/shared/our_story_navbar', active_tab: @active_tab, title: @title %>
 <div class="white-background">
-  <div class="container press-page">
+  <div class="container press-page about-the-org-page">
     <div class="press-highlight-container">
       <h1>Press highlights</h1>
 

--- a/services/QuillLMS/app/views/pages/team.html.erb
+++ b/services/QuillLMS/app/views/pages/team.html.erb
@@ -5,7 +5,7 @@
 <% base_image_url = "#{ENV['CDN_URL']}/images/team/webp/" %>
 
 <div class="white-background">
-  <div class="container pages-container team-page about-us-page">
+  <div class="container pages-container team-page about-us-page about-the-org-page">
 
     <div class="header">
       <h1>Meet our team</h1>

--- a/services/QuillLMS/client/app/bundles/Grammar/styles/intro.scss
+++ b/services/QuillLMS/client/app/bundles/Grammar/styles/intro.scss
@@ -32,6 +32,7 @@
     }
   }
   &.landing-page {
+    white-space: pre-wrap;
     .quill-button {
       margin-top: 40px;
     }


### PR DESCRIPTION
## WHAT
Various styling tweaks:
1. Update all pages on the "about us" tab to have the same top margin size of 80px. Remove all other types of styling on margins and paddings of these pages, and unify the styling using the new styling class "about-the-org-page".
2. Add "White space: pre-wrap" to landing page intro element so that the whitespace in the admin-produced HTML code does not get condensed into one white space.
3. Add a light green border to the teacher account dropdown button.

## WHY
Will help our site be more visually elegant.

## HOW
See above.

### Screenshots
![Screenshot 2024-05-21 at 11 45 11 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/f3ea417b-0ba1-4630-9a0c-04028b383583)
![Screenshot 2024-05-21 at 11 44 47 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/f5c77faf-d17e-4f1e-9127-45faf65c0880)


### Notion Card Links
https://www.notion.so/quill/Spaces-aren-t-always-honored-in-landing-pages-e7639b3d20c447d6806390b99fc6e9e1?pvs=4
https://www.notion.so/quill/Minor-UI-Update-on-Global-Header-Border-on-Account-Menu-dd12b05e0beb48a88978b3cc4fad3452?pvs=4
https://www.notion.so/quill/Quill-org-Public-Pages-Normalize-Top-Margin-H1-a890098271af41a6b4e4bb9c193b4f50?pvs=4
![Screenshot 2024-05-21 at 11 56 42 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/ed0fbf6d-bc6c-49ed-aa0f-1c8b6ef7e706)
![Screenshot 2024-05-21 at 11 56 37 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/13f7a9be-0d0a-4bc0-af8c-18f570c8f72b)
![Screenshot 2024-05-21 at 11 56 31 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/8fabb176-ba9a-4410-a13f-1ebb4769504e)
![Screenshot 2024-05-21 at 11 56 27 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/9534d547-ce83-45b2-ab92-9087c7934fc6)
![Screenshot 2024-05-21 at 11 56 22 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/f649ce12-195d-4eed-946e-e95d7b83bc23)
![Screenshot 2024-05-21 at 11 56 09 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/291ac190-aba6-431f-9122-6b85baa505f6)
![Screenshot 2024-05-21 at 11 56 03 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/2fd797b5-e00d-4395-a207-9415ba3d68fb)


### What have you done to QA this feature?
These are all purely visual changes, so I deployed to staging and accessed the pages to verify that the style changes did appear (see attached screenshots).

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, small styling changes
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | yes
