### PR TITLE
Rubocop enforce hash syntax

### DIFF
--- a/services/QuillLMS/.rubocop.yml
+++ b/services/QuillLMS/.rubocop.yml
@@ -164,4 +164,4 @@ Style/RescueModifier:
     - db/migrate/20140916143956_make_username_downcase.rb
 
 Style/HashSyntax:
-  EnforcedShorthandSyntax: consistent
+  EnforcedShorthandSyntax: always

--- a/services/QuillLMS/.rubocop.yml
+++ b/services/QuillLMS/.rubocop.yml
@@ -162,3 +162,6 @@ Style/RedundantInterpolation:
 Style/RescueModifier:
   Exclude:
     - db/migrate/20140916143956_make_username_downcase.rb
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: consistent


### PR DESCRIPTION
Add `EnforcedShorthandSyntax: always` to rubocop. 

Note, this will catch instances of this: 
``` 
{ foo: foo } 
``` 

But it will not catch instances in named arguments for method calls: 
```
def foo(bar:)
...
end

foo(bar: bar)
```