### PR TITLE
Add project to automl model

### DIFF
--- a/services/QuillLMS/db/migrate/20240521201204_add_project_to_evidence_automl_models.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240521201204_add_project_to_evidence_automl_models.evidence.rb
@@ -5,7 +5,7 @@ class AddProjectToEvidenceAutomlModels < ActiveRecord::Migration[7.0]
   def up
     add_column :evidence_automl_models, :project, :string, null: true
 
-    # Backfill the location column with the original location
+    # Backfill the project column with the original location
     Evidence::AutomlModel.update_all(project: 'comprehension')
 
     change_column_null :evidence_automl_models, :project, false

--- a/services/QuillLMS/db/migrate/20240521201204_add_project_to_evidence_automl_models.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240521201204_add_project_to_evidence_automl_models.evidence.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240521200827)
+class AddProjectToEvidenceAutomlModels < ActiveRecord::Migration[7.0]
+  def up
+    add_column :evidence_automl_models, :project, :string, null: true
+
+    # Backfill the location column with the original location
+    Evidence::AutomlModel.update_all(project: 'comprehension')
+
+    change_column_null :evidence_automl_models, :project, false
+  end
+
+  def down
+    remove_column :evidence_automl_models, :project
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -2701,7 +2701,8 @@ CREATE TABLE public.evidence_automl_models (
     state character varying NOT NULL,
     notes text DEFAULT ''::text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    project character varying NOT NULL
 );
 
 
@@ -11358,6 +11359,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240407173007'),
 ('20240411135759'),
 ('20240425125302'),
-('20240513162849');
+('20240513162849'),
+('20240521201204');
 
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/automl_models_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/automl_models_controller.rb
@@ -90,7 +90,7 @@ module Evidence
     private def automl_model_params
       params
         .require(:automl_model)
-        .permit(:name, :notes, :prompt_id)
+        .permit(:name, :notes, :prompt_id, :project)
     end
 
   end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
@@ -13,6 +13,7 @@ module Evidence
               .pluck(:llm_config_id, :llm_prompt_id, :passage_prompt_id, :num_examples)
               .map { |llm_config_id, llm_prompt_id, passage_prompt_id, num_examples| { llm_config_id:, llm_prompt_id:, passage_prompt_id:, num_examples: } }
               .to_set
+
           @experiments = Experiment.all.reject do |experiment|
             experiment.failed? && completed_experiments.include?(
               llm_config_id: experiment.llm_config_id,

--- a/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/automl_model.rb
@@ -8,6 +8,7 @@
 #  labels               :string           default([]), is an Array
 #  name                 :string           not null
 #  notes                :text             default("")
+#  project              :string           not null
 #  state                :string           not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null

--- a/services/QuillLMS/engines/evidence/db/migrate/20240521200827_add_project_to_evidence_automl_models.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240521200827_add_project_to_evidence_automl_models.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddProjectToEvidenceAutomlModels < ActiveRecord::Migration[7.0]
+  def up
+    add_column :evidence_automl_models, :project, :string, null: true
+
+    # Backfill the location column with the original location
+    Evidence::AutomlModel.update_all(project: 'comprehension')
+
+    change_column_null :evidence_automl_models, :project, false
+  end
+
+  def down
+    remove_column :evidence_automl_models, :project
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240521200827_add_project_to_evidence_automl_models.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240521200827_add_project_to_evidence_automl_models.rb
@@ -4,7 +4,7 @@ class AddProjectToEvidenceAutomlModels < ActiveRecord::Migration[7.0]
   def up
     add_column :evidence_automl_models, :project, :string, null: true
 
-    # Backfill the location column with the original location
+    # Backfill the project column with the original location
     Evidence::AutomlModel.update_all(project: 'comprehension')
 
     change_column_null :evidence_automl_models, :project, false

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/automl_models_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/automl_models_controller_spec.rb
@@ -56,7 +56,8 @@ module Evidence
 
       context 'valid params' do
         let(:name) { 'name' }
-        let(:automl_model_params) { { name: name, prompt_id: prompt.id } }
+        let(:project) { 'project' }
+        let(:automl_model_params) { { name:, prompt_id: prompt.id, project: } }
         let(:endpoint_external_id) { 'endpoint_external_id' }
         let(:model_external_id) { 'model_external_id' }
         let(:state) { AutomlModel::STATE_INACTIVE }

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -659,7 +659,8 @@ CREATE TABLE public.evidence_automl_models (
     state character varying NOT NULL,
     notes text DEFAULT ''::text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    project character varying NOT NULL
 );
 
 
@@ -2076,6 +2077,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240407172612'),
 ('20240411135531'),
 ('20240425125151'),
-('20240513162557');
+('20240513162557'),
+('20240521200827');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/automl_models.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/automl_models.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: evidence_automl_models
+#
+#  id                   :bigint           not null, primary key
+#  labels               :string           default([]), is an Array
+#  name                 :string           not null
+#  notes                :text             default("")
+#  project              :string           not null
+#  state                :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  endpoint_external_id :string           not null
+#  model_external_id    :string           not null
+#  prompt_id            :bigint
+#
+# Indexes
+#
+#  index_evidence_automl_models_on_prompt_id  (prompt_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (prompt_id => comprehension_prompts.id)
+#
+
 FactoryBot.define do
   factory :evidence_automl_model, class: 'Evidence::AutomlModel' do
     sequence(:model_external_id) { |n| "MODEL-ID-#{n}" }
@@ -9,6 +34,7 @@ FactoryBot.define do
     state { Evidence::AutomlModel::STATE_INACTIVE }
     labels { ["label1"] }
     notes { '' }
+    project { 'comprehension' }
 
     trait(:active) { state { Evidence::AutomlModel::STATE_ACTIVE } }
     trait(:inactive) { state { Evidence::AutomlModel::STATE_INACTIVE } }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/automl_model_spec.rb
@@ -2,17 +2,27 @@
 
 # == Schema Information
 #
-# Table name: comprehension_automl_models
+# Table name: evidence_automl_models
 #
-#  id              :integer          not null, primary key
-#  automl_model_id :string           not null
-#  name            :string           not null
-#  labels          :string           default([]), is an Array
-#  prompt_id       :integer
-#  state           :string           not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  notes           :text             default("")
+#  id                   :bigint           not null, primary key
+#  labels               :string           default([]), is an Array
+#  name                 :string           not null
+#  notes                :text             default("")
+#  project              :string           not null
+#  state                :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  endpoint_external_id :string           not null
+#  model_external_id    :string           not null
+#  prompt_id            :bigint
+#
+# Indexes
+#
+#  index_evidence_automl_models_on_prompt_id  (prompt_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (prompt_id => comprehension_prompts.id)
 #
 require 'rails_helper'
 


### PR DESCRIPTION
## WHAT
Add a non-null string attribute 'project' to `Evidence::AutomlModel`

## WHY
We are adding another project to our VertexAI configuration and we want to be able to specify which project is associated with a given `AutomlModel`.  The `project` value will serve as a key to the appropriate configuration.

## HOW
Add a migration and backfill existing data

### What have you done to QA this feature?
Ran migration on staging and it completed.  Also inspected values to make sure backfill was performed properly.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | N/A
