### PR TITLE
fix zero width user input bug

### DIFF
--- a/services/QuillLMS/app/controllers/invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/invitations_controller.rb
@@ -2,7 +2,7 @@
 
 class InvitationsController < ApplicationController
   before_action :verify_current_user_owns_classrooms, only: :create_coteacher_invitation
-  before_action :set_classroom_ids_and_inviteee_email, only: :create_coteacher_invitation
+  before_action :set_classroom_ids_and_invitee_email, only: :create_coteacher_invitation
 
 
   def create_coteacher_invitation
@@ -58,9 +58,9 @@ class InvitationsController < ApplicationController
     raise StandardError, "Please make sure you've entered a valid email."
   end
 
-  private def set_classroom_ids_and_inviteee_email
+  private def set_classroom_ids_and_invitee_email
     @classroom_ids = params[:classroom_ids]
-    @invitee_email = params[:invitee_email]&.gsub(/\s/, '') # strip whitespace
+    @invitee_email = params[:invitee_email]&.strip_whitespace&.strip_zero_width_chars
   end
 
 

--- a/services/QuillLMS/app/controllers/invitations_controller.rb
+++ b/services/QuillLMS/app/controllers/invitations_controller.rb
@@ -60,7 +60,7 @@ class InvitationsController < ApplicationController
 
   private def set_classroom_ids_and_invitee_email
     @classroom_ids = params[:classroom_ids]
-    @invitee_email = params[:invitee_email]&.strip_whitespace&.strip_zero_width_chars
+    @invitee_email = params[:invitee_email]&.strip_whitespace&.strip_zero_width
   end
 
 

--- a/services/QuillLMS/config/initializers/core_extensions.rb
+++ b/services/QuillLMS/config/initializers/core_extensions.rb
@@ -17,3 +17,15 @@ Rails.application.config.to_prepare do
 
   ::Array.include CoreExtensions::Array
 end
+
+
+String.class_eval do
+  # Source: https://unicode-explorer.com/articles/space-characters
+  def strip_zero_width
+    gsub(/[\u200B\u200C\u200D\uFEFF]/, '')
+  end
+
+  def strip_whitespace
+    gsub(/\s/, '')
+  end
+end

--- a/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe InvitationsController, type: :controller do
   end
 
   it { should use_before_action :verify_current_user_owns_classrooms }
-  it { should use_before_action :set_classroom_ids_and_inviteee_email }
+  it { should use_before_action :set_classroom_ids_and_invitee_email }
 
   describe '#create_coteacher_invitation' do
     it 'should set the classroom ids' do
@@ -30,6 +30,11 @@ RSpec.describe InvitationsController, type: :controller do
     it 'should give error for invalid email format' do
       post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "test@testcom" }
       expect(response.body).to eq({error: "Please make sure you've entered a valid email."}.to_json)
+    end
+
+    it 'should autostrip zero width characters' do
+      post :create_coteacher_invitation, params: { classroom_ids: [classroom.id], invitee_email: "test\u200B@test.com " }
+      expect(assigns(:invitee_email)).to eq "test@test.com"
     end
 
     it 'should give error when multiple emails entered' do

--- a/services/QuillLMS/spec/initializers/core_extensions_spec.rb
+++ b/services/QuillLMS/spec/initializers/core_extensions_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+
+RSpec.describe String do
+  describe '#strip_zero_width' do
+    it 'removes zero-width space characters from the string' do
+      expect("hello\u200Bworld".strip_zero_width).to eq('helloworld')
+    end
+
+    it 'removes zero-width non-joiner characters from the string' do
+      expect("hello\u200Cworld".strip_zero_width).to eq('helloworld')
+    end
+
+    it 'removes zero-width joiner characters from the string' do
+      expect("hello\u200Dworld".strip_zero_width).to eq('helloworld')
+    end
+
+    it 'removes zero-width no-break space characters from the string' do
+      expect("hello\uFEFFworld".strip_zero_width).to eq('helloworld')
+    end
+
+    it 'does not affect strings without zero-width characters' do
+      expect('hello world'.strip_zero_width).to eq('hello world')
+    end
+
+    it 'handles strings composed entirely of zero-width characters' do
+      expect("\u200B\u200C\u200D\uFEFF".strip_zero_width).to eq('')
+    end
+  end
+
+  describe '#strip_whitespace' do
+    it 'removes all whitespace from the string' do
+      expect("hello world".strip_whitespace).to eq('helloworld')
+    end
+
+    it 'removes tabs, spaces, and newlines' do
+      expect("hello \t\n world \r\n".strip_whitespace).to eq('helloworld')
+    end
+
+    it 'works with strings that have no whitespace' do
+      expect("helloworld".strip_whitespace).to eq('helloworld')
+    end
+
+    it 'returns an empty string if the original string was only whitespace' do
+      expect(" \t\n\r\n".strip_whitespace).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Sanitizes zero width spaces from user input 

## WHY
These are not detectable with the naked eye, leading to confusing bugs. Also, zero width chars are not removed via common methods like `String#strip` 


## HOW
Create a convenience strip method for these characters. Make note to discuss a default solution (i.e. running the sanitizing method on all user input, as middleware) in the next eng meeting. 


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Teacher-cannot-invite-a-co-teacher-2d6a2eaca9494312825664e2427ec2ac

### What have you done to QA this feature?
tested in rails console

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
