### PR TITLE
Add in histogram for LLM api call response times (#11853)

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
@@ -13,7 +13,6 @@ module Evidence
               .pluck(:llm_config_id, :llm_prompt_id, :passage_prompt_id, :num_examples)
               .map { |llm_config_id, llm_prompt_id, passage_prompt_id, num_examples| { llm_config_id:, llm_prompt_id:, passage_prompt_id:, num_examples: } }
               .to_set
-
           @experiments = Experiment.all.reject do |experiment|
             experiment.failed? && completed_experiments.include?(
               llm_config_id: experiment.llm_config_id,
@@ -52,6 +51,7 @@ module Evidence
 
         def show
           @experiment = Experiment.find(params[:id])
+          @histogram = @experiment.api_call_times.map(&:round).tally if @experiment.api_call_times.present?
           @next = Experiment.where("id > ?", @experiment.id).order(id: :asc).first
           @previous = Experiment.where("id < ?", @experiment.id).order(id: :desc).first
         end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -47,6 +47,8 @@ module Evidence
         scope :completed, -> { where(status: COMPLETED) }
         scope :failed, -> { where(status: FAILED) }
 
+        store_accessor :results, :api_call_times, :accuracy_identical, :accuracy_optimal_sub_optimal, :confusion_matrix
+
         attr_readonly :llm_config_id, :llm_prompt_id, :passage_prompt_id
 
         attr_accessor :llm_config_ids, :llm_prompt_template_ids, :passage_prompt_ids

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
@@ -24,17 +24,23 @@ module Evidence
           GEMINI_1_5_FLASH_LATEST = 'gemini-1-5-flash-latest'
         ].freeze
 
-        JSON_FORMAT_RESPONSES = { "generationConfig": { "response_mime_type": "application/json" } }.freeze
+        GOOGLE_JSON_FORMAT_RESPONSES = { "generationConfig": { "response_mime_type": "application/json" } }.freeze
 
         OPEN_AI = 'open_ai'
+
+        OPEN_AI_VERSIONS = [
+          GPT_3_5_TURBO_0125 = 'gpt-3.5-turbo-0125',
+          GPT_4_TURBO_2024_04_09 = 'gpt-4-turbo-2024-04-09',
+          GPT_4_O = 'gpt-4o'
+        ]
+
+        OPEN_AI_JSON_FORMAT_RESPONSES = { "response_format": {"type": "json_object"} }.freeze
 
         VENDOR_MAP = {
           GOOGLE => Evidence::Gemini::Completion,
           OPEN_AI => Evidence::OpenAI::Completion
         }.freeze
 
-        VERSIONS_MAP = {
-        }
 
         validates :vendor, presence: true
         validates :version, presence: true
@@ -43,11 +49,14 @@ module Evidence
 
         def llm_client = VENDOR_MAP.fetch(vendor) { raise UnsupportedVendorError }
 
-        def request_body_customizations
-          return {} unless vendor == GOOGLE
-          return {} unless version.in? [GEMINI_1_5_PRO_LATEST, GEMINI_1_5_FLASH_LATEST]
+        def google? = vendor == GOOGLE
+        def open_ai? = vendor == OPEN_AI
 
-          JSON_FORMAT_RESPONSES
+        def request_body_customizations
+          return OPEN_AI_JSON_FORMAT_RESPONSES if open_ai? && version.in?([GPT_3_5_TURBO_0125, GPT_4_TURBO_2024_04_09, GPT_4_O])
+          return GOOGLE_JSON_FORMAT_RESPONSES if google? && version.in?([GEMINI_1_5_PRO_LATEST, GEMINI_1_5_FLASH_LATEST])
+
+          {}
         end
 
         def to_s = "#{vendor}: #{version}"

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
@@ -35,7 +35,7 @@ module Evidence
         end
 
         def feedback_prompt(response)
-          "#{prompt}\n\nResponse: #{response}\nProvide feedback in the following format: #{FEEDBACK_JSON_SCHEMA}"
+          "#{prompt}\n\nResponse: #{response}\nProvide feedback in the following JSON format: #{FEEDBACK_JSON_SCHEMA}"
         end
 
         def evaluation_prompt(response) = "#{prompt}\n\nResponse: #{response}\nParaphrase:"

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/application/_histogram.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/application/_histogram.html.erb
@@ -1,0 +1,69 @@
+<% histogram_height = 100 %>
+
+<style>
+  .histogram-wrapper {
+    display: flex;
+    align-items: flex-end;
+  }
+  .histogram-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  .bars-container {
+    display: flex;
+    align-items: flex-end;
+    height: <%= histogram_height %>;
+    border-left: 1px solid black;
+    border-bottom: 1px solid black;
+    margin-bottom: 20px;
+  }
+  .bar {
+    display: inline-block;
+    margin-right: 2px;
+    background-color: blue;
+    text-align: center;
+    color: white;
+    width: 30px;
+  }
+  .bar-label {
+    writing-mode: vertical-rl;
+    text-align: center;
+    transform: rotate(180deg);
+  }
+  .x-axis-labels {
+    display: flex;
+    justify-content: center;
+  }
+  .x-axis-label {
+    width: 30px;
+    text-align: center;
+    margin-right: 2px;
+  }
+  .x-axis-title {
+    text-align: center;
+    margin-top: 10px;
+  }
+</style>
+
+<div class="histogram-wrapper">
+  <% max_value = @histogram.values.max %>
+  <div class="histogram-container">
+    <div class="bars-container">
+      <% @histogram.keys.sort.each do |bin| %>
+        <% frequency = @histogram[bin] %>
+        <div class="bar" style="height: <%= (frequency.to_f / max_value) * histogram_height %>px;">
+          <div class="bar-label"><%= frequency %></div>
+        </div>
+      <% end %>
+    </div>
+    <div class="x-axis-labels">
+      <% @histogram.keys.sort.each do |bin| %>
+        <div class="x-axis-label"><%= bin %></div>
+      <% end %>
+    </div>
+    <div class="x-axis-title">
+      Elapsed Time / API call
+    </div>
+  </div>
+</div>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -27,8 +27,8 @@
   <hr/>
   <h3>Results</h3>
   <% if @experiment.results %>
-    <p>Accuracy (identical): <%= @experiment.results['accuracy_identical'] %></p>
-    <p>Accuracy (sub/optimal): <%= @experiment.results['accuracy_optimal_sub_optimal'] %></p>
+    <p>Accuracy (identical): <%= @experiment.accuracy_identical&.round(2) %></p>
+    <p>Accuracy (sub/optimal): <%= @experiment.accuracy_optimal_sub_optimal&.round(2) %></p>
     <p>Bleu: <%= @experiment.results.dig('misc_metrics', 'bleu', 'bleu')&.round(2) %></p>
     <p>Rouge1: <%= @experiment.results.dig('misc_metrics', 'rouge', 'rouge1')&.round(2) %></p>
     <p>Rouge2: <%= @experiment.results.dig('misc_metrics', 'rouge', 'rouge2')&.round(2) %></p>
@@ -36,9 +36,13 @@
     <p>RougeL Sum: <%= @experiment.results.dig('misc_metrics', 'rouge', 'rougeLsum')&.round(2) %></p>
     <p>Experiment duration: <%= experiment_duration(@experiment) %></p>
     <p>Evaluation duration: <%= evaluation_duration(@experiment) %></p>
-    <p>Api call times: <%= @experiment.results['api_call_times'] %></p>
 
-    <%= render 'matrix', matrix: @experiment.results['confusion_matrix'], title: 'Confusion Matrix' %>
+    <% if @experiment.api_call_times %>
+      <p>Api call times: <%= @experiment.api_call_times %></p>
+      <%= render 'histogram', histogram: @histogram %>
+    <% end %>
+
+    <%= render 'matrix', matrix: @experiment.confusion_matrix, title: 'Confusion Matrix' %>
 
     <table>
       <thead>

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
@@ -29,7 +29,7 @@ module Evidence
           messages: [
             { role: 'user', content: prompt }
           ],
-        }
+        }.merge(llm_config.request_body_customizations)
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 module Evidence
   module OpenAI
     RSpec.describe Completion do
-      %w[gpt-3.5-turbo-0125 gpt-4-turbo-2024-04-09].each do |version|
+      Evidence::Research::GenAI::LLMConfig::OPEN_AI_VERSIONS.each do |version|
         subject { described_class.new(prompt:, llm_config:) }
 
         let(:prompt) { 'some prompt' }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_config_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_config_spec.rb
@@ -29,11 +29,33 @@ module Evidence
 
           let(:llm_config) { build(:evidence_research_gen_ai_llm_config, vendor:, version:) }
 
-          context 'when vendor is not GOOGLE' do
-            let(:vendor) { described_class::OPEN_AI }
+          context 'when vendor is not GOOGLE or OPEN_AI' do
+            let(:vendor) { 'any_vendor' }
             let(:version) { 'any_version' }
 
             it { is_expected.to eq({}) }
+          end
+
+          context 'when vendor is OPEN_AI' do
+            let(:vendor) { described_class::OPEN_AI }
+
+            context 'when version is GPT_3_5_TURBO_0125' do
+              let(:version) { described_class::GPT_3_5_TURBO_0125 }
+
+              it { is_expected.to eq described_class::OPEN_AI_JSON_FORMAT_RESPONSES  }
+            end
+
+            context 'when version is GPT_4_TURBO_2024_04_09' do
+              let(:version) { described_class::GPT_4_TURBO_2024_04_09 }
+
+              it { is_expected.to eq described_class::OPEN_AI_JSON_FORMAT_RESPONSES  }
+            end
+
+            context 'when version is GPT_4_O' do
+              let(:version) { described_class::GPT_4_O }
+
+              it { is_expected.to eq described_class::OPEN_AI_JSON_FORMAT_RESPONSES  }
+            end
           end
 
           context 'when vendor is GOOGLE' do
@@ -42,13 +64,13 @@ module Evidence
             context 'when version is GEMINI_1_5_PRO_LATEST' do
               let(:version) { described_class::GEMINI_1_5_PRO_LATEST }
 
-              it { is_expected.to eq described_class::JSON_FORMAT_RESPONSES  }
+              it { is_expected.to eq described_class::GOOGLE_JSON_FORMAT_RESPONSES  }
             end
 
             context 'version is GEMINI_1_5_FLASH_LATEST' do
               let(:version) { described_class::GEMINI_1_5_FLASH_LATEST }
 
-              it { is_expected.to eq described_class::JSON_FORMAT_RESPONSES  }
+              it { is_expected.to eq described_class::GOOGLE_JSON_FORMAT_RESPONSES  }
             end
 
             context 'version is not GEMINI_1_5_PRO_LATEST or GEMINI_1_5_FLASH_LATEST' do


### PR DESCRIPTION
* Add histogram for elapsed time per API call

* Add in JSON mode for open ai as well as gpt-4o config

* Fix specs

* Dan suggestions

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
