### PR TITLE
Add translations to the hints admin interface

### DIFF
--- a/services/QuillLMS/README.md
+++ b/services/QuillLMS/README.md
@@ -109,7 +109,7 @@ bundle exec rspec spec
 ```
 
 - frontend
-  TBD
+  - ESLint: from the root directory run `npm run eslint`
 
 ## Deployment
 

--- a/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
@@ -53,6 +53,7 @@ class Api::V1::ConceptFeedbackController < Api::ApiController
 
   private def fetch_all_concept_feedbacks_and_cache
     concept_feedbacks = ConceptFeedback
+      .includes(:translation_mappings, :english_texts, :translated_texts)
       .where(activity_type: params[:activity_type])
       .all
       .reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }

--- a/services/QuillLMS/app/models/concept_feedback.rb
+++ b/services/QuillLMS/app/models/concept_feedback.rb
@@ -39,7 +39,10 @@ class ConceptFeedback < ApplicationRecord
   def cache_key = "#{ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}"
 
   def as_json(options=nil)
-    data
+    translation = translation(locale: "es-la")
+    return data unless translation.present?
+
+    data.merge({"translatedDescription" => translation(locale: "es-la")})
   end
 
   def create_translation_mappings
@@ -50,6 +53,9 @@ class ConceptFeedback < ApplicationRecord
     translation_mappings.create(english_text: )
   end
 
+  def translation(locale:) = translated_texts.find_by(locale:)&.translation
+
+  def translate! = Gengo::RequestTranslations.run(english_texts)
   def fetch_translations! = translated_texts.each(&:fetch_translation!)
 
   private def data_must_be_hash

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
@@ -38,8 +38,9 @@ class ConceptFeedback extends React.Component {
   }
 
   toggleTranslation = () => {
-    const { translated } = this.state
-    this.setState({ translated: !translated })
+    this.setState(prevState => (
+      {translated: !prevState.translated}
+    ))
   }
 
   renderTranslationButton(data) {

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
@@ -83,7 +83,7 @@ class ConceptFeedback extends React.Component {
           <div className="admin-container" key={conceptFeedbackID}>
             {conceptName}
             <ConceptExplanation {...data[conceptFeedbackID]} translated={this.state.translated} />
-            <p className="control">
+            <p className="concept-feedback-control">
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
               <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
               { this.renderTranslationButton(data[conceptFeedbackID]) }

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
@@ -7,6 +7,10 @@ import FeedbackForm from './feedbackForm.jsx'
 
 class ConceptFeedback extends React.Component {
 
+  constructor(props) {
+    super(props)
+    this.state = {translated: false}
+  }
   cancelEdit = (feedbackID) => {
     const { dispatch } = this.props
     dispatch(actions.cancelConceptsFeedbackEdit(feedbackID))
@@ -31,6 +35,16 @@ class ConceptFeedback extends React.Component {
     const { params } = match
     const { conceptFeedbackID } = params
     dispatch(actions.startConceptsFeedbackEdit(conceptFeedbackID))
+  }
+
+  toggleTranslation = () => {
+    const translated = !this.state.translated
+    this.setState({...this.state, ...{translated: translated}})
+    if (translated) {
+      document.getElementById('toggle-translation').innerHTML = "Hide translation"
+    } else {
+      document.getElementById('toggle-translation').innerHTML = "Show translation"
+    }
   }
 
   concept = () => {
@@ -64,9 +78,11 @@ class ConceptFeedback extends React.Component {
         return (
           <div className="admin-container" key={conceptFeedbackID}>
             {conceptName}
-            <ConceptExplanation {...data[conceptFeedbackID]} />
+            <ConceptExplanation {...data[conceptFeedbackID]} translated={this.state.translated} />
             <p className="control">
-              <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button> <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
+              <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
+              <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
+              <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button>
             </p>
           </div>
         )

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
@@ -38,14 +38,18 @@ class ConceptFeedback extends React.Component {
   }
 
   toggleTranslation = () => {
-    const translated = !this.state.translated
-    this.setState({...this.state, ...{translated: translated}})
-    if (translated) {
-      document.getElementById('toggle-translation').innerHTML = "Hide translation"
-    } else {
-      document.getElementById('toggle-translation').innerHTML = "Show translation"
+    const { translated } = this.state
+    this.setState({ translated: !translated })
+  }
+
+  renderTranslationButton(data) {
+    const { translated } = this.state
+    if(data.translatedDescription) {
+      const buttonText = translated ? "Hide translation" : "Show translation"
+      return <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>{buttonText}</button>
     }
   }
+
 
   concept = () => {
     const { match, concepts } = this.props
@@ -82,7 +86,7 @@ class ConceptFeedback extends React.Component {
             <p className="control">
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
               <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
-              {data[conceptFeedbackID].translatedDescription && <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button> }
+              { this.renderTranslationButton(data[conceptFeedbackID]) }
             </p>
           </div>
         )

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
@@ -82,7 +82,7 @@ class ConceptFeedback extends React.Component {
             <p className="control">
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
               <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
-              <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button>
+              {data[conceptFeedbackID].translatedDescription && <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button> }
             </p>
           </div>
         )

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -23,9 +23,12 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
 
     this.deleteConceptsFeedback = this.deleteConceptsFeedback.bind(this)
     this.toggleEdit = this.toggleEdit.bind(this)
+    this.toggleTranslation = this.toggleTranslation.bind(this)
     this.submitNewFeedback = this.submitNewFeedback.bind(this)
     this.cancelEdit = this.cancelEdit.bind(this)
     this.concept = this.concept.bind(this)
+
+    this.state = {translated: false}
   }
 
   deleteConceptsFeedback() {
@@ -41,6 +44,16 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
     const conceptFeedbackID = this.props.match.params.conceptFeedbackID
     if (conceptFeedbackID) {
       this.props.dispatch(actions.startConceptsFeedbackEdit(conceptFeedbackID))
+    }
+  }
+
+  toggleTranslation() {
+    const translated = !this.state.translated
+    this.setState({...this.state, ...{translated: translated}})
+    if (translated) {
+      document.getElementById('toggle-translation').innerHTML = "Hide translation"
+    } else {
+      document.getElementById('toggle-translation').innerHTML = "Show translation"
     }
   }
 
@@ -75,9 +88,11 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
         return (
           <div key={conceptFeedbackID}>
             {conceptName}
-            <ConceptExplanation {...data[conceptFeedbackID]} />
+            <ConceptExplanation {...data[conceptFeedbackID]} translated={this.state.translated} />
             <p className="control">
-              <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button> <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
+              <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
+              <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
+              <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button>
             </p>
           </div>
         )

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -92,7 +92,8 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
             <p className="control">
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
               <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
-              <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button>
+
+              {data[conceptFeedbackID].translationDescription && <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button> }
             </p>
           </div>
         )

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -92,7 +92,7 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
           <div key={conceptFeedbackID}>
             {conceptName}
             <ConceptExplanation {...data[conceptFeedbackID]} translated={this.state.translated} />
-            <p className="control">
+            <p className="concept-feedback-control">
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
               <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
               {this.renderTranslationButton(data[conceptFeedbackID])}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -48,8 +48,7 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
   }
 
   toggleTranslation() {
-    const { translated } = this.state
-    this.setState({ translated: !translated })
+    this.setState(prevState => ({ translated: !prevState.translated }))
   }
 
   renderTranslationButton(data) {

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -48,12 +48,15 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
   }
 
   toggleTranslation() {
-    const translated = !this.state.translated
-    this.setState({...this.state, ...{translated: translated}})
-    if (translated) {
-      document.getElementById('toggle-translation').innerHTML = "Hide translation"
-    } else {
-      document.getElementById('toggle-translation').innerHTML = "Show translation"
+    const { translated } = this.state
+    this.setState({ translated: !translated })
+  }
+
+  renderTranslationButton(data) {
+    const { translated } = this.state
+    if(data.translatedDescription) {
+      const buttonText = translated ? "Hide translation" : "Show translation"
+      return <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>{buttonText}</button>
     }
   }
 
@@ -92,8 +95,7 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
             <p className="control">
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
               <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
-
-              {data[conceptFeedbackID].translatedDescription && <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button> }
+              {this.renderTranslationButton(data[conceptFeedbackID])}
             </p>
           </div>
         )

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -93,7 +93,7 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
               <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
 
-              {data[conceptFeedbackID].translationDescription && <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button> }
+              {data[conceptFeedbackID].translatedDescription && <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>Show Translation</button> }
             </p>
           </div>
         )

--- a/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react'
 
-function getClassName(description, leftBox, rightBox) {
+function getClassName(description, leftBox, rightBox, translatedDescription) {
   if (description && leftBox && rightBox) {
     return "concept-explanation"
   }
   return "concept-explanation empty"
 }
 
-const ConceptExplanation = ({ description, leftBox, rightBox, }) => (
+const ConceptExplanation = ({ description, leftBox, rightBox, translatedDescription, translated}) => (
   <div className={getClassName(description, leftBox, rightBox)}>
     <div className="concept-explanation-title"><img alt="Light Bulb Icon" src="https://assets.quill.org/images/icons/hint.svg" /><span>Hint</span></div>
     <div className="concept-explanation-description" dangerouslySetInnerHTML={{__html: description}} />
+    { translated && translatedDescription && <div className="concept-explanation-translation" dangerouslySetInnerHTML={{__html: translatedDescription}} /> }
     <div className="concept-explanation-see-write">
       <div className="concept-explanation-see" dangerouslySetInnerHTML={{__html: leftBox}} />
       <div className="concept-explanation-write" dangerouslySetInnerHTML={{__html: rightBox}} />

--- a/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-function getClassName(description, leftBox, rightBox, translatedDescription) {
+function getClassName(description, leftBox, rightBox) {
   if (description && leftBox && rightBox) {
     return "concept-explanation"
   }

--- a/services/QuillLMS/client/app/bundles/Shared/styles/conceptFeedback.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/conceptFeedback.scss
@@ -1,3 +1,10 @@
+.control {
+  margin-top: 10px;
+}
+
+.control button {
+  margin-right: 10px;
+}
 .concept-explanation {
   font-size: 20px;
   padding: 16px;
@@ -12,7 +19,7 @@
       margin-right: 8px;
     }
   }
-  .concept-explanation-description {
+  .concept-explanation-description, .concept-explanation-translation {
     padding-left: 33px;
     margin-bottom: 16px;
   }

--- a/services/QuillLMS/client/app/bundles/Shared/styles/conceptFeedback.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/conceptFeedback.scss
@@ -1,8 +1,8 @@
-.control {
+.concept-feedback-control {
   margin-top: 10px;
 }
 
-.control button {
+.concept-feedback-control button {
   margin-right: 10px;
 }
 .concept-explanation {


### PR DESCRIPTION
## WHAT
In the admin interface, add a button to show translations for hints if they are available. 
## WHY
So that the admin can see how a hint will look once it's in the app. 
## HOW
Added the translations to the api for hints, and then show them if the toggle is on. 
### Screenshots

![2024-06-17 at 5 49 PM](https://github.com/empirical-org/Empirical-Core/assets/126436/ca862a28-e6fe-46a9-a91b-fc8f68724411)
![2024-06-17 at 5 49 PM](https://github.com/empirical-org/Empirical-Core/assets/126436/9c6ab4e8-aa27-45c5-8745-92f1076a8a53)

### Notion Card Links
[Show translations to admins](https://www.notion.so/quill/Show-hints-translations-in-the-admin-interface-6b3ba14ea6a6472ba9c981a45c58004a?pvs=4)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
