### PR TITLE
Update the width on hints to 100%

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/styles/components/_student-question.scss
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/styles/components/_student-question.scss
@@ -137,54 +137,6 @@
   transform: rotate(180deg);
 }
 
-.concept-explanation {
-  font-family: $family-monospace;
-  margin: 1em 0;
-  font-size: 20px;
-  width: 100%;
-  .concept-explanation-title {
-    font-weight: bold;
-    padding-left: 15px;
-    padding-right: 15px;
-    display: flex;
-    align-items: center;
-    img {
-      margin-right: 8px;
-    }
-  }
-  .concept-explanation-description {
-    padding-left: 15px;
-    padding-right: 15px;
-    margin-bottom: 15px;
-  }
-
-  .concept-explanation-see-write {
-    display: flex;
-    background-color: #fefefe;
-    padding: 15px 25px;
-    border: 1px dashed #cecece;
-    // border-radius: 5px;
-    margin-bottom: 0.5em;
-    .concept-explanation-see {
-      flex-grow: 1;
-      flex-basis: 0;
-    }
-    .concept-explanation-write {
-      flex-grow: 1;
-      flex-basis: 0;
-    }
-  }
-  .concept-explanation-remember {
-    padding-left: 15px;
-    padding-right: 15px;
-    margin-bottom: 0.5em;
-    ul {
-      margin: 10px 30px;
-      list-style: circle;
-    }
-  }
-}
-
 .landing-page {
   padding-top: 20px;
   font-size: 20px;

--- a/services/QuillLMS/client/app/bundles/Diagnostic/styles/components/_student-question.scss
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/styles/components/_student-question.scss
@@ -141,6 +141,7 @@
   font-family: $family-monospace;
   margin: 1em 0;
   font-size: 20px;
+  width: 100%;
   .concept-explanation-title {
     font-weight: bold;
     padding-left: 15px;

--- a/services/QuillLMS/client/app/bundles/Shared/styles/conceptFeedback.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/conceptFeedback.scss
@@ -3,6 +3,7 @@
   padding: 16px;
   border-radius: 2px;
   background-color: #e5e5e5;
+  width: 100%;
   .concept-explanation-title {
     font-weight: bold;
     display: flex;


### PR DESCRIPTION
## WHAT
Made the hint box full width. 

## WHY
The hints box should always be full width, but in the case where the hint text was too short, it was not coming up as full width. 

## HOW
Edited the CSS to add width: 100% 

### Screenshots
Production: 
![2024-05-30 at 11 31 AM](https://github.com/empirical-org/Empirical-Core/assets/126436/4a41335d-4fec-4e88-bdf0-e39ff6c66d59)


New: 
![2024-05-30 at 11 31 AM](https://github.com/empirical-org/Empirical-Core/assets/126436/8dccf926-ab48-452d-aef6-544224b436fe)


### Notion Card Links
https://www.notion.so/quill/Ensure-all-Concept-Feedback-spans-the-width-of-the-activity-20d47a7b07c3439a8641a9ec49a68d3e?pvs=4

### What have you done to QA this feature?
Looked at it on my local machine. 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, because it was just a style change. 
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
