### PR TITLE
further adjustment for fill in the blank input styling

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/__tests__/__snapshots__/playFillInTheBlankQuestion.test.tsx.snap
@@ -195,8 +195,8 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                   onChange={[Function]}
                   style={
                     Object {
-                      "paddingRight": "0px",
-                      "textAlign": "left",
+                      "paddingRight": "10px",
+                      "textAlign": "center",
                       "width": "20px",
                     }
                   }
@@ -275,8 +275,8 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                   onChange={[Function]}
                   style={
                     Object {
-                      "paddingRight": "0px",
-                      "textAlign": "left",
+                      "paddingRight": "10px",
+                      "textAlign": "center",
                       "width": "20px",
                     }
                   }
@@ -351,8 +351,8 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                 onChange={[Function]}
                 style={
                   Object {
-                    "paddingRight": "0px",
-                    "textAlign": "left",
+                    "paddingRight": "10px",
+                    "textAlign": "center",
                     "width": "20px",
                   }
                 }
@@ -390,8 +390,8 @@ Completa el espacio en blanco con una de estas palabras: a, an, the. Si no se ne
                 onChange={[Function]}
                 style={
                   Object {
-                    "paddingRight": "0px",
-                    "textAlign": "left",
+                    "paddingRight": "10px",
+                    "textAlign": "center",
                     "width": "20px",
                   }
                 }

--- a/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputStyle.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputStyle.tsx
@@ -1,6 +1,8 @@
 import { determineShortestCue, generateSpan, generateOffsetWidth, } from './fillInBlankInputStyleHelpers'
 
+// these two are coming from the style files (see .fill-in-blank-input) and will need to get updated if the styling does
 const PADDING_WIDTH = 20
+const ELEMENT_MIN_WIDTH = 55
 
 export function fillInBlankInputStyle(value: string|null, cues: Array<string>) {
   const spanForShortestCue = generateSpan(determineShortestCue(cues))
@@ -14,7 +16,9 @@ export function fillInBlankInputStyle(value: string|null, cues: Array<string>) {
   document.body.removeChild(spanForShortestCue);
   document.body.removeChild(spanForValue);
 
+  const elementShorterThanMinWidth = ELEMENT_MIN_WIDTH >= elementWidth
   const valueShorterThanShortestCue = shortestCueSpanWidth > valueSpanWidth
+  const shouldCenterInput = elementShorterThanMinWidth || valueShorterThanShortestCue
 
-  return { width: `${elementWidth}px`, textAlign: valueShorterThanShortestCue ? 'center' : 'left', paddingRight: valueShorterThanShortestCue ? '10px' : '0px' };
+  return { width: `${elementWidth}px`, textAlign: shouldCenterInput ? 'center' : 'left', paddingRight: shouldCenterInput ? '10px' : '0px' };
 }

--- a/services/QuillLMS/client/app/bundles/Shared/libs/tests/fillInBlankInputStyle.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/tests/fillInBlankInputStyle.test.tsx
@@ -58,8 +58,14 @@ describe('fillInBlankInputStyle function', () => {
     expect(paddingRight).toBe("10px");
   });
 
-  it('assigns the textAlign value to left and paddingRight to 0px when the valueSpan is longer than the shortest cue', () => {
-    const { textAlign, paddingRight } = fillInBlankInputStyle('aaaa', ['a', 'longercue', 'muchlongercue']);
+  it('assigns the textAlign value to center and paddingRight to 10px when the value is longer than the shortest but the element is shorter than ELEMENT_MIN_WIDTH', () => {
+    const { textAlign, paddingRight } = fillInBlankInputStyle('aaaaa', ['a', 'longercue', 'muchlongercue']);
+    expect(textAlign).toBe('left');
+    expect(paddingRight).toBe("0px");
+  });
+
+  it('assigns the textAlign value to left and paddingRight to 0px when the valueSpan is longer than the shortest cue and the element is longer than ELEMENT_MIN_WIDTH', () => {
+    const { textAlign, paddingRight } = fillInBlankInputStyle('aaaaaa', ['a', 'longercue', 'muchlongercue']);
     expect(textAlign).toBe('left');
     expect(paddingRight).toBe("0px");
   });


### PR DESCRIPTION
## WHAT
Another adjustment to fill in the blank input styling.

## WHY
Last PR fixed this issue for some, but not all, cases. This one should cover everything.

## HOW
Add additional logic for when both the value and the shortest cue are shorter than the minimum width of the element.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Off-centered-fill-in-the-blank-414cabf160ea4ed7829d053af67cfd5a?pvs=4

### What have you done to QA this feature?
Looked at shorter cues locally, as well as the longer ones I'd been testing with last time.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
