### PR TITLE
student dashboard and footer UI updates

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
@@ -222,12 +222,18 @@
     border: 1px solid #E0E0E0;
     padding: 20px;
     margin-top: 16px;
+    background-color: $quill-grey-1;
     header {
       margin-bottom: 24px;
     }
     h2 {
-      font-size: 20px;
+      font-size: 18px;
       line-height: 1.3;
+      font-weight: 700;
+      color: $quill-grey-90;
+    }
+    .key-metric h4 {
+      font-weight: 700;
     }
     .dropdown-container {
       font-size: 14px;
@@ -247,6 +253,9 @@
     }
     .dropdown-container .dropdown .dropdown__menu {
       width: 142px;
+    }
+    .dropdown__control {
+      background-color: transparent;
     }
   }
 }

--- a/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/profile.scss
@@ -223,6 +223,7 @@
     padding: 20px;
     margin-top: 16px;
     background-color: $quill-grey-1;
+    max-width: 780px;
     header {
       margin-bottom: 24px;
     }

--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -28,17 +28,28 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    background-color: $quill-grey-1;
     h2 {
       font-size: 20px;
       font-weight: bold;
       line-height: normal;
+      color: $quill-grey-90;
     }
     .quill-tooltip-wrapper {
       transform: translateX(-70%);
     }
   }
+  .subheader {
+    padding: 16px 24px;
+    border-top: 1px solid #E0E0E0;
+    h3 {
+      font-size: 16px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: normal;
+    }
+  }
   .activities-container {
-    padding: 32px 0px;
     border-top: 1px solid $quill-grey-5;
     h3 {
       font-size: 16px;
@@ -60,13 +71,13 @@
       .data-table-row {
         min-height: 72px;
         height: min-content;
-        padding: 18px 20px;
+        padding: 18px 24px;
         &:hover {
           background-color: transparent;
         }
       }
       .data-table-headers {
-        padding: 0px 20px;
+        padding: 0px 24px;
       }
     }
     .action-button-section {

--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_profile_unit.scss
@@ -1,5 +1,5 @@
 .student-profile-unit {
-  border-radius: 6px;
+  border-radius: 8px;
   border: solid 1px $quill-grey-5;
   background-color: $quill-white;
   margin-bottom: 24px;
@@ -29,6 +29,7 @@
     justify-content: space-between;
     align-items: center;
     background-color: $quill-grey-1;
+    border-radius: 8px 8px 0px 0px;
     h2 {
       font-size: 20px;
       font-weight: bold;

--- a/services/QuillLMS/app/assets/stylesheets/shared/footer.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/footer.scss
@@ -22,7 +22,7 @@
     }
   }
   .footer-navigation {
-    margin: 0 auto;
+    margin: 0 auto 32px;
     max-width: $sitewidepagewidth;
     display: flex;
     >* {
@@ -31,6 +31,7 @@
     ul {
       margin-top: 0;
       padding-left: 0px;
+      margin-bottom: 0px;
     }
     ul li {
       list-style: none;
@@ -139,14 +140,14 @@
     }
   }
   .partners-footer {
-    padding-top: 27px;
-    padding-bottom: 35px;
+    padding: 32px 0px;
     color: #e1e1e1;
     font-size: 12px;
     line-height: 1.93;
     max-width: $sitewidepagewidth;
     margin: 0 auto;
-    border-bottom: 1px solid rgba(203, 203, 203, 0.5);
+    border: 1px rgba(203, 203, 203, 0.5);
+    border-style: solid none;
     p a {
       color: #e1e1e1;
       margin: 0 0 8px;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_unit.test.jsx.snap
@@ -16,6 +16,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
       <span />
     </div>
     <div
+      class="subheader"
+    >
+      <h3>
+        Completed activities
+      </h3>
+    </div>
+    <div
       class="activities-container completed-activities"
     >
       <table
@@ -37,7 +44,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             <th
               class="data-table-header name-section"
               scope="col"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <span>
                 Activity
@@ -107,7 +114,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -195,7 +202,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -283,7 +290,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -371,7 +378,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -459,7 +466,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -547,7 +554,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -635,7 +642,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -728,6 +735,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
       <span />
     </div>
     <div
+      class="subheader"
+    >
+      <h3>
+        Completed activities
+      </h3>
+    </div>
+    <div
       class="activities-container completed-activities"
     >
       <table
@@ -749,7 +763,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             <th
               class="data-table-header name-section"
               scope="col"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <span>
                 Activity
@@ -819,7 +833,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -911,7 +925,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -1003,7 +1017,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -1095,7 +1109,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -1187,7 +1201,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -1279,7 +1293,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -1371,7 +1385,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <div
                 class="score-tooltip-activator"
@@ -1468,6 +1482,13 @@ exports[`StudentProfileUnit component should render completed activities when sh
       <span />
     </div>
     <div
+      class="subheader"
+    >
+      <h3>
+        Completed activities
+      </h3>
+    </div>
+    <div
       class="activities-container completed-activities"
     >
       <table
@@ -1489,7 +1510,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             <th
               class="data-table-header name-section"
               scope="col"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               <span>
                 Activity
@@ -1555,7 +1576,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               Capitalizing People, Places, & the Pronoun - Mixed Topics
             </td>
@@ -1636,7 +1657,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               Capitalizing Names of People & the Pronoun  - Mixed Topics
             </td>
@@ -1717,7 +1738,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               Capitalizing Names of People - Mixed Topics 1
             </td>
@@ -1798,7 +1819,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               Capitalizing Holidays, People, & Places - Mixed Topics
             </td>
@@ -1879,7 +1900,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               Capitalizing Dates & Holidays - Mixed Topics 1
             </td>
@@ -1960,7 +1981,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               Capitalizing Geographic Names - Mixed Topics 1
             </td>
@@ -2041,7 +2062,7 @@ exports[`StudentProfileUnit component should render completed activities when sh
             </td>
             <td
               class="data-table-row-section name-section tooltip-section"
-              style="width: 440px; min-width: 440px; text-align: left;"
+              style="width: 432px; min-width: 432px; text-align: left;"
             >
               Capitalizing Geographic Names & Holidays - Mixed Topics
             </td>
@@ -2131,6 +2152,13 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
       <span />
     </div>
     <div
+      class="subheader"
+    >
+      <h3>
+        To-do activities
+      </h3>
+    </div>
+    <div
       class="activities-container incomplete-activities"
     >
       <table
@@ -2152,7 +2180,7 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
             <th
               class="data-table-header name-section"
               scope="col"
-              style="width: 874px; min-width: 874px; text-align: left;"
+              style="width: 866px; min-width: 866px; text-align: left;"
             >
               <span>
                 Activity
@@ -2188,7 +2216,7 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
             />
             <td
               class="data-table-row-section name-section"
-              style="width: 874px; min-width: 874px; text-align: left;"
+              style="width: 866px; min-width: 866px; text-align: left;"
             >
               The Travels of Marco Polo
             </td>
@@ -2220,7 +2248,7 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
             />
             <td
               class="data-table-row-section name-section"
-              style="width: 874px; min-width: 874px; text-align: left;"
+              style="width: 866px; min-width: 866px; text-align: left;"
             >
               Christopher Columbus
             </td>
@@ -2252,7 +2280,7 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
             />
             <td
               class="data-table-row-section name-section"
-              style="width: 874px; min-width: 874px; text-align: left;"
+              style="width: 866px; min-width: 866px; text-align: left;"
             >
               A, An, The
             </td>
@@ -2284,7 +2312,7 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
             />
             <td
               class="data-table-row-section name-section"
-              style="width: 874px; min-width: 874px; text-align: left;"
+              style="width: 866px; min-width: 866px; text-align: left;"
             >
               Magellan
             </td>
@@ -2316,7 +2344,7 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
             />
             <td
               class="data-table-row-section name-section"
-              style="width: 874px; min-width: 874px; text-align: left;"
+              style="width: 866px; min-width: 866px; text-align: left;"
             >
               Jamestown
             </td>
@@ -2348,7 +2376,7 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
             />
             <td
               class="data-table-row-section name-section"
-              style="width: 874px; min-width: 874px; text-align: left;"
+              style="width: 866px; min-width: 866px; text-align: left;"
             >
               Age of Exploration: Sailing with the Stars
             </td>
@@ -2380,7 +2408,7 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
             />
             <td
               class="data-table-row-section name-section"
-              style="width: 874px; min-width: 874px; text-align: left;"
+              style="width: 866px; min-width: 866px; text-align: left;"
             >
               Age of Exploration: The Cape of Good Hope
             </td>
@@ -2412,7 +2440,7 @@ exports[`StudentProfileUnit component should render incomplete activities 1`] = 
             />
             <td
               class="data-table-row-section name-section"
-              style="width: 874px; min-width: 874px; text-align: left;"
+              style="width: 866px; min-width: 866px; text-align: left;"
             >
               Age of Exploration: Roanoke
             </td>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
@@ -392,6 +392,13 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -412,7 +419,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -517,9 +524,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -588,9 +595,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -701,9 +708,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -814,9 +821,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -1111,6 +1118,13 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -1131,7 +1145,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -1289,9 +1303,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -1360,9 +1374,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -1437,9 +1451,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -1514,9 +1528,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -1591,9 +1605,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -1668,9 +1682,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -1745,9 +1759,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -1822,9 +1836,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -1899,9 +1913,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -2352,6 +2366,13 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -2372,7 +2393,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -2477,9 +2498,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -2548,9 +2569,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -2661,9 +2682,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -2774,9 +2795,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -3071,6 +3092,13 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -3091,7 +3119,7 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -3249,9 +3277,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -3320,9 +3348,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -3397,9 +3425,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -3474,9 +3502,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -3551,9 +3579,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -3628,9 +3656,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -3705,9 +3733,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -3782,9 +3810,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -3859,9 +3887,9 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -4388,6 +4416,13 @@ exports[`StudentProfileUnits component should render only completed activities i
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            Completed activities
+          </h3>
+        </div>
+        <div
           className="activities-container completed-activities"
         >
           <DataTable
@@ -4408,7 +4443,7 @@ exports[`StudentProfileUnits component should render only completed activities i
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section tooltip-section",
-                  "width": "440px",
+                  "width": "432px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -4544,9 +4579,9 @@ exports[`StudentProfileUnits component should render only completed activities i
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "440px",
+                        "minWidth": "432px",
                         "textAlign": "left",
-                        "width": "440px",
+                        "width": "432px",
                       }
                     }
                   >
@@ -4661,9 +4696,9 @@ exports[`StudentProfileUnits component should render only completed activities i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "440px",
+                        "minWidth": "432px",
                         "textAlign": "left",
-                        "width": "440px",
+                        "width": "432px",
                       }
                     }
                   >
@@ -4800,9 +4835,9 @@ exports[`StudentProfileUnits component should render only completed activities i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "440px",
+                        "minWidth": "432px",
                         "textAlign": "left",
-                        "width": "440px",
+                        "width": "432px",
                       }
                     }
                   >
@@ -5433,6 +5468,13 @@ exports[`StudentProfileUnits component should render only incomplete activities 
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -5453,7 +5495,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -5571,9 +5613,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -5642,9 +5684,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -5719,9 +5761,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -5832,9 +5874,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -5945,9 +5987,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -6242,6 +6284,13 @@ exports[`StudentProfileUnits component should render only incomplete activities 
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -6262,7 +6311,7 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -6420,9 +6469,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -6491,9 +6540,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -6568,9 +6617,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -6645,9 +6694,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -6722,9 +6771,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -6799,9 +6848,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -6876,9 +6925,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -6953,9 +7002,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -7030,9 +7079,9 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -7601,6 +7650,13 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -7621,7 +7677,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -7739,9 +7795,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -7810,9 +7866,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -7887,9 +7943,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -8000,9 +8056,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -8113,9 +8169,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -8410,6 +8466,13 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -8430,7 +8493,7 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -8588,9 +8651,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -8659,9 +8722,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -8736,9 +8799,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -8813,9 +8876,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -8890,9 +8953,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -8967,9 +9030,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -9044,9 +9107,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -9121,9 +9184,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -9198,9 +9261,9 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -9769,6 +9832,13 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -9789,7 +9859,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -9907,9 +9977,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -9978,9 +10048,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -10055,9 +10125,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -10168,9 +10238,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -10281,9 +10351,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -10578,6 +10648,13 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
           <span />
         </div>
         <div
+          className="subheader"
+        >
+          <h3>
+            To-do activities
+          </h3>
+        </div>
+        <div
           className="activities-container incomplete-activities"
         >
           <DataTable
@@ -10598,7 +10675,7 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                   "name": "Activity",
                   "noTooltip": true,
                   "rowSectionClassName": "name-section",
-                  "width": "874px",
+                  "width": "866px",
                 },
                 Object {
                   "attribute": "dueDate",
@@ -10756,9 +10833,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     scope="col"
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -10827,9 +10904,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -10904,9 +10981,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -10981,9 +11058,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -11058,9 +11135,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -11135,9 +11212,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -11212,9 +11289,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -11289,9 +11366,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >
@@ -11366,9 +11443,9 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                     onMouseLeave={[Function]}
                     style={
                       Object {
-                        "minWidth": "874px",
+                        "minWidth": "866px",
                         "textAlign": "left",
-                        "width": "874px",
+                        "width": "866px",
                       }
                     }
                   >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -40,7 +40,7 @@ const incompleteHeaders = [
     headerClassName: 'tool-icon-section',
     rowSectionClassName: 'tool-icon-section'
   }, {
-    width: '874px',
+    width: '866px',
     name: 'Activity',
     attribute: 'name',
     noTooltip: onMobile(), // On mobile we don't want a tooltip wrapper since they basically don't work there
@@ -72,7 +72,7 @@ const completeHeaders = [
     headerClassName: 'tool-icon-section',
     rowSectionClassName: 'tool-icon-section tooltip-section'
   }, {
-    width: '440px',
+    width: '432px',
     name: 'Activity',
     attribute: 'name',
     noTooltip: true,
@@ -389,7 +389,7 @@ export default class StudentProfileUnit extends React.Component {
   }
 
   render() {
-    const { unitName, id, isSelectedUnit, staggeredReleaseStatus, } = this.props
+    const { unitName, id, isSelectedUnit, staggeredReleaseStatus, data, } = this.props
     const className = isSelectedUnit ? `student-profile-unit selected-unit ${staggeredReleaseStatus}` : `student-profile-unit ${staggeredReleaseStatus}`
 
     let activityContent = (
@@ -423,6 +423,9 @@ export default class StudentProfileUnit extends React.Component {
         <div className="unit-name-and-staggered-release-status">
           <h2 className="unit-name">{unitName}</h2>
           {staggeredReleaseElement}
+        </div>
+        <div className="subheader">
+          <h3>{data.complete?.length ? 'Completed activities' : 'To-do activities'}</h3>
         </div>
         {activityContent}
       </div>


### PR DESCRIPTION
## WHAT
Make UI changes to the student dashboard (Your progress section and section subheaders) and the public footer.

## WHY
These were requested by Jack.

## HOW
HTML and CSS.

### Screenshots
<img width="1347" alt="Screenshot 2024-05-30 at 6 50 12 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/a3ad54f7-47f0-4539-abb3-05c7527b6031">
<img width="637" alt="Screenshot 2024-05-30 at 6 50 41 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/2f55573a-6ea3-41e7-b781-ac252e6e3a2e">

### Notion Card Links
https://www.notion.so/quill/Student-Dashboard-Activity-Summary-UI-Update-24ced33933344873afa6a77aa7ad7119?pvs=4

https://www.notion.so/quill/Footer-UI-Update-2b6a2645150a47b6853215e4de76a33f?pvs=4

### What have you done to QA this feature?
Tested on staging and had Jack test.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
