### PR TITLE
Remove materialized views that are not used by any queries

### DIFF
--- a/services/QuillLMS/config/big_query_views.yml
+++ b/services/QuillLMS/config/big_query_views.yml
@@ -1,16 +1,6 @@
 # NB: if using create options, include OPTIONS(), e.g.
 # create_options: "OPTIONS(enable_refresh = true)"
 default:
-  active_classroom_stubs_view:
-    dataset: 'lms'
-    name: 'active_classroom_stubs_view'
-    name_fallback: 'active_classroom_stubs_local'
-    sql: 'active_classroom_stubs_view.sql'
-  active_classroom_unit_stubs_view:
-    dataset: 'lms'
-    name: 'active_classroom_unit_stubs_view'
-    name_fallback: 'active_classroom_unit_stubs_local'
-    sql: 'active_classroom_unit_stubs_view.sql'
   active_user_names_view:
     dataset: 'lms'
     name: 'active_user_names_view'
@@ -22,11 +12,6 @@ default:
     name_fallback: 'pre_post_diagnostic_skill_performance_local'
     sql: 'pre_post_diagnostic_skill_group_performance_view.sql'
     create_options: "OPTIONS(allow_non_incremental_definition = true, enable_refresh = true, max_staleness = INTERVAL '8' HOUR, refresh_interval_minutes = 360)"
-  recommendation_activity_session_stubs_view:
-    dataset: 'lms'
-    name: 'recommendation_activity_session_stubs_view'
-    name_fallback: 'recommendation_activity_session_stubs_local'
-    sql: 'recommendation_activity_session_stubs_view.sql'
   recommendation_count_rollup_view:
     dataset: 'lms'
     name: 'recommendation_count_rollup_view'

--- a/services/QuillLMS/db/big_query/views/active_classroom_stubs_view.sql
+++ b/services/QuillLMS/db/big_query/views/active_classroom_stubs_view.sql
@@ -1,1 +1,0 @@
-SELECT id, name, grade FROM lms.classrooms

--- a/services/QuillLMS/db/big_query/views/active_classroom_unit_stubs_view.sql
+++ b/services/QuillLMS/db/big_query/views/active_classroom_unit_stubs_view.sql
@@ -1,1 +1,0 @@
-SELECT id, classroom_id, unit_id, ARRAY_LENGTH(assigned_student_ids) AS assigned_student_count FROM lms.classroom_units

--- a/services/QuillLMS/db/big_query/views/recommendation_activity_session_stubs_view.sql
+++ b/services/QuillLMS/db/big_query/views/recommendation_activity_session_stubs_view.sql
@@ -1,4 +1,0 @@
-SELECT id, user_id, classroom_unit_id, timespent, completed_at
-  FROM lms.activity_sessions
-  WHERE visible = true
-    AND completed_at IS NOT NULL


### PR DESCRIPTION
## WHAT
- Remove `active_classroom_stubs` BigQuery materialized view definition
- Remove `active_classroom_unit_stubs ` BigQuery materialized view definition
- Remove `recommendation_activity_session_stubs ` BigQuery materialized view definition
- Remove references to all three views from the config file
## WHY
These views are not used by any active queries.  They are left-overs from various approaches used during the development of the Admin Diagnostic Growth Report feature that ended up being unneded.
## HOW
Go through the list of defined views and search the codebase for any references to them.  Remove the ones that are wholly unreferenced.

NOTE: There will need to be a follow-up task to remove the actual view files in BigQuery once they are no longer in our code-base.

### Notion Card Links
https://www.notion.so/quill/ADGR-Post-work-Clean-up-unused-Mat-Views-3fabec2eb206407282ad8e17289e2764?pvs=4

### What have you done to QA this feature?
Removed files and config, deployed to staging, loaded all three of the Admin Diagnostic reports in the web interface to ensure that no code-path is somehow secretly trying to use these views.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No test coverage since this is dead code
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
