### PR TITLE
Tiny styling change for student name dropdown

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_navbar.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_dashboard/student_navbar.scss
@@ -7,7 +7,7 @@
       font-weight: 600;
       display: flex;
       align-items: center;
-      border: none;
+      border: 1px solid $quill-green-15;
       background-color: $quill-green-5;
       color: $quill-green;
       padding: 4px 16px;


### PR DESCRIPTION
## WHAT
Add a green border to the student name dropdown.

## WHY
Part of the new UI styling updates.

## HOW
Add this border in the css.

### Screenshots
![Screenshot 2024-06-19 at 8 02 25 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/8a60f62d-ff94-46e4-a3b3-f7be6ce0ab5f)


### Notion Card Links
https://www.notion.so/quill/Minor-UI-Update-on-Global-Header-Border-on-Account-Menu-Student-View-530dfb76c171481f91034fe105bdf3af?pvs=4

### What have you done to QA this feature?
Deploy to staging and verify that the border appears.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
