### PR TITLE
guard against requests with bad params

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/questions_controller.rb
@@ -5,6 +5,13 @@ class Api::V1::QuestionsController < Api::ApiController
   before_action :get_question_by_uid, except: [:index, :create, :show]
 
   def index
+    if @question_type.nil?
+      return render json: {
+        error: 'Bad Request',
+        message: 'question_type is a required param'
+      }, status: 400
+    end
+
     render json: Question.all_questions_json_cached(@question_type)
   end
 

--- a/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
@@ -16,6 +16,16 @@ describe Api::V1::QuestionsController, type: :controller do
       expect(JSON.parse(response.body).keys.length).to eq(1)
       expect(JSON.parse(response.body).keys.first).to eq(question.uid)
     end
+
+    context 'invalid arguments' do
+      it 'should return early without exception on nil question_type' do
+        get :index, as: :json
+        expect(JSON.parse(response.body)).to eq(
+          {"error"=>"Bad Request", "message"=>"question_type is a required param"}
+        )
+        expect(response.status).to eq 400
+      end
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
## WHAT
Questions#index is occasionally called with no params (from a web crawler, if we believe the User Agent header: `facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)`). This is not a supported request. Currently, these requests raise an unhandled exception. This PR validates input and returns an HTTP 400 JSON response with a helpful message. 

## WHY
- So that [New Relic error panels ](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/MjYzOTExM3xBUE18QVBQTElDQVRJT058NTQ4ODU2ODc1?duration=86400000&state=d708368e-f362-ebbc-650e-c8ce5ec9b7d2)are less cluttered
- So that the error is easily explained to the casual reader. 


### Screenshots
Before:
![Screenshot 2024-06-10 at 10 24 03 AM](https://github.com/empirical-org/Empirical-Core/assets/90669/d84ba1f4-d0a2-4a02-bc6b-8929901d5b78)

After:
![Screenshot 2024-06-10 at 10 24 18 AM](https://github.com/empirical-org/Empirical-Core/assets/90669/dffee947-c896-4aa1-9738-072b7ff4b46c)


### Notion Card Links
none

### What have you done to QA this feature?
Request the degenerate URL directly from the browser on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
