### PR TITLE
lms/duplicate-administered-premium-schools

### DIFF
--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -81,6 +81,7 @@ class School < ApplicationRecord
       .left_outer_joins(district: :subscriptions)
       # Below is a slightly weird construction, but Rails magic doesn't work so we had to get explicit
       .where('(subscriptions.expiration >= ? OR subscriptions_districts.expiration >= ?)', current_time, current_time)
+      .distinct
   end)
 
   ALTERNATIVE_SCHOOL_NAMES = [

--- a/services/QuillLMS/spec/models/school_spec.rb
+++ b/services/QuillLMS/spec/models/school_spec.rb
@@ -78,6 +78,12 @@ describe School, type: :model do
       it { is_expected.not_to include(non_premium_school) }
       it { is_expected.to include(school_premium_school) }
       it { is_expected.to include(district_premium_school) }
+
+      context 'district is connected to the same subscription multiple times' do
+        before { create(:district_subscription, subscription: district_subscription, district:) }
+
+        it { expect(subject.length).to eq(2) }
+      end
     end
   end
 


### PR DESCRIPTION
## WHAT
Ensure that the School.premium scope doesn't duplicate records
## WHY
There are joins in that query that could, theoretically (and sometimes in production), result in the same School getting double counted in SQL.  Specifically, there is at least one `District` that has two different `DistrictSubscription` records linking it to the same `Subscription`.
## HOW
Add `distinct` to the end of the scope query constructor.

### Screenshots
OLD
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/390f76f1-6bfd-4aed-894c-8950b5e91791)
NEW
![image](https://github.com/empirical-org/Empirical-Core/assets/331565/47b75063-b280-4bed-aefd-dd1f00505f11)

### Notion Card Links
https://www.notion.so/quill/ADGR-QA-June-26-56d9fef98dac45aa8a28fe192e027321?pvs=4#d247df26c9944f4396303d472e5fbd90

### What have you done to QA this feature?
Deploy to staging.  Log in with a user that has known duplication (as evidenced by duplicate schools appearing in their admin filters).  Confirm that there are no duplicate schools in their admin filters in the new code.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes