### PR TITLE
lms/only-include-premium-schools-in-all-schools

### DIFF
--- a/services/QuillLMS/app/models/admin_report_filter_selection.rb
+++ b/services/QuillLMS/app/models/admin_report_filter_selection.rb
@@ -74,7 +74,7 @@ class AdminReportFilterSelection < ApplicationRecord
   def timeframe_value = filter_selections.dig('timeframe', 'value')
 
   private def all_grades_selected? = selected_grades&.sort == GRADE_OPTION_NAMES
-  private def all_schools = School.joins(:schools_admins).where(schools_admins: { user: user })
+  private def all_schools = user.administered_premium_schools
   private def selected_grades = filter_selections['grades']&.pluck('name')
   private def selected_grade_values = filter_selections['grades']&.pluck('value')
 end

--- a/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
+++ b/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
@@ -167,8 +167,12 @@ RSpec.describe AdminReportFilterSelection, type: :model, redis: true do
       subject { admin_report_filter_selection.school_ids }
 
       let(:school) { create(:school) }
+      let(:subscription) { create(:subscription, account_type: Subscription::SCHOOL_PAID) }
 
-      before { create(:schools_admins, user: admin_report_filter_selection.user, school:) }
+      before do
+        create(:schools_admins, user: admin_report_filter_selection.user, school:)
+        create(:school_subscription, school:, subscription:)
+      end
 
       context 'when school ids are present in filter selections' do
         let(:selected_schools) { [{'id'=> school.id, 'name'=> school.name, 'label'=> school.name, 'value'=> school.id}] }
@@ -182,6 +186,14 @@ RSpec.describe AdminReportFilterSelection, type: :model, redis: true do
         let(:selected_schools) { nil }
 
         it { is_expected.to eq [school.id] }
+
+        context 'user is admin of non-premium school' do
+          let(:non_premium_school) { create(:school) }
+
+          before { create(:schools_admins, user: admin_report_filter_selection.user, school: non_premium_school) }
+
+          it { is_expected.to_not include(non_premium_school.id) }
+        end
       end
     end
 


### PR DESCRIPTION
## WHAT
Only include schools with active Premium in filter "all_schools"
## WHY
We were pulling all administered schools, but in all cases with AdminReportFilterSelections (at least at the moment), we only want schools with active subscriptions
## HOW
Replace the existing method of finding `all_schools` (a query for all Schools that the user associated with an `AdminReportFilterSelection` is an administrator for) with a version that only finds schools that the user is an administrator for that have an active Premium subscription

### Notion Card Links
https://www.notion.so/quill/ADGR-QA-June-26-56d9fef98dac45aa8a28fe192e027321?pvs=4#cd483441c32f4690b598ccd4e6795809

### What have you done to QA this feature?
On staging using a test admin account add a Premium school and a non-Premium school to their administered schools list.  Send an email report to that user.  Confirm that there is data in the CSVs for the Premium school, but not for the non-Premium school.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes