### PR TITLE
Move logic for translations admin into the model and out of the view …

### DIFF
--- a/services/QuillLMS/app/models/translation_mapping.rb
+++ b/services/QuillLMS/app/models/translation_mapping.rb
@@ -15,4 +15,14 @@ class TranslationMapping < ApplicationRecord
   belongs_to :english_text
   belongs_to :source, polymorphic: true
   has_many :translated_texts, through: :english_text
+  delegate :text, to: :english_text
+  scope :translated, lambda { |locale|
+    joins(english_text: :translated_texts)
+      .where(translated_texts: { locale:})
+      .distinct
+  }
+
+  def translation(locale: Translatable::DEFAULT_LOCALE, source_api: Translatable::OPEN_AI_SOURCE)
+    translated_texts.where(locale:).ordered_by_source_api(source_api).first&.translation || ""
+  end
 end

--- a/services/QuillLMS/app/views/pages/translations.html.erb
+++ b/services/QuillLMS/app/views/pages/translations.html.erb
@@ -8,8 +8,8 @@
     <%@translations.each do |translation|%>
       <tr class="data-row">
         <td><%= translation.source.class.name %></td>
-        <td><%= raw(translation.english_text.text)%></td>
-        <td><%= raw(translation.translated_texts.ordered_by_source_api.first.translation) %></td>
+        <td><%= raw(translation.text)%></td>
+        <td><%= raw(translation.translation) %></td>
       </tr>
     <%end%>
   </tbody>

--- a/services/QuillLMS/spec/models/translation_mapping_spec.rb
+++ b/services/QuillLMS/spec/models/translation_mapping_spec.rb
@@ -16,5 +16,90 @@ RSpec.describe TranslationMapping, type: :model do
   describe 'active_record associations' do
     it {should belong_to(:english_text) }
     it {should belong_to(:source) }
+    it {should have_many(:translated_texts) }
   end
+
+  describe '.translated(language)' do
+    subject { TranslationMapping.translated(locale) }
+
+    let!(:mapping_no_translation) { create(:translation_mapping)}
+    let(:english_text) { create(:english_text)}
+    let(:locale) { Translatable::DEFAULT_LOCALE }
+    let!(:translated_text) { create(:translated_text, english_text:, locale: translated_locale)}
+    let!(:mapping_with_translation) { create(:translation_mapping, english_text:)}
+
+    context 'a mapping with translation in the correct locale' do
+      let(:translated_locale) { locale }
+
+      it 'only returns records that have a translated_text associated' do
+        expect(subject).to include(mapping_with_translation)
+        expect(subject).not_to include(mapping_no_translation)
+      end
+    end
+
+    context 'a mapping in the wrong locale' do
+      let(:translated_locale) { "jp" }
+
+      it 'does not return records in the wrong locale' do
+        expect(subject).not_to include(mapping_with_translation)
+      end
+    end
+  end
+
+  describe '#text' do
+    it { is_expected.to delegate_method(:text).to(:english_text) }
+  end
+
+  describe "#translation(locale:source:)" do
+    let(:translation_mapping) { create(:translation_mapping, english_text:)}
+    let(:english_text) { create(:english_text)}
+    let(:locale) { "fa" }
+    let(:source_api) { Translatable::GENGO_SOURCE }
+
+    context "there is a translation that does not match the source_api" do
+      subject { translation_mapping.translation(locale:, source_api:)}
+
+      let!(:translated_text_open_ai_source) { create(:translated_text, english_text:, locale:, source_api: Translatable::OPEN_AI_SOURCE)}
+
+      it "returns that translation" do
+        expect(subject).to eq(translated_text_open_ai_source.translation)
+      end
+    end
+
+    context 'there is a translation' do
+      let!(:translated_text_wrong_locale) { create(:translated_text, english_text:, locale: "jp", source_api:)}
+      let!(:translated_text_open_ai_source) { create(:translated_text, english_text:, locale:, source_api: Translatable::OPEN_AI_SOURCE)}
+      let!(:translated_text_gengo_source) { create(:translated_text, english_text:, locale:, source_api:)}
+
+      context "parameters passed in" do
+        subject { translation_mapping.translation(locale:, source_api:)}
+
+        it "returns the first translated_text record's translation for that locale and source" do
+          expect(subject).to eq(translated_text_gengo_source.translation)
+        end
+      end
+
+      context "no parameters passed in" do
+        let(:locale) { Translatable::DEFAULT_LOCALE }
+
+        subject { translation_mapping.translation }
+
+        it "defaults to open_ai and DEFAULT_LOCALE" do
+          expect(subject).to eq(translated_text_open_ai_source.translation)
+        end
+      end
+    end
+
+    context 'there is no translation' do
+      subject { translation_mapping.translation }
+
+      let(:translation_mapping) { create(:translation_mapping)}
+
+      it "returns an empty string" do
+        expect(subject).to eq("")
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
…(#12024)

* Factor translation_mapping logic into the logic and out of the view (plus catch some edge cases)

* Fix rubocop

---------

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
