### PR TITLE
Fix delete concept feedback feature, add new default instruction

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::ConceptFeedbackController < Api::ApiController
 
   def destroy
     @concept_feedback.destroy
-    render(plain: 'OK')
+    render json: {}, status: :ok
   end
 
   private def activity_type

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
@@ -16,7 +16,9 @@ class ConceptFeedback extends React.Component {
     const { dispatch, match } = this.props
     const { params } = match
     const { conceptFeedbackID } = params
-    dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+    if (confirm('⚠️ Are you sure you’d like to delete this concept feedback?')) {
+      dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+    }
   }
 
   submitNewFeedback = (feedbackID, data) => {

--- a/services/QuillLMS/client/app/bundles/Connect/constants.js
+++ b/services/QuillLMS/client/app/bundles/Connect/constants.js
@@ -331,7 +331,8 @@ export default {
     "Fill in the blank with the correct word.",
     "Fill in the blank with the correct pronoun.",
     "Fill in the blank with the correct action word.",
-    "Fill in the blank with the correct set of words."
+    "Fill in the blank with the correct set of words.",
+    "Fill in the blank with the correct option."
   ],
 
   // flags

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/concept-feedback.jsx
@@ -10,7 +10,9 @@ class ConceptFeedback extends React.Component {
     const { dispatch, match } = this.props;
     const { params } = match;
     const { conceptFeedbackID } = params;
-    dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+    if (confirm('⚠️ Are you sure you’d like to delete this concept feedback?')) {
+      dispatch(actions.deleteConceptsFeedback(conceptFeedbackID, () => window.location.reload()))
+    }
   };
 
   toggleEdit = () => {

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/concept-feedback.jsx
@@ -11,7 +11,7 @@ class ConceptFeedback extends React.Component {
     const { params } = match;
     const { conceptFeedbackID } = params;
     if (confirm('⚠️ Are you sure you’d like to delete this concept feedback?')) {
-      dispatch(actions.deleteConceptsFeedback(conceptFeedbackID, () => window.location.reload()))
+      dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
     }
   };
 

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -31,7 +31,9 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
   deleteConceptsFeedback() {
     const conceptFeedbackID = this.props.match.params.conceptFeedbackID
     if (conceptFeedbackID) {
-      this.props.dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+      if (confirm('⚠️ Are you sure you’d like to delete this concept feedback?')) {
+        this.props.dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+      }
     }
   }
 


### PR DESCRIPTION
## WHAT
The delete concept feedback feature wasn't working as expected. Also added a new "fill in the blank to..." default instruction for Connect Fill in Blank questions.

## WHY
Admin want these features to be working as expected to smoothly edit activities.

## HOW
Add a popup confirmation wrapper around deleting concept feedback. Fix the back end so it returns an empty json object instead of "OK" because the string "OK" can't be properly read by the response parser. Also just add the desired string constant to fill in blank directions.

### Screenshots
<img width="529" alt="Screenshot 2024-05-23 at 10 07 27 PM" src="https://github.com/empirical-org/Empirical-Core/assets/57366100/be7e0477-c108-41d5-813e-46f6ae0102eb">
<img width="607" alt="Screenshot 2024-05-23 at 8 21 01 PM" src="https://github.com/empirical-org/Empirical-Core/assets/57366100/9c28971b-a618-476b-be88-b18f5821ac33">


### Notion Card Links
https://www.notion.so/quill/Add-validation-to-Delete-Concept-Feedback-button-b64e2cfcee634191ae025d0b9f1fe410?pvs=4
https://www.notion.so/quill/Add-Fill-in-the-blank-with-the-correct-option-to-the-default-FITB-instructions-drop-down-options-0e30b69e943848888d9ab5a525459a38?pvs=4

### What have you done to QA this feature?
Deploy to staging and test out the features on all three pertinent apps.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, small changes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
