### PR TITLE
update homepage/impact page rounding

### DIFF
--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -38,8 +38,8 @@ class PagesController < ApplicationController
     @title = 'Quill.org | Interactive Writing and Grammar'
     @description = 'Quill provides free writing and grammar activities for middle and high school students.'
     # default numbers are current as of 06/03/24
-    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 1972000000
-    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 8900000
+    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 2000000000
+    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 9000000
 
     if request.env['affiliate.tag']
       name = ReferrerUser.find_by(referral_code: request.env['affiliate.tag'])&.user&.name
@@ -346,11 +346,11 @@ class PagesController < ApplicationController
 
   def impact
     # default numbers are current as of 06/03/24
-    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 8900000
-    @number_of_schools = $redis.get(NUMBER_OF_SCHOOLS) || 38018
-    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 1972000000
-    @number_of_low_income_schools = $redis.get(NUMBER_OF_LOW_INCOME_SCHOOLS) || 23951
-    @number_of_teachers = $redis.get(NUMBER_OF_TEACHERS) || 186300
+    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 9000000
+    @number_of_schools = $redis.get(NUMBER_OF_SCHOOLS) || 38000
+    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 2000000000
+    @number_of_low_income_schools = $redis.get(NUMBER_OF_LOW_INCOME_SCHOOLS) || 23940
+    @number_of_teachers = $redis.get(NUMBER_OF_TEACHERS) || 186000
   end
 
   def team

--- a/services/QuillLMS/app/controllers/pages_controller.rb
+++ b/services/QuillLMS/app/controllers/pages_controller.rb
@@ -19,6 +19,10 @@ class PagesController < ApplicationController
   NUMBER_OF_TEACHERS = "NUMBER_OF_TEACHERS"
   NUMBER_OF_SCHOOLS = "NUMBER_OF_SCHOOLS"
   NUMBER_OF_LOW_INCOME_SCHOOLS = "NUMBER_OF_LOW_INCOME_SCHOOLS"
+
+  # default numbers are current as of 06/03/24
+  DEFAULT_NUMBER_OF_SENTENCES = 2000000000
+  DEFAULT_NUMBER_OF_STUDENTS = 9000000
   OPEN_POSITIONS = Configs[:careers][:open_positions]
 
   def home
@@ -37,9 +41,9 @@ class PagesController < ApplicationController
 
     @title = 'Quill.org | Interactive Writing and Grammar'
     @description = 'Quill provides free writing and grammar activities for middle and high school students.'
-    # default numbers are current as of 06/03/24
-    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 2000000000
-    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 9000000
+
+    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || DEFAULT_NUMBER_OF_SENTENCES
+    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || DEFAULT_NUMBER_OF_STUDENTS
 
     if request.env['affiliate.tag']
       name = ReferrerUser.find_by(referral_code: request.env['affiliate.tag'])&.user&.name
@@ -346,9 +350,9 @@ class PagesController < ApplicationController
 
   def impact
     # default numbers are current as of 06/03/24
-    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || 9000000
+    @number_of_students = $redis.get(NUMBER_OF_STUDENTS) || DEFAULT_NUMBER_OF_STUDENTS
     @number_of_schools = $redis.get(NUMBER_OF_SCHOOLS) || 38000
-    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || 2000000000
+    @number_of_sentences = $redis.get(NUMBER_OF_SENTENCES) || DEFAULT_NUMBER_OF_SENTENCES
     @number_of_low_income_schools = $redis.get(NUMBER_OF_LOW_INCOME_SCHOOLS) || 23940
     @number_of_teachers = $redis.get(NUMBER_OF_TEACHERS) || 186000
   end

--- a/services/QuillLMS/app/views/pages/home_new.html.erb
+++ b/services/QuillLMS/app/views/pages/home_new.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class="q-hero-footer">
     <p class="text-white">
-      <span class="hero-footer-underline"><%= Utils::Numeric.to_human_string(@number_of_students).downcase %></span> students have written <span class="hero-footer-underline"><%= Utils::Numeric.to_human_string(@number_of_sentences).downcase %></span> sentences on Quill.
+      <span class="hero-footer-underline"><%= ActiveSupport::NumberHelper.number_to_human(@number_of_students, precision: 2).downcase %></span> students have written <span class="hero-footer-underline"><%= ActiveSupport::NumberHelper.number_to_human(@number_of_sentences, precision: 1).downcase %></span> sentences on Quill.
     </p>
   </div>
 </section>

--- a/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
@@ -37,27 +37,28 @@ describe SetImpactMetricsWorker do
 
     it 'should set the NUMBER_OF_SENTENCES redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_SENTENCES)).to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.size) * SetImpactMetricsWorker::SENTENCES_PER_ACTIVITY_SESSION).to_s)
+      expect($redis.get(PagesController::NUMBER_OF_SENTENCES)).to eq((SetImpactMetricsWorker.round_to_hundred_millions(activity_sessions_payload.size * SetImpactMetricsWorker::SENTENCES_PER_ACTIVITY_SESSION)).to_s)
     end
 
     it 'should set the NUMBER_OF_STUDENTS redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_STUDENTS)).to eq((SetImpactMetricsWorker.round_to_ten_thousands(activity_sessions_payload.count('DISTINCT(user_id)'))).to_s)
+      expect($redis.get(PagesController::NUMBER_OF_STUDENTS)).to eq((SetImpactMetricsWorker.round_to_hundred_thousands(activity_sessions_payload.count('DISTINCT(user_id)'))).to_s)
     end
 
     it 'should set the NUMBER_OF_TEACHERS redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_TEACHERS)).to eq(SetImpactMetricsWorker.round_to_hundreds(teachers.length).to_s)
+      expect($redis.get(PagesController::NUMBER_OF_TEACHERS)).to eq(SetImpactMetricsWorker.round_to_thousands(teachers.length).to_s)
     end
 
     it 'should set the NUMBER_OF_SCHOOLS redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_SCHOOLS)).to eq(schools_payload.length.to_s)
+      expect($redis.get(PagesController::NUMBER_OF_SCHOOLS)).to eq(SetImpactMetricsWorker.round_to_thousands(schools_payload.length).to_s)
     end
 
     it 'should set the NUMBER_OF_LOW_INCOME_SCHOOLS redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_LOW_INCOME_SCHOOLS)).to eq((schools_payload.length * SetImpactMetricsWorker::LOW_INCOME_PERCENTAGE).floor.to_s)
+      number_of_schools = SetImpactMetricsWorker.round_to_thousands(schools_payload.length)
+      expect($redis.get(PagesController::NUMBER_OF_LOW_INCOME_SCHOOLS)).to eq(SetImpactMetricsWorker.round_to_thousands((number_of_schools * SetImpactMetricsWorker::LOW_INCOME_PERCENTAGE)).to_s)
     end
   end
 end


### PR DESCRIPTION
## WHAT
Update how we round metrics on the homepage and impact page.

## WHY
Peter Gault requested these changes.

## HOW
Update a) how they are stored in Redis and b) how they display (with the human-readable text) on the home page.

### Screenshots
<img width="700" alt="Screenshot 2024-06-04 at 8 46 27 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/6fd29abb-21e7-4287-ad88-7c61c98e2fca">

### Notion Card Links
https://www.notion.so/quill/Update-to-metrics-formatting-on-homepage-and-impact-page-11298a469b314508aae17fbaa452f0c2?pvs=4

### What have you done to QA this feature?
Ran the rake task and looked at both the home and impact page to confirm that the numbers match and rounding looks good.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
