### PR TITLE
Update display of time spent on the Overview tab to match Student

### DIFF
--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/diagnosticGrowthReportsHelpers.test.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/diagnosticGrowthReportsHelpers.test.tsx
@@ -170,7 +170,7 @@ const mockRecommendationsData = [{
 const mockCombinedData = [{
   aggregate_rows: [
     {
-      averageActivitiesAndTimeSpent: "22 Activities (206:56)",
+      averageActivitiesAndTimeSpent: "22 (3 hrs 26 mins)",
       id: "5",
       name: "Grade 5",
       overallSkillGrowth: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>+12%</button>,
@@ -179,7 +179,7 @@ const mockCombinedData = [{
       studentsCompletedPractice: "113 Students"
     },
     {
-      averageActivitiesAndTimeSpent: "12 Activities (85:57)",
+      averageActivitiesAndTimeSpent: "12 (1 hr 25 mins)",
       id: "7",
       name: "Grade 7",
       overallSkillGrowth: <button className="interactive-wrapper emphasized-content" onClick={mockArgs.handleGrowthChipClick} value={1663}>+10%</button>,
@@ -188,7 +188,7 @@ const mockCombinedData = [{
       studentsCompletedPractice: "46 Students"
     }
   ],
-  averageActivitiesAndTimeSpent: "19 Activities (171:56)",
+  averageActivitiesAndTimeSpent: "19 (2 hrs 51 mins)",
   averageActivitiesCount: 19.40880503144654,
   completedPracticeCount: 159,
   id: 1663,

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/helpers.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/diagnosticGrowthReports/helpers.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { getTimeInMinutesAndSeconds } from "../../shared"
 import { getTimeSpent } from '../../../Teacher/helpers/studentReports'
 import moment from 'moment'
 import { Tooltip, helpIcon } from '../../../Shared'
@@ -81,7 +80,7 @@ function studentsCompletedPracticeValue(studentsCompletedPractice) {
 }
 
 function averageActivitiesAndTimeSpentValue(averageActivitiesCount, averageTimespent) {
-  return averageActivitiesCount ? `${Math.round(averageActivitiesCount) || 0} Activities (${getTimeInMinutesAndSeconds(averageTimespent)})` : noDataToShow
+  return averageActivitiesCount ? `${Math.round(averageActivitiesCount) || 0} (${getTimeSpent(averageTimespent)})` : noDataToShow
 }
 
 function postDiagnosticCompleted(postStudentsAssigned, postStudentsCompleted) {

--- a/services/QuillLMS/client/app/bundles/PremiumHub/shared.tsx
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/shared.tsx
@@ -80,15 +80,3 @@ export function hashPayload(payloadArray: Array<any>) {
   const joinedPayload = payloadArray.join('-')
   return md5(joinedPayload)
 }
-
-export function getTimeInMinutesAndSeconds(seconds) {
-  if(!seconds) return NOT_APPLICABLE
-
-  let numminutes = Math.floor(seconds / 60).toString();
-  let numseconds = Math.floor(seconds % 60).toString();
-
-  if (numminutes.length === 1) numminutes = "0" + numminutes
-  if (numseconds.length === 1) numseconds = "0" + numseconds
-
-  return `${numminutes}:${numseconds}`
-}


### PR DESCRIPTION
## WHAT
- Use `getTimeSpent` function to format time spent for Overview practice activities column
- Remove now-unused `getTimeInMinutesAndSeconds` function from the code base
- Update snapshots
## WHY
We want to consistently display average activities and time spent data, so update the Overview styling to match the preferred styling in use on the Students display.
## HOW
- Remove "Activities" from the formatter
- Replace old function with new function
- Delete unused function definition from shared module

### Screenshots
OLD
<img width="201" alt="image" src="https://github.com/empirical-org/Empirical-Core/assets/331565/29b0f26a-0f41-45fd-9290-0ffdda10d7ac">
NEW
<img width="204" alt="image" src="https://github.com/empirical-org/Empirical-Core/assets/331565/e4ad5f9f-e154-4ee2-ae4f-8e8bc129ce3d">

### Notion Card Links
https://www.notion.so/quill/ADGR-Update-the-format-of-data-in-the-Average-Activities-Time-Spent-column-on-the-Performance-86fea620f88140d9bc8d6565023cd5ff?pvs=4

### What have you done to QA this feature?
Deploy code to staging, load Admin Diagnostic Overview report, confirm new styling.  Additionally confirm that rows without data for this column don't break

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
