### PR TITLE
fix how multiple correct answers are formatted in proofreader

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/__tests__/__snapshots__/edit.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/__tests__/__snapshots__/edit.test.tsx.snap
@@ -87,7 +87,9 @@ exports[`<Edit /> correct edit should render when active 1`] = `
             >
               Correct
             </p>
-            <p>
+            <p
+              className="correct-answers"
+            >
               <span
                 className="correct-answer"
                 key="lose"
@@ -262,7 +264,9 @@ exports[`<Edit /> incorrect edit should render when active 1`] = `
             >
               Correct
             </p>
-            <p>
+            <p
+              className="correct-answers"
+            >
               <span
                 className="correct-answer"
                 key="then"
@@ -418,7 +422,9 @@ exports[`<Edit /> multiple unnecessary addition edit should render when active 1
             >
               Correct
             </p>
-            <p>
+            <p
+              className="correct-answers"
+            >
               <span
                 className="correct-answer"
                 key="crew"
@@ -547,7 +553,9 @@ exports[`<Edit /> multiple unnecessary deletion edit should render when active 1
             >
               Correct
             </p>
-            <p>
+            <p
+              className="correct-answers"
+            >
               <span
                 className="correct-answer"
                 key="crew was"
@@ -676,7 +684,9 @@ exports[`<Edit /> single unnecessary addition edit should render when active 1`]
             >
               Correct
             </p>
-            <p>
+            <p
+              className="correct-answers"
+            >
               <span
                 className="correct-answer"
                 key="crew"
@@ -805,7 +815,9 @@ exports[`<Edit /> single unnecessary deletion edit should render when active 1`]
             >
               Correct
             </p>
-            <p>
+            <p
+              className="correct-answers"
+            >
               <span
                 className="correct-answer"
                 key="crew"
@@ -936,7 +948,9 @@ exports[`<Edit /> unnecessary change edit should render when active 1`] = `
             >
               Correct
             </p>
-            <p>
+            <p
+              className="correct-answers"
+            >
               <span
                 className="correct-answer"
                 key="1914,"
@@ -1066,7 +1080,9 @@ exports[`<Edit /> unnecessary space edit should render when active 1`] = `
             >
               Correct
             </p>
-            <p>
+            <p
+              className="correct-answers"
+            >
               <span
                 className="correct-answer"
                 key="crew"

--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editTooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/editTooltip.tsx
@@ -29,7 +29,7 @@ const renderCorrectAnswers = (displayText) => {
 
   const correctAnswerArray = displayText ? displayText.split('~') : []
   const correctAnswers = correctAnswerArray.map(ca => <span className="correct-answer" key={ca}>{ca}</span>)
-  const correctAnswerHTML = <p>{correctAnswers}</p>
+  const correctAnswerHTML = <p className="correct-answers">{correctAnswers}</p>
   return (
     <div aria-hidden={true}>
       <p className="label">Correct</p>

--- a/services/QuillLMS/client/app/bundles/Proofreader/styles/edit.scss
+++ b/services/QuillLMS/client/app/bundles/Proofreader/styles/edit.scss
@@ -78,6 +78,12 @@
         margin-bottom: 24px;
       }
 
+      .correct-answers {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
       .correct-answer {
         border-radius: 4px;
         background-color: #eeeeee;


### PR DESCRIPTION
## WHAT
Fix display for multiple correct answers in Proofreader.

## WHY
We want these to be legible and formatted nicely.

## HOW
Just add a className and some CSS.

### Screenshots
<img width="849" alt="Screenshot 2024-06-17 at 9 37 38 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/4a43645d-fe99-449b-baca-6ca3a40ba249">


### Notion Card Links
https://www.notion.so/quill/Display-problem-in-proofreader-6db126cf95c840daabd0c96179e23023

### What have you done to QA this feature?
Looked at a Proofreader activity locally.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
