### PR TITLE
Add OpenAI translation option (#11981)

### DIFF
--- a/services/QuillLMS/app/models/concept_feedback.rb
+++ b/services/QuillLMS/app/models/concept_feedback.rb
@@ -32,6 +32,7 @@ class ConceptFeedback < ApplicationRecord
   has_many :translation_mappings, as: :source
   has_many :english_texts, through: :translation_mappings
   has_many :translated_texts, through: :english_texts
+  has_many :gengo_jobs, through: :english_texts
   store_accessor :data, :description
 
   after_commit :clear_concept_feedbacks_cache
@@ -39,10 +40,11 @@ class ConceptFeedback < ApplicationRecord
   def cache_key = "#{ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}"
 
   def as_json(options=nil)
-    translation = translation(locale: "es-la")
+    source_api = options&.dig(:source_api) || TranslatedText::OPEN_AI_SOURCE
+    translation = translation(source_api:)
     return data unless translation.present?
 
-    data.merge({"translatedDescription" => translation(locale: "es-la")})
+    data.merge({"translatedDescription" => translation})
   end
 
   def create_translation_mappings
@@ -53,10 +55,23 @@ class ConceptFeedback < ApplicationRecord
     translation_mappings.create(english_text: )
   end
 
-  def translation(locale:) = translated_texts.find_by(locale:)&.translation
+  def translation(locale: TranslatedText::DEFAULT_LOCALE, source_api: TranslatedText::OPEN_AI_SOURCE)
+    translations(locale:, source_api:)&.first&.translation
+  end
 
-  def translate! = Gengo::RequestTranslations.run(english_texts)
-  def fetch_translations! = translated_texts.each(&:fetch_translation!)
+  private def translations(locale:, source_api:)
+    translated_texts.where(locale:).ordered_by_source_api(source_api)
+  end
+
+  def translate!(locale:, source_api:)
+    case source_api
+    when TranslatedText::GENGO_SOURCE
+      Gengo::RequestTranslations.run(english_texts, locale)
+    when TranslatedText::OPEN_AI_SOURCE
+      english_texts.each{ |text| OpenAI::TranslateAndSaveText.run(text) }
+    end
+  end
+  def fetch_translations! = gengo_jobs.each(&:fetch_translation!)
 
   private def data_must_be_hash
     errors.add(:data, "must be a hash") unless data.is_a?(Hash)

--- a/services/QuillLMS/app/models/english_text.rb
+++ b/services/QuillLMS/app/models/english_text.rb
@@ -12,8 +12,9 @@
 class EnglishText < ApplicationRecord
   has_many :translated_texts
   has_many :translation_mappings
+  has_many :gengo_jobs
 
-  def needs_translation?(locale: Gengo::SPANISH_LOCALE)
-    translated_texts.where(locale:).empty?
+  def gengo_translation?(locale: TranslatedText::DEFAULT_LOCALE)
+    gengo_jobs.where(locale:).present?
   end
 end

--- a/services/QuillLMS/app/models/gengo_job.rb
+++ b/services/QuillLMS/app/models/gengo_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: gengo_jobs
+#
+#  id                 :bigint           not null, primary key
+#  locale             :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  english_text_id    :integer          not null
+#  translated_text_id :integer
+#  translation_job_id :string           not null
+#
+class GengoJob < ApplicationRecord
+  belongs_to :translated_text
+  belongs_to :english_text
+  scope :pending_translation, -> { where(translated_text_id: nil) }
+
+  def self.fetch_and_save_pending! = pending_translation.each(&:fetch_translation!)
+
+  def fetch_translation! = Gengo::SaveTranslatedTextWorker.perform_async(translation_job_id)
+
+end

--- a/services/QuillLMS/app/services/concerns/open_ai/api.rb
+++ b/services/QuillLMS/app/services/concerns/open_ai/api.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module OpenAI
+  module Api
+    extend ActiveSupport::Concern
+
+    BASE_URI = 'https://api.openai.com/v1'
+    TIMEOUT = 5.minutes.to_i
+
+    included do
+      include HTTParty
+      base_uri BASE_URI
+
+      attr_accessor :response
+    end
+
+    # classes using this concern require these methods
+    def endpoint
+      raise NotImplementedError
+    end
+
+    def request_body
+      raise NotImplementedError
+    end
+
+    def cleaned_results
+      raise NotImplementedError
+    end
+
+    def run
+      return cleaned_results if response.present?
+
+      @response = post_request
+
+      cleaned_results
+    rescue *Evidence::HTTP_TIMEOUT_ERRORS
+      []
+    end
+
+    private def headers
+      {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer #{ENV['OPENAI_API_KEY']}"
+      }
+    end
+
+    private def post_request
+      self.class.post(endpoint, body: request_body.to_json, headers: headers, timeout: TIMEOUT)
+    end
+  end
+end

--- a/services/QuillLMS/app/services/gengo/request_translations.rb
+++ b/services/QuillLMS/app/services/gengo/request_translations.rb
@@ -3,7 +3,7 @@
 module Gengo
   class RequestTranslations < ApplicationService
     class RequestTranslationError < StandardError; end
-    attr_reader :english_texts
+    attr_reader :english_texts, :locale
 
     STANDARD_COMMENT = <<~STRING
       We are translating the instructions for an English-language grammar activity. The content of the activity itself is not translated. Therefore, please leave words that sound like they are part of the activity in the original english. Often they will between an HTML tag such as in <em>english word</em> or <ul>english  word</ul>.
@@ -11,8 +11,9 @@ module Gengo
     RESPONSE = "response"
     ORDER_ID = "order_id"
 
-    def initialize(english_texts)
+    def initialize(english_texts, locale)
       @english_texts = english_texts
+      @locale = locale
     end
 
     def run
@@ -28,20 +29,20 @@ module Gengo
     def gengo_payload
       @gengo_payload ||= begin
         english_texts
-          .select(&:needs_translation?)
+          .reject{|e| e.gengo_translation?(locale:)}
           .each_with_object({}) do |english_text, hash|
-          hash[english_text.id.to_s] = {
-            type: "text",
-            body_src: english_text.text,
-            lc_src: "en",
-            lc_tgt: Gengo::SPANISH_LOCALE,
-            tier: "standard",
-            slug: english_text.id,
-            group: true,
-            auto_approve: true,
-            comment: STANDARD_COMMENT
-          }
-        end
+            hash[english_text.id.to_s] = {
+              type: "text",
+              body_src: english_text.text,
+              lc_src: "en",
+              lc_tgt: TranslatedText::DEFAULT_LOCALE,
+              tier: "standard",
+              slug: english_text.id,
+              group: true,
+              auto_approve: true,
+              comment: STANDARD_COMMENT
+            }
+          end
       end
     end
   end

--- a/services/QuillLMS/app/services/gengo/save_translated_text.rb
+++ b/services/QuillLMS/app/services/gengo/save_translated_text.rb
@@ -3,7 +3,7 @@
 module Gengo
   class SaveTranslatedText < ApplicationService
     class FetchTranslationJobError < StandardError; end
-    attr_accessor :job_id
+    attr_reader :translation_job_id
 
     SLUG = "slug"
     RESPONSE = "response"
@@ -15,31 +15,46 @@ module Gengo
     BODY_TGT = "body_tgt"
     LC_TGT = "lc_tgt"
 
-    def initialize(job_id)
-      @job_id = job_id
+    def initialize(translation_job_id)
+      @translation_job_id = translation_job_id
     end
 
     def run
+      return if gengo_job.translated_text.present?
       raise FetchTranslationJobError unless response.present?
+      return unless new_translation
 
-      return unless active_job?
-      return if translated_text.translation == new_translation
-      return unless new_translation.present?
-
-      translated_text.update(translation: new_translation)
+      gengo_job.update(translated_text:)
     end
 
-    private def response = @response ||= GengoAPI.getTranslationJob({id: job_id})
-    private def job = response.dig(RESPONSE, JOB)
+    private def response = @response ||= GengoAPI.getTranslationJob({id: translation_job_id})
+    private def job = response&.dig(RESPONSE, JOB)
     private def active_job? = ![DELETED, CANCELED].include?(job[STATUS])
     private def new_translation = job[BODY_TGT]
+    private def locale = job[LC_TGT]
+    private def english_text_id = job[SLUG]
+
+    private def gengo_job
+      # Not using find_or_create_by because the find_by doesn't make an external API request
+      @gengo_job ||= GengoJob.find_by(translation_job_id: ) || create_gengo_job
+    end
 
     private def translated_text
-      @translated_text ||= TranslatedText.find_or_create_by(
-        english_text_id: job[SLUG],
-        translation_job_id: job[JOB_ID],
-        locale: job[LC_TGT]
+      TranslatedText.create(
+        english_text_id: gengo_job.english_text_id,
+        locale:,
+        translation: new_translation,
+        source_api: TranslatedText::GENGO_SOURCE
       )
     end
+
+    private def create_gengo_job
+      GengoJob.create(
+        english_text_id:,
+        translation_job_id:,
+        locale:
+      )
+    end
+
   end
 end

--- a/services/QuillLMS/app/services/open_ai/translate.rb
+++ b/services/QuillLMS/app/services/open_ai/translate.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module OpenAI
+  class Translate < ApplicationService
+    include OpenAI::Api
+    PROMPT_START = <<~STRING
+      can you translate the following phrase from english into latin american spanish for me? Please return just the translated text preserving (but not translating) the HTML. I'd also like to receive valid JSON as the response. We are translating the instructions for an English-language grammar activity. The content of the activity itself is not translated. Therefore, please leave words that sound like they are part of the activity in the original english. Often they will between an HTML tag such as in <em>english word</em> or <ul>english word</ul>.
+      Here is what I want translated:
+
+    STRING
+
+    ENDPOINT = '/chat/completions'
+    MODEL = 'gpt-4-turbo'
+
+    KEY_ROLE = "role"
+    KEY_CONTENT = "content"
+    ROLE_SYSTEM = "system"
+    ROLE_USER = "user"
+    ROLE_ASSISTANT = "assistant"
+    RESPONSE_FORMAT = { "type" => "json_object" }
+    attr_reader :english_text
+
+    def initialize(english_text:)
+      @english_text = english_text
+    end
+
+    private def system_prompt = PROMPT_START + english_text
+    private def system_message = {KEY_ROLE => ROLE_SYSTEM, KEY_CONTENT => system_prompt}
+
+    def cleaned_results
+      return nil if response&.body&.nil?
+
+      result_json_string
+    end
+
+    private def result_json_string
+      response
+        .parsed_response['choices']
+        &.first
+        &.dig('message', 'content')
+    end
+
+    def endpoint = ENDPOINT
+
+    def messages = [system_message]
+
+    def request_body
+      {
+        model: MODEL,
+        messages: messages,
+        n: 1,
+        response_format: RESPONSE_FORMAT
+      }
+    end
+  end
+end

--- a/services/QuillLMS/app/services/open_ai/translate_and_save_text.rb
+++ b/services/QuillLMS/app/services/open_ai/translate_and_save_text.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module OpenAI
+  class TranslateAndSaveText < ApplicationService
+
+    class OpenAITranslationError < StandardError; end
+    attr_reader :english_text, :locale
+
+    def initialize(english_text, locale: TranslatedText::DEFAULT_LOCALE)
+      @english_text = english_text
+      @locale = locale
+    end
+
+    def run
+      raise OpenAITranslationError unless response.present?
+
+      translated_text.update(translation: response)
+    end
+
+    private def response = @response ||= Translate.run(english_text: english_text.text)
+    private def source_api = TranslatedText::OPEN_AI_SOURCE
+    private def translated_text = @translated_text || TranslatedText.find_or_initialize_by(english_text:, locale:, source_api:)
+  end
+end

--- a/services/QuillLMS/app/workers/gengo/save_translated_text_worker.rb
+++ b/services/QuillLMS/app/workers/gengo/save_translated_text_worker.rb
@@ -7,7 +7,7 @@ module Gengo
     sidekiq_options queue: SidekiqQueue::LOW
 
     def perform(job_id)
-      SaveTranslatedText.run(job_id)
+      Gengo::SaveTranslatedText.run(job_id)
     end
   end
 end

--- a/services/QuillLMS/config/initializers/gengo.rb
+++ b/services/QuillLMS/config/initializers/gengo.rb
@@ -5,5 +5,3 @@ GengoAPI = Gengo::API.new({
   public_key: ENV["GENGO_PUBLIC_KEY"],
   sandbox: !Rails.env.production?
 })
-
-Gengo::SPANISH_LOCALE = "es-la"

--- a/services/QuillLMS/db/migrate/20240621215153_create_openai_translated_texts.rb
+++ b/services/QuillLMS/db/migrate/20240621215153_create_openai_translated_texts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateOpenaiTranslatedTexts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :openai_translated_texts do |t|
+      t.integer :english_text_id, null: false
+      t.text :translation, null: false
+      t.string :locale, null: false
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20240625131834_combine_translation_tables_and_add_gengo_table.rb
+++ b/services/QuillLMS/db/migrate/20240625131834_combine_translation_tables_and_add_gengo_table.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CombineTranslationTablesAndAddGengoTable < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :translated_texts
+    rename_table :openai_translated_texts, :translated_texts
+    add_column :translated_texts, :source_api, :string
+
+  end
+end

--- a/services/QuillLMS/db/migrate/20240625142619_create_gengo_jobs.rb
+++ b/services/QuillLMS/db/migrate/20240625142619_create_gengo_jobs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateGengoJobs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :gengo_jobs do |t|
+      t.integer :english_text_id, null: false
+      t.integer :translated_text_id
+      t.string :translation_job_id, null: false
+      t.string :locale, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3872,6 +3872,40 @@ ALTER SEQUENCE public.firebase_apps_id_seq OWNED BY public.firebase_apps.id;
 
 
 --
+-- Name: gengo_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.gengo_jobs (
+    id bigint NOT NULL,
+    english_text_id integer NOT NULL,
+    translated_text_id integer,
+    translation_job_id character varying NOT NULL,
+    locale character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: gengo_jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.gengo_jobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: gengo_jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.gengo_jobs_id_seq OWNED BY public.gengo_jobs.id;
+
+
+--
 -- Name: images; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5849,11 +5883,11 @@ ALTER SEQUENCE public.topics_id_seq OWNED BY public.topics.id;
 CREATE TABLE public.translated_texts (
     id bigint NOT NULL,
     english_text_id integer NOT NULL,
-    translation text,
+    translation text NOT NULL,
     locale character varying NOT NULL,
-    translation_job_id character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    source_api character varying
 );
 
 
@@ -6060,8 +6094,7 @@ CREATE TABLE public.user_activity_classifications (
     user_id bigint,
     activity_classification_id bigint,
     count integer DEFAULT 0,
-    created_at timestamp(6) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp(6) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+    created_at timestamp(6) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 
@@ -7056,6 +7089,13 @@ ALTER TABLE ONLY public.file_uploads ALTER COLUMN id SET DEFAULT nextval('public
 --
 
 ALTER TABLE ONLY public.firebase_apps ALTER COLUMN id SET DEFAULT nextval('public.firebase_apps_id_seq'::regclass);
+
+
+--
+-- Name: gengo_jobs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gengo_jobs ALTER COLUMN id SET DEFAULT nextval('public.gengo_jobs_id_seq'::regclass);
 
 
 --
@@ -8377,6 +8417,14 @@ ALTER TABLE ONLY public.file_uploads
 
 ALTER TABLE ONLY public.firebase_apps
     ADD CONSTRAINT firebase_apps_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: gengo_jobs gengo_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gengo_jobs
+    ADD CONSTRAINT gengo_jobs_pkey PRIMARY KEY (id);
 
 
 --
@@ -12020,8 +12068,11 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240620115611'),
 ('20240620123025'),
 ('20240620152448'),
+('20240621215153'),
 ('20240625123600'),
+('20240625131834'),
 ('20240625135530'),
+('20240625142619'),
 ('20240625205613'),
 ('20240626142949'),
 ('20240627001654'),

--- a/services/QuillLMS/lib/tasks/temporary/translate.rake
+++ b/services/QuillLMS/lib/tasks/temporary/translate.rake
@@ -3,9 +3,110 @@
 namespace :translate do
   desc 'translate hints (concept feedback)'
   task hints: :environment do
-    hints = ConceptFeedback.limit(3)
-    hints.map(&:create_translation_mappings)
-    english_texts = hints.map(&:english_texts).flatten
-    Gengo::RequestTranslations.run(english_texts)
+    hints = ConceptFeedback.all
+    count = hints.count
+    hints.each_with_index do |hint, index|
+      puts "translating #{index + 1}/#{count}..."
+      res = Evidence::OpenAI::Translate.run(english_text: hint.description)
+      hint.create_translation_mappings
+      hint.english_texts.first.openai_translated_texts.create(
+        translation: res,
+        locale: TranslatedText::DEFAULT_LOCALE)
+    end
+
+  end
+
+  task activities: :environment do
+    activities = Activity.where("id in (?)", activity_ids).limit(50)
+    CSV.open("open_ai_spanish_activities.csv", "wb") do |csv|
+      csv << ["english", "spanish"]
+      activities.each_with_index do |activity, index|
+        puts "translating #{index + 1}/50..."
+        html = activity.data["landingPageHtml"]
+        next unless html.present?
+
+        res = Evidence::OpenAI::Translate.run(english_text: html)
+        csv << [html, res]
+        puts ""
+      end
+    end
+  end
+
+  task questions: :environment do
+    activities = Activity.where("id in (?)", activity_ids).limit(1)
+    CSV.open("open_ai_spanish_questions.csv", "wb") do |csv|
+      csv << ["question_id", "question_uid", "english", "spanish"]
+      activities.each_with_index do |activity, index|
+        puts "translating activity #{index + 1}/50..."
+        questions = activity.data["questions"]
+        next if questions.empty?
+
+        length = questions.length
+        questions.each_with_index do |q, q_index|
+          puts "translating question #{q_index + 1}/#{length} for activity #{index + 1}"
+          question = Question.find_by(uid: q["key"])
+          instruction = question.data["instructions"]
+          next unless instruction.present?
+
+          res = Evidence::OpenAI::Translate.run(english_text: instruction)
+          csv << [question.id, question.uid, instruction, res]
+        end
+      end
+    end
+
+  end
+
+  def activity_ids
+    %w(
+      1100
+      1849
+      1127
+      1123
+      1101
+      1567
+      2119
+      1913
+      1569
+      1153
+      1834
+      1154
+      1852
+      1155
+      1904
+      1151
+      1853
+      1138
+      1662
+      2146
+      1551
+      1914
+      1581
+      2121
+      1571
+      1959
+      1657
+      2150
+      1658
+      2148
+      1135
+      1844
+      1157
+      1891
+      1156
+      1113
+      1114
+      1134
+      1843
+      1580
+      2117
+      1584
+      2124
+      1552
+      1916
+      1583
+      2123
+      1585
+      2125
+      )
   end
 end

--- a/services/QuillLMS/spec/factories/gengo_jobs.rb
+++ b/services/QuillLMS/spec/factories/gengo_jobs.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: gengo_jobs
+#
+#  id                 :bigint           not null, primary key
+#  locale             :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  english_text_id    :integer          not null
+#  translated_text_id :integer
+#  translation_job_id :string           not null
+#
+FactoryBot.define do
+  factory :gengo_job do
+    english_text
+    translation_job_id { 23 }
+    locale { TranslatedText::DEFAULT_LOCALE }
+  end
+end

--- a/services/QuillLMS/spec/factories/translated_texts.rb
+++ b/services/QuillLMS/spec/factories/translated_texts.rb
@@ -4,18 +4,24 @@
 #
 # Table name: translated_texts
 #
-#  id                 :bigint           not null, primary key
-#  locale             :string           not null
-#  translation        :text
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  english_text_id    :integer          not null
-#  translation_job_id :string           not null
+#  id              :bigint           not null, primary key
+#  locale          :string           not null
+#  source_api      :string
+#  translation     :text             not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  english_text_id :integer          not null
 #
 FactoryBot.define do
   factory :translated_text do
-    locale {Gengo::SPANISH_LOCALE}
-    english_text_id { 1 }
-    translation_job_id { 33 }
+    locale {TranslatedText::DEFAULT_LOCALE}
+    english_text
+    source_api { TranslatedText::OPEN_AI_SOURCE }
+    translation { Faker::Quotes::Shakespeare.as_you_like_it_quote }
+
+    factory :gengo_translated_text, class: 'TranslatedText' do
+      source_api { TranslatedText::GENGO_SOURCE }
+    end
   end
+
 end

--- a/services/QuillLMS/spec/models/concept_feedback_spec.rb
+++ b/services/QuillLMS/spec/models/concept_feedback_spec.rb
@@ -54,8 +54,9 @@ RSpec.describe ConceptFeedback, type: :model do
   end
 
   describe '#as_json' do
-    subject { concept_feedback.as_json }
+    subject { concept_feedback.as_json(options) }
 
+    let(:options) { nil }
     let(:data) { concept_feedback.data }
 
     context 'there are no translations' do
@@ -74,39 +75,116 @@ RSpec.describe ConceptFeedback, type: :model do
       it 'adds the translations to the data' do
         expect(subject["translatedDescription"]).to eq(translation)
       end
+
+      context 'there is only a gengo translation' do
+        let(:translated_text) { create(:gengo_translated_text, translation: translation)}
+
+        it 'adds the translations to the data' do
+          expect(subject["translatedDescription"]).to eq(translation)
+        end
+      end
+
+      context 'there is a gengo and open ai translation' do
+        let(:gengo_text) { create(:gengo_translated_text)}
+
+        before do
+          concept_feedback.english_texts.first.translated_texts = [gengo_text, translated_text]
+        end
+
+        it 'defaults to the open_ai translation' do
+          expect(subject["translatedDescription"]).to eq(translation)
+        end
+
+        context 'passed in gengo as an option' do
+          let(:options) { {source_api: TranslatedText::GENGO_SOURCE} }
+
+          it 'returns the gengo translation' do
+            expect(subject["translatedDescription"]).to eq(gengo_text.translation)
+          end
+        end
+
+      end
     end
   end
 
-  describe '#translation(locale:)' do
+  describe '#translation(locale:, source:)' do
     let(:locale) {"es-la"}
+    let(:translation_locale) { locale }
+    let(:source_api) { TranslatedText::OPEN_AI_SOURCE }
 
-    subject { concept_feedback.translation(locale: locale)}
+    context 'source is not passed in' do
+      subject { concept_feedback.translation(locale: locale)}
 
-    context 'a translation exists' do
-      let(:translation) { "test translation" }
-      let(:translated_text) { create(:translated_text, translation: translation, locale: translation_locale)}
+      context 'a translation exists' do
+        let(:translation) { "test translation" }
+        let(:translated_text) do
+          create(:translated_text,
+           translation: translation,
+           locale: translation_locale,
+           source_api:
+          )
+        end
 
-      before do
-        concept_feedback.create_translation_mappings
-        concept_feedback.english_texts.first.translated_texts << translated_text
+        before do
+          concept_feedback.create_translation_mappings
+          concept_feedback.english_texts.first.translated_texts << translated_text
+        end
+
+        context 'the translation is from open_ai' do
+          context 'there is a translation for the locale' do
+            it {expect(subject).to eq(translation)}
+          end
+
+          context 'there are only translations for different locales' do
+            let(:translation_locale) { "jp" }
+
+            it {expect(subject).to be_nil}
+          end
+        end
+
+        context 'the translation is from gengo' do
+          let(:source) { TranslatedText::GENGO_SOURCE}
+
+          it { expect(subject).to eq(translation)}
+        end
+
+        context 'there are two translations' do
+          let(:gengo_translation) { create(:gengo_translated_text) }
+
+          before do
+            concept_feedback.english_texts.first.translated_texts << gengo_translation
+          end
+
+          it 'returns the open ai translation' do
+            expect(subject).to eq(translation)
+          end
+        end
       end
 
-      context 'there is a translation for the locale' do
-        let(:translation_locale) { locale }
-
-        it {expect(subject).to eq(translation)}
-      end
-
-      context 'there are only translations for different locales' do
-        let(:translation_locale) { "jp" }
-
+      context 'there are no translations' do
         it {expect(subject).to be_nil}
       end
+
     end
 
-    context 'there are no translations' do
-      it {expect(subject).to be_nil}
+    context 'the source is gengo' do
+      subject { concept_feedback.translation(locale: locale, source_api: TranslatedText::GENGO_SOURCE)}
+
+      context 'there are two translations' do
+        let(:gengo_translated_text) { create(:gengo_translated_text) }
+        let(:open_ai_translated_text) { create(:translated_text) }
+
+        before do
+          concept_feedback.create_translation_mappings
+          concept_feedback.english_texts.first.translated_texts = [open_ai_translated_text, gengo_translated_text]
+        end
+
+        it 'returns the gengo translation' do
+          expect(subject).to eq(gengo_translated_text.translation)
+        end
+      end
     end
+
   end
 
   describe '#callbacks' do
@@ -192,19 +270,64 @@ RSpec.describe ConceptFeedback, type: :model do
     end
   end
 
-  describe "#fetch_translations!" do
-    context "there is a translated_text associated" do
-      let(:t1) { create(:translated_text)}
-      let(:t2) { create(:translated_text)}
+  describe "#gengo_jobs" do
+    subject { concept_feedback.gengo_jobs }
 
-      it "calls fetch_translation! on each of the translated_text" do
-        allow(concept_feedback).to receive(:translated_texts)
-        .and_return([t1, t2])
-        expect(t1).to receive(:fetch_translation!)
-        expect(t2).to receive(:fetch_translation!)
+    let(:english_text) { create(:english_text)}
+    let!(:gengo_job) { create(:gengo_job, english_text:)}
+    let(:concept_feedback) { create(:concept_feedback) }
+    let!(:mapping) { create(:translation_mapping, english_text:, source: concept_feedback)}
+
+    it { expect(subject).to include(gengo_job)}
+  end
+
+  describe "#fetch_translations!" do
+    context "there is a gengo_job associated" do
+      let(:translation1) { create(:gengo_job)}
+      let(:translation2) { create(:gengo_job)}
+
+      before do
+        allow(concept_feedback).to receive(:gengo_jobs)
+        .and_return([translation1, translation2])
+      end
+
+      it "calls fetch_translation! on each of the gengo jobs" do
+        expect(translation1).to receive(:fetch_translation!)
+        expect(translation2).to receive(:fetch_translation!)
         concept_feedback.fetch_translations!
       end
     end
   end
 
+  describe "#translate!(source_api)" do
+    subject { concept_feedback.translate!(locale:, source_api:)}
+
+    let(:locale) { TranslatedText::DEFAULT_LOCALE }
+    let(:concept_feedback) { create(:concept_feedback)}
+
+    before do
+      concept_feedback.create_translation_mappings
+    end
+
+    context 'open_ai' do
+      let(:source_api) {TranslatedText::OPEN_AI_SOURCE}
+
+      it 'sends a request to the OpenAI api' do
+        concept_feedback.english_texts.each do |text|
+          expect(OpenAI::TranslateAndSaveText).to receive(:run)
+            .with(text)
+        end
+        subject
+      end
+    end
+
+    context 'gengo' do
+      let(:source_api) {TranslatedText::GENGO_SOURCE}
+
+      it 'requests translations for the english_texts' do
+        expect(Gengo::RequestTranslations).to receive(:run).with(concept_feedback.english_texts, locale)
+        subject
+      end
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/english_text_spec.rb
+++ b/services/QuillLMS/spec/models/english_text_spec.rb
@@ -17,31 +17,34 @@ RSpec.describe EnglishText, type: :model do
     it {should have_many(:translation_mappings) }
   end
 
-  describe "#needs_translation?(locale:)" do
-    subject { english_text.needs_translation?(locale: locale) }
+  describe "#gengo_translation?(locale:)" do
+    subject { english_text.gengo_translation?(locale: locale) }
 
     let(:english_text) { create(:english_text) }
-    let(:locale) { Gengo::SPANISH_LOCALE }
-    let!(:translated_text) {
-      create(:translated_text,
-      english_text: english_text,
-      locale: other_locale)
-    }
+    let(:locale) { TranslatedText::DEFAULT_LOCALE }
+    let!(:gengo_job) do
+      create(
+        :gengo_job,
+        english_text:,
+        locale: other_locale
+      )
+    end
+
 
     context 'there is a translated_text record associated with that locale' do
       let(:other_locale) { locale }
 
-      it { is_expected.to be false }
+      it { is_expected.to be true }
 
-      it "defaults to Gengo::SPANISH_LOCALE" do
-        expect(english_text.needs_translation?).to be false
+      it "defaults to TranslatedText::DEFAULT_LOCALE" do
+        expect(english_text.gengo_translation?).to be true
       end
     end
 
     context 'there is not a translated_text record with that locale' do
       let(:other_locale) { "jp" }
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
   end
 end

--- a/services/QuillLMS/spec/models/gengo_job_spec.rb
+++ b/services/QuillLMS/spec/models/gengo_job_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: gengo_jobs
+#
+#  id                 :bigint           not null, primary key
+#  locale             :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  english_text_id    :integer          not null
+#  translated_text_id :integer
+#  translation_job_id :string           not null
+#
+require 'rails_helper'
+
+RSpec.describe GengoJob, type: :model do
+  describe "self.pending_translation" do
+    subject { GengoJob.pending_translation }
+
+    let!(:untranslated) { create(:gengo_job) }
+    let!(:complete) { create(:gengo_job, translated_text_id: 2) }
+
+    it { expect(subject).to include(untranslated) }
+    it { expect(subject).not_to include(complete) }
+  end
+
+  describe "fetch_and_save_pending!" do
+    subject { GengoJob.fetch_and_save_pending! }
+
+    let(:untranslated) { create(:gengo_job) }
+    let!(:complete) { create(:gengo_job, translated_text_id: 2) }
+
+    it "calls fetch_translation! on all the pending translations" do
+      expect(GengoJob).to receive(:pending_translation)
+      .and_return([untranslated])
+      expect(untranslated).to receive(:fetch_translation!)
+      expect(complete).not_to receive(:fetch_translation!)
+      subject
+    end
+  end
+
+  describe "fetch_translation!" do
+    subject {gengo_job.fetch_translation!}
+
+    let(:gengo_job) { create(:gengo_job) }
+
+    it do
+      expect(Gengo::SaveTranslatedTextWorker).to receive(:perform_async)
+      .with(gengo_job.translation_job_id)
+      subject
+    end
+  end
+end

--- a/services/QuillLMS/spec/models/translated_text_spec.rb
+++ b/services/QuillLMS/spec/models/translated_text_spec.rb
@@ -4,54 +4,51 @@
 #
 # Table name: translated_texts
 #
-#  id                 :bigint           not null, primary key
-#  locale             :string           not null
-#  translation        :text
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  english_text_id    :integer          not null
-#  translation_job_id :string           not null
+#  id              :bigint           not null, primary key
+#  locale          :string           not null
+#  source_api      :string
+#  translation     :text             not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  english_text_id :integer          not null
 #
 require 'rails_helper'
 
 RSpec.describe TranslatedText, type: :model do
-  describe "self.pending_translation" do
-    subject { TranslatedText.pending_translation }
-
-    let!(:untranslated) { create(:translated_text) }
-    let!(:complete) { create(:translated_text, translation: "foo") }
-
-    it { expect(subject).to(include{untranslated}) }
-    it { expect(subject).not_to(include{complete}) }
-
+  describe 'active_record associations' do
+    it {should belong_to(:english_text) }
   end
 
-  describe "fetch_and_save_pending!" do
-    subject { TranslatedText.fetch_and_save_pending! }
+  describe 'ordered_by_source_api' do
+    let!(:gengo_text) { create(:gengo_translated_text).translation }
+    let!(:open_ai_text) { create(:translated_text).translation }
 
-    let(:untranslated) { create(:translated_text) }
-    let(:complete) { create(:translated_text, translation: "foo") }
+    context 'no source API' do
+      subject{ TranslatedText.ordered_by_source_api }
 
-    it "calls fetch_translation! on all the pending translations" do
-      expect(TranslatedText).to receive(:pending_translation)
-      .and_return([untranslated])
-      expect(untranslated).to receive(:fetch_translation!)
-      expect(complete).not_to receive(:fetch_translation!)
-      subject
+      it { expect(subject.map(&:translation)).to eq([open_ai_text, gengo_text])}
     end
 
+    context 'with a source API' do
+      subject{ TranslatedText.ordered_by_source_api(source_api) }
 
-  end
+      context 'open_ai' do
+        let(:source_api) {TranslatedText::OPEN_AI_SOURCE}
 
-  describe "fetch_translation!" do
-    subject {translated_text.fetch_translation!}
+        it { expect(subject.map(&:translation)).to eq([open_ai_text, gengo_text])}
+      end
 
-    let(:translated_text) { create(:translated_text) }
+      context 'gengo' do
+        let(:source_api) {TranslatedText::GENGO_SOURCE}
 
-    it do
-      expect(Gengo::SaveTranslatedText).to receive(:run)
-      .with(translated_text.translation_job_id)
-      subject
+        it { expect(subject.map(&:translation)).to eq([gengo_text, open_ai_text])}
+      end
+
+      context 'not in our list' do
+        let(:source_api) { "sql injection attempt" }
+
+        it { expect(subject.map(&:translation)).to eq([open_ai_text, gengo_text])}
+      end
     end
   end
 end

--- a/services/QuillLMS/spec/services/concerns/open_ai/api_spec.rb
+++ b/services/QuillLMS/spec/services/concerns/open_ai/api_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module OpenAI
+  RSpec.describe(OpenAI::Api, type: :model) do
+
+    let(:endpoint) {'https://api.openai.com/v1/some_endpoint'}
+    let(:sample_response_body) {{"key"=>"value"}}
+
+    # include headers in response for proper parsing by HTTParty
+    let(:sample_response) { {body: sample_response_body.to_json, headers: {content_type: 'application/json'}} }
+
+    let(:class_without_defined_methods) { Class.new { include ::OpenAI::Api } }
+
+    let(:class_with_methods) do
+      Class.new do
+        include OpenAI::Api
+
+        def request_body = {}
+        def endpoint = '/some_endpoint'
+        def cleaned_results = response.body
+      end
+    end
+
+    context "#class_without_defined_methods" do
+      it "should raise an error on run" do
+        expect{class_without_defined_methods.new.run}.to raise_error(NotImplementedError)
+      end
+    end
+
+    context "#class_with_defined_methods" do
+      it "should run" do
+        stub_request(:post, endpoint).to_return(sample_response)
+        expect(JSON.parse(class_with_methods.new.run)).to eq(sample_response_body)
+      end
+    end
+
+    context "#run hitting a timeout" do
+      it "should rescue and return an empty array" do
+        stub_request(:post, endpoint).to_timeout
+        expect(class_with_methods.new.run).to eq([])
+      end
+    end
+
+    context "#post_request" do
+      let(:api_response) { class_with_methods.new.send(:post_request) }
+
+      it "should pass a timeout" do
+        stub_request(:post, endpoint).to_return(sample_response)
+        expect(api_response.request.options[:timeout]).to eq 300
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/gengo/request_translations_spec.rb
+++ b/services/QuillLMS/spec/services/gengo/request_translations_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Gengo::RequestTranslations, type: :service do
         type: "text",
         body_src: text2.text,
         lc_src: "en",
-        lc_tgt: Gengo::SPANISH_LOCALE,
+        lc_tgt: TranslatedText::DEFAULT_LOCALE,
         tier: "standard",
         auto_approve: true,
         slug: text2.id,
@@ -30,7 +30,7 @@ RSpec.describe Gengo::RequestTranslations, type: :service do
         type: "text",
         body_src: text1.text,
         lc_src: "en",
-        lc_tgt: Gengo::SPANISH_LOCALE,
+        lc_tgt: TranslatedText::DEFAULT_LOCALE,
         tier: "standard",
         auto_approve: true,
         slug: text1.id,
@@ -40,7 +40,7 @@ RSpec.describe Gengo::RequestTranslations, type: :service do
     end
     let(:combined_payload) { { text1.id.to_s => text1_payload, text2.id.to_s => text2_payload }}
 
-    subject { described_class.new([text1, text2]).gengo_payload}
+    subject { described_class.new([text1, text2], TranslatedText::DEFAULT_LOCALE).gengo_payload}
 
     context "the english text does not yet have a translation for that language" do
       it "creates a gengo payload for the english text" do
@@ -50,7 +50,7 @@ RSpec.describe Gengo::RequestTranslations, type: :service do
 
     context "the english text already has a translated_text for that language" do
       it "does not add that text to the payload" do
-        text1.translated_texts << create(:translated_text, locale: Gengo::SPANISH_LOCALE)
+        text1.gengo_jobs << create(:gengo_job, locale: TranslatedText::DEFAULT_LOCALE)
         expect(subject).to eq({text2.id.to_s => text2_payload})
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe Gengo::RequestTranslations, type: :service do
 
 
   describe "run" do
-    subject { described_class.run([text1, text2])}
+    subject { described_class.run([text1, text2], TranslatedText::DEFAULT_LOCALE)}
 
     let(:order_id) { "123" }
 
@@ -91,7 +91,7 @@ RSpec.describe Gengo::RequestTranslations, type: :service do
     end
 
     context "the payload returns an empty hash" do
-      subject { described_class.run([])}
+      subject { described_class.run([], TranslatedText::DEFAULT_LOCALE)}
 
       it {
         subject

--- a/services/QuillLMS/spec/services/gengo/save_translated_text_spec.rb
+++ b/services/QuillLMS/spec/services/gengo/save_translated_text_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe Gengo::SaveTranslatedText, type: :service do
   describe "run" do
     subject { described_class.run(job_id)}
 
+    let(:status) { "available" }
     let(:order_id) { "123" }
     let(:job_id) { "124" }
     let(:english_text_id) { "1493" }
-    let(:locale) { Gengo::SPANISH_LOCALE }
+    let(:locale) { TranslatedText::DEFAULT_LOCALE }
     let(:job_payload) do
       {"job_id"=> job_id,
             "order_id"=> order_id,
@@ -43,104 +44,85 @@ RSpec.describe Gengo::SaveTranslatedText, type: :service do
       allow(GengoAPI).to receive(:getTranslationJob).and_return(response)
     end
 
-    context 'the response status is available' do
-      let(:status) { "available" }
 
-      it do
-        expect { subject }
-          .to change(TranslatedText, :count)
-          .by(1)
-      end
+    it { expect{subject}.to change{GengoJob.where(english_text_id:, locale:, translation_job_id: job_id).count}.by(1) }
 
-      it do
-        expect { subject }
-          .to change {
-                TranslatedText
-                .where(english_text_id: english_text_id)
-                .count
-              }.by(1)
-      end
+    context 'the gengo_job already exists in our database' do
+      let(:translated_text_id) { nil }
+      let(:gengo_job) { create(:gengo_job, translation_job_id: job_id, translated_text_id:) }
 
-      it do
-        expect { subject }
-          .to change {
-                TranslatedText
-                .where(locale:)
-                .count
-              }.by(1)
-      end
+      before { gengo_job }
 
-      it do
-        expect { subject }
-          .to change {
-                TranslatedText
-                .where(translation_job_id: job_id)
-                .count
-              }.by(1)
-      end
+      it { expect{subject}.to not_change(GengoJob, :count) }
 
-      it "doesn't update if the translated_text" do
-        translated_text = create(:translated_text,
-        translation_job_id: job_id,
-        english_text_id: english_text_id,
-        translation: "Foo",
-        locale:)
-        expect {subject}.not_to change {translated_text.reload.translation}
-      end
+      context 'the gengo_job already has a translation' do
+        let(:translated_text) { create(:gengo_translated_text) }
+        let(:translated_text_id) { translated_text.id }
 
-      context 'gengo payload contains translated text' do
-        let(:translated_text) { "test translation" }
-        let(:response_job) do
-          job_payload.merge({"body_tgt" => translated_text })
+        it do
+          expect(GengoAPI).not_to receive(:getTranslationJob)
+          subject
         end
 
         it do
-          expect { subject }
-            .to change {
-                  TranslatedText
-                  .find_by(translation_job_id: job_id)
-                  &.translation
-                }.to(translated_text)
-        end
-
-        context 'gengo payload has the same translation as the db model' do
-          let(:translation_text) { create(:translated_text, translation: translated_text)}
-
-          before do
-            allow(TranslatedText).to receive(:find_or_create_by)
-            .and_return(translation_text)
-          end
-
-          it do
-            expect(translation_text).not_to receive(:update)
-            subject
-          end
+          expect{subject}.to not_change(TranslatedText, :count)
+            .and not_change(gengo_job, :translated_text_id)
         end
       end
-    end
 
-    context 'the response status is deleted' do
-      let(:status) { "deleted" }
+      context 'the gengo job does not have a translation' do
+        context 'the response status is available' do
+          let(:status) { "available" }
 
-      it 'does not save the translated text' do
-        expect { subject }
-          .not_to change(TranslatedText, :count)
+          it { expect{subject}.to not_change(TranslatedText, :count) }
+
+          context 'gengo payload contains translated text' do
+            let(:translation) { "Usa una letra mayuscula para indicar que es un nombre." }
+            let(:response_job) do
+              job_payload.merge({"body_tgt" => translation })
+            end
+
+            it { expect{subject}.to change(TranslatedText, :count).by(1) }
+
+            it do
+              expect{subject}.to change{TranslatedText.where(translation:, source_api: TranslatedText::GENGO_SOURCE).count}
+                .from(0)
+                .to(1)
+            end
+
+            it do
+              translated_text = create(:gengo_translated_text, translation:)
+              expect(TranslatedText).to receive(:create).and_return(translated_text)
+              expect{subject}.to change{ gengo_job.reload.translated_text_id}.to(translated_text.id)
+            end
+          end
+
+        end
+
+        context 'the response status is deleted' do
+          let(:status) { "deleted" }
+
+          it 'does not save the translated text' do
+            expect { subject }
+              .not_to change(TranslatedText, :count)
+          end
+        end
+
+        context 'the response status is canceled' do
+          let(:status) { "canceled" }
+
+          it 'does not save the translated text' do
+            expect { subject }
+              .not_to change(TranslatedText, :count)
+          end
+        end
+
+        context "the response is nil" do
+          let(:response) { nil }
+
+          it { expect{subject}.to raise_error(described_class::FetchTranslationJobError)}
+        end
       end
-    end
-
-    context 'the response status is canceled' do
-      let(:status) { "canceled" }
-
-      it 'does not save the translated text' do
-        expect { subject }
-          .not_to change(TranslatedText, :count)
-      end
-    end
-
-    context "the response is nil" do
-      let(:response) { nil }
-
-      it { expect{subject}.to raise_error(described_class::FetchTranslationJobError)}
     end
   end
 end

--- a/services/QuillLMS/spec/services/open_ai/translate_and_save_text_spec.rb
+++ b/services/QuillLMS/spec/services/open_ai/translate_and_save_text_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe OpenAI::TranslateAndSaveText, type: :service do
+  describe "run" do
+    subject { described_class.run(english_text)}
+
+    let(:english_text) {create(:english_text)}
+    let(:text) { english_text.text}
+    let(:response) { "Do not go gentle into that good night" }
+    let(:locale) { TranslatedText::DEFAULT_LOCALE }
+
+    before do
+      allow(OpenAI::Translate).to receive(:run).with(english_text: text).and_return(response)
+    end
+
+    context 'the response is a success' do
+      it do
+        expect { subject }
+          .to change(TranslatedText, :count)
+          .by(1)
+      end
+
+      it do
+        expect { subject }
+          .to change {
+                TranslatedText
+                .where(english_text_id: english_text.id)
+                .count
+              }.by(1)
+      end
+
+      it "always translates to spanish" do
+        expect { subject }
+          .to change {
+                TranslatedText
+                .where(locale:)
+                .count
+              }.by(1)
+      end
+
+      it 'sets the translation to be the response' do
+        subject
+        expect(english_text.translated_texts.first.translation).to eq(response)
+      end
+
+      it "updates if the translated_text exists" do
+        translated_text = create(:translated_text,
+          english_text_id: english_text.id,
+          translation: "Foo",
+          locale:
+        )
+        subject
+        expect(translated_text.reload.translation).to eq(response)
+      end
+
+    end
+
+    context "the response is nil" do
+      let(:response) { nil }
+
+      it { expect{subject}.to raise_error(described_class::OpenAITranslationError)}
+    end
+  end
+end

--- a/services/QuillLMS/spec/services/open_ai/translate_spec.rb
+++ b/services/QuillLMS/spec/services/open_ai/translate_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OpenAI::Translate, type: :service do
+  subject { described_class.new(english_text:) }
+
+  let(:english_text) { 'some prompt' }
+
+  context 'test endpoint', external_api: true do
+    it { expect { subject.run }.not_to raise_error }
+  end
+
+  context 'test request body' do
+    let(:endpoint) { 'https://api.openai.com/v1/chat/completions' }
+    let(:content) { 'a text response' }
+    let(:body) do
+      {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "gpt-4-turbo-2024-04-09",
+        "system_fingerprint": "fp_44709d6fcb",
+        "choices": [{
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": content
+          },
+          "logprobs": nil,
+          "finish_reason": "stop"
+        }],
+        "usage": {
+          "prompt_tokens": 9,
+          "completion_tokens": 12,
+          "total_tokens": 21
+        }
+      }.to_json
+    end
+
+    let(:headers) { { content_type: 'application/json' } }
+
+    before { stub_request(:post, endpoint).to_return(body:, headers:) }
+
+    it { expect(subject.run).to eq content }
+  end
+end


### PR DESCRIPTION
* Add openAI as a translation option and move Gengo job sync into the gengo model so that translatedText can support either gengo or OpenAI

* Ensure that we can handle a nil options in the as_json method.

* Rubocop fixes.

* Add locale to initializer

* Make fetch_translations! Run an asynchronous job

* Delete unused method

* Don’t reference evidence module in open_ai concern.

* Change needs_gengo_translation? To has_gengo_translation?

* Change source to source_api

* Use better variable names

* Default hash name

* Remove unused methods

* Require source_api for translatedText

* Change Gengo::SPANISH_LOCALE to TranslatedText::DEFAULT_LOCALE

* Rename class

* Add newline

* Change factory to use association

* Use a one-liner for system_prompt

* Factory use association

* Update indentation

* Remove extraneous class

* Protect against SQL injection in custom order_by

* Use locale as a default argument

* Fix job_id -> Translation_job_id

* has_gengo_translation? => gengo_translation?

* Whitespace

* Fix name error

* Fix spec

* Use longer names

* Remove extra line to structure.sql

* Rollback accidental change

---------

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
