### PR TITLE
GenAI Reorg Part 6: Create LLMPromptPromptExample

### DIFF
--- a/services/QuillLMS/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/config/initializers/zeitwerk.rb
@@ -19,6 +19,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_prompt' => 'LLMPrompt',
     'llm_prompts_controller' => 'LLMPromptsController',
     'llm_prompt_builder' => 'LLMPromptBuilder',
+    'llm_prompt_guideline' => 'LLMPromptGuideline',
     'llm_prompt_prompt_example' => 'LLMPromptPromptExample',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',

--- a/services/QuillLMS/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/config/initializers/zeitwerk.rb
@@ -19,6 +19,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_prompt' => 'LLMPrompt',
     'llm_prompts_controller' => 'LLMPromptsController',
     'llm_prompt_builder' => 'LLMPromptBuilder',
+    'llm_prompt_prompt_example' => 'LLMPromptPromptExample',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',
     'malformed_json_fixer' => 'MalformedJSONFixer',

--- a/services/QuillLMS/db/migrate/20240620113751_create_evidence_research_gen_ai_llm_prompt_prompt_examples.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240620113751_create_evidence_research_gen_ai_llm_prompt_prompt_examples.evidence.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240620113244)
+class CreateEvidenceResearchGenAILLMPromptPromptExamples < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompt_prompt_examples do |t|
+      t.integer :llm_prompt_id, null: false
+      t.integer :prompt_example_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20240620115611_create_evidence_research_gen_ai_llm_prompt_guidelines.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240620115611_create_evidence_research_gen_ai_llm_prompt_guidelines.evidence.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240620115506)
+class CreateEvidenceResearchGenAILLMPromptGuidelines < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompt_guidelines do |t|
+      t.integer :llm_prompt_id, null: false
+      t.integer :guideline_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3146,6 +3146,70 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_feedbacks_id_seq OWNED BY pub
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompt_guidelines (
+    id bigint NOT NULL,
+    llm_prompt_id integer NOT NULL,
+    guideline_id integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompt_guidelines_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_guidelines_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompt_guidelines.id;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompt_prompt_examples (
+    id bigint NOT NULL,
+    llm_prompt_id integer NOT NULL,
+    prompt_example_id integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompt_prompt_examples.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6778,6 +6842,20 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_feedbacks ALTER COLUMN id S
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_guidelines ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompt_guidelines_id_seq'::regclass);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_prompt_examples ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -8047,6 +8125,22 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_guidelines
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_feedbacks
     ADD CONSTRAINT evidence_research_gen_ai_llm_feedbacks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines evidence_research_gen_ai_llm_prompt_guidelines_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_guidelines
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_guidelines_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples evidence_research_gen_ai_llm_prompt_prompt_examples_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_prompt_examples
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_prompt_examples_pkey PRIMARY KEY (id);
 
 
 --
@@ -11822,6 +11916,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240619191903'),
 ('20240619220045'),
 ('20240619230446'),
+('20240620113751'),
+('20240620115611'),
 ('20240620152448');
 
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_feedback.rb
@@ -19,8 +19,8 @@ module Evidence
       class LLMFeedback < ApplicationRecord
         include HasOptimalAndSuboptimal
 
-        belongs_to :trial, class_name: 'Evidence::Research::GenAI::Trial'
-        belongs_to :student_response, class_name: 'Evidence::Research::GenAI::StudentResponse'
+        belongs_to :trial
+        belongs_to :student_response
 
         validates :raw_text, presence: true
         validates :text, presence: true

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt.rb
@@ -16,9 +16,9 @@ module Evidence
       class LLMPrompt < ApplicationRecord
         FEEDBACK_JSON_SCHEMA = { 'optimal': 'boolean', 'feedback': 'string' }.to_json
 
-        belongs_to :llm_prompt_template, class_name: 'Evidence::Research::GenAI::LLMPromptTemplate'
+        belongs_to :llm_prompt_template
 
-        has_many :trials, class_name: 'Evidence::Research::GenAI::Trial', dependent: :destroy
+        has_many :trials, dependent: :destroy
 
         validates :prompt, presence: true
         validates :llm_prompt_template_id, presence: true

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_guideline.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_guideline.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_guidelines
+#
+#  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  guideline_id  :integer          not null
+#  llm_prompt_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class LLMPromptGuideline < ApplicationRecord
+        belongs_to :llm_prompt
+        belongs_to :guideline
+
+        validates :llm_prompt_id, presence: true
+        validates :guideline_id, presence: true
+
+        attr_readonly :llm_prompt_id, :guideline_id
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_prompt_example.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_prompt_example.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_prompt_examples
+#
+#  id                :bigint           not null, primary key
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  llm_prompt_id     :integer          not null
+#  prompt_example_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class LLMPromptPromptExample < ApplicationRecord
+        belongs_to :llm_prompt
+        belongs_to :prompt_example
+
+        validates :llm_prompt_id, presence: true
+        validates :prompt_example_id, presence: true
+
+        attr_readonly :llm_prompt_id, :prompt_example_id
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_template.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_template.rb
@@ -19,9 +19,7 @@ module Evidence
 
         attr_readonly :description, :contents
 
-        has_many :llm_prompts,
-          class_name: 'Evidence::Research::GenAI::LLMPrompt',
-          dependent: :destroy
+        has_many :llm_prompts,dependent: :destroy
 
         def to_s = description
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/quill_feedback.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/quill_feedback.rb
@@ -25,7 +25,7 @@ module Evidence
           TESTING_DATA = 'testing'
         ].freeze
 
-        belongs_to :student_response, class_name: 'Evidence::Research::GenAI::StudentResponse'
+        belongs_to :student_response
 
         validates :text, presence: true
         validates :label, presence: true

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
@@ -27,7 +27,7 @@ module Evidence
           SO => :so_text
         }.freeze
 
-        belongs_to :activity, class_name: 'Evidence::Research::GenAI::Activity'
+        belongs_to :activity
 
         has_many :trials, dependent: :destroy
         has_many :student_responses, dependent: :destroy

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/student_response.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/student_response.rb
@@ -14,10 +14,10 @@ module Evidence
   module Research
     module GenAI
       class StudentResponse < ApplicationRecord
-        belongs_to :stem_vault, class_name: 'Evidence::Research::GenAI::StemVault'
+        belongs_to :stem_vault
 
-        has_one :quill_feedback, class_name: 'Evidence::Research::GenAI::QuillFeedback', dependent: :destroy
-        has_many :llm_feedbacks, class_name: 'Evidence::Research::GenAI::LLMFeedback', dependent: :destroy
+        has_one :quill_feedback, dependent: :destroy
+        has_many :llm_feedbacks, dependent: :destroy
 
         validates :text, presence: true
         validates :stem_vault_id, presence: true

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/readme.md
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/readme.md
@@ -1,6 +1,6 @@
 # Generative AI Trials
 ## 1. Data Importing
-`Activity`, `StemVault`, `StudentResponse` and `QuillFeedback` records are imported with the following structure
+`Activity`, `StemVault`, `Dataset`, `TestExample`, and `PromptExample` records are imported with the following structure
 
 ```mermaid
 classDiagram
@@ -10,25 +10,38 @@ classDiagram
     }
     class StemVault {
          conjunction
-         instructions
+         stem
          prompt
-         relevant_passage
     }
-    class StudentResponse {
-         response
+    class Guideline {
+     text
+     category
     }
-    class QuillFeedback {
-         text
-         evaluation
-         label
+    class Dataset {
+          num_optimal
+          num_sub_optimal
+          locked
+    }
+    class TestExample {
+          student_response
+          human_status
+          human_feedback
+          highlight
+    }
+    class PromptExample {
+          student_response
+          human_status
+          human_feedback
     }
     Activity --|> StemVault
-    StemVault --|> StudentResponse
-    StudentResponse --|> QuillFeedback
+    StemVault --|> Guideline
+    StemVault --|> Dataset
+    Dataset --|> TestExample
+    Dataset --|> PromptExample
 ```
 
-## 2. Trial Configuration
-Within the create `Trial` UI, `LLM`, `LLMPromptTemplate` and `StemVault` are all selected. Before creation, substitutions are made to the `LLMPromptTemplate` contents and yielding an `LLMPrompt` record which is associated with the trial
+## 2a. Trial Configuration
+Within the create `Trial` UI, `LLM`, `LLMPromptTemplate` are selected. Before creation, substitutions are made to the `LLMPromptTemplate` contents and yielding an `LLMPrompt` record which is associated with the trial.
 
 ```mermaid
 classDiagram
@@ -38,37 +51,51 @@ classDiagram
     }
     class LLMPrompt {
          prompt
+         num_optimal_guidelines
+         num_sub_optimal_guidelines
+         num_optimal_examples
+         num_sub_optimal_examples
+         locked
     }
     class LLMPromptTemplate {
          contents
          description
     }
-    class StemVault {
-    }
-    class Trial {
-         status
-    }
 
-    StemVault --|> Trial
+    Dataset --|> Trial
     LLM --|> Trial
-    LLMPromptTemplate --|> LLMPrompt
     LLMPrompt --|> Trial
 ```
 
-## 3. Trial Ouptut
-As the `Trial` is run, the LLM returns feedback relevant to the `StudentResponse` which is stored as `LLMFeedback` along with the corresponding `trial_id`.   These results are compared with `QuillFeedback` and evaluated.
+## 3. LLMPrompt Configuration
+
+Within the UI, the user can select `PromptExample` and `Guideline` records for the `LLMPrompt` which will create `LLMPromptExample` and `LLMPromptGuideline` records respectively.
 
 ```mermaid
 classDiagram
-    class StudentResponse {
-    }
-    class QuillFeedback {
+    StemVault --|> Guideline
+    Guideline --|> LLMPromptGuideline
+    LLMPrompt --|> LLMPromptGuideline
+    LLMPrompt --|> LLMPromptExample
+    Dataset --|> PromptExample
+    PromptExample --|> LLMPromptExample
+    Trial --|> LLMPrompt
+```
+
+## 3. Trial Ouptut
+
+As the `Trial` is run, the LLM returns feedback relevant to each `TestExample` which is stored as `LLMFeedback` along with the corresponding `trial_id`.   These results are compared with `QuillFeedback` and evaluated.
+
+```mermaid
+classDiagram
+    class TestExample {
     }
     class LLMFeedback {
         feedback
         label
     }
-    StudentResponse --|> QuillFeedback
-    StudentResponse --|> LLMFeedback
+    class Trial {
+    }
+    TestExample --|> LLMFeedback
     Trial --|> LLMFeedback
 ```

--- a/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
@@ -15,6 +15,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_prompt' => 'LLMPrompt',
     'llm_prompts_controller' => 'LLMPromptsController',
     'llm_prompt_builder' => 'LLMPromptBuilder',
+    'llm_prompt_prompt_example' => 'LLMPromptPromptExample',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',
     'malformed_json_fixer' => 'MalformedJSONFixer',

--- a/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
@@ -15,6 +15,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_prompt' => 'LLMPrompt',
     'llm_prompts_controller' => 'LLMPromptsController',
     'llm_prompt_builder' => 'LLMPromptBuilder',
+    'llm_prompt_guideline' => 'LLMPromptGuideline',
     'llm_prompt_prompt_example' => 'LLMPromptPromptExample',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',

--- a/services/QuillLMS/engines/evidence/db/migrate/20240620113244_create_evidence_research_gen_ai_llm_prompt_prompt_examples.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240620113244_create_evidence_research_gen_ai_llm_prompt_prompt_examples.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAILLMPromptPromptExamples < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompt_prompt_examples do |t|
+      t.integer :llm_prompt_id, null: false
+      t.integer :prompt_example_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20240620115506_create_evidence_research_gen_ai_llm_prompt_guidelines.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240620115506_create_evidence_research_gen_ai_llm_prompt_guidelines.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateEvidenceResearchGenAILLMPromptGuidelines < ActiveRecord::Migration[7.0]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompt_guidelines do |t|
+      t.integer :llm_prompt_id, null: false
+      t.integer :guideline_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1105,6 +1105,70 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_feedbacks_id_seq OWNED BY pub
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompt_guidelines (
+    id bigint NOT NULL,
+    llm_prompt_id integer NOT NULL,
+    guideline_id integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompt_guidelines_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_guidelines_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompt_guidelines.id;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompt_prompt_examples (
+    id bigint NOT NULL,
+    llm_prompt_id integer NOT NULL,
+    prompt_example_id integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompt_prompt_examples.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1725,6 +1789,20 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_feedbacks ALTER COLUMN id S
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_guidelines ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompt_guidelines_id_seq'::regclass);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_prompt_examples ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2054,6 +2132,22 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_guidelines
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_llm_feedbacks
     ADD CONSTRAINT evidence_research_gen_ai_llm_feedbacks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_guidelines evidence_research_gen_ai_llm_prompt_guidelines_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_guidelines
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_guidelines_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_prompt_examples evidence_research_gen_ai_llm_prompt_prompt_examples_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_prompt_examples
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_prompt_examples_pkey PRIMARY KEY (id);
 
 
 --
@@ -2438,6 +2532,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240619171521'),
 ('20240619184956'),
 ('20240619215433'),
-('20240619224707');
+('20240619224707'),
+('20240620113244'),
+('20240620115506');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_guidelines.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_guidelines.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_guidelines
+#
+#  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  guideline_id  :integer          not null
+#  llm_prompt_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_llm_prompt_guideline, class: 'Evidence::Research::GenAI::LLMPromptGuideline' do
+          llm_prompt { association :evidence_research_gen_ai_llm_prompt }
+          guideline { association :evidence_research_gen_ai_guideline }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_prompt_examples.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_prompt_examples.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_prompt_examples
+#
+#  id                :bigint           not null, primary key
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  llm_prompt_id     :integer          not null
+#  prompt_example_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_llm_prompt_prompt_example, class: 'Evidence::Research::GenAI::LLMPromptPromptExample' do
+          llm_prompt { association :evidence_research_gen_ai_llm_prompt }
+          prompt_example { association :evidence_research_gen_ai_prompt_example }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_spec.rb
@@ -34,7 +34,7 @@ module Evidence
         it { have_many(:test_examples).dependent(:destroy)}
         it { have_many(:prompt_examples).dependent(:destroy)}
 
-        it { belong_to(:stem_vault) }
+        it { should belong_to(:stem_vault) }
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_guideline_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_guideline_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_guidelines
+#
+#  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  guideline_id  :integer          not null
+#  llm_prompt_id :integer          not null
+#
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe LLMPromptGuideline, type: :model do
+        let(:factory) { described_class.model_name.singular.to_sym }
+
+        it { expect(build(factory)).to be_valid }
+
+        it { should belong_to(:llm_prompt) }
+        it { should belong_to(:guideline)}
+
+        it { should validate_presence_of(:llm_prompt_id) }
+        it { should validate_presence_of(:guideline_id) }
+
+        it { should have_readonly_attribute(:llm_prompt_id) }
+        it { should have_readonly_attribute(:guideline_id) }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_prompt_example_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_prompt_example_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_prompt_examples
+#
+#  id                :bigint           not null, primary key
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  llm_prompt_id     :integer          not null
+#  prompt_example_id :integer          not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe LLMPromptPromptExample, type: :model do
+        let(:factory) { described_class.model_name.singular.to_sym }
+
+        it { expect(build(factory)).to be_valid }
+
+        it { should belong_to(:llm_prompt) }
+        it { should belong_to(:prompt_example)}
+
+        it { should validate_presence_of(:llm_prompt_id) }
+        it { should validate_presence_of(:prompt_example_id) }
+
+        it { should have_readonly_attribute(:llm_prompt_id) }
+        it { should have_readonly_attribute(:prompt_example_id) }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/prompt_example_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/prompt_example_spec.rb
@@ -22,7 +22,7 @@ module Evidence
 
         it { expect(build(factory)).to be_valid }
 
-        it { belong_to(:dataset)}
+        it { should belong_to(:dataset)}
 
         it { should validate_presence_of(:staff_assigned_status) }
         it { should validate_presence_of(:student_response) }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/stem_vault_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/stem_vault_spec.rb
@@ -29,7 +29,7 @@ module Evidence
         it { should have_readonly_attribute(:conjunction) }
         it { should have_readonly_attribute(:activity_id) }
 
-        it { belong_to(:activity) }
+        it { should belong_to(:activity) }
 
         it { have_many(:student_responses).dependent(:destroy) }
         it { have_many(:quill_feedbacks).through(:student_responses) }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/test_example_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/test_example_spec.rb
@@ -26,7 +26,7 @@ module Evidence
 
         it { expect(build(factory)).to be_valid }
 
-        it { belong_to(:dataset)}
+        it { should belong_to(:dataset)}
 
         it { should validate_presence_of(:staff_assigned_status) }
         it { should validate_presence_of(:student_response) }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
@@ -36,9 +36,9 @@ module Evidence
         it { should have_readonly_attribute(:llm_prompt_id) }
         it { should have_readonly_attribute(:stem_vault_id) }
 
-        it { belong_to(:llm) }
-        it { belong_to(:llm_prompt) }
-        it { belong_to(:stem_vault) }
+        it { should belong_to(:llm) }
+        it { should belong_to(:llm_prompt) }
+        it { should belong_to(:stem_vault) }
 
         it { have_many(:llm_feedbacks) }
         it { have_many(:student_responses).through(:stem_vault) }


### PR DESCRIPTION
## WHAT
1.  Create `Evidence::Research::GenAI::LLMPromptPromptExample` model
2.  Fix some specs using `it { belong_to(...) }`
3.  Remove `class: Evidence::Research::GenAI::...` from various `belongs_to` and `has_many` associations

## WHY
1.  When running a Trial to a record that [associates](https://www.notion.so/quill/Internal-Tool-Organizing-Trials-into-Datasets-8dbc188caf194157a2a28395e907ddc0?pvs=4#78a75b19fb6046808946eaebe9d97f5c) each selected `PromptExample` with a particular `LLMPrompt`
2.  They don't do anything and should be `it { should belong_to(...) }`
3.  They are unnecessary

## HOW
1.  Write a migration and a model file.
2.  Add `should` into the test
3.  Remove the setting

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Internal-Tool-Organizing-Trials-into-Datasets-8dbc188caf194157a2a28395e907ddc0?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
