### PR TITLE
stripe mailer should filter out unpaid subscriptions

### DIFF
--- a/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions_worker.rb
+++ b/services/QuillLMS/app/workers/identify_stripe_invoices_without_subscriptions_worker.rb
@@ -5,7 +5,7 @@ class IdentifyStripeInvoicesWithoutSubscriptionsWorker
 
   FAILED_CHARGE = 'failed'
   INVOICE_START_EPOCH = DateTime.new(2023,1,1).to_i # Date we began using this workflow
-  RELEVANT_INVOICE_STATUSES = ['open', 'paid'].freeze
+  RELEVANT_INVOICE_STATUSES = ['paid'].freeze
 
   def perform
     StripeIntegration::Mailer

--- a/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/identify_stripe_invoices_without_subscriptions_worker_spec.rb
@@ -7,6 +7,33 @@ RSpec.describe IdentifyStripeInvoicesWithoutSubscriptionsWorker do
 
   subject { described_class.new }
 
+  describe '#relevant_stripe_invoice?' do
+    let(:worker) { described_class.new }
+    let(:invoice) do
+      double(
+        amount_due: 1000,
+        status: 'paid',
+        id: 'inv_123',
+        charge: 'ch_123'
+      )
+    end
+
+    before do
+      allow(worker).to receive(:linked_quill_subscription?).and_return(false)
+      allow(worker).to receive(:invoice_refunded?).and_return(false)
+      allow(worker).to receive(:charge_failed?).and_return(false)
+    end
+
+    it 'returns true when all conditions are met' do
+      expect(worker.send(:relevant_stripe_invoice?, invoice)).to be true
+    end
+
+    it 'returns false when status is not in RELEVANT_INVOICE_STATUSES' do
+      allow(invoice).to receive(:status).and_return('open')
+      expect(worker.send(:relevant_stripe_invoice?, invoice)).to be false
+    end
+  end
+
   describe '#perform' do
     let(:mailer_double) { double(deliver_now!: nil) }
     let(:charge_double) { double(amount: 100, amount_refunded: 0, status: nil) }


### PR DESCRIPTION
## WHAT
1. filter out not-paid subscriptions from the Identify StripeInvoicesWithoutSubscriptionsWorker
2. filter at API time, rather than at API response time

## WHY
1. Because users (e.g. Peter Gault) don't expect open subscriptions to be flagged in this mailer 
2. Because the current logic takes over 6 minutes to process, and will only get longer with time

## HOW
1. Filter for `status = 'paid'` using the API

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-Stripe-Nightly-Email-Update-Logic-for-Flagging-Sales-that-Have-Missing-Subscriptions-a0a73e77f4854f94ae48ca33f4f4b062

### What have you done to QA this feature?
Send mailer to self

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
