### PR TITLE
fix border radius for hovered row on dashboard

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/post_checklist.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/post_checklist.scss
@@ -85,6 +85,10 @@
           padding: 0px 24px;
           margin: 0px;
         }
+
+        .data-table-row:last-of-type:hover {
+          border-radius: 0px 0px 8px 8px;
+        }
       }
 
       .data-table .data-table-header {


### PR DESCRIPTION
## WHAT
Fix the corner radius of the last row in the teacher dashboard tables on hover.

## WHY
So the hover color doesn't extend beyond the table's corners.

## HOW
CSS.

### Screenshots
<img width="849" alt="Screenshot 2024-06-12 at 1 07 26 PM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/ee7bcb6e-1dbf-47bc-9a4c-05f85b4eea48">


### Notion Card Links
https://www.notion.so/quill/Teacher-Dashboard-UI-Issue-Table-Row-Corner-Radius-659ce2dde3134b1ca21e38b3b58e9c32

### What have you done to QA this feature?
Look at the table on hover and make sure it looks as it should.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO CSS tests
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
