### PR TITLE
fix create location errors

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityStats.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/activityStats.test.tsx.snap
@@ -52,16 +52,6 @@ exports[`ActivityStats component should render ActivityStats 1`] = `
           "unregisterTransitionHook": [Function],
         }
       }
-      location={
-        Object {
-          "action": "POP",
-          "hash": "",
-          "key": null,
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        }
-      }
       match={
         Object {
           "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/healthDashboard.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/healthDashboard.test.tsx.snap
@@ -52,16 +52,6 @@ exports[`HealthDashboard component should render HealthDashboard 1`] = `
           "unregisterTransitionHook": [Function],
         }
       }
-      location={
-        Object {
-          "action": "POP",
-          "hash": "",
-          "key": null,
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        }
-      }
       match={
         Object {
           "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/plagiarismRulesIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/plagiarismRulesIndex.test.tsx.snap
@@ -52,16 +52,6 @@ exports[`PlagiarismRulesIndex component should render PlagiarismRulesIndex 1`] =
           "unregisterTransitionHook": [Function],
         }
       }
-      location={
-        Object {
-          "action": "POP",
-          "hash": "",
-          "key": null,
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        }
-      }
       match={
         Object {
           "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/regexRulesIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/regexRulesIndex.test.tsx.snap
@@ -52,16 +52,6 @@ exports[`RegexRulesIndex component should render RegexRulesIndex 1`] = `
           "unregisterTransitionHook": [Function],
         }
       }
-      location={
-        Object {
-          "action": "POP",
-          "hash": "",
-          "key": null,
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        }
-      }
       match={
         Object {
           "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rule.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rule.test.tsx.snap
@@ -52,16 +52,6 @@ exports[`Rule component should render Rule 1`] = `
           "unregisterTransitionHook": [Function],
         }
       }
-      location={
-        Object {
-          "action": "POP",
-          "hash": "",
-          "key": null,
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        }
-      }
       match={
         Object {
           "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleAnalysis.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/ruleAnalysis.test.tsx.snap
@@ -52,16 +52,6 @@ exports[`RuleAnalysis component should render RuleAnalysis 1`] = `
           "unregisterTransitionHook": [Function],
         }
       }
-      location={
-        Object {
-          "action": "POP",
-          "hash": "",
-          "key": null,
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        }
-      }
       match={
         Object {
           "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rules.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rules.test.tsx.snap
@@ -53,16 +53,6 @@ exports[`Rules component should render Rules 1`] = `
           "unregisterTransitionHook": [Function],
         }
       }
-      location={
-        Object {
-          "action": "POP",
-          "hash": "",
-          "key": null,
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        }
-      }
       match={
         Object {
           "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulesAnalysis.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulesAnalysis.test.jsx.snap
@@ -52,16 +52,6 @@ exports[`RulesAnalysis component should render RulesAnalysis 1`] = `
           "unregisterTransitionHook": [Function],
         }
       }
-      location={
-        Object {
-          "action": "POP",
-          "hash": "",
-          "key": null,
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        }
-      }
       match={
         Object {
           "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/sessionsIndex.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/sessionsIndex.test.tsx.snap
@@ -52,16 +52,6 @@ exports[`SessionsIndex component should render SessionsIndex 1`] = `
           "unregisterTransitionHook": [Function],
         }
       }
-      location={
-        Object {
-          "action": "POP",
-          "hash": "",
-          "key": null,
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        }
-      }
       match={
         Object {
           "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/turkSessions.test.tsx.snap
@@ -738,16 +738,6 @@ exports[`TurkSessions component should render TurkSessions 1`] = `
         "unregisterTransitionHook": [Function],
       }
     }
-    location={
-      Object {
-        "action": "POP",
-        "hash": "",
-        "key": null,
-        "pathname": "/",
-        "search": "",
-        "state": null,
-      }
-    }
     match={
       Object {
         "isExact": true,

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activities.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activities.test.tsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 import 'whatwg-fetch';
@@ -9,6 +9,8 @@ import Activities from '../activities';
 
 const queryClient = new DefaultReactQueryClient();
 
+const history = createMemoryHistory()
+
 describe('Activities component', () => {
   const mockProps = {
     match: {
@@ -17,8 +19,8 @@ describe('Activities component', () => {
       path: '',
       url:''
     },
-    history: createMemoryHistory(),
-    location: createLocation('')
+    history,
+    location: history.location,
   }
   const container = shallow(
     <QueryClientProvider client={queryClient} contextSharing={true}>

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activitySettings.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activitySettings.test.tsx
@@ -1,9 +1,11 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import 'whatwg-fetch';
 
 import ActivitySettings from '../configureSettings/activitySettings';
+
+const history = createMemoryHistory()
 
 const mockProps = {
   match: {
@@ -14,8 +16,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location,
 }
 
 describe('ActivitySettings component', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activityStats.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/activityStats.test.tsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 import 'whatwg-fetch';
@@ -8,6 +8,8 @@ import { DefaultReactQueryClient } from '../../../../Shared/index';
 import ActivityStats from '../activityStats/activityStats';
 
 const queryClient = new DefaultReactQueryClient();
+
+const history = createMemoryHistory()
 
 const mockProps = {
   match: {
@@ -18,8 +20,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location,
 }
 
 describe('ActivityStats component', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/healthDashboard.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/healthDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 import 'whatwg-fetch';
@@ -8,6 +8,8 @@ import { DefaultReactQueryClient } from '../../../../Shared/index';
 import HealthDashboard from '../healthDashboards/activityHealthDashboard';
 
 const queryClient = new DefaultReactQueryClient();
+
+const history = createMemoryHistory()
 
 const mockProps = {
   match: {
@@ -18,8 +20,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location,
 }
 
 describe('HealthDashboard component', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/plagiarismRulesIndex.test.tsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 import 'whatwg-fetch';
@@ -8,6 +8,8 @@ import { DefaultReactQueryClient } from '../../../../Shared/index';
 import PlagiarismRulesIndex from '../plagiarismRules/plagiarismRulesIndex';
 
 const queryClient = new DefaultReactQueryClient();
+
+const history = createMemoryHistory()
 
 const mockProps = {
   match: {
@@ -18,8 +20,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location,
 }
 
 describe('PlagiarismRulesIndex component', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/regexRulesIndex.test.tsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 import 'whatwg-fetch';
@@ -11,6 +11,8 @@ const queryClient = new DefaultReactQueryClient();
 
 const { firstBy } = jest.requireActual('thenby');
 
+const history = createMemoryHistory()
+
 const mockProps = {
   match: {
     params: {
@@ -20,8 +22,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location,
 }
 
 describe('RegexRulesIndex component', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rule.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rule.test.tsx
@@ -1,11 +1,13 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 
 import 'whatwg-fetch';
 import { DefaultReactQueryClient } from '../../../../Shared';
 import Rule from '../configureRules/rule';
+
+const history = createMemoryHistory()
 
 const mockProps = {
   match: {
@@ -17,8 +19,8 @@ const mockProps = {
     path: '',
     url:'`https://comprehension-247816.appspot.com/api/activities/:activityId/rulesets/:ruleSetId.json/`'
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location,
 };
 
 const fields = [

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleAnalysis.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/ruleAnalysis.test.tsx
@@ -1,11 +1,13 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory, } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 
 import 'whatwg-fetch';
 import { DefaultReactQueryClient } from '../../../../Shared';
 import RuleAnalysis from '../rulesAnalysis/ruleAnalysis';
+
+const history = createMemoryHistory()
 
 const mockProps = {
   match: {
@@ -16,8 +18,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location
 }
 
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rules.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rules.test.tsx
@@ -1,11 +1,13 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 
 import 'whatwg-fetch';
 import { DefaultReactQueryClient } from '../../../../Shared';
 import Rules from '../configureRules/rules';
+
+const history = createMemoryHistory()
 
 const mockProps = {
   activityId: '17',
@@ -18,8 +20,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location,
 }
 
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulesAnalysis.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/rulesAnalysis.test.jsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 import 'whatwg-fetch';
@@ -14,6 +14,8 @@ jest.mock('qs', () => ({
 })
 )
 
+const history = createMemoryHistory()
+
 const mockProps = {
   match: {
     params: {
@@ -23,8 +25,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location
 }
 
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionOverview.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionOverview.test.tsx
@@ -1,11 +1,12 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import 'whatwg-fetch';
 
 import SessionOverview from '../activitySessions/sessionOverview';
-
 import sessionData from '../__mocks__/sessionData.json';
+
+const history = createMemoryHistory()
 
 const mockProps = {
   match: {
@@ -16,8 +17,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation(''),
+  history,
+  location: history.location,
   sessionData: sessionData,
   activity: {}
 }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionView.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionView.test.tsx
@@ -1,9 +1,11 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import 'whatwg-fetch';
 
 import SessionView from '../activitySessions/sessionView';
+
+const history = createMemoryHistory()
 
 const mockProps = {
   match: {
@@ -14,8 +16,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location
 }
 
 describe('SessionView component', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionsIndex.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/sessionsIndex.test.tsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 import 'whatwg-fetch';
@@ -8,6 +8,8 @@ import { DefaultReactQueryClient } from '../../../../Shared/index';
 import SessionsIndex from '../activitySessions/sessionsIndex';
 
 const queryClient = new DefaultReactQueryClient();
+
+const history = createMemoryHistory()
 
 const mockProps = {
   match: {
@@ -18,8 +20,8 @@ const mockProps = {
     path: '',
     url:''
   },
-  history: createMemoryHistory(),
-  location: createLocation('')
+  history,
+  location: history.location
 }
 
 describe('SessionsIndex component', () => {

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/turkSessions.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/turkSessions.test.tsx
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import { createLocation, createMemoryHistory } from 'history';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 
@@ -9,6 +9,8 @@ import TurkSessions from '../gatherResponses/turkSessions';
 
 const queryClient = new DefaultReactQueryClient();
 
+const history = createMemoryHistory()
+
 describe('TurkSessions component', () => {
   const mockProps = {
     match: {
@@ -17,8 +19,8 @@ describe('TurkSessions component', () => {
       path: '',
       url:''
     },
-    history: createMemoryHistory(),
-    location: createLocation('')
+    history,
+    location: history.location
   }
   const container = mount(
     <QueryClientProvider client={queryClient} contextSharing={true}>


### PR DESCRIPTION
## WHAT
Fix the "Warning: [history] Using createLocation without a history instance is deprecated; please use history.createLocation instead" we were getting on some jest tests. Note: this is a test-only error that wasn't showing up in the console.

## WHY
We are trying to clean up our console and test suite.

## HOW
Restructure mock props for these tests to use history.location.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
