### PR TITLE
Show hint translations in the student view

### DIFF
--- a/lambdas/rematching/vite.config.js
+++ b/lambdas/rematching/vite.config.js
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig( () => {
   const entryPoint = process.env.ENTRY_POINT || 'index.js';
-  console.log(`using entrypoint ${entryPoint}`)
+  console.log(`using entrypoint ${entryPoint}`) // eslint-disable-line no-console
 
   return {
     build: {

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concept-feedback.jsx
@@ -83,7 +83,7 @@ class ConceptFeedback extends React.Component {
         return (
           <div className="admin-container" key={conceptFeedbackID}>
             {conceptName}
-            <ConceptExplanation {...data[conceptFeedbackID]} translated={this.state.translated} />
+            <ConceptExplanation {...data[conceptFeedbackID]} adminShowTranslation={this.state.translated} />
             <p className="concept-feedback-control">
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
               <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>

--- a/services/QuillLMS/client/app/bundles/Shared/__tests__/components/feedback/__snapshots__/conceptExplanation.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Shared/__tests__/components/feedback/__snapshots__/conceptExplanation.test.tsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConceptExplanation it should render 1`] = `
+<DocumentFragment>
+  <div
+    class="concept-explanation"
+  >
+    <div
+      class="concept-explanation-title"
+    >
+      <img
+        alt="Light Bulb Icon"
+        src="https://assets.quill.org/images/icons/hint.svg"
+      />
+      <span>
+        Hint
+      </span>
+    </div>
+    <div
+      class="concept-explanation-description"
+    >
+      Combine two describing words using and.
+    </div>
+    <div
+      class="concept-explanation-translation"
+    >
+      Combinar dos palabras usando and.
+    </div>
+    <div
+      class="concept-explanation-see-write"
+    >
+      <div
+        class="concept-explanation-see"
+      >
+        The sun was bright. The sun was warm.
+      </div>
+      <div
+        class="concept-explanation-write"
+      >
+        The sun was bright and warm.
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/services/QuillLMS/client/app/bundles/Shared/__tests__/components/feedback/conceptExplanation.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/__tests__/components/feedback/conceptExplanation.test.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+
+import { ConceptExplanation } from "../../../components/feedback/conceptExplanation";
+
+const props = {
+  description: "Combine two describing words using and.",
+  leftBox: "The sun was bright. The sun was warm.",
+  rightBox: "The sun was bright and warm.",
+  translatedDescription: "Combinar dos palabras usando and.",
+  adminShowTranslation: true
+}
+
+describe('ConceptExplanation', () => {
+  test('it should render', () => {
+    const { asFragment } = render(<ConceptExplanation {...props} />);
+    expect(asFragment()).toMatchSnapshot();
+  })
+})

--- a/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
@@ -7,16 +7,22 @@ function getClassName(description, leftBox, rightBox) {
   return "concept-explanation empty"
 }
 
-const ConceptExplanation = ({ description, leftBox, rightBox, translatedDescription, translated}) => (
-  <div className={getClassName(description, leftBox, rightBox)}>
-    <div className="concept-explanation-title"><img alt="Light Bulb Icon" src="https://assets.quill.org/images/icons/hint.svg" /><span>Hint</span></div>
-    <div className="concept-explanation-description" dangerouslySetInnerHTML={{__html: description}} />
-    { translated && translatedDescription && <div className="concept-explanation-translation" dangerouslySetInnerHTML={{__html: translatedDescription}} /> }
-    <div className="concept-explanation-see-write">
-      <div className="concept-explanation-see" dangerouslySetInnerHTML={{__html: leftBox}} />
-      <div className="concept-explanation-write" dangerouslySetInnerHTML={{__html: rightBox}} />
+const ConceptExplanation = ({ description, leftBox, rightBox, translatedDescription, translated}) => {
+  const urlParams = new URLSearchParams(window.location.search)
+  const translatedOverride = urlParams.get('showTranslations')
+  const showsTranslation = translatedDescription && (translated || translatedOverride)
+  return (
+    <div className={getClassName(description, leftBox, rightBox)}>
+      <div className="concept-explanation-title"><img alt="Light Bulb Icon" src="https://assets.quill.org/images/icons/hint.svg" /><span>Hint</span></div>
+      <div className="concept-explanation-description" dangerouslySetInnerHTML={{__html: description}} />
+      { showsTranslation && <div className="concept-explanation-translation" dangerouslySetInnerHTML={{__html: translatedDescription}} /> }
+
+      <div className="concept-explanation-see-write">
+        <div className="concept-explanation-see" dangerouslySetInnerHTML={{__html: leftBox}} />
+        <div className="concept-explanation-write" dangerouslySetInnerHTML={{__html: rightBox}} />
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 export { ConceptExplanation }

--- a/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
@@ -7,10 +7,11 @@ function getClassName(description, leftBox, rightBox) {
   return "concept-explanation empty"
 }
 
-const ConceptExplanation = ({ description, leftBox, rightBox, translatedDescription, translated}) => {
+const ConceptExplanation = ({ description, leftBox, rightBox, translatedDescription, adminShowTranslation}) => {
   const urlParams = new URLSearchParams(window.location.search)
-  const translatedOverride = urlParams.get('showTranslations')
-  const showsTranslation = translatedDescription && (translated || translatedOverride)
+  // This is a temporary way to show translations until we add a language selector in the top bar.
+  const showTranslationsFromQueryString = urlParams.get('showTranslations') === 'true'
+  const showsTranslation = (translatedDescription != null) && (adminShowTranslation || showTranslationsFromQueryString)
   return (
     <div className={getClassName(description, leftBox, rightBox)}>
       <div className="concept-explanation-title"><img alt="Light Bulb Icon" src="https://assets.quill.org/images/icons/hint.svg" /><span>Hint</span></div>


### PR DESCRIPTION
## WHAT
If you add `?showTranslations=true` to the URL (before the # mark) you will see the translated version of the hints. 

## WHY
So that we can start looking at the translations in the app 

## HOW
Added a flag to the hints JS to show the translations

### Screenshots
![2024-06-24 at 10 24 AM](https://github.com/empirical-org/Empirical-Core/assets/126436/fa0b085d-2072-4099-ad91-e90b880b6c41)

### Notion Card Links
[Show users translations for hints](https://www.notion.so/quill/Show-users-the-translations-for-hints-f2702f0426bd44b1bed732a633eec41a?pvs=4)

### What have you done to QA this feature?
Looked at it in development. We will have to run some translations in staging in order to see it there.
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, it was a frontend only change, not sure we have tests for that component. 
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
