### PR TITLE
Add G-Eval to experiment configuration

### DIFF
--- a/services/QuillLMS/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/config/initializers/zeitwerk.rb
@@ -8,6 +8,8 @@ Rails.autoloaders.each do |autoloader|
     'concept_replacement_lms_worker' => 'ConceptReplacementLMSWorker',
     'ell_starter_diagnostic_email_job' => 'ELLStarterDiagnosticEmailJob',
     'gen_ai' => 'GenAI',
+    'g_eval' => 'GEval',
+    'g_evals_controller' => 'GEvalsController',
     'graphiql' => 'GraphiQL',
     'html_tag_remover' => 'HTMLTagRemover',
     'llm_config' => 'LLMConfig',

--- a/services/QuillLMS/db/migrate/20240529125138_create_evidence_research_gen_ai_g_evals.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240529125138_create_evidence_research_gen_ai_g_evals.evidence.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240528185315)
+class CreateEvidenceResearchGenAIGEvals < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_g_evals do |t|
+      t.text :task_introduction, null: false
+      t.text :evaluation_criteria, null: false
+      t.text :evaluation_steps, null: false
+      t.string :metric, null: false
+      t.integer :max_score, null: false
+      t.boolean :selectable, default: true
+      t.jsonb :misc, default: {}
+      t.integer :version, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3014,6 +3014,44 @@ ALTER SEQUENCE public.evidence_research_gen_ai_experiments_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_g_evals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_g_evals (
+    id bigint NOT NULL,
+    task_introduction text NOT NULL,
+    evaluation_criteria text NOT NULL,
+    evaluation_steps text NOT NULL,
+    metric character varying NOT NULL,
+    max_score integer NOT NULL,
+    selectable boolean DEFAULT true,
+    misc jsonb DEFAULT '{}'::jsonb,
+    version integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_g_evals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_g_evals_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_g_evals_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_g_evals_id_seq OWNED BY public.evidence_research_gen_ai_g_evals.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6440,6 +6478,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_experiments ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_g_evals id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_g_evals ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_g_evals_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7642,6 +7687,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_example_feedbacks
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_experiments
     ADD CONSTRAINT evidence_research_gen_ai_experiments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_g_evals evidence_research_gen_ai_g_evals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_g_evals
+    ADD CONSTRAINT evidence_research_gen_ai_g_evals_pkey PRIMARY KEY (id);
 
 
 --
@@ -11360,6 +11413,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240411135759'),
 ('20240425125302'),
 ('20240513162849'),
-('20240521201204');
+('20240521201204'),
+('20240529125138');
 
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/auto_chain_of_thoughts_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/auto_chain_of_thoughts_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      class AutoChainOfThoughtsController < ApplicationController
+        EVALUATION_STEPS_JSON_FORMAT = { steps: ['Step 1', 'Step 2', 'Step 3'] }.to_json
+
+        def create
+          redirect_to new_research_gen_ai_g_eval_path(
+            research_gen_ai_g_eval: { metric:, task_introduction:, evaluation_criteria:, evaluation_steps: }
+          )
+        end
+
+        private def task_introduction = params[:task_introduction]
+
+        private def evaluation_criteria = params[:evaluation_criteria]
+
+        private def metric = params[:metric]
+
+        private def evaluation_steps
+          JSON
+            .parse(llm_response)['steps']
+            .join("\n")
+            .strip
+        end
+
+        private def llm_response = LLMConfig.auto_cot.completion(prompt:)
+
+        private def prompt
+          "
+            Based on the following task: #{task_introduction}
+
+            Please generate evaluation steps for the following evaluation criteria.
+            #{evaluation_criteria}
+
+            There should be 3-4 steps outlining how to evaluate #{metric}.
+
+            Please give the output in the following JSON format: #{EVALUATION_STEPS_JSON_FORMAT}
+          "
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
@@ -87,7 +87,7 @@ module Evidence
         private def llm_config_ids = experiment_params[:llm_config_ids].reject(&:blank?).map(&:to_i)
         private def llm_prompt_template_ids = experiment_params[:llm_prompt_template_ids].reject(&:blank?).map(&:to_i)
         private def passage_prompt_ids = experiment_params[:passage_prompt_ids].reject(&:blank?).map(&:to_i)
-        private def g_eval_ids = experiment_params[:g_eval_ids].reject(&:blank?).map(&:to_i).sort
+        private def g_eval_ids = experiment_params[:g_eval_ids]&.reject(&:blank?)&.map(&:to_i)&.sort || []
 
         private def num_examples(passage_prompt_id)
           max_num_examples = PassagePrompt.find(passage_prompt_id).passage_prompt_responses.testing_data.count

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
@@ -56,7 +56,7 @@ module Evidence
           @histogram = @experiment.api_call_times.map(&:round).tally if @experiment.api_call_times.present?
           @next = Experiment.where("id > ?", @experiment.id).order(id: :asc).first
           @previous = Experiment.where("id < ?", @experiment.id).order(id: :desc).first
-          @g_evals = GEval.where(id: @experiment.g_evals.keys).order(:id)
+          @g_evals = GEval.where(id: @experiment.g_eval_ids).order(:id)
         end
 
         def retry
@@ -66,8 +66,8 @@ module Evidence
         end
 
         private def run_experiment(llm_config_id:, llm_prompt_id:, passage_prompt_id:, num_examples:)
-          results = { g_evals:  g_eval_ids.index_with { |id| [] } }
-          experiment = Experiment.new(llm_config_id:, passage_prompt_id:, llm_prompt_id:, num_examples:, results:)
+          experiment = Experiment.new(llm_config_id:, passage_prompt_id:, llm_prompt_id:, num_examples:)
+          experiment.results = { g_eval_ids: }
 
           RunExperimentWorker.perform_async(experiment.id) if experiment.save
         end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/experiments_controller.rb
@@ -29,6 +29,7 @@ module Evidence
           @llm_configs = LLMConfig.all
           @passage_prompts = PassagePrompt.all
           @llm_prompt_templates = LLMPromptTemplate.all
+          @g_evals = GEval.selectable
         end
 
         def create
@@ -55,6 +56,7 @@ module Evidence
           @histogram = @experiment.api_call_times.map(&:round).tally if @experiment.api_call_times.present?
           @next = Experiment.where("id > ?", @experiment.id).order(id: :asc).first
           @previous = Experiment.where("id < ?", @experiment.id).order(id: :desc).first
+          @g_evals = GEval.where(id: @experiment.g_evals.keys).order(:id)
         end
 
         def retry
@@ -64,7 +66,8 @@ module Evidence
         end
 
         private def run_experiment(llm_config_id:, llm_prompt_id:, passage_prompt_id:, num_examples:)
-          experiment = Experiment.new(llm_config_id:, passage_prompt_id:, llm_prompt_id:, num_examples:)
+          results = { g_evals:  g_eval_ids.index_with { |id| [] } }
+          experiment = Experiment.new(llm_config_id:, passage_prompt_id:, llm_prompt_id:, num_examples:, results:)
 
           RunExperimentWorker.perform_async(experiment.id) if experiment.save
         end
@@ -76,13 +79,15 @@ module Evidence
               :num_examples,
               llm_config_ids: [],
               llm_prompt_template_ids: [],
-              passage_prompt_ids: []
+              passage_prompt_ids: [],
+              g_eval_ids: []
             )
         end
 
         private def llm_config_ids = experiment_params[:llm_config_ids].reject(&:blank?).map(&:to_i)
         private def llm_prompt_template_ids = experiment_params[:llm_prompt_template_ids].reject(&:blank?).map(&:to_i)
         private def passage_prompt_ids = experiment_params[:passage_prompt_ids].reject(&:blank?).map(&:to_i)
+        private def g_eval_ids = experiment_params[:g_eval_ids].reject(&:blank?).map(&:to_i).sort
 
         private def num_examples(passage_prompt_id)
           max_num_examples = PassagePrompt.find(passage_prompt_id).passage_prompt_responses.testing_data.count

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/g_evals_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/g_evals_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      class GEvalsController < ApplicationController
+        def new
+          @g_eval = GEval.new(g_eval_params)
+        end
+
+        def create
+          @g_eval = GEval.new(g_eval_params)
+
+          @g_eval.save ? redirect_to(@g_eval) : render(:new)
+        end
+
+        def show = @g_eval = GEval.find(params[:id])
+
+        private def g_eval_params
+          params
+            .require(:research_gen_ai_g_eval)
+            .permit(:task_introduction, :evaluation_criteria, :evaluation_steps, :metric, :max_score)
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai.rb
@@ -6,6 +6,14 @@ module Evidence
       EVAL_API_KEY = ENV['GEN_AI_EXPERIMENT_EVAL_API_KEY']
       EVAL_API_BASE_URI = ENV['GEN_AI_EXPERIMENT_EVAL_API_BASE_URI']
 
+      GOOGLE = 'google'
+      OPEN_AI = 'open_ai'
+
+      VENDOR_COMPLETION_MAP = {
+        GOOGLE => Evidence::Gemini::Completion,
+        OPEN_AI => Evidence::OpenAI::Completion
+      }.freeze
+
       def self.table_name_prefix
         "evidence_research_gen_ai_"
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/example_feedback.rb
@@ -40,7 +40,7 @@ module Evidence
         scope :fine_tuning_data, -> { where(data_partition: FINE_TUNING_DATA) }
         scope :prompt_engineering_data, -> { where(data_partition: PROMPT_ENGINEERING_DATA) }
 
-        def response_and_feedback = { response:, feedback: text }.to_json
+        def response_and_feedback = { response:, feedback: text, optimal: optimal? }.to_json
 
         def to_s = text
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -40,14 +40,18 @@ module Evidence
         validates :status, presence: true, inclusion: { in: STATUSES }
 
         delegate :conjunction, :name, to: :passage_prompt
-        delegate :llm_client, to: :llm_config
         delegate :vendor, :version, to: :llm_config
         delegate :llm_prompt_template_id, to: :llm_prompt
 
         scope :completed, -> { where(status: COMPLETED) }
         scope :failed, -> { where(status: FAILED) }
 
-        store_accessor :results, :api_call_times, :accuracy_identical, :accuracy_optimal_sub_optimal, :confusion_matrix
+        store_accessor :results,
+          :api_call_times,
+          :accuracy_identical,
+          :accuracy_optimal_sub_optimal,
+          :confusion_matrix,
+          :g_evals
 
         attr_readonly :llm_config_id, :llm_prompt_id, :passage_prompt_id
 
@@ -85,7 +89,7 @@ module Evidence
           [].tap do |api_call_times|
             passage_prompt_responses.testing_data.limit(num_examples).each do |passage_prompt_response|
               api_call_start_time = Time.zone.now
-              raw_text = llm_client.run(llm_config:, prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
+              raw_text = llm_config.completion(prompt: llm_prompt.feedback_prompt(passage_prompt_response.response))
               api_call_times << (Time.zone.now - api_call_start_time).round(2)
 
               text = Resolver.run(raw_text:)

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/experiment.rb
@@ -51,6 +51,7 @@ module Evidence
           :accuracy_identical,
           :accuracy_optimal_sub_optimal,
           :confusion_matrix,
+          :g_eval_ids,
           :g_evals
 
         attr_readonly :llm_config_id, :llm_prompt_id, :passage_prompt_id

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/g_eval.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/g_eval.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_g_evals
+#
+#  id                  :bigint           not null, primary key
+#  evaluation_criteria :text             not null
+#  evaluation_steps    :text             not null
+#  max_score           :integer          not null
+#  metric              :string           not null
+#  misc                :jsonb
+#  selectable          :boolean          default(TRUE)
+#  task_introduction   :text             not null
+#  version             :integer          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class GEval < ApplicationRecord
+        validates :task_introduction, presence: true
+        validates :evaluation_criteria, presence: true
+        validates :evaluation_steps, presence: true
+        validates :metric, presence: true
+        validates :max_score, presence: true
+        validates :version, presence: true
+        validates :selectable, inclusion: { in: [true, false] }
+
+        attr_readonly :task_introduction,
+          :evaluation_criteria,
+          :evaluation_steps,
+          :metric,
+          :max_score,
+          :version
+
+        before_create :set_version
+
+        scope :selectable, -> { where(selectable: true) }
+
+        def set_version
+          existing_version = self.class.where(metric: metric).order(version: :desc).first&.version
+          self.version = existing_version.is_a?(Integer) ? existing_version + 1 : 1
+        end
+
+        def name = "#{metric} v#{version}"
+
+        def to_s = name
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/g_eval.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/g_eval.rb
@@ -25,7 +25,6 @@ module Evidence
         validates :evaluation_steps, presence: true
         validates :metric, presence: true
         validates :max_score, presence: true
-        validates :version, presence: true
         validates :selectable, inclusion: { in: [true, false] }
 
         attr_readonly :task_introduction,

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/g_eval.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/g_eval.rb
@@ -35,7 +35,7 @@ module Evidence
           :max_score,
           :version
 
-        before_create :set_version
+        before_validation :set_version
 
         scope :selectable, -> { where(selectable: true) }
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_config.rb
@@ -10,23 +10,20 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+
 module Evidence
   module Research
     module GenAI
       class LLMConfig < ApplicationRecord
         class UnsupportedVendorError < StandardError; end
 
-        GOOGLE = 'google'
-
         GOOGLE_VERSIONS = [
           GEMINI_1_0_PRO = 'gemini-1.0-pro',
           GEMINI_1_5_PRO_LATEST = 'gemini-1.5-pro-latest',
-          GEMINI_1_5_FLASH_LATEST = 'gemini-1-5-flash-latest'
+          GEMINI_1_5_FLASH_LATEST = 'gemini-1.5-flash-latest'
         ].freeze
 
         GOOGLE_JSON_FORMAT_RESPONSES = { "generationConfig": { "response_mime_type": "application/json" } }.freeze
-
-        OPEN_AI = 'open_ai'
 
         OPEN_AI_VERSIONS = [
           GPT_3_5_TURBO_0125 = 'gpt-3.5-turbo-0125',
@@ -36,18 +33,17 @@ module Evidence
 
         OPEN_AI_JSON_FORMAT_RESPONSES = { "response_format": {"type": "json_object"} }.freeze
 
-        VENDOR_MAP = {
-          GOOGLE => Evidence::Gemini::Completion,
-          OPEN_AI => Evidence::OpenAI::Completion
-        }.freeze
-
-
         validates :vendor, presence: true
         validates :version, presence: true
 
         attr_readonly :vendor, :version
 
-        def llm_client = VENDOR_MAP.fetch(vendor) { raise UnsupportedVendorError }
+        def self.auto_cot = find_by(vendor: OPEN_AI, version: GPT_4_O)
+        def self.g_eval = find_by(vendor: GOOGLE, version: GEMINI_1_5_FLASH_LATEST)
+
+        def completion_client = VENDOR_COMPLETION_MAP.fetch(vendor) { raise UnsupportedVendorError }
+
+        def completion(prompt:) = completion_client.run(prompt:, llm_config: self)
 
         def google? = vendor == GOOGLE
         def open_ai? = vendor == OPEN_AI

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
@@ -14,7 +14,7 @@ module Evidence
   module Research
     module GenAI
       class LLMPrompt < ApplicationRecord
-        FEEDBACK_JSON_SCHEMA = { type: 'object', properties: { feedback: { type: 'string' } } }.to_json
+        FEEDBACK_JSON_SCHEMA = { 'optimal': 'boolean', 'feedback': 'string' }.to_json
 
         belongs_to :llm_prompt_template, class_name: 'Evidence::Research::GenAI::LLMPromptTemplate'
 

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/results_fetcher.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/results_fetcher.rb
@@ -38,7 +38,7 @@ module Evidence
         end
 
         private def g_evals
-          experiment.g_evals&.[]('ids')&.index_with do |g_eval_id|
+          experiment.g_eval_ids&.index_with do |g_eval_id|
             llm_feedbacks.map do |llm_feedback|
               GEvalRunner.run(g_eval_id:, llm_feedback:)
             end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/results_fetcher.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/results_fetcher.rb
@@ -12,10 +12,11 @@ module Evidence
 
         base_uri BASE_URI
 
-        attr_reader :llm_feedbacks, :predictions, :references
+        attr_reader :experiment, :llm_feedbacks, :predictions, :references
 
-        def initialize(llm_feedbacks)
-          @llm_feedbacks = llm_feedbacks
+        def initialize(experiment)
+          @experiment = experiment
+          @llm_feedbacks = experiment.llm_feedbacks
           @predictions = llm_feedbacks.map(&:text)
           @references = llm_feedbacks.map(&:example_feedback).map(&:text)
         end
@@ -25,6 +26,7 @@ module Evidence
             accuracy_identical:,
             accuracy_optimal_sub_optimal: optimal_and_sub_optimal_results[:accuracy],
             confusion_matrix: optimal_and_sub_optimal_results[:confusion_matrix],
+            g_evals:,
             misc_metrics:
           }
         end
@@ -33,6 +35,14 @@ module Evidence
           return nil if llm_feedbacks.empty?
 
           1.0 * llm_feedbacks.select(&:identical_feedback?).size / llm_feedbacks.size
+        end
+
+        private def g_evals
+          experiment.g_evals&.[]('ids')&.index_with do |g_eval_id|
+            llm_feedbacks.map do |llm_feedback|
+              GEvalRunner.run(g_eval_id:, llm_feedback:)
+            end
+          end
         end
 
         private def optimal_and_sub_optimal_results

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/auto_chain_of_thoughts/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/auto_chain_of_thoughts/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: research_gen_ai_auto_cots_path, local: true do |f| %>
+<%= form_with url: research_gen_ai_auto_chain_of_thoughts_path, local: true do |f| %>
   <h1>New AutoCoT</h1>
 
   <div class="field-spacing">

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/auto_chain_of_thoughts/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/auto_chain_of_thoughts/new.html.erb
@@ -1,0 +1,22 @@
+<%= form_with url: research_gen_ai_auto_cots_path, local: true do |f| %>
+  <h1>New AutoCoT</h1>
+
+  <div class="field-spacing">
+    <%= f.label :metric %><br>
+    <%= f.text_field :metric, required: true %>
+  </div>
+
+  <div class="field-spacing">
+    <%= f.label :task_introduction %><br>
+    <%= f.text_area :task_introduction, cols: 100, rows: 10, required: true %>
+  </div>
+
+  <div class="field-spacing">
+    <%= f.label :evaluation_criteria %><br>
+    <%= f.text_area :evaluation_criteria, cols: 100, rows: 30, required: true %>
+  </div>
+
+  <div>
+    <%= f.submit "Submit" %>
+  </div>
+<% end %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
@@ -9,8 +9,10 @@
       <label style="margin-right: 10px;">llm config:</label>
       <%= link_to 'new', new_research_gen_ai_llm_config_path, class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
     </div>
+
     <%= check_box_tag 'select_all_llm_config', '', false, id: 'select_all_llm_config', class: 'check-all' %> Select all
     <br/>
+
     <% @llm_configs.each do |llm_config| %>
       <div class="llm-config-item" style="display: flex; align-items: baseline;">
         <%= check_box_tag 'research_gen_ai_experiment[llm_config_ids][]', llm_config.id, false, id: dom_id(llm_config), class: 'llm-config-checkbox' %>
@@ -25,15 +27,17 @@
       <label style="margin-right: 10px;">llm prompt template:</label>
       <%= link_to 'new', new_research_gen_ai_llm_prompt_template_path, class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
     </div>
+
     <%= check_box_tag 'select_all_llm_prompt_template', '', false, id: 'select_all_llm_prompt_template', class: 'check-all' %> Select all
     <br/>
-  <% @llm_prompt_templates.each do |llm_prompt_template| %>
+
+    <% @llm_prompt_templates.each do |llm_prompt_template| %>
       <div class="llm-prompt-template-item" style="display: flex; align-items: baseline;">
         <%= check_box_tag 'research_gen_ai_experiment[llm_prompt_template_ids][]', llm_prompt_template.id, false, id: dom_id(llm_prompt_template), class: 'llm-prompt-template-checkbox' %>
         <%= label_tag dom_id(llm_prompt_template), llm_prompt_template.to_s %><br/>
         <%= link_to 'view', llm_prompt_template, class: 'new-link', style: 'margin-left: 10px;' %>
       </div>
-  <% end %>
+    <% end %>
   </div>
 
   <div id="passage-prompts-container" class="field-spacing">
@@ -41,13 +45,33 @@
       <label style="margin-right: 10px;">passage prompt:</label>
       <%= link_to 'new', new_research_gen_ai_passage_prompt_path, class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
     </div>
+
     <%= check_box_tag 'select_all_passage_prompt', '', false, id: 'select_all_passage_prompt', class: 'check-all' %> Select all
     <br/>
+
     <% @passage_prompts.each do |passage_prompt| %>
       <div class="passage-prompt-item" style="display: flex; align-items: baseline;">
         <%= check_box_tag 'research_gen_ai_experiment[passage_prompt_ids][]', passage_prompt.id, false, id: dom_id(passage_prompt), class: 'passage-prompt-checkbox' %>
         <%= label_tag dom_id(passage_prompt), passage_prompt.to_s %>
         <%= link_to 'view', passage_prompt, class: 'new-link', style: 'margin-left: 10px;' %>
+      </div>
+    <% end %>
+  </div>
+
+  <div id="g-evals-container" class="field-spacing">
+    <div style="display: flex; align-items: baseline;">
+      <label style="margin-right: 10px;">g-eval:</label>
+      <%= link_to 'new', new_research_gen_ai_auto_cot_path, class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
+    </div>
+
+    <%= check_box_tag 'select_all_g_eval', '', false, id: 'select_all_g_eval', class: 'check-all' %> Select all
+    <br/>
+
+    <% @g_evals.each do |g_eval| %>
+      <div class="g-eval-item" style="display: flex; align-items: baseline;">
+        <%= check_box_tag 'research_gen_ai_experiment[g_eval_ids][]', g_eval.id, false, id: dom_id(g_eval), class: 'g-eval-checkbox' %>
+        <%= label_tag dom_id(g_eval), g_eval.to_s %>
+        <%= link_to 'view', g_eval, class: 'new-link', style: 'margin-left: 10px;' %>
       </div>
     <% end %>
   </div>
@@ -82,6 +106,7 @@
       {selector: '#llm-configs-container', name: 'LLM Config'},
       {selector: '#llm-prompt-templates-container', name: 'LLM Prompt Template'},
       {selector: '#passage-prompts-container', name: 'Passage Prompt'},
+      {selector: '#g-evals-container', name: 'G-Eval'}
     ];
 
     const messages = [];

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/new.html.erb
@@ -61,7 +61,7 @@
   <div id="g-evals-container" class="field-spacing">
     <div style="display: flex; align-items: baseline;">
       <label style="margin-right: 10px;">g-eval:</label>
-      <%= link_to 'new', new_research_gen_ai_auto_cot_path, class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
+      <%= link_to 'new', new_research_gen_ai_auto_chain_of_thought_path, class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
     </div>
 
     <%= check_box_tag 'select_all_g_eval', '', false, id: 'select_all_g_eval', class: 'check-all' %> Select all

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -26,7 +26,7 @@
 
   <hr/>
   <h3>Results</h3>
-  <% if @experiment.results %>
+  <% if @experiment.api_call_times %>
     <p>Accuracy (identical): <%= @experiment.accuracy_identical&.round(2) %></p>
     <p>Accuracy (sub/optimal): <%= @experiment.accuracy_optimal_sub_optimal&.round(2) %></p>
     <p>Bleu: <%= @experiment.results.dig('misc_metrics', 'bleu', 'bleu')&.round(2) %></p>
@@ -37,7 +37,7 @@
     <p>Experiment duration: <%= experiment_duration(@experiment) %></p>
     <p>Evaluation duration: <%= evaluation_duration(@experiment) %></p>
 
-    <% if @experiment.api_call_times %>
+    <% if @experiment.api_call_times && @histogram %>
       <p>Api call times: <%= @experiment.api_call_times %></p>
       <%= render 'histogram', histogram: @histogram %>
     <% end %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -24,6 +24,13 @@
   <h3>LLM Prompt</h3>
   <p><%= link_to @experiment.llm_prompt.description, @experiment.llm_prompt %></p>
 
+  <% if @g_evals %>
+    <h3>G-eval</h3>
+    <% @g_evals.each do |g_eval| %>
+      <p><%= link_to g_eval, g_eval %></p>
+    <% end %>
+  <% end %>
+
   <hr/>
   <h3>Results</h3>
   <% if @experiment.api_call_times %>
@@ -52,8 +59,10 @@
           <th>BertScore (F1)</th>
           <th>BertScore (Precision)</th>
           <th>BertScore (Recall)</th>
-          <% @g_evals.each do |g_eval| %>
-            <th>G-Eval (<%= g_eval %>)</th>
+          <% if @experiment.g_evals %>
+            <% @g_evals.each do |g_eval| %>
+              <th>G-Eval (<%= g_eval %>)</th>
+            <% end %>
           <% end %>
           <th>Prompt Response</th>
           <th class='feedback-column'>Example Feedback</th>
@@ -69,8 +78,10 @@
             <td><%= @experiment.results.dig('misc_metrics', 'bert_score', 'f1', index)&.round(2) %></td>
             <td><%= @experiment.results.dig('misc_metrics', 'bert_score', 'precision', index)&.round(2) %></td>
             <td><%= @experiment.results.dig('misc_metrics', 'bert_score', 'recall', index)&.round(2) %></td>
-            <% @experiment.g_evals.keys.each do |g_eval_id| %>
-              <td><%= @experiment.g_evals[g_eval_id][index] %></td>
+            <% if @experiment.g_evals %>
+              <% @experiment.g_evals.keys.each do |g_eval_id| %>
+                <td><%= @experiment.g_evals[g_eval_id][index] %></td>
+              <% end %>
             <% end %>
             <td><%= llm_feedback.passage_prompt_response %></td>
             <td><%= llm_feedback.example_feedback %></td>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/experiments/show.html.erb
@@ -52,6 +52,9 @@
           <th>BertScore (F1)</th>
           <th>BertScore (Precision)</th>
           <th>BertScore (Recall)</th>
+          <% @g_evals.each do |g_eval| %>
+            <th>G-Eval (<%= g_eval %>)</th>
+          <% end %>
           <th>Prompt Response</th>
           <th class='feedback-column'>Example Feedback</th>
           <th class='feedback-column'>LLM Feedback</th>
@@ -66,6 +69,9 @@
             <td><%= @experiment.results.dig('misc_metrics', 'bert_score', 'f1', index)&.round(2) %></td>
             <td><%= @experiment.results.dig('misc_metrics', 'bert_score', 'precision', index)&.round(2) %></td>
             <td><%= @experiment.results.dig('misc_metrics', 'bert_score', 'recall', index)&.round(2) %></td>
+            <% @experiment.g_evals.keys.each do |g_eval_id| %>
+              <td><%= @experiment.g_evals[g_eval_id][index] %></td>
+            <% end %>
             <td><%= llm_feedback.passage_prompt_response %></td>
             <td><%= llm_feedback.example_feedback %></td>
             <td><%= llm_feedback  %></td>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/g_evals/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/g_evals/new.html.erb
@@ -1,0 +1,34 @@
+<%= form_for @g_eval do |f| %>
+  <%= render 'errors', object: @g_eval %>
+
+  <h1>New G-Eval</h1>
+
+  <div class="field-spacing">
+    <%= f.label :metric %>
+    <%= f.text_field :metric, size: 50, required: true %>
+  </div>
+
+  <div class="field-spacing">
+    <%= f.label :task_introduction %><br>
+    <%= f.text_area :task_introduction, cols: 100, rows: 5, required: true %>
+  </div>
+
+  <div class="field-spacing">
+    <%= f.label :evaluation_criteria %><br>
+    <%= f.text_area :evaluation_criteria, cols: 100, rows: 5, required: true %>
+  </div>
+
+  <div class="field-spacing">
+    <%= f.label :evaluation_steps %><br>
+    <%= f.text_area :evaluation_steps, cols: 100, rows: 20, required: true %>
+  </div>
+
+  <div class="field-spacing">
+    <%= f.label :max_score %>
+    <%= f.number_field :max_score, min: 1, class: 'number-input', required: true, style: "width: 75px;" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Create" %>
+  </div>
+<% end %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/g_evals/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/g_evals/show.html.erb
@@ -1,0 +1,24 @@
+<div>
+  <h2>G-Eval</h2>
+
+  <h3>Metric</h3>
+  <p><%= @g_eval.metric %></p>
+
+  <h3>Version</h3>
+  <p><%= @g_eval.version %></p>
+
+  <h3>Task Introduction</h3>
+  <p><%= simple_format(@g_eval.task_introduction) %></p>
+
+  <h3>Evaluation Criteria</h3>
+  <p><%= simple_format(@g_eval.evaluation_criteria) %></p>
+
+  <h3>Evaluation Steps</h3>
+  <p><%= simple_format(@g_eval.evaluation_steps) %></p>
+</div>
+
+<br>
+<%= link_to 'New Experiment', new_research_gen_ai_experiment_path %>
+<br>
+<br>
+<%= link_to 'Experiments', research_gen_ai_experiments_path %>

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/research/gen_ai/calculate_results_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/research/gen_ai/calculate_results_worker.rb
@@ -14,8 +14,7 @@ module Evidence
           return if ENV.fetch('STOP_ALL_GEN_AI_EXPERIMENTS', 'false') == 'true'
 
           experiment = Experiment.find(experiment_id)
-          experiment.update_results(ResultsFetcher.run(experiment.llm_feedbacks))
-        ensure
+          experiment.update_results(ResultsFetcher.run(experiment))
           experiment&.update!(evaluation_duration: Time.zone.now - start_time)
         end
       end

--- a/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
@@ -5,6 +5,8 @@ Rails.autoloaders.each do |autoloader|
   autoloader.inflector.inflect(
     'auto_ml' => 'AutoML',
     'gen_ai' => 'GenAI',
+    'g_eval' => 'GEval',
+    'g_evals_controller' => 'GEvalsController',
     'html_tag_remover' => 'HTMLTagRemover',
     'llm_config' => 'LLMConfig',
     'llm_configs_controller' => 'LLMConfigsController',

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -52,6 +52,7 @@ Evidence::Engine.routes.draw do
       resources :llm_prompt_templates, only: [:new, :create, :show, :index]
       resources :passage_prompts, only: [:new, :create, :show, :index]
       resources :passages, only: [:new, :create, :show]
+      resources :auto_chain_of_thoughts, only: [:new, :create]
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -53,6 +53,7 @@ Evidence::Engine.routes.draw do
       resources :passage_prompts, only: [:new, :create, :show, :index]
       resources :passages, only: [:new, :create, :show]
       resources :auto_chain_of_thoughts, only: [:new, :create]
+      resources :g_evals, only: [:new, :create, :show]
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240528185315_create_evidence_research_gen_ai_g_evals.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240528185315_create_evidence_research_gen_ai_g_evals.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAIGEvals < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_g_evals do |t|
+      t.text :task_introduction, null: false
+      t.text :evaluation_criteria, null: false
+      t.text :evaluation_steps, null: false
+      t.string :metric, null: false
+      t.integer :max_score, null: false
+      t.boolean :selectable, default: true
+      t.jsonb :misc, default: {}
+      t.integer :version, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/auto_chain_of_thoughts_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/auto_chain_of_thoughts_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe AutoChainOfThoughtsController, type: :controller do
+        routes { Evidence::Engine.routes }
+
+        let(:user) { double('User') }
+
+        before do
+          allow(controller).to receive(:current_user).and_return(user)
+          allow(user).to receive(:staff?).and_return(true)
+        end
+
+        describe 'POST #create' do
+          subject { post :create, params: }
+
+          let(:task_introduction) { 'Test Task Introduction' }
+          let(:evaluation_criteria) { 'Test Evaluation Criteria' }
+          let(:metric) { 'Test Metric' }
+          let(:step1) { 'Step 1' }
+          let(:step2) { 'Step 2' }
+          let(:step3) { 'Step 3' }
+          let(:steps) { [step1, step2, step3] }
+          let(:llm_response) { { 'steps' => steps }.to_json }
+
+          let(:evaluation_steps) { steps.join("\n").strip }
+          let(:llm_config) { double('LLMConfig', completion: llm_response) }
+
+          before { allow(LLMConfig).to receive(:auto_cot).and_return(llm_config) }
+
+          context 'valid params' do
+            let(:params) { { task_introduction:, evaluation_criteria:, metric: } }
+
+            it 'redirects to the new evaluation path with correct params' do
+              subject
+
+              expect(response).to redirect_to(
+                new_research_gen_ai_g_eval_path(
+                  research_gen_ai_g_eval: { metric:, task_introduction:, evaluation_criteria:, evaluation_steps: }
+                )
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/g_evals_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/g_evals_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe GEvalsController, type: :controller do
+        routes { Evidence::Engine.routes }
+
+        let(:user) { double('User') }
+
+        let(:valid_params) do
+          {
+            research_gen_ai_g_eval: {
+              task_introduction: 'Introduction',
+              evaluation_criteria: 'Criteria',
+              evaluation_steps: 'Steps',
+              metric: 'Metric',
+              max_score: 10
+            }
+          }
+        end
+
+        let(:invalid_params) do
+          {
+            research_gen_ai_g_eval: {
+              task_introduction: '',
+              evaluation_criteria: '',
+              evaluation_steps: '',
+              metric: '',
+              max_score: nil
+            }
+          }
+        end
+
+        before do
+          allow(controller).to receive(:current_user).and_return(user)
+          allow(user).to receive(:staff?).and_return(true)
+        end
+
+        describe "POST #create" do
+          subject { post :create, params: }
+
+          context "with valid params" do
+            let(:params) { valid_params}
+
+            it { expect { subject }.to change(GEval, :count).by(1) }
+
+            it "redirects to the created g_eval" do
+              subject
+              expect(response).to redirect_to(GEval.last)
+            end
+          end
+
+          context "with invalid params" do
+            let(:params) { invalid_params }
+
+            it { expect { subject }.not_to change(GEval, :count) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -972,6 +972,44 @@ ALTER SEQUENCE public.evidence_research_gen_ai_experiments_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_g_evals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_g_evals (
+    id bigint NOT NULL,
+    task_introduction text NOT NULL,
+    evaluation_criteria text NOT NULL,
+    evaluation_steps text NOT NULL,
+    metric character varying NOT NULL,
+    max_score integer NOT NULL,
+    selectable boolean DEFAULT true,
+    misc jsonb DEFAULT '{}'::jsonb,
+    version integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_g_evals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_g_evals_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_g_evals_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_g_evals_id_seq OWNED BY public.evidence_research_gen_ai_g_evals.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1455,6 +1493,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_experiments ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_g_evals id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_g_evals ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_g_evals_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1731,6 +1776,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_example_feedbacks
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_experiments
     ADD CONSTRAINT evidence_research_gen_ai_experiments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_g_evals evidence_research_gen_ai_g_evals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_g_evals
+    ADD CONSTRAINT evidence_research_gen_ai_g_evals_pkey PRIMARY KEY (id);
 
 
 --
@@ -2078,6 +2131,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240411135531'),
 ('20240425125151'),
 ('20240513162557'),
-('20240521200827');
+('20240521200827'),
+('20240528185315');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/experiments.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/experiments.rb
@@ -27,6 +27,7 @@ module Evidence
           llm_config { association :evidence_research_gen_ai_llm_config }
           llm_prompt { association :evidence_research_gen_ai_llm_prompt }
           passage_prompt { association :evidence_research_gen_ai_passage_prompt }
+          results { {}.to_json }
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/experiments.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/experiments.rb
@@ -27,7 +27,6 @@ module Evidence
           llm_config { association :evidence_research_gen_ai_llm_config }
           llm_prompt { association :evidence_research_gen_ai_llm_prompt }
           passage_prompt { association :evidence_research_gen_ai_passage_prompt }
-          results { {}.to_json }
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/g_evals.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/g_evals.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_g_evals
+#
+#  id                  :bigint           not null, primary key
+#  evaluation_criteria :text             not null
+#  evaluation_steps    :text             not null
+#  max_score           :integer          not null
+#  metric              :string           not null
+#  misc                :jsonb
+#  selectable          :boolean          default(TRUE)
+#  task_introduction   :text             not null
+#  version             :integer          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
+FactoryBot.define do
+  factory :evidence_research_gen_ai_g_eval, class: 'Evidence::Research::GenAI::GEval' do
+    task_introduction { 'Sample Task Introduction' }
+    evaluation_criteria { 'Sample Criteria' }
+    evaluation_steps { 'Sample Steps' }
+    metric { 'sample_metric' }
+    max_score { 10 }
+    selectable { true }
+    version { 1 }
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_configs.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_configs.rb
@@ -15,11 +15,11 @@ module Evidence
     module GenAI
       FactoryBot.define do
         factory :evidence_research_gen_ai_llm_config, class: 'Evidence::Research::GenAI::LLMConfig' do
-          vendor { Evidence::Research::GenAI::LLMConfig::VENDOR_MAP.keys.sample }
+          vendor { Evidence::Research::GenAI::VENDOR_COMPLETION_MAP.keys.sample }
           version { 'v1.0' }
 
-          trait(:google) { vendor { Evidence::Research::GenAI::LLMConfig::GOOGLE } }
-          trait(:open_ai) { vendor { Evidence::Research::GenAI::LLMConfig::OPEN_AI } }
+          trait(:google) { vendor { Evidence::Research::GenAI::GOOGLE } }
+          trait(:open_ai) { vendor { Evidence::Research::GenAI::OPEN_AI } }
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/g_eval_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/g_eval_spec.rb
@@ -32,7 +32,6 @@ module Evidence
         it { should validate_presence_of(:evaluation_steps) }
         it { should validate_presence_of(:metric) }
         it { should validate_presence_of(:max_score) }
-        it { should validate_presence_of(:version) }
 
         it { should have_readonly_attribute(:task_introduction) }
         it { should have_readonly_attribute(:evaluation_criteria) }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/g_eval_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/g_eval_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_g_evals
+#
+#  id                  :bigint           not null, primary key
+#  evaluation_criteria :text             not null
+#  evaluation_steps    :text             not null
+#  max_score           :integer          not null
+#  metric              :string           not null
+#  misc                :jsonb
+#  selectable          :boolean          default(TRUE)
+#  task_introduction   :text             not null
+#  version             :integer          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe GEval, type: :model do
+        let(:factory) { :evidence_research_gen_ai_g_eval }
+
+        it { expect(FactoryBot.build(factory)).to be_valid }
+
+        it { should validate_presence_of(:task_introduction) }
+        it { should validate_presence_of(:evaluation_criteria) }
+        it { should validate_presence_of(:evaluation_steps) }
+        it { should validate_presence_of(:metric) }
+        it { should validate_presence_of(:max_score) }
+        it { should validate_presence_of(:version) }
+
+        it { should have_readonly_attribute(:task_introduction) }
+        it { should have_readonly_attribute(:evaluation_criteria) }
+        it { should have_readonly_attribute(:evaluation_steps) }
+        it { should have_readonly_attribute(:metric) }
+        it { should have_readonly_attribute(:max_score) }
+        it { should have_readonly_attribute(:version) }
+
+        describe 'callbacks' do
+          let(:metric) { 'test_metric'}
+
+          it 'sets version before create' do
+            g_eval = build(factory, metric:)
+            expect(g_eval).to receive(:set_version)
+            g_eval.save
+          end
+
+          it 'increments version based on metric' do
+            create(factory, metric:, version: 1)
+            g_eval = create(factory, metric:)
+            expect(g_eval.version).to eq 2
+          end
+
+          it 'sets version to 1 if no existing version' do
+            g_eval = create(factory, metric:)
+            expect(g_eval.version).to eq 1
+          end
+        end
+
+        describe 'scopes' do
+          context '.selectable' do
+            subject { described_class.selectable }
+
+            let!(:selectable) { create(factory, selectable: true) }
+            let!(:non_selectable) { create(factory, selectable: false) }
+
+            it { is_expected.to include(selectable) }
+            it { is_expected.not_to include(non_selectable) }
+          end
+        end
+
+        describe '#name' do
+          subject { g_eval.name }
+
+          let(:metric) { 'test_metric' }
+          let(:version) { 1 }
+          let(:name) { "#{metric} v#{version}" }
+          let(:g_eval) { create(factory, metric:, version:) }
+
+          it { is_expected.to eq(name) }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/experiment_spec.rb
@@ -50,7 +50,6 @@ module Evidence
           let(:passage_prompt) { experiment.passage_prompt }
           let(:llm_config) { experiment.llm_config }
           let(:llm_prompt) { experiment.llm_prompt }
-          let(:llm_client) { double(:llm_client) }
           let(:llm_feedback_text) { { 'feedback' => 'This is feedback' }.to_json }
 
           let(:passage_prompt_responses) do
@@ -58,11 +57,11 @@ module Evidence
           end
 
           before do
-            allow(experiment).to receive(:llm_client).and_return(llm_client)
+            allow(experiment).to receive(:llm_config).and_return(llm_config)
 
-            allow(llm_client)
-              .to receive(:run)
-              .with(llm_config:, prompt: instance_of(String))
+            allow(llm_config)
+              .to receive(:completion)
+              .with(prompt: instance_of(String))
               .and_return(llm_feedback_text)
 
             allow(CalculateResultsWorker).to receive(:perform_async).with(experiment.id)
@@ -77,7 +76,7 @@ module Evidence
 
           context 'when creating LLM prompt responses feedbacks' do
             it 'only processes testing data responses' do
-              expect(llm_client).to receive(:run).exactly(num_examples).times
+              expect(llm_config).to receive(:completion).exactly(num_examples).times
 
               subject
             end
@@ -88,7 +87,7 @@ module Evidence
 
               subject
 
-              expect(experiment.reload.results['api_call_times'].size).to eq(num_examples)
+              expect(experiment.reload.api_call_times.size).to eq(num_examples)
             end
           end
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_config_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_config_spec.rb
@@ -37,7 +37,7 @@ module Evidence
           end
 
           context 'when vendor is OPEN_AI' do
-            let(:vendor) { described_class::OPEN_AI }
+            let(:vendor) { OPEN_AI }
 
             context 'when version is GPT_3_5_TURBO_0125' do
               let(:version) { described_class::GPT_3_5_TURBO_0125 }
@@ -59,7 +59,7 @@ module Evidence
           end
 
           context 'when vendor is GOOGLE' do
-            let(:vendor) { described_class::GOOGLE }
+            let(:vendor) { GOOGLE }
 
             context 'when version is GEMINI_1_5_PRO_LATEST' do
               let(:version) { described_class::GEMINI_1_5_PRO_LATEST }

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/g_eval_runner_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/g_eval_runner_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe GEvalRunner do
+        subject { described_class.run(g_eval_id:, llm_feedback:) }
+
+        let(:g_eval) { create(:evidence_research_gen_ai_g_eval) }
+        let(:g_eval_id) { g_eval.id }
+        let(:metric) { g_eval.metric }
+
+        let(:example_feedback) { create(:evidence_research_gen_ai_example_feedback) }
+
+        let(:llm_feedback) do
+          create(
+           :evidence_research_gen_ai_llm_feedback,
+           passage_prompt_response: example_feedback.passage_prompt_response,
+           text: example_feedback.text
+          )
+        end
+
+        let(:llm_config) { instance_double('LLMConfig', completion: llm_response) }
+        let(:llm_response) { { metric => score }.to_json }
+        let(:score) { rand(1..g_eval.max_score) }
+
+        before { allow(LLMConfig).to receive(:g_eval).and_return(llm_config) }
+
+        it { is_expected.to eq score }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/results_fetcher_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/results_fetcher_spec.rb
@@ -6,35 +6,39 @@ module Evidence
   module Research
     module GenAI
       RSpec.describe ResultsFetcher, type: :service do
-        subject { described_class.run(llm_feedbacks) }
+        subject { described_class.run(experiment) }
+
+        let(:experiment) { create(:evidence_research_gen_ai_experiment) }
+
+        let(:example_feedback1) { create(:evidence_research_gen_ai_example_feedback) }
+
+        let(:llm_feedback_identical) do
+          create(
+           :evidence_research_gen_ai_llm_feedback,
+           passage_prompt_response: example_feedback1.passage_prompt_response,
+           text: example_feedback1.text
+          )
+        end
+
+        let(:example_feedback2) { create(:evidence_research_gen_ai_example_feedback) }
+
+        let(:llm_feedback_non_identical) do
+          create(
+            :evidence_research_gen_ai_llm_feedback,
+            passage_prompt_response: example_feedback2.passage_prompt_response,
+            text: 'this is different feedback'
+          )
+        end
 
         before do
           stub_const("Evidence::Research::GenAI::ResultsFetcher::ENDPOINT", 'http://example.com/metrics')
           stub_request(:post, described_class::ENDPOINT).to_return(misc_metrics)
+          allow(experiment).to receive(:llm_feedbacks).and_return(llm_feedbacks)
         end
 
         context 'accuracy_identical results' do
           let(:result) { subject[:accuracy_identical] }
 
-          let(:example_feedback1) { create(:evidence_research_gen_ai_example_feedback) }
-
-          let(:llm_feedback_identical) do
-            create(
-             :evidence_research_gen_ai_llm_feedback,
-             passage_prompt_response: example_feedback1.passage_prompt_response,
-             text: example_feedback1.text
-            )
-          end
-
-          let(:example_feedback2) { create(:evidence_research_gen_ai_example_feedback) }
-
-          let(:llm_feedback_non_identical) do
-            create(
-              :evidence_research_gen_ai_llm_feedback,
-              passage_prompt_response: example_feedback2.passage_prompt_response,
-              text: 'this is different feedback'
-            )
-          end
 
           let(:misc_metrics) { {} }
 
@@ -60,6 +64,18 @@ module Evidence
             let(:llm_feedbacks) { [llm_feedback_identical, llm_feedback_non_identical] }
 
             it { expect(result).to eq 0.5 }
+          end
+        end
+
+        context 'with g_eval ids' do
+          let(:misc_metrics) { {} }
+          let(:llm_feedbacks) { [llm_feedback_identical, llm_feedback_non_identical] }
+
+          before { experiment.update!(results: { g_evals: { 'ids' => [1, 2, 3] } } ) }
+
+          it 'runs GEvalRunner for each g_eval id' do
+            expect(GEvalRunner).to receive(:run).exactly(6).times
+            subject
           end
         end
       end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/results_fetcher_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/results_fetcher_spec.rb
@@ -8,7 +8,7 @@ module Evidence
       RSpec.describe ResultsFetcher, type: :service do
         subject { described_class.run(experiment) }
 
-        let(:experiment) { create(:evidence_research_gen_ai_experiment) }
+        let(:experiment) { create(:evidence_research_gen_ai_experiment, results: '{}') }
 
         let(:example_feedback1) { create(:evidence_research_gen_ai_example_feedback) }
 
@@ -38,7 +38,6 @@ module Evidence
 
         context 'accuracy_identical results' do
           let(:result) { subject[:accuracy_identical] }
-
 
           let(:misc_metrics) { {} }
 
@@ -71,7 +70,7 @@ module Evidence
           let(:misc_metrics) { {} }
           let(:llm_feedbacks) { [llm_feedback_identical, llm_feedback_non_identical] }
 
-          before { experiment.update!(results: { g_evals: { 'ids' => [1, 2, 3] } } ) }
+          before { experiment.update!(results: { g_eval_ids: [1, 2, 3] }) }
 
           it 'runs GEvalRunner for each g_eval id' do
             expect(GEvalRunner).to receive(:run).exactly(6).times

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/research/gen_ai/calculate_results_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/research/gen_ai/calculate_results_worker_spec.rb
@@ -28,7 +28,7 @@ module Evidence
           before do
             allow(ResultsFetcher)
               .to receive(:run)
-              .with(experiment.llm_feedbacks)
+              .with(experiment)
               .and_return(fetched_results)
 
             allow(Experiment)


### PR DESCRIPTION
## WHAT
Add [g-eval]() to the GenAI experiment configuration.

## WHY
We'd like to use a SOTA evaluation tool for LLM feedback

## HOW
1.  Add GEval model to store different G-eval configurations
1.  Add AutoChainOfThoughtController.   G-Eval generation requires an intermediate step of generating a "Evaluation Steps" (see Auto CoT in screenshot below) from an LLM.  This controller handles the intermediate step and redirects to the GEvalController, specifically the new template.
1.  Add GEval runner to evaluate LLM Feedback from Ideal Feedback using a g-eval configuration.

### Screenshots
Figure from [arxiv](https://arxiv.org/abs/2303.16634) paper:
<img width="643" alt="Screenshot 2024-05-30 at 3 47 10 PM" src="https://github.com/empirical-org/Empirical-Core/assets/2057805/4a199b56-eefb-4dfe-8a22-401c709e92b3">

![Screenshot 2024-05-30 at 3 59 45 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/7c0408fc-d06a-4d41-be53-8a2e763f1e4f)

![Screenshot 2024-05-30 at 3 14 43 PM](https://github.com/empirical-org/Empirical-Core/assets/2057805/a3afb7d5-1885-479c-b299-a0bf5a9c3f19)


### Notion Card Links
https://www.notion.so/quill/Host-G-Eval-endpoint-45eef4c938e445d78875e4f9bf8d941d?pvs=4

### What have you done to QA this feature?
I tested this functionality out both locally and on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YS
