### PR TITLE
UI fixes/ AGDR spacing and Evidences Rules Analysis dropdown

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/data-export.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/data-export.scss
@@ -94,6 +94,12 @@
     }
 
     .data-table-body {
+      &:has(.empty-state-message) {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        margin: 18px 0px;
+      }
       .data-table-row {
         td {
           display: flex;

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/growth-diagnostic-reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_hub/growth-diagnostic-reports.scss
@@ -325,7 +325,7 @@ main {
         color: $quill-green;
       }
     }
-    .quill-button {
+    .quill-button-archived {
       margin-top: 16px;
       padding: 13px 16px;
       border-radius: 8px;

--- a/services/QuillLMS/client/app/bundles/Staff/styles/rules_analysis.scss
+++ b/services/QuillLMS/client/app/bundles/Staff/styles/rules_analysis.scss
@@ -1,14 +1,21 @@
 .rules-analysis-container {
   .dropdowns {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
     margin: 20px 0px;
     min-height: 58px;
     display: flex;
   }
 
   .dropdown-container {
-    max-width: 600px;
+    max-width: 1000px;
     width: 100%;
     margin-right: 40px;
+    min-height: 72px;
+    .html-dropdown-option {
+      margin-bottom: 16px;
+    }
   }
 
   .date-selection-container {


### PR DESCRIPTION
## WHAT
fix a few small UI issues in the AGDR and Evidence Rules Analysis tab

## WHY
we want the UI to look as expected

## HOW
just tweak the CSS

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1222" alt="Screen Shot 2024-07-02 at 10 25 53 AM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/d4a16109-8660-46c4-b8cc-0cd974d3f960">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Wonky-dropdown-on-Rules-Analysis-Page-af616737c2524c8fbd9405d256ed227d
https://www.notion.so/quill/Address-regressions-in-admin-report-ables-82b771bcb5b14052846f33a1002cc257

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
tested on staging that the UI renders as expected for the AGDR Data export page (with no data), the AGDR Student section page (Load more button spacing) and the Evidence Rules Analysis page (Select prompt dropdown)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no-- small CSS change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
