### PR TITLE
Alphabetize list items for Connect/Diagnostic Admin

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/concepts/concepts.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/concepts/concepts.jsx
@@ -17,6 +17,7 @@ class Concepts extends React.Component {
     const { data } = concepts
     const dataRow = data["0"];
     if (dataRow) {
+      dataRow.sort((a, b) => a.displayName.localeCompare(b.displayName))
       return dataRow.map((concept) => {
         return (
           <LinkListItem

--- a/services/QuillLMS/client/app/bundles/Connect/components/feedback/concepts-feedback.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/feedback/concepts-feedback.jsx
@@ -23,7 +23,7 @@ class ConceptsFeedback extends React.Component {
     const { concepts, conceptsFeedback } = this.props
     const { data } = concepts
     if (data && data["0"]) {
-      return data["0"].map((concept) => {
+      return data["0"].sort((a, b) => a.displayName.localeCompare(b.displayName)).map((concept) => {
         const hasFeedback = !!conceptsFeedback.data[concept.uid];
         return (
           <LinkListItem

--- a/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessons.jsx
@@ -53,7 +53,11 @@ class Lessons extends React.Component {
         })
       })
     }
-    keys.sort((a, b) => data[a].name.localeCompare(data[b].name))
+    keys.sort((a, b) => {
+      const firstName = data[a].name || 'No name'
+      const secondName = data[b].name || 'No name'
+      return firstName.localeCompare(secondName)
+    })
     return keys.map(key => {
       if (!data[key].questions) {
         return ''

--- a/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/lessons/lessons.jsx
@@ -53,6 +53,7 @@ class Lessons extends React.Component {
         })
       })
     }
+    keys.sort((a, b) => data[a].name.localeCompare(data[b].name))
     return keys.map(key => {
       if (!data[key].questions) {
         return ''

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/concepts/concepts.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/concepts/concepts.jsx
@@ -19,6 +19,7 @@ class Concepts extends React.Component {
     const { data } = concepts;
     const dataRow = data["0"];
     if (dataRow) {
+      dataRow.sort((a, b) => a.displayName.localeCompare(b.displayName))
       return dataRow.map((concept) => {
         const { uid, displayName } = concept;
         return (

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankQuestions.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankQuestions.jsx
@@ -46,7 +46,7 @@ class FillInBlankQuestions extends Component {
           <p className="menu-label">Fill In The Blank</p>
           <QuestionList
             basePath="fill-in-the-blanks"
-            questions={hashToCollection(diagnosticQuestions) || []}
+            questions={sortedDiagnosticQuestions}
             showOnlyArchived={showOnlyArchived}
           />
         </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankQuestions.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/fillInBlank/fillInBlankQuestions.jsx
@@ -35,6 +35,7 @@ class FillInBlankQuestions extends Component {
 
   render() {
     const { diagnosticQuestions, showOnlyArchived } = this.state;
+    const sortedDiagnosticQuestions = hashToCollection(diagnosticQuestions).sort((a, b) => a.prompt.localeCompare(b.prompt))
     return (
       <section className="section">
         <div className="admin-container">

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessons.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/lessons/lessons.jsx
@@ -45,6 +45,7 @@ class Lessons extends React.Component {
     if (this.state.showOnlyArchived) {
       keys = keys.filter(key => data[key].questions && data[key].questions.some(q => q.flag === 'archived'))
     }
+    keys.sort((a, b) => data[a].name.localeCompare(data[b].name))
     return keys.map(key => (
       <LinkListItem
         activeClassName='is-active'


### PR DESCRIPTION
## WHAT
Sort activities, questions and concepts in alphabetical order as requested by admin for Connect and Diagnostic tools.

## WHY
To make items easier to find in these lists.

## HOW
use sort() function to sort these lists before displaying them

### Screenshots
![Screenshot 2024-07-04 at 3 50 29 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/1e76eeb7-3391-4038-a17c-7505e8e159fc)
![Screenshot 2024-07-04 at 3 50 25 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/17b1c699-26f3-4ef3-aa47-3bdc8c954009)
![Screenshot 2024-07-04 at 3 50 21 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/ad1a649f-016b-4eca-81f0-3697220be53c)
![Screenshot 2024-07-04 at 3 50 12 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/8d7054d9-4113-42ff-875b-f3f75196688b)
![Screenshot 2024-07-04 at 3 50 08 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/bf4ad700-fd76-4637-8fa7-9b3d26108910)
![Screenshot 2024-07-04 at 3 50 04 PM](https://github.com/empirical-org/Empirical-Core/assets/57366100/685811ce-59e8-4e14-8dbb-8b0401214b4d)

### Notion Card Links
[
](https://www.notion.so/quill/Alphabetize-the-Connect-and-Diagnostic-CMS-f229d5e731f34200805e552515237d3d?pvs=4)

### What have you done to QA this feature?
Deploy to staging and check each page changed to confirm that the items are sorted.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
