### PR TITLE
lms/update-mat-view-for-new-column-type

### DIFF
--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_assigned_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/post_diagnostic_assigned_query.rb
@@ -10,7 +10,7 @@ module AdminDiagnosticReports
 
     def from_and_join_clauses
       super + <<-SQL
-        CROSS JOIN UNNEST(classroom_units.assigned_student_ids) AS assigned_student_id
+        CROSS JOIN UNNEST(JSON_VALUE_ARRAY(classroom_units.assigned_student_ids)) AS assigned_student_id
         JOIN lms.unit_activities
           ON classroom_units.unit_id = unit_activities.unit_id
         JOIN lms.activities AS post_activities

--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_assigned_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/pre_diagnostic_assigned_query.rb
@@ -10,7 +10,7 @@ module AdminDiagnosticReports
 
     def from_and_join_clauses
       super + <<-SQL
-        CROSS JOIN UNNEST(classroom_units.assigned_student_ids) AS assigned_student_id
+        CROSS JOIN UNNEST(JSON_VALUE_ARRAY(classroom_units.assigned_student_ids)) AS assigned_student_id
         JOIN lms.unit_activities
           ON classroom_units.unit_id = unit_activities.unit_id
         JOIN lms.activities

--- a/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/activities_assigned_query.rb
@@ -10,7 +10,7 @@ module Snapshots
     end
 
     def select_clause
-      "SELECT DISTINCT unit_activities.id, ARRAY_LENGTH(classroom_units.assigned_student_ids) AS assigned_count"
+      "SELECT DISTINCT unit_activities.id, ARRAY_LENGTH(JSON_VALUE_ARRAY(classroom_units.assigned_student_ids)) AS assigned_count"
     end
 
     def from_and_join_clauses

--- a/services/QuillLMS/app/queries/snapshots/activity_packs_assigned_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/activity_packs_assigned_query.rb
@@ -10,7 +10,7 @@ module Snapshots
     end
 
     def select_clause
-      "SELECT DISTINCT classroom_units.id, ARRAY_LENGTH(classroom_units.assigned_student_ids) AS assigned_count"
+      "SELECT DISTINCT classroom_units.id, ARRAY_LENGTH(JSON_VALUE_ARRAY(classroom_units.assigned_student_ids)) AS assigned_count"
     end
 
     def from_and_join_clauses

--- a/services/QuillLMS/app/queries/snapshots/baseline_diagnostics_assigned_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/baseline_diagnostics_assigned_query.rb
@@ -12,7 +12,7 @@ module Snapshots
     end
 
     def select_clause
-      "SELECT DISTINCT classroom_units.id, ARRAY_LENGTH(assigned_student_ids) AS students_assigned"
+      "SELECT DISTINCT classroom_units.id, ARRAY_LENGTH(JSON_VALUE_ARRAY(assigned_student_ids)) AS students_assigned"
     end
 
     def from_and_join_clauses

--- a/services/QuillLMS/app/queries/snapshots/growth_diagnostics_assigned_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/growth_diagnostics_assigned_query.rb
@@ -12,7 +12,7 @@ module Snapshots
     end
 
     def select_clause
-      "SELECT DISTINCT classroom_units.id, ARRAY_LENGTH(assigned_student_ids) AS students_assigned"
+      "SELECT DISTINCT classroom_units.id, ARRAY_LENGTH(JSON_VALUE_ARRAY(assigned_student_ids)) AS students_assigned"
     end
 
     def from_and_join_clauses

--- a/services/QuillLMS/app/queries/snapshots/most_assigned_activities_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/most_assigned_activities_query.rb
@@ -15,7 +15,7 @@ module Snapshots
 
     def from_and_join_clauses
       super + <<-SQL
-        JOIN (SELECT created_at, classroom_id, unit_id, ARRAY_LENGTH(assigned_student_ids) AS assigned_student_count FROM lms.classroom_units) AS classroom_units
+        JOIN (SELECT created_at, classroom_id, unit_id, ARRAY_LENGTH(JSON_VALUE_ARRAY(assigned_student_ids)) AS assigned_student_count FROM lms.classroom_units) AS classroom_units
           ON classrooms.id = classroom_units.classroom_id
         JOIN lms.unit_activities
           ON classroom_units.unit_id = unit_activities.unit_id

--- a/services/QuillLMS/app/queries/snapshots/top_concepts_assigned_query.rb
+++ b/services/QuillLMS/app/queries/snapshots/top_concepts_assigned_query.rb
@@ -15,7 +15,7 @@ module Snapshots
 
     def from_and_join_clauses
       super + <<-SQL
-        JOIN (SELECT created_at, classroom_id, unit_id, ARRAY_LENGTH(assigned_student_ids) AS assigned_student_count FROM lms.classroom_units) AS classroom_units
+        JOIN (SELECT created_at, classroom_id, unit_id, ARRAY_LENGTH(JSON_VALUE_ARRAY(assigned_student_ids)) AS assigned_student_count FROM lms.classroom_units) AS classroom_units
           ON classrooms.id = classroom_units.classroom_id
         JOIN lms.unit_activities
           ON classroom_units.unit_id = unit_activities.unit_id

--- a/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
+++ b/services/QuillLMS/db/big_query/views/pre_post_diagnostic_skill_group_performance_view.sql
@@ -35,7 +35,7 @@ SELECT
       FROM lms.classroom_units
       JOIN lms.unit_activities ON classroom_units.unit_id = unit_activities.unit_id
       JOIN lms.activities ON unit_activities.activity_id = activities.id
-      CROSS JOIN UNNEST(classroom_units.assigned_student_ids) AS assigned_student_id
+      CROSS JOIN UNNEST(JSON_VALUE_ARRAY(classroom_units.assigned_student_ids)) AS assigned_student_id
       LEFT OUTER JOIN (
         /* This sub-select is used to ensure that we only count the most recent completion from a student for a given activity in a given classroom */
         SELECT activity_sessions.*
@@ -105,7 +105,7 @@ SELECT
       FROM lms.classroom_units
       JOIN lms.unit_activities ON classroom_units.unit_id = unit_activities.unit_id
       JOIN lms.activities ON unit_activities.activity_id = activities.follow_up_activity_id
-      CROSS JOIN UNNEST(classroom_units.assigned_student_ids) AS assigned_student_id
+      CROSS JOIN UNNEST(JSON_VALUE_ARRAY(classroom_units.assigned_student_ids)) AS assigned_student_id
       LEFT OUTER JOIN (
         /* This sub-select is used to ensure that we only count the most recent completion from a student for a given activity in a given classroom */
         SELECT activity_sessions.*


### PR DESCRIPTION
## WHAT
Update queries to match new Airbyte behavior
## WHY
Airbyte has changed the way that it ETLs SQL `Array<Integer>` values so that they're now landing in BigQuery as JSON data.  We want our queries to work with the way data is actually getting put into BigQuery, and our spec behavior matches what Airbyte is actually doing when transferring data.
## HOW
- Explicitly parse the value from JSON into a scalar before calling `UNNEST` in queries.
- Update the spec test runner to explicitly make this JSON data in spec setup so that specs match real life expectations around data shape

### What have you done to QA this feature?
- Use new materialized view fallback in local environment to ensure that it runs and that data looks reasonable

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | No.  Staging using production BigQuery
Self-Review: Have you done an initial self-review of the code below on Github? | Yes