### PR TITLE
add view and button for admin usage pdf snapshot unsubscribe

### DIFF
--- a/services/QuillLMS/app/controllers/pdf_subscriptions_controller.rb
+++ b/services/QuillLMS/app/controllers/pdf_subscriptions_controller.rb
@@ -47,9 +47,7 @@ class PdfSubscriptionsController < ApplicationController
   def unsubscribe
     @pdf_subscription = PdfSubscription.find_by(token:)
 
-    if @pdf_subscription.nil?
-      redirect_to root_path, flash: { error: 'Subscription not found' }
-    end
+    redirect_to root_path, flash: { error: 'Subscription not found' } if @pdf_subscription.nil?
   end
 
   private def admin_report_filter_selection_id = pdf_subscription_params[:admin_report_filter_selection_id]

--- a/services/QuillLMS/app/controllers/pdf_subscriptions_controller.rb
+++ b/services/QuillLMS/app/controllers/pdf_subscriptions_controller.rb
@@ -22,23 +22,32 @@ class PdfSubscriptionsController < ApplicationController
     end
   end
 
-  # This is used in ReportSubscriptionModal when a user turns off a subscription and clicks save
+  # This is used in ReportSubscriptionModal when a user turns off a subscription and clicks save, and from the unsubscribe page when they confirm
   def destroy
     @pdf_subscription = PdfSubscription.find_by(id: params[:id])
 
-    return render json: {}, status: :unauthorized if @pdf_subscription&.user != current_user
+    respond_to do |format|
+      format.html do
+        return redirect_to root_path, flash: { error: 'Subscription not found' } if @pdf_subscription.nil?
 
-    @pdf_subscription.destroy
-    render json: {}, status: :ok
+        @pdf_subscription.destroy!
+        redirect_to root_path, flash: { notice: 'You have been unsubscribed from the Admin Usage Snapshot Report' }
+      end
+
+      format.json do
+        return render json: {}, status: :unauthorized if @pdf_subscription&.user != current_user
+
+        @pdf_subscription.destroy!
+        render json: {}, status: :ok
+      end
+    end
   end
 
   # This is used by the unsubscribe link in the email
   def unsubscribe
     @pdf_subscription = PdfSubscription.find_by(token:)
 
-    if @pdf_subscription&.destroy
-      render json: {}, status: :ok
-    else
+    if @pdf_subscription.nil?
       redirect_to root_path, flash: { error: 'Subscription not found' }
     end
   end

--- a/services/QuillLMS/app/views/pdf_subscriptions/unsubscribe.html.erb
+++ b/services/QuillLMS/app/views/pdf_subscriptions/unsubscribe.html.erb
@@ -1,3 +1,4 @@
 <div class="container account-form">
-  <h1>You have been unsubscribed from the Admin Usage Snapshot Report.<h1>
+  <h1>Are you sure you want to unsubscribe from the Admin Usage Snapshot Report?<h1>
+  <%= button_to "Unsubscribe", @pdf_subscription, method: :delete, class:"quill-button focus-on-light primary large contained" %>
 </div>

--- a/services/QuillLMS/spec/controllers/pdf_subscriptions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/pdf_subscriptions_controller_spec.rb
@@ -76,25 +76,66 @@ RSpec.describe PdfSubscriptionsController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    subject { delete :destroy, params: { id: pdf_subscription.id } }
-
-    let(:pdf_subscription) { create(:pdf_subscription, admin_report_filter_selection:) }
-
-    before { subject }
-
     context 'when the pdf subscription belongs to the current user' do
       let(:admin_report_filter_selection) { create(:usage_snapshot_report_pdf_filter_selection, user:) }
+      let!(:pdf_subscription) { create(:pdf_subscription, admin_report_filter_selection:) }
 
-      it { expect(PdfSubscription.count).to eq 0 }
+      context 'HTML format' do
+        subject { delete :destroy, params: { id: pdf_subscription.id }, format: :html }
+
+        it 'deletes the subscription and redirects to root path with notice' do
+          expect { subject }.to change(PdfSubscription, :count).by(-1)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:notice]).to eq('You have been unsubscribed from the Admin Usage Snapshot Report')
+        end
+      end
+
+      context 'JSON format' do
+        subject { delete :destroy, params: { id: pdf_subscription.id }, format: :json }
+
+        it 'deletes the subscription and returns status ok' do
+          expect { subject }.to change(PdfSubscription, :count).by(-1)
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
 
     context 'when the pdf subscription belongs to a different user' do
       let(:admin_report_filter_selection) { create(:usage_snapshot_report_pdf_filter_selection) }
+      let!(:pdf_subscription) { create(:pdf_subscription, admin_report_filter_selection:) }
 
-      it { expect(PdfSubscription.all).to eq [pdf_subscription] }
-      it { expect(response).to have_http_status(:unauthorized) }
+      context 'JSON format' do
+        subject { delete :destroy, params: { id: pdf_subscription.id }, format: :json }
+
+        it 'does not delete the subscription and returns status unauthorized' do
+          expect { subject }.not_to change(PdfSubscription, :count)
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+    end
+
+    context 'when the pdf subscription does not exist' do
+      context 'HTML format' do
+        subject { delete :destroy, params: { id: -1 }, format: :html }
+
+        it 'redirects to root path with error' do
+          expect { subject }.to change(PdfSubscription, :count).by(0)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:error]).to eq('Subscription not found')
+        end
+      end
+
+      context 'JSON format' do
+        subject { delete :destroy, params: { id: -1 }, format: :json }
+
+        it 'returns status unauthorized' do
+          expect { subject }.not_to change(PdfSubscription, :count)
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
     end
   end
+
 
   describe 'GET #unsubscribe' do
     subject { get :unsubscribe, params: { token: } }
@@ -103,17 +144,14 @@ RSpec.describe PdfSubscriptionsController, type: :controller do
 
     before { subject }
 
-    context 'when the pdf subscription exists with a given token' do
-      let(:token) { pdf_subscription.token }
-
-      it { expect(response).to have_http_status(:ok) }
-      it { expect(PdfSubscription.count).to eq 0 }
-    end
-
     context 'when no pdf subscription is found with that token' do
       let(:token) { 'invalid-token' }
 
-      it { expect(PdfSubscription.all).to eq [pdf_subscription] }
+      it 'does not change subscription count and redirects to root path with error' do
+        expect { subject }.not_to change(PdfSubscription, :count)
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq('Subscription not found')
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Update how unsubscribing from the Admin Usage Snapshot PDF works by adding a button to the page that calls the DELETE action.

## WHY
I tried to fix this by just turning the whole thing into a GET request, but then we were getting [this Sentry error](https://quillorg-5s.sentry.io/issues/5512423280/?project=11238&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&stream_index=4) on production. 

## HOW
Update the logic for the #unsubscribe and #destroy controller actions so that unsubscribe doesn't actually try to write to the database, just renders a page with a button that will link to destroy, which in turn handles HTML requests by destroying the subscription if it exists and redirecting with a notice. Note: the JSON version of this endpoint will error if the user is not the user associated with the subscription, while the HTML version will not. This preserves the previously-implemented logic of the unsubscribe endpoint, and since the idea is that we get here via a link from an email, I think it makes the UX of unsubscribing less cumbersome (I hate it when websites make me log in in order to unsubscribe). However, if people feel strongly, I can change this logic.

### Screenshots
<img width="1439" alt="Screenshot 2024-06-24 at 9 12 47 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/489ccf83-dbf0-4255-a831-015255a28dd9">

### Notion Card Links
https://www.notion.so/quill/Email-unsubscribe-option-for-the-Usage-Snapshot-report-is-not-working-c15257596a074f67af9b37d19aec4a92?pvs=4

### What have you done to QA this feature?
Deployed to staging and tested both HTM and JSON versions of this endpoint. Also having Peter Sharkey check it out.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
