### PR TITLE
July1 time bugs

### DIFF
--- a/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/timeframes_spec.rb
@@ -98,7 +98,7 @@ module Snapshots
     it_behaves_like 'snapshots period length', 'last-90-days', 90
     it_behaves_like 'snapshots period length', 'this-month', DateTime.current.yesterday.day
     it_behaves_like 'snapshots period length', 'last-month', Time.days_in_month(DateTime.current.yesterday.prev_month.month)
-    it_behaves_like 'snapshots period length', 'this-school-year', DateTime.current.yesterday.end_of_day - School.school_year_start(DateTime.current)
+    it_behaves_like 'snapshots period length', 'this-school-year', DateTime.current.yesterday.end_of_day - School.school_year_start(DateTime.current.yesterday)
     it_behaves_like 'snapshots period length', 'last-school-year', Date.leap?(DateTime.current.prev_year.year) ? 366 : 365
     it_behaves_like 'snapshots period length', 'custom', 4, (DateTime.current - 3.days).to_s, DateTime.current.to_s
 

--- a/services/QuillLMS/spec/queries/student_dashboard_metrics_spec.rb
+++ b/services/QuillLMS/spec/queries/student_dashboard_metrics_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 describe StudentDashboardMetrics do
   before do
+    travel_to 1.month.from_now if Time.current.month == 7
+
     now = Time.current
     wednesday_noon = now.beginning_of_week(:wednesday).noon
     first_of_month = now.beginning_of_month

--- a/services/QuillLMS/spec/services/analytics/cache_segment_school_data_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/cache_segment_school_data_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Analytics::CacheSegmentSchoolData do
   let(:school) { create(:school) }
   let(:teacher1) { create(:teacher, last_sign_in: Time.zone.today - 366.days) }
-  let(:teacher2) { create(:teacher, last_sign_in: Time.zone.today) }
+  let(:teacher2) { create(:teacher, last_sign_in: Time.zone.today + 1.day) }
   let!(:schools_users1) { create(:schools_users, school: school, user: teacher1 )}
   let!(:schools_users2) { create(:schools_users, school: school, user: teacher2 )}
   let(:classrooms_teachers1) { create(:classrooms_teacher, user: teacher1) }
@@ -13,14 +13,14 @@ RSpec.describe Analytics::CacheSegmentSchoolData do
   let(:students_classrooms1) { create_list(:students_classrooms, 10, classroom: classrooms_teachers1.classroom)}
   let(:students_classrooms2) { create_list(:students_classrooms, 10, classroom: classrooms_teachers2.classroom)}
   let!(:activity_sessions1) { create_list(:activity_session, 20, user: students_classrooms1.map(&:student).sample, completed_at: Time.zone.today - 367.days ) }
-  let!(:activity_sessions2) { create_list(:activity_session, 20, user: students_classrooms2.map(&:student).sample, completed_at: Time.zone.today ) }
+  let!(:activity_sessions2) { create_list(:activity_session, 20, user: students_classrooms2.map(&:student).sample, completed_at: Time.zone.today + 1.day ) }
 
   before do
     students_classrooms1.each do |sc|
       sc.student.update(last_sign_in: Time.zone.today - 366.days)
     end
     students_classrooms2.each do |sc|
-      sc.student.update(last_sign_in: Time.zone.today)
+      sc.student.update(last_sign_in: Time.zone.today + 1.day)
     end
   end
 


### PR DESCRIPTION
## WHAT
Fix some bugs involving calculations that hit edge cases when run on a date in early July.

## WHY
There are some specs that do calculations where the week, month and year calculations can overlap with the current date occurring in the first week of July.  (e.g. July 1)

## HOW
To fix many of these, just have the test travel_forward a month to August if the current date is in this range.

NB.  This doesn't actually fix the underlying problem, but it's a temporary fix so that tests can pass on develop.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? |  NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
