### PR TITLE
guard against empty props.states

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/questions/responseList.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/__tests__/questions/responseList.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import ResponseList from '../../questions/responseList';
+
+describe('ResponseList', () => {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      responses: [{ id: 1, key: '1', text: 'response text', statusCode: 2 }],
+      massEdit: { selectedResponses: [] },
+      dispatch: jest.fn(),
+      selectedIncorrectSequences: ['sequence1'],
+      selectedFocusPoints: ['focus1'],
+      expanded: {},
+      conceptID: 1,
+      concepts: [],
+      conceptsFeedback: [],
+      expand: jest.fn(),
+      getChildResponses: jest.fn(),
+      getMatchingResponse: jest.fn(),
+      getResponse: jest.fn(),
+      mode: 'mode',
+      question: 'question',
+      questionID: 1,
+      admin: false,
+      states: {},
+    };
+  });
+
+  it('should render', () => {
+    expect(() => render(<ResponseList {...props} />) ).not.toThrow()
+  });
+
+  it('should render when props.states is undefined', () => {
+    let specialProps = {...props, states: undefined }
+    expect(() => render(<ResponseList {...specialProps} />) ).not.toThrow()
+  });
+
+});

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseList.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/responseList.tsx
@@ -66,7 +66,7 @@ export default class ResponseList extends React.Component {
         readOnly={this.props.admin}
         response={resp}
         responses={this.props.responses}
-        state={this.props.states[this.props.questionID]}
+        state={this.props.states ? this.props.states[this.props.questionID] : {}}
         states={this.props.states}
       />
     )


### PR DESCRIPTION
## WHAT
`this.props.states` should default to `{}`, to avoid `Uncaught TypeError: Cannot read properties of undefined (reading '-Koi65FF8xUpLSuPTMKW')`

## WHY
This uncaught error is preventing Curriculum from editing Grammar activities 

## HOW
Add a guard 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Can-t-add-focus-points-to-grammar-questions-c200457143584311a892a957e281e8c3

### What have you done to QA this feature?
1. In staging/local, go to a Grammar question with > 0 responses. 
2. Click `Edit Focus Points > Add Focus Point` 
3. Observe the error. 
4. Apply patch 
5. Refresh and observe no error.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
