### PR TITLE
better LW API error handling

### DIFF
--- a/services/QuillLMS/app/services/learn_worlds_integration/suspended_users_request.rb
+++ b/services/QuillLMS/app/services/learn_worlds_integration/suspended_users_request.rb
@@ -10,13 +10,21 @@ module LearnWorldsIntegration
 
     def fetch_page(page_number)
       response = HTTParty.get("#{endpoint}&page=#{page_number}", headers:)
-      raise UnexpectedApiResponse unless response&.response&.message == "OK"
 
-      response
+      case response&.response&.message
+      when "Not Found"
+        :no_users
+      when "OK"
+        response
+      else
+        raise UnexpectedApiResponse, response.to_s
+      end
     end
 
     def fetch_ids_to_suspend
       initial_page = fetch_page(1)
+      return [] if initial_page == :no_users
+
       total_pages = initial_page.dig('meta', 'totalPages')
       raise UnexpectedApiResponse, "No totalPages value" unless total_pages&.to_i
 

--- a/services/QuillLMS/app/services/learn_worlds_integration/suspended_users_request.rb
+++ b/services/QuillLMS/app/services/learn_worlds_integration/suspended_users_request.rb
@@ -11,10 +11,10 @@ module LearnWorldsIntegration
     def fetch_page(page_number)
       response = HTTParty.get("#{endpoint}&page=#{page_number}", headers:)
 
-      case response&.response&.message
-      when "Not Found"
+      case response.code
+      when 404
         :no_users
-      when "OK"
+      when 200
         response
       else
         raise UnexpectedApiResponse, response.to_s

--- a/services/QuillLMS/spec/services/learn_worlds_integration/suspended_users_request_spec.rb
+++ b/services/QuillLMS/spec/services/learn_worlds_integration/suspended_users_request_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe LearnWorldsIntegration::SuspendedUsersRequest do
   describe '#fetch_page' do
     let(:page_number) { 1 }
 
-    context 'when the response is OK' do
-      let(:response) { instance_double(HTTParty::Response, response: double(message: 'OK')) }
+    context 'when the response is 200' do
+      let(:response) { double(code: 200) }
 
       it 'returns the response' do
         allow(HTTParty).to receive(:get).and_return(response)
@@ -17,8 +17,8 @@ RSpec.describe LearnWorldsIntegration::SuspendedUsersRequest do
       end
     end
 
-    context 'when the response is Not Found' do
-      let(:response) { instance_double(HTTParty::Response, response: double(message: 'Not Found')) }
+    context 'when the response is 404' do
+      let(:response) { double(code: 404) }
 
       it 'returns :no_users' do
         allow(HTTParty).to receive(:get).and_return(response)
@@ -28,9 +28,7 @@ RSpec.describe LearnWorldsIntegration::SuspendedUsersRequest do
     end
 
     context 'when the response is unexpected' do
-      let(:response) do
-        instance_double(HTTParty::Response, response: double(message: 'Internal Server Error'), to_s: 'Error details')
-      end
+      let(:response) { double(code: 500, to_s: 'Error details') }
 
       it 'raises an UnexpectedApiResponse error' do
         allow(HTTParty).to receive(:get).and_return(response)


### PR DESCRIPTION
## WHAT
- handles case where the LW `GET suspended users` API returns a 404

## WHY
- The API has the unexpected behavior of returning a 404, rather than an empty list, when there are zero suspended users. This scenario occurred during the initial SyncOrchestrator rollout. It's unlikely to occur again, but it's worth fixing now to avoid a possible confusing error in the future. 

## HOW
- in the 0 suspended users scenario, return early with `[]`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
none

### What have you done to QA this feature?
Run `SuspendedUsersRequest` in staging, when the suspend list is zero. Observe the output.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
