### PR TITLE
Fix delete concept feedback feature, add new default instruction (#11…

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::ConceptFeedbackController < Api::ApiController
 
   def destroy
     @concept_feedback.destroy
-    render(plain: 'OK')
+    render json: {}, status: :ok
   end
 
   private def activity_type

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
@@ -16,7 +16,9 @@ class ConceptFeedback extends React.Component {
     const { dispatch, match } = this.props
     const { params } = match
     const { conceptFeedbackID } = params
-    dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+    if (confirm('⚠️ Are you sure you’d like to delete this concept feedback?')) {
+      dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+    }
   }
 
   submitNewFeedback = (feedbackID, data) => {

--- a/services/QuillLMS/client/app/bundles/Connect/constants.js
+++ b/services/QuillLMS/client/app/bundles/Connect/constants.js
@@ -331,7 +331,8 @@ export default {
     "Fill in the blank with the correct word.",
     "Fill in the blank with the correct pronoun.",
     "Fill in the blank with the correct action word.",
-    "Fill in the blank with the correct set of words."
+    "Fill in the blank with the correct set of words.",
+    "Fill in the blank with the correct option."
   ],
 
   // flags

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/feedback/concept-feedback.jsx
@@ -10,7 +10,9 @@ class ConceptFeedback extends React.Component {
     const { dispatch, match } = this.props;
     const { params } = match;
     const { conceptFeedbackID } = params;
-    dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+    if (confirm('⚠️ Are you sure you’d like to delete this concept feedback?')) {
+      dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+    }
   };
 
   toggleEdit = () => {

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -31,7 +31,9 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
   deleteConceptsFeedback() {
     const conceptFeedbackID = this.props.match.params.conceptFeedbackID
     if (conceptFeedbackID) {
-      this.props.dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+      if (confirm('⚠️ Are you sure you’d like to delete this concept feedback?')) {
+        this.props.dispatch(actions.deleteConceptsFeedback(conceptFeedbackID))
+      }
     }
   }
 


### PR DESCRIPTION
…862)

* add fill in blank instruction constant

* concept feedback changes added

* remove additional callback diagnostic

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
