### PR TITLE
Update capitalization of names with a couple of edge cases

### DIFF
--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -120,6 +120,8 @@ class User < ApplicationRecord
 
   SCHOOL_CHANGELOG_ATTRIBUTE = 'school_id'
 
+  LEADING_CAPITALIZE_NAMES = %w(van dit)
+
   attr_accessor :newsletter,
     :require_password_confirmation_when_password_present,
     :skip_capitalize_names_callback,
@@ -473,7 +475,11 @@ class User < ApplicationRecord
   end
 
   def capitalize_name
-    self.name = ::CapitalizeNames.capitalize(name)
+    temp_name = ::CapitalizeNames.capitalize(name)
+    words = temp_name.split
+    words[0].capitalize! if words[0].in?(LEADING_CAPITALIZE_NAMES)
+
+    self.name = words.join(' ')
   end
 
   def admin?

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -367,7 +367,7 @@ RSpec.describe User, type: :model do
   describe '#capitalize_name' do
     subject { user.capitalize_name }
 
-    let(:user) { build(:user, name: name) }
+    let(:user) { build(:user, name:) }
 
     context 'single name' do
       let(:name) { 'test' }
@@ -385,6 +385,30 @@ RSpec.describe User, type: :model do
       let(:name) { 'test mctest'}
 
       it { expect { subject }.to change(user, :name).from(name).to('Test McTest') }
+    end
+
+    context 'van as first name' do
+      let(:name) { 'van Test'}
+
+      it { expect { subject }.to change(user, :name).from(name).to('Van Test') }
+    end
+
+    context 'van elsewhere in name' do
+      let(:name) { 'Test van Test'}
+
+      it { expect { subject }.not_to change(user, :name) }
+    end
+
+    context 'dit as first name' do
+      let(:name) { 'dit Test'}
+
+      it { expect { subject }.to change(user, :name).from(name).to('Dit Test') }
+    end
+
+    context 'dit elsewhere in name' do
+      let(:name) { 'Test dit Test'}
+
+      it { expect { subject }.not_to change(user, :name) }
     end
   end
 


### PR DESCRIPTION
## WHAT
Fix an edge case involving users whose first name is 'van' or 'dit'

## WHY
The capitalize_names gem lower cases these names.

## HOW
After the capitalize_name.capitalize, capitalize the first word if it is 'van' or 'dit' (since the capitalize_name gem will lowercase them).  We'd like to keep the existing functionality of the gem outside of these two cases.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I've created a user locally and going to create a user on staging to verify that capitalization happens with a first name: "van" and last_name: "user"

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
