### PR TITLE
Backpack/ add semibold display fonts

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/variables.scss
+++ b/services/QuillLMS/app/assets/stylesheets/variables.scss
@@ -200,8 +200,18 @@ $family-monospace: "Roboto-mono", "Monaco", "Inconsolata", monospace;
   font-size: 32px;
 }
 
+@mixin display-2xl-semibold {
+  font-weight: semibold;
+  font-size: 32px;
+}
+
 @mixin display-xl {
   font-weight: bold;
+  font-size: 24px;
+}
+
+@mixin display-xl-semibold {
+  font-weight: semibold;
   font-size: 24px;
 }
 
@@ -210,7 +220,7 @@ $family-monospace: "Roboto-mono", "Monaco", "Inconsolata", monospace;
   font-size: 20px;
 }
 
-@mixin display-l-alt {
+@mixin display-l-semibold {
   font-weight: semibold;
   font-size: 20px;
 }
@@ -220,8 +230,18 @@ $family-monospace: "Roboto-mono", "Monaco", "Inconsolata", monospace;
   font-size: 18px;
 }
 
+@mixin display-m-semibold {
+  font-weight: semibold;
+  font-size: 18px;
+}
+
 @mixin display-s {
   font-weight: bold;
+  font-size: 16px;
+}
+
+@mixin display-s-semibold {
+  font-weight: semibold;
   font-size: 16px;
 }
 
@@ -230,8 +250,18 @@ $family-monospace: "Roboto-mono", "Monaco", "Inconsolata", monospace;
   font-size: 13px;
 }
 
+@mixin display-xs-semibold {
+  font-weight: semibold;
+  font-size: 13px;
+}
+
 @mixin display-2xs {
   font-weight: bold;
+  font-size: 12px;
+}
+
+@mixin display-2xs-semibold {
+  font-weight: semibold;
   font-size: 12px;
 }
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/typography.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/typography.test.tsx.snap
@@ -1,0 +1,263 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Typography it should render 1`] = `
+<DocumentFragment>
+  <div
+    id="typography"
+  >
+    <h2
+      class="style-guide-h2"
+    >
+      Typography
+    </h2>
+    <p>
+      In order to use these styles, include the mixin name (on the left) inside a CSS rule, ex: 
+      <code>
+        @include display-m
+      </code>
+    </p>
+    <div
+      class="element-container"
+    >
+      <div
+        class="display-2xl"
+      >
+        <span>
+          display-2xl
+        </span>
+        <span>
+          Adelle Sans - Bold 32pt
+        </span>
+      </div>
+      <div
+        class="display-2xl-semibold"
+      >
+        <span>
+          display-2xl-semibold
+        </span>
+        <span>
+          Adelle Sans - Semibold 32pt
+        </span>
+      </div>
+      <div
+        class="display-xl"
+      >
+        <span>
+          display-xl
+        </span>
+        <span>
+          Adelle Sans - Bold 24pt
+        </span>
+      </div>
+      <div
+        class="display-xl-semibold"
+      >
+        <span>
+          display-xl-semibold
+        </span>
+        <span>
+          Adelle Sans - Semibold 24pt
+        </span>
+      </div>
+      <div
+        class="display-l"
+      >
+        <span>
+          display-l
+        </span>
+        <span>
+          Adelle Sans - Bold 20pt
+        </span>
+      </div>
+      <div
+        class="display-l-semibold"
+      >
+        <span>
+          display-l-semibold
+        </span>
+        <span>
+          Adelle Sans - Semibold 20pt
+        </span>
+      </div>
+      <div
+        class="display-m"
+      >
+        <span>
+          display-m
+        </span>
+        <span>
+          Adelle Sans - Bold 18pt
+        </span>
+      </div>
+      <div
+        class="display-m-semibold"
+      >
+        <span>
+          display-m-semibold
+        </span>
+        <span>
+          Adelle Sans - Semibold 18pt
+        </span>
+      </div>
+      <div
+        class="display-s"
+      >
+        <span>
+          display-s
+        </span>
+        <span>
+          Adelle Sans - Bold 16pt
+        </span>
+      </div>
+      <div
+        class="display-s-semibold"
+      >
+        <span>
+          display-s-semibold
+        </span>
+        <span>
+          Adelle Sans - Semibold 16pt
+        </span>
+      </div>
+      <div
+        class="display-xs"
+      >
+        <span>
+          display-xs
+        </span>
+        <span>
+          Adelle Sans - Bold 13pt
+        </span>
+      </div>
+      <div
+        class="display-xs-semibold"
+      >
+        <span>
+          display-xs-semibold
+        </span>
+        <span>
+          Adelle Sans - Semibold 13pt
+        </span>
+      </div>
+      <div
+        class="display-2xs"
+      >
+        <span>
+          display-2xs
+        </span>
+        <span>
+          Adelle Sans - Bold 12pt
+        </span>
+      </div>
+      <div
+        class="display-2xs-semibold"
+      >
+        <span>
+          display-2xs-semibold
+        </span>
+        <span>
+          Adelle Sans - Semibold 12pt
+        </span>
+      </div>
+    </div>
+    <div
+      class="element-container"
+    >
+      <div
+        class="text-2xl"
+      >
+        <span>
+          text-2xl
+        </span>
+        <span>
+          Adelle Sans - Regular 24pt
+        </span>
+      </div>
+      <div
+        class="text-xl"
+      >
+        <span>
+          text-xl
+        </span>
+        <span>
+          Adelle Sans - Regular 20pt
+        </span>
+      </div>
+      <div
+        class="text-l"
+      >
+        <span>
+          text-l
+        </span>
+        <span>
+          Adelle Sans - Regular 18pt
+        </span>
+      </div>
+      <div
+        class="text-m"
+      >
+        <span>
+          text-m
+        </span>
+        <span>
+          Adelle Sans - Regular 16pt
+        </span>
+      </div>
+      <div
+        class="text-s"
+      >
+        <span>
+          text-s
+        </span>
+        <span>
+          Adelle Sans - Regular 14pt
+        </span>
+      </div>
+      <div
+        class="text-xs"
+      >
+        <span>
+          text-xs
+        </span>
+        <span>
+          Adelle Sans - Regular 13pt
+        </span>
+      </div>
+      <div
+        class="text-2xs"
+      >
+        <span>
+          text-2xs
+        </span>
+        <span>
+          Adelle Sans - Regular 12pt
+        </span>
+      </div>
+    </div>
+    <div
+      class="element-container"
+    >
+      <div
+        class="navigation-l"
+      >
+        <span>
+          navigation-l
+        </span>
+        <span>
+          Adelle Sans - Semibold 14pt
+        </span>
+      </div>
+      <div
+        class="navigation-m"
+      >
+        <span>
+          navigation-m
+        </span>
+        <span>
+          Adelle Sans - Semibold 13pt
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/typography.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/typography.test.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+
+import Typography from "../typography";
+
+describe('Typography', () => {
+  test('it should render', () => {
+    const { asFragment } = render(<Typography />);
+    expect(asFragment()).toMatchSnapshot();
+  })
+})

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/typography.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/typography.tsx
@@ -6,15 +6,23 @@ const displayScale = [
     displayText: 'Adelle Sans - Bold 32pt'
   },
   {
+    mixinName: 'display-2xl-semibold',
+    displayText: 'Adelle Sans - Semibold 32pt'
+  },
+  {
     mixinName: 'display-xl',
     displayText: 'Adelle Sans - Bold 24pt'
+  },
+  {
+    mixinName: 'display-xl-semibold',
+    displayText: 'Adelle Sans - Semibold 24pt'
   },
   {
     mixinName: 'display-l',
     displayText: 'Adelle Sans - Bold 20pt'
   },
   {
-    mixinName: 'display-l-alt',
+    mixinName: 'display-l-semibold',
     displayText: 'Adelle Sans - Semibold 20pt'
   },
   {
@@ -22,16 +30,32 @@ const displayScale = [
     displayText: 'Adelle Sans - Bold 18pt'
   },
   {
+    mixinName: 'display-m-semibold',
+    displayText: 'Adelle Sans - Semibold 18pt'
+  },
+  {
     mixinName: 'display-s',
     displayText: 'Adelle Sans - Bold 16pt'
+  },
+  {
+    mixinName: 'display-s-semibold',
+    displayText: 'Adelle Sans - Semibold 16pt'
   },
   {
     mixinName: 'display-xs',
     displayText: 'Adelle Sans - Bold 13pt'
   },
   {
+    mixinName: 'display-xs-semibold',
+    displayText: 'Adelle Sans - Semibold 13pt'
+  },
+  {
     mixinName: 'display-2xs',
     displayText: 'Adelle Sans - Bold 12pt'
+  },
+  {
+    mixinName: 'display-2xs-semibold',
+    displayText: 'Adelle Sans - Semibold 12pt'
   },
 ]
 

--- a/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/style_guide.scss
@@ -340,26 +340,44 @@
   .display-2xl {
     @include display-2xl;
   }
+  .display-2xl-semibold {
+    @include display-2xl-semibold;
+  }
   .display-xl {
     @include display-xl;
+  }
+  .display-xl-semibold {
+    @include display-xl-semibold;
   }
   .display-l {
     @include display-l;
   }
-  .display-l-alt {
-    @include display-l-alt;
+  .display-l-semibold {
+    @include display-l-semibold;
   }
   .display-m {
     @include display-m;
   }
+  .display-m-semibold {
+    @include display-m-semibold;
+  }
   .display-s {
     @include display-s;
+  }
+  .display-s-semibold {
+    @include display-s-semibold;
   }
   .display-xs {
     @include display-xs;
   }
+  .display-xs-semibold {
+    @include display-xs-semibold;
+  }
   .display-2xs {
     @include display-2xs;
+  }
+  .display-2xs-semibold {
+    @include display-2xs-semibold;
   }
   .text-2xl {
     @include text-2xl;
@@ -393,12 +411,13 @@
     margin: 16px 0px 20px;
     span {
       display: inline-block;
+      white-space: nowrap;
     }
     div {
       margin-bottom: 4px;
     }
     div span:first-of-type {
-      width: 250px;
+      width: 350px;
     }
   }
 }


### PR DESCRIPTION
## WHAT
add semibold display fonts to Typography section in Backpack

## WHY
we are expanding our component library

## HOW
just add new mixins for these display fonts

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="911" alt="Screen Shot 2024-06-11 at 2 11 49 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/3441d46d-c61f-410b-b7b3-726bc302b8cf">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Quill-Backpack-Buttons-Menus-Text-Fields-Segmented-Controls-Lists-85b0fa6c8cee4a108a015f307befb7a7?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
verified on staging that the display fonts render as expected

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
