### PR TITLE
Update the sample environment to point to the stagigng CMS

### DIFF
--- a/services/QuillLMS/.env-sample
+++ b/services/QuillLMS/.env-sample
@@ -22,6 +22,7 @@ MIXPANEL_KEY=
 REDISCLOUD_URL=redis://localhost:6379/0
 QUILL_API_URL=https://localhost:3000/api/v1
 DEFAULT_URL=http://localhost:3000
+QUILL_CMS=https://staging-cms.quill.org/
 CDN_URL=https://assets.quill.org
 # PUSHER
 PUSHER_APP_ID=

--- a/services/QuillLMS/.env-sample
+++ b/services/QuillLMS/.env-sample
@@ -22,7 +22,7 @@ MIXPANEL_KEY=
 REDISCLOUD_URL=redis://localhost:6379/0
 QUILL_API_URL=https://localhost:3000/api/v1
 DEFAULT_URL=http://localhost:3000
-QUILL_CMS=https://staging-cms.quill.org/
+QUILL_CMS=https://staging-cms.quill.org
 CDN_URL=https://assets.quill.org
 # PUSHER
 PUSHER_APP_ID=


### PR DESCRIPTION
## WHAT
Added a new key to the sample env so that we can get data from the staging CMS database. 
## WHY
The default development CMS has no data, we don't use this often, so rather than seeding it we rely on the staging version. 
## HOW
Added the key to the sample env


### What have you done to QA this feature?
Used it on my own setup. 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, because this code is never run, you'd have to copy it into your env file to see a change
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
