### PR TITLE
fix route to unsubscribe from usage snapshot emails

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/tests/helpers/determineUnnecessaryEditType.spec.ts
+++ b/services/QuillLMS/client/app/bundles/Proofreader/tests/helpers/determineUnnecessaryEditType.spec.ts
@@ -1,4 +1,3 @@
-import * as expect from 'expect';
 import {
   MULTIPLE_UNNECESSARY_ADDITION,
   MULTIPLE_UNNECESSARY_DELETION,

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -774,7 +774,7 @@ EmpiricalGrammar::Application.routes.draw do
     collection do
       post :create_or_update
       get :current
-      delete 'unsubscribe/:token', to: 'pdf_subscriptions#unsubscribe', as: :unsubscribe
+      get 'unsubscribe/:token', to: 'pdf_subscriptions#unsubscribe', as: :unsubscribe
     end
   end
 

--- a/services/QuillLMS/spec/controllers/pdf_subscriptions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pdf_subscriptions_controller_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe PdfSubscriptionsController, type: :controller do
     end
   end
 
-  describe 'DELETE #unsubscribe' do
-    subject { delete :unsubscribe, params: { token: } }
+  describe 'GET #unsubscribe' do
+    subject { get :unsubscribe, params: { token: } }
 
     let(:pdf_subscription) { create(:pdf_subscription) }
 


### PR DESCRIPTION
## WHAT
Make it so that the link users receive to unsubscribe from usage snapshot emails works as expected.

## WHY
The link was taking users to a 404 page and failing to unsubscribe them.

## HOW
I changed the verb to GET from DELETE, since following the link was always being treated as a GET request, resulting in the 404. I couldn't figure out a way to generate the email link with a DELETE method, but I recognize that this is not the most RESTful approach, so please let me know if you have other suggestions. I'm not clear on how this worked at one point or when it broke.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Email-unsubscribe-option-for-the-Usage-Snapshot-report-is-not-working-c15257596a074f67af9b37d19aec4a92

### What have you done to QA this feature?
Confirmed that following a link with this pattern no longer results in the 404 page.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
