### PR TITLE
If the user writes in Dit or Van as their name, don’t lowercase it for them

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -473,7 +473,7 @@ class User < ApplicationRecord
   end
 
   def capitalize_name
-    self.name = ::CapitalizeNames.capitalize(name)
+    self.name = ::CapitalizeNames.capitalize(name, skip_van_space: true, skip_dit_space: true)
   end
 
   def admin?

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -389,16 +389,19 @@ RSpec.describe User, type: :model do
 
     context 'van is the first name' do
       let(:name) { 'van nieman'}
+
       it { expect { subject }.to change(user, :name).from(name).to('Van Nieman') }
     end
 
     context 'dit is the first name' do
       let(:name) { 'dit ditsy'}
+
       it { expect { subject }.to change(user, :name).from(name).to('Dit Ditsy') }
     end
 
     context 'van is in the middle' do
       let(:name) { 'betsy van foo'}
+
       it { expect { subject }.to change(user, :name).from(name).to('Betsy Van Foo') }
     end
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -386,6 +386,22 @@ RSpec.describe User, type: :model do
 
       it { expect { subject }.to change(user, :name).from(name).to('Test McTest') }
     end
+
+    context 'van is the first name' do
+      let(:name) { 'van nieman'}
+      it { expect { subject }.to change(user, :name).from(name).to('Van Nieman') }
+    end
+
+    context 'dit is the first name' do
+      let(:name) { 'dit ditsy'}
+      it { expect { subject }.to change(user, :name).from(name).to('Dit Ditsy') }
+    end
+
+    context 'van is in the middle' do
+      let(:name) { 'betsy van foo'}
+      it { expect { subject }.to change(user, :name).from(name).to('Betsy Van Foo') }
+    end
+
   end
 
   context 'capitalize_name callback' do


### PR DESCRIPTION
## WHAT
Our tests were sporadically failing when faker generated the name "Van" as a first name because it would not get capitalized as expected. 
## WHY
We are using a [capitalization gem](https://github.com/infiton/capitalize-names) that by default lowercases Van and Dit, but maybe those could be your first name! That would be weird for that person if their first name was not capitalized. 
## HOW
Passed in an option to skip the van and dit rules on the capitalize gem. 

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO, small change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
