### PR TITLE
Set role selected at sign up when creating TeacherInfo record

### DIFF
--- a/services/QuillLMS/app/controllers/accounts_controller.rb
+++ b/services/QuillLMS/app/controllers/accounts_controller.rb
@@ -27,6 +27,7 @@ class AccountsController < ApplicationController
     @user.attributes = user_params
     @user.safe_role_assignment(role)
     @user.validate_username = true
+    @user.role_selected_at_signup = session[:role]
     if @user.save
       sign_in @user
       trigger_account_creation_callbacks

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -125,6 +125,8 @@ class User < ApplicationRecord
     :skip_capitalize_names_callback,
     :validate_username
 
+  attribute :role_selected_at_signup, :string
+
   has_secure_password validations: false
   has_one :admin_info, dependent: :destroy
   has_one :auth_credential, dependent: :destroy
@@ -969,7 +971,7 @@ class User < ApplicationRecord
 
   private def generate_default_teacher_info
     # in addition to setting the notification_email_frequency here, show_students_exact_score is also being set to true automatically on creation
-    create_teacher_info(notification_email_frequency: TeacherInfo::DAILY_EMAIL)
+    create_teacher_info(notification_email_frequency: TeacherInfo::DAILY_EMAIL, role_selected_at_signup: role_selected_at_signup)
   end
 
   private def generate_default_teacher_notification_settings

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -971,7 +971,7 @@ class User < ApplicationRecord
 
   private def generate_default_teacher_info
     # in addition to setting the notification_email_frequency here, show_students_exact_score is also being set to true automatically on creation
-    create_teacher_info(notification_email_frequency: TeacherInfo::DAILY_EMAIL, role_selected_at_signup: role_selected_at_signup)
+    create_teacher_info(notification_email_frequency: TeacherInfo::DAILY_EMAIL, role_selected_at_signup:)
   end
 
   private def generate_default_teacher_notification_settings

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2007,12 +2007,21 @@ RSpec.describe User, type: :model do
       teacher.save
     end
 
-    it 'should create new TeacherInfo record' do
-      teacher = build(:teacher)
+    context 'should create new TeacherInfo record' do
 
-      expect do
-        teacher.save
-      end.to change(TeacherInfo, :count).by(1)
+      it 'should create a record' do
+        teacher = build(:teacher)
+
+        expect do
+          teacher.save
+        end.to change(TeacherInfo, :count).by(1)
+      end
+
+      it 'should save the role_selected_at_signup attribute to TeacherInfo record' do
+        teacher = create(:teacher, role_selected_at_signup: 'admin')
+        expect(teacher.teacher_info.role_selected_at_signup).to eq(teacher.role_selected_at_signup)
+      end
+
     end
 
     it 'should create new TeacherNotificationSetting records based on configured defaults' do

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2012,14 +2012,14 @@ RSpec.describe User, type: :model do
       it 'should create a record' do
         teacher = build(:teacher)
 
-        expect do
-          teacher.save
-        end.to change(TeacherInfo, :count).by(1)
+        expect{teacher.save}.to change(TeacherInfo, :count).by(1)
       end
 
       it 'should save the role_selected_at_signup attribute to TeacherInfo record' do
-        teacher = create(:teacher, role_selected_at_signup: 'admin')
-        expect(teacher.teacher_info.role_selected_at_signup).to eq(teacher.role_selected_at_signup)
+        role_selected_at_signup = "admin"
+        teacher = create(:teacher, role_selected_at_signup:)
+
+        expect(teacher.teacher_info.role_selected_at_signup).to eq(role_selected_at_signup)
       end
 
     end


### PR DESCRIPTION
## WHAT
We've been creating new `TeacherInfo` records without the "`role_selected_at_sign_up`" attribute, because of a change last year that accidentally began omitting this field when we switched to the account creation callback flow.

## WHY
This attribute is useful for admin to see when viewing a teacher's behavior and we should have it filled in.

## HOW
Since only the controllers have access to the session object, I created a virtual attribute `role_selected_at_sign_up` on the User object to store this field temporarily until the after-save callback creates the `TeacherInfo` object. We can't use the "User.role" field for this because it disallows the `individual-contributor` option, which we want to allow because we want to differentiate teachers, admins, and individual contributors.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Role-selected-on-signup-mostly-blank-in-teacher_infos-eba4f00c2d4547b18b6c640fa4849d63?pvs=4

### What have you done to QA this feature?
Deployed to staging and tested the sign up flow for teachers, admins, individual contributors, and students to make sure the TeacherInfo role field was set correctly for all four (students should not have a record created at all).

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
