### PR TITLE
Add order to payload object in Regex Input and Concept Selector form

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/internalTools/regexInputAndConceptSelectorForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/internalTools/regexInputAndConceptSelectorForm.tsx
@@ -19,6 +19,7 @@ export class RegexInputAndConceptSelectorForm extends React.Component {
       itemFeedback: item?.feedback || '',
       itemConcepts: item?.conceptResults || {},
       caseInsensitive: item ? (item.caseInsensitive ? item.caseInsensitive : false) : true,
+      order: item ? item.order : null,
       matchedCount: 0
     }
   }
@@ -94,7 +95,7 @@ export class RegexInputAndConceptSelectorForm extends React.Component {
   }
 
   submit = (record) => {
-    const { name, itemText, itemFeedback, itemConcepts, caseInsensitive, } = this.state
+    const { name, itemText, itemFeedback, itemConcepts, caseInsensitive, order, } = this.state
     const { onSubmit, focusPointOrIncorrectSequence, } = this.props
 
     const regexes = itemText.split(/\|{3}(?!\|)/).filter(val => val !== '')
@@ -105,6 +106,7 @@ export class RegexInputAndConceptSelectorForm extends React.Component {
         text: regexString,
         feedback: itemFeedback,
         conceptResults: itemConcepts,
+        order: order,
       };
 
       if (focusPointOrIncorrectSequence === INCORRECT_SEQUENCE) {


### PR DESCRIPTION
## WHAT
Bugfix on this form -- the "order" attribute wasn't being read into the React class's state and therefore not being sent on the submission callback. This caused the "order" attribute of the object to get lost when admin use this page and then the overall order of incorrect sequences and focus points is scrambled after they submit their edits.

## WHY
The order needs to be sent in the payload in order for the overall order of sequences to stay in the same order after the admin uses this page.

## HOW
Just read the order into the initial state and then send it through on the submit action.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Incorrect-Sequence-Shuffling-1d58145f28264fc9bd2bff7fb0788845?pvs=4

### What have you done to QA this feature?
Deploy to staging and test editing the incorrect sequences and focus points on Connect, Grammar and Diagnostic to determine that order does not reshuffle after editing the sequences.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
