### PR TITLE
Connect play bug2

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
@@ -2,8 +2,8 @@ import { stringNormalize } from 'quill-string-normalizer';
 import * as React from 'react';
 import { stripHtml } from "string-strip-html";
 import * as _ from 'underscore';
-import { checkFillInTheBlankQuestion, } from '../../../Shared/quill-marking-logic/src/main'
 
+import { checkFillInTheBlankQuestion, } from '../../../Shared/quill-marking-logic/src/main'
 import {
   ConceptExplanation,
   Feedback,
@@ -86,7 +86,8 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
     const { responses } = this.state
     const { question } = this.props
     let text
-    if (Object.keys(responses).length) {
+
+    if (responses && Object.keys(responses).length) {
       const responseArray = hashToCollection(responses).sort((a: Response, b: Response) => b.count - a.count)
       const firstOptimalResponse = responseArray.find((r: Response) => r.optimal)
       if (firstOptimalResponse) {

--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/fillInBlank.tsx
@@ -94,7 +94,7 @@ export class PlayFillInTheBlankQuestion extends React.Component<PlayFillInTheBla
       }
     }
     if (!text) {
-      text = question.answers[0].text.replace(/{|}/gm, '')
+      text = question?.answers?.[0]?.text?.replace(/{|}/gm, '')
     }
     return text
   }


### PR DESCRIPTION
## WHAT
There's a race condition when user plays through a question until the final correct response iteration. FillInBlank component state is saved when tabbing between `Responses` and `Play Question`, but when tabbing back to `PlayQuestion`, `FillInBlank` does not handle a null `state.responses` correctly 

## WHY
So that Curriculum can tab back and forth  between Responses and Play Question easily 

## HOW
Add guard clauses around `props.question` and `state.responses`
### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Page-crashes-when-playing-activity-in-fill-in-the-blank-CMS-f0fc28a742ea475aa9d23aff05133da7

### What have you done to QA this feature?
Go through the repro steps outlined in the Notion card, and confirm that no error is raised. 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - manual testing
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
