### PR TITLE
add header to remove column on activity review page and support for header in datatable

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/lesson_planner_and_unit_template_editor.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/lesson_planner_and_unit_template_editor.scss
@@ -290,7 +290,7 @@
       }
     }
 
-    @media (max-width: 991px) {
+    @media (max-width: 1165px) {
       .review-activities-section {
         display: none;
       }

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/dataTable.tsx
@@ -51,6 +51,7 @@ interface DataTableProps {
   emptyStateMessage?: string;
   showCheckboxes?: boolean;
   showRemoveIcon?: boolean;
+  removeHeaderText?: string;
   showActions?: boolean;
   removeRow?: (event: any) => void;
   checkRow?: (event: any) => void;
@@ -218,10 +219,10 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
   }
 
   renderHeaderForRemoval() {
-    const { showRemoveIcon } = this.props
+    const { showRemoveIcon, removeHeaderText, } = this.props
     if (!showRemoveIcon) { return null }
 
-    return <th aria-label="Header for remove column" className={dataTableHeaderClassName} scope="col" />
+    return <th aria-label="Header for remove column" className={dataTableHeaderClassName} scope="col">{removeHeaderText}</th>
   }
 
   renderHeaderForOrder() {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/review_activities.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/review_activities.test.jsx.snap
@@ -39,7 +39,7 @@ exports[`ReviewActivities component should render 1`] = `
             "attribute": "activity",
             "name": "Activity",
             "rowSectionClassName": "tooltip-section review-activities-data-table-section",
-            "width": "322px",
+            "width": "392px",
           },
           Object {
             "attribute": "concept",
@@ -92,6 +92,7 @@ exports[`ReviewActivities component should render 1`] = `
           },
         ]
       }
+      removeHeaderText="Remove activities"
       removeRow={[Function]}
       rows={
         Array [
@@ -103,7 +104,7 @@ exports[`ReviewActivities component should render 1`] = `
               tooltipTriggerTextClass="clipped-content"
               tooltipTriggerTextStyle={
                 Object {
-                  "maxWidth": "322px",
+                  "maxWidth": "392px",
                 }
               }
             />,
@@ -147,7 +148,7 @@ exports[`ReviewActivities component should render 1`] = `
               tooltipTriggerTextClass="clipped-content"
               tooltipTriggerTextStyle={
                 Object {
-                  "maxWidth": "322px",
+                  "maxWidth": "392px",
                 }
               }
             />,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/review_activities.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/review_activities.jsx
@@ -21,7 +21,7 @@ import PreviouslyAssignedTooltip from '../../previouslyAssignedTooltip';
 const PUBLISH_DATE_ATTRIBUTE_KEY = 'publishDates'
 const DUE_DATE_ATTRIBUTE_KEY = 'dueDates'
 
-const activityColumnMaxWidth = '322px';
+const activityColumnMaxWidth = '392px';
 const rowSectionTooltipClassName =  'tooltip-section review-activities-data-table-section';
 
 const tableHeaders = [
@@ -277,6 +277,7 @@ export default class ReviewActivities extends React.Component {
         <div className="assignment-section-body">
           <DataTable
             headers={tableHeaders}
+            removeHeaderText="Remove activities"
             removeRow={this.removeRow}
             rows={this.rows()}
             showRemoveIcon


### PR DESCRIPTION
## WHAT
Update the datatable to accept a header text prop for the remove column, and use it on the Review Activities section of activity assignment.

## WHY
Teachers were missing that it is possible to remove an activity at this stage.

## HOW
Update DataTable to receive a prop and ReviewActivities to pass that prop, plus some minor stylistic changes to accommodate the new header.

### Screenshots
<img width="1232" alt="Screenshot 2024-06-27 at 11 30 42 AM" src="https://github.com/empirical-org/Empirical-Core/assets/18669014/fdc2754e-c3d3-444e-bc10-3c45a1503ca7">

### Notion Card Links
https://www.notion.so/quill/Add-Remove-Activity-Copy-to-the-Review-Assign-page-219c168236f6495a9bdc373e9a8ea1d1?pvs=4

### What have you done to QA this feature?
Looked at the page on regular view and mobile width and confirmed that it looks good.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? | YES
