### PR TITLE
show blue for ungraded activites on activity analysis student overview

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
@@ -72,6 +72,7 @@ $lightgray: #cecece;
 #individual-activity-classroom-view {
   max-width: 950px;
   margin: auto;
+  margin-top: 48px;
     th:first-of-type,
     tr td:first-of-type {
         width: 110px;
@@ -362,6 +363,12 @@ $lightgray: #cecece;
     background-color: #FADDE2;
   }
 }
+.blue-score-color {
+  background-color: $quill-blue-1;
+  &:hover {
+    background-color: $quill-blue-5;
+  }
+}
 .yellow-score-color, .orange-score-color {
   background-color: #FFF6E2;
   &:hover {
@@ -378,12 +385,18 @@ $lightgray: #cecece;
 
 /* for class reports*/
 
+#student-groupings-wrapper {
+  margin: 48px 0px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
 .student-groupings {
   @include gray-border;
   display: inline-block;
-  margin-top: 15px;
-  margin-right: 15px;
   width: min-content;
+  min-width: 242px;
   padding: 10px;
   h3 {
     font-size: 20px;

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -68,7 +68,7 @@ module PublicProgressReports
       curr_quest[:total] += 1
       curr_quest[:prompt] ||= answer.concept_result_prompt&.text
       curr_quest[:question_number] ||= answer.question_number
-      curr_quest[:question_uid] ||= answer.extra_metadata['question_uid']
+      curr_quest[:question_uid] ||= answer.extra_metadata && answer.extra_metadata['question_uid']
       if answer.attempt_number == 1 || !curr_quest[:instructions]
         direct = answer.concept_result_directions&.text || answer.concept_result_instructions&.text || ""
         curr_quest[:instructions] = direct.gsub(/(<([^>]+)>)/i, "").gsub("()", "").gsub("&nbsp;", "")

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/grade_color.js
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/grade_color.js
@@ -1,6 +1,6 @@
 export default (grade) => {
   if (grade == null) {
-    return 'gray';
+    return 'blue';
   } else if (grade < 0.32) {
     return 'red';
   } else if (grade < 0.83) {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/modules/score_color.js
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/modules/score_color.js
@@ -2,6 +2,7 @@ import GradeColor from './grade_color'
 
 // generally used for setting color class names, hence the score color concat at end
 export default function (grade) {
-  const color = GradeColor(grade/100)
+  const color = grade === null ? GradeColor(grade) : GradeColor(grade/100)
+
   return `${color}-score-color`;
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/overview_boxes.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/overview_boxes.jsx
@@ -1,5 +1,6 @@
 import Pluralize from 'pluralize';
 import React from 'react';
+
 import ScoreColor from '../../modules/score_color.js';
 
 export default class OverviewBoxes extends React.Component {
@@ -8,9 +9,11 @@ export default class OverviewBoxes extends React.Component {
   }
 
   countBoxType = () => {
+    const { data, } = this.props
     let count = {};
     let scoreColor;
-    this.props.data.forEach(student => {
+
+    data.forEach(student => {
       scoreColor = ScoreColor(student.score);
       count[scoreColor] = count[scoreColor] || 0;
       count[scoreColor] += 1;
@@ -34,7 +37,7 @@ export default class OverviewBoxes extends React.Component {
     return (
       <div className={'student-groupings ' + group} key={group}>
         <h3>{(count || 0) + ' ' + Pluralize('Student', count)}</h3>
-        <span>{range + '  |  ' + proficiency}</span>
+        <span>{group === 'blue-score-color' ? 'Completed' : `${range} | ${proficiency}`}</span>
       </div>
     )
   };
@@ -43,7 +46,7 @@ export default class OverviewBoxes extends React.Component {
     // need to list the keys in an array instead of just using a for in
     // loop as we want them in this particular order
     let groupCounts = this.countBoxType();
-    let groups = ['red', 'yellow', 'green'];
+    let groups = ['red', 'yellow', 'green', 'blue'];
     return groups.map(group => {
       group += '-score-color'
       return this.boxCreator(group, groupCounts[group])


### PR DESCRIPTION
## WHAT
Updated the Activity Analysis Student Overview to show rows for ungraded activities (aka a score of null) in blue rather than red. Also fix some spacing issues and add blue to the key.

## WHY
Red is the color we use for scores of less than 31%, which isn't appropriate for activities that just don't have scores.

## HOW
Update the color logic, HTML, and CSS.

### Screenshots
<img width="1268" alt="Screenshot 2024-06-12 at 1 53 23 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/a98f8f88-fbe7-4ee5-9475-5cfde5d09c64">


### Notion Card Links
https://www.notion.so/quill/Activity-Analysis-Design-Updates-91e18c4df26044d1b4e536274a469aee?pvs=4

### What have you done to QA this feature?
Looked at the relevant pages on various screen widths.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
