### PR TITLE
Disable diagnostic assignment

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
@@ -130,6 +130,27 @@
     }
   }
   .diagnostic-page {
+    .disabled-diagnostic-banner {
+      max-width: 600px;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 16px;
+      background-color: $quill-yellow-50;
+      border-radius: 8px;
+      margin-bottom: 24px;
+      color: $quill-black;
+      font-size: 14px;
+      a {
+        margin-left: 8px;
+        font-weight: 700;
+        text-decoration: underline;
+        &:focus {
+          outline-offset: 2px;
+        }
+      }
+    }
     .filter-tabs {
       border-bottom: 1px solid $quill-grey-5;
       max-width: 582px;

--- a/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
@@ -130,27 +130,6 @@
     }
   }
   .diagnostic-page {
-    .disabled-diagnostic-banner {
-      max-width: 600px;
-      width: 100%;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 16px;
-      background-color: $quill-yellow-50;
-      border-radius: 8px;
-      margin-bottom: 24px;
-      color: $quill-black;
-      font-size: 14px;
-      a {
-        margin-left: 8px;
-        font-weight: 700;
-        text-decoration: underline;
-        &:focus {
-          outline-offset: 2px;
-        }
-      }
-    }
     .filter-tabs {
       border-bottom: 1px solid $quill-grey-5;
       max-width: 582px;
@@ -220,6 +199,38 @@
   .share-activity-pack-modal-container {
     .quill-snackbar {
       z-index: 3;
+    }
+  }
+}
+
+.disabled-diagnostic-banner {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+  background-color: $quill-yellow-50;
+  border-radius: 8px;
+  margin-bottom: 24px;
+  color: $quill-black;
+  font-size: 14px;
+
+  &.assignment-flow {
+    max-width: 600px;
+  }
+
+  &.recommendations {
+    max-width: 1034px;
+    margin-top: 32px;
+  }
+
+  a {
+    margin-left: 8px;
+    font-weight: 700;
+    text-decoration: underline;
+
+    &:focus {
+      outline-offset: 2px;
     }
   }
 }

--- a/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/assignment_flow.scss
@@ -220,7 +220,7 @@
   }
 
   &.recommendations {
-    max-width: 1034px;
+    width: max-content;
     margin-top: 32px;
   }
 

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_individual_pack.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_individual_pack.scss
@@ -186,6 +186,9 @@
         padding-right: 32px;
       }
     }
+    .disabled-diagnostic-banner {
+      margin-left: 28px;
+    }
 
   }
 

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
@@ -6,8 +6,8 @@ interface BannerProps {
   tagText?: string,
   primaryHeaderText: string,
   secondaryHeaderText?: string,
-  bodyText: string,
-  icon: {
+  bodyText?: string,
+  icon?: {
     alt: string,
     src: string
   },
@@ -30,7 +30,7 @@ export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHead
           {secondaryHeaderText && <p className="secondary-header">{secondaryHeaderText}</p>}
         </div>}
         <p className="primary-header">{primaryHeaderText}</p>
-        <p className="body">{bodyText}</p>
+        {bodyText && <p className="body">{bodyText}</p>}
         <div className="buttons-container">
           {buttons.map((button, i) => {
             const { onClick, href, standardButtonStyle, text, target } = button
@@ -43,7 +43,7 @@ export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHead
           })}
         </div>
       </div>
-      <img alt={icon.alt} className="banner-icon" src={icon.src} />
+      {icon && <img alt={icon.alt} className="banner-icon" src={icon.src} />}
     </div>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
@@ -6,8 +6,8 @@ interface BannerProps {
   tagText?: string,
   primaryHeaderText: string,
   secondaryHeaderText?: string,
-  bodyText?: string,
-  icon?: {
+  bodyText: string,
+  icon: {
     alt: string,
     src: string
   },
@@ -30,7 +30,7 @@ export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHead
           {secondaryHeaderText && <p className="secondary-header">{secondaryHeaderText}</p>}
         </div>}
         <p className="primary-header">{primaryHeaderText}</p>
-        {bodyText && <p className="body">{bodyText}</p>}
+        <p className="body">{bodyText}</p>
         <div className="buttons-container">
           {buttons.map((button, i) => {
             const { onClick, href, standardButtonStyle, text, target } = button
@@ -43,7 +43,7 @@ export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHead
           })}
         </div>
       </div>
-      {icon && <img alt={icon.alt} className="banner-icon" src={icon.src} />}
+      <img alt={icon.alt} className="banner-icon" src={icon.src} />
     </div>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -71,6 +71,25 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
       <h1>
         Which diagnostic covers the skills you want to assess?
       </h1>
+      <DisabledDiagnosticsBanner
+        className="assignment-flow"
+      >
+        <div
+          className="disabled-diagnostic-banner assignment-flow"
+        >
+          <p>
+            New diagnostics for the 2024-2025 school year are coming August 1st.
+          </p>
+          <a
+            className="focus-on-dark"
+            href="https://www.quill.org/teacher-center/important-update-to-diagnostics"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Learn more
+          </a>
+        </div>
+      </DisabledDiagnosticsBanner>
       <section
         className="filter-tabs"
       >
@@ -182,7 +201,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className=" assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <div
                   className="top-row"
@@ -201,26 +220,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1663"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -298,7 +302,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className="show-new-tag assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <span
                   className="new-tag"
@@ -322,26 +326,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1664"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -419,7 +408,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className=" assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <div
                   className="top-row"
@@ -438,26 +427,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1668"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -535,7 +509,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className="show-new-tag assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <span
                   className="new-tag"
@@ -559,73 +533,12 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1669"
-                      onClick={[Function]}
-                      target="_blank"
+                    <button
+                      className="quill-button small disabled contained"
+                      type="button"
                     >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
-                    <Tooltip
-                      isTabbable={true}
-                      tooltipText="This is locked because you haven't assigned the Intermediate Baseline Diagnostic yet. Assign it to unlock the Intermediate Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
-                      tooltipTriggerText={
-                        <button
-                          className="quill-button-archived small disabled contained"
-                          type="button"
-                        >
-                          <img
-                            alt="Lock icon"
-                            src="undefined/images/icons/icons-locked.svg"
-                          />
-                           Locked
-                        </button>
-                      }
-                    >
-                      <span
-                        aria-hidden={false}
-                        className="quill-tooltip-trigger "
-                        role="tooltip"
-                      >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
-                          <button
-                            className="quill-button-archived small disabled contained"
-                            type="button"
-                          >
-                            <img
-                              alt="Lock icon"
-                              src="undefined/images/icons/icons-locked.svg"
-                            />
-                             Locked
-                          </button>
-                        </span>
-                        <span
-                          className="quill-tooltip-wrapper"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="quill-tooltip"
-                          />
-                        </span>
-                      </span>
-                    </Tooltip>
+                      Coming Aug 1
+                    </button>
                   </div>
                 </div>
                 <div
@@ -702,7 +615,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className=" assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <div
                   className="top-row"
@@ -721,26 +634,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1678"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -818,7 +716,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className="show-new-tag assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <span
                   className="new-tag"
@@ -842,73 +740,12 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1680"
-                      onClick={[Function]}
-                      target="_blank"
+                    <button
+                      className="quill-button small disabled contained"
+                      type="button"
                     >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
-                    <Tooltip
-                      isTabbable={true}
-                      tooltipText="This is locked because you haven't assigned the Advanced Baseline Diagnostic yet. Assign it to unlock the Advanced Growth Diagnostic. If you are a co-teacher, please ask the classroom's owner to assign the diagnostics."
-                      tooltipTriggerText={
-                        <button
-                          className="quill-button-archived small disabled contained"
-                          type="button"
-                        >
-                          <img
-                            alt="Lock icon"
-                            src="undefined/images/icons/icons-locked.svg"
-                          />
-                           Locked
-                        </button>
-                      }
-                    >
-                      <span
-                        aria-hidden={false}
-                        className="quill-tooltip-trigger "
-                        role="tooltip"
-                      >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
-                          <button
-                            className="quill-button-archived small disabled contained"
-                            type="button"
-                          >
-                            <img
-                              alt="Lock icon"
-                              src="undefined/images/icons/icons-locked.svg"
-                            />
-                             Locked
-                          </button>
-                        </span>
-                        <span
-                          className="quill-tooltip-wrapper"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="quill-tooltip"
-                          />
-                        </span>
-                      </span>
-                    </Tooltip>
+                      Coming Aug 1
+                    </button>
                   </div>
                 </div>
                 <div
@@ -985,7 +822,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className=" assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <div
                   className="top-row"
@@ -1004,26 +841,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1161"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -1099,7 +921,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className="show-new-tag assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <span
                   className="new-tag"
@@ -1123,26 +945,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1774"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -1220,7 +1027,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className=" assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <div
                   className="top-row"
@@ -1239,26 +1046,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1568"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -1334,7 +1126,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className="show-new-tag assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <span
                   className="new-tag"
@@ -1358,26 +1150,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1814"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -1455,7 +1232,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className=" assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <div
                   className="top-row"
@@ -1474,26 +1251,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1590"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -1569,7 +1331,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
             >
               <div
                 className="show-new-tag assignment-card quill-card"
-                onClick={[Function]}
+                onClick={null}
               >
                 <span
                   className="new-tag"
@@ -1593,26 +1355,11 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                   <div
                     className="button-container"
                   >
-                    <a
-                      className="interactive-wrapper focus-on-light"
-                      href="/activity_sessions/anonymous?activity_id=1818"
-                      onClick={[Function]}
-                      target="_blank"
-                    >
-                      <img
-                        alt="Eye icon"
-                        src="undefined/images/icons/icons-preview.svg"
-                      />
-                      <span>
-                        Preview
-                      </span>
-                    </a>
                     <button
-                      className="quill-button-archived fun contained primary focus-on-light"
-                      onClick={[Function]}
+                      className="quill-button small disabled contained"
                       type="button"
                     >
-                      Select
+                      Coming Aug 1
                     </button>
                   </div>
                 </div>
@@ -1721,7 +1468,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                     </span>
                   </a>
                   <button
-                    className="quill-button-archived fun contained primary focus-on-light"
+                    className="quill-button fun contained primary focus-on-light"
                     onClick={[Function]}
                     type="button"
                   >
@@ -1833,7 +1580,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                     </span>
                   </a>
                   <button
-                    className="quill-button-archived fun contained primary focus-on-light"
+                    className="quill-button fun contained primary focus-on-light"
                     onClick={[Function]}
                     type="button"
                   >
@@ -1945,7 +1692,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                     </span>
                   </a>
                   <button
-                    className="quill-button-archived fun contained primary focus-on-light"
+                    className="quill-button fun contained primary focus-on-light"
                     onClick={[Function]}
                     type="button"
                   >
@@ -2057,7 +1804,7 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
                     </span>
                   </a>
                   <button
-                    className="quill-button-archived fun contained primary focus-on-light"
+                    className="quill-button fun contained primary focus-on-light"
                     onClick={[Function]}
                     type="button"
                   >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
@@ -32,6 +32,8 @@ export const PRE_AP_WRITINGS_SKILLS_2_UNIT_TEMPLATE_ID = 195
 export const AP_WRITINGS_SKILLS_UNIT_TEMPLATE_ID = 193
 export const SPRING_BOARD_SKILLS_UNIT_TEMPLATE_ID = 253
 
+export const DISABLED_DIAGNOSTIC_RECOMMENDATIONS_IDS = [1663, 1668, 1678, 1161, 1568, 1590]
+
 export const starterPreTest = {
   activityId: 1663,
   name: 'Starter Baseline Diagnostic (Pre)',

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
@@ -255,3 +255,18 @@ export const ACTIVITY_PACK_TYPES = [
     id: 'whole-class'
   },
 ]
+
+export const DISABLED_DIAGNOSTICS = [
+  'Starter Baseline Diagnostic (Pre)',
+  'Starter Growth Diagnostic (Post)',
+  'Intermediate Baseline Diagnostic (Pre)',
+  'Intermediate Growth Diagnostic (Post)',
+  'Advanced Baseline Diagnostic (Pre)',
+  'Advanced Growth Diagnostic (Post)',
+  'ELL Starter Baseline Diagnostic (Pre)',
+  'ELL Starter Growth Diagnostic (Post)',
+  'ELL Intermediate Baseline Diagnostic (Pre)',
+  'ELL Intermediate Growth Diagnostic (Post)',
+  'ELL Advanced Baseline Diagnostic (Pre)',
+  'ELL Advanced Growth Diagnostic (Post)'
+]

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assignment_card.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assignment_card.test.jsx.snap
@@ -41,7 +41,7 @@ exports[`AssignmentCard component should render 1`] = `
         </span>
       </a>
       <button
-        className="quill-button-archived fun contained primary focus-on-light"
+        className="quill-button fun contained primary focus-on-light"
         type="button"
       >
         Select

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -5,6 +5,7 @@ import AssignmentCard from './assignment_card';
 import ScrollToTop from '../../shared/scroll_to_top';
 import * as constants from '../assignmentFlowConstants';
 import AssignmentFlowNavigation from '../assignment_flow_navigation';
+import { PostNavigationBanner } from '../../../../Shared';
 
 const ALL = 'All'
 const GENERAL = 'General'
@@ -125,13 +126,16 @@ const AssignADiagnostic = ({ history, assignedPreTests, }) => {
       minis = collegeBoard;
       break;
   }
-
   return (
     <div className="assignment-flow-container">
       <AssignmentFlowNavigation />
       <ScrollToTop />
       <div className="diagnostic-page container">
         <h1>Which diagnostic covers the skills you want to assess?</h1>
+        <div className="disabled-diagnostic-banner">
+          <p>New diagnostics for the 2024-2025 school year are coming August 1st.</p>
+          <a className="focus-on-dark" href="https://www.quill.org/teacher-center/important-update-to-diagnostics" target="_blank" rel='noopener noreferrer'>Learn more</a>
+        </div>
         <section className="filter-tabs">
           <FilterTab activeFilter={filter} filter={ALL} number={16} setFilter={setFilter} />
           <FilterTab activeFilter={filter} filter={GENERAL} number={6} setFilter={setFilter} />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -5,7 +5,6 @@ import AssignmentCard from './assignment_card';
 import ScrollToTop from '../../shared/scroll_to_top';
 import * as constants from '../assignmentFlowConstants';
 import AssignmentFlowNavigation from '../assignment_flow_navigation';
-import { PostNavigationBanner } from '../../../../Shared';
 import { DisabledDiagnosticsBanner } from '../../../helpers/unitTemplates';
 
 const ALL = 'All'

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -6,6 +6,7 @@ import ScrollToTop from '../../shared/scroll_to_top';
 import * as constants from '../assignmentFlowConstants';
 import AssignmentFlowNavigation from '../assignment_flow_navigation';
 import { PostNavigationBanner } from '../../../../Shared';
+import { DisabledDiagnosticsBanner } from '../../../helpers/unitTemplates';
 
 const ALL = 'All'
 const GENERAL = 'General'
@@ -132,10 +133,7 @@ const AssignADiagnostic = ({ history, assignedPreTests, }) => {
       <ScrollToTop />
       <div className="diagnostic-page container">
         <h1>Which diagnostic covers the skills you want to assess?</h1>
-        <div className="disabled-diagnostic-banner">
-          <p>New diagnostics for the 2024-2025 school year are coming August 1st.</p>
-          <a className="focus-on-dark" href="https://www.quill.org/teacher-center/important-update-to-diagnostics" target="_blank" rel='noopener noreferrer'>Learn more</a>
-        </div>
+        <DisabledDiagnosticsBanner className="assignment-flow"/>
         <section className="filter-tabs">
           <FilterTab activeFilter={filter} filter={ALL} number={16} setFilter={setFilter} />
           <FilterTab activeFilter={filter} filter={GENERAL} number={6} setFilter={setFilter} />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -133,7 +133,7 @@ const AssignADiagnostic = ({ history, assignedPreTests, }) => {
       <ScrollToTop />
       <div className="diagnostic-page container">
         <h1>Which diagnostic covers the skills you want to assess?</h1>
-        <DisabledDiagnosticsBanner className="assignment-flow"/>
+        <DisabledDiagnosticsBanner className="assignment-flow" />
         <section className="filter-tabs">
           <FilterTab activeFilter={filter} filter={ALL} number={16} setFilter={setFilter} />
           <FilterTab activeFilter={filter} filter={GENERAL} number={6} setFilter={setFilter} />

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assignment_card.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assignment_card.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
-import { Tooltip, lockedIcon, previewIcon, } from '../../../../Shared/index';
+import { Tooltip, lockedIcon, previewIcon } from '../../../../Shared/index';
+import { DISABLED_DIAGNOSTICS } from '../assignmentFlowConstants';
 
 interface AssignmentCardProps {
   selectCard?: () => void;
@@ -28,17 +29,21 @@ export default class AssignmentCard extends React.Component<AssignmentCardProps,
   handleAnchorClick = (e) => e.stopPropagation();
 
   renderButtons = () => {
-    const { buttonText, buttonLink, selectCard, lockedText, } = this.props;
+    const { buttonText, buttonLink, selectCard, lockedText, header} = this.props;
+    const isDisabled = DISABLED_DIAGNOSTICS.includes(header)
     /* eslint-disable react/jsx-no-target-blank */
     const button = buttonText && buttonLink ? <a className="interactive-wrapper focus-on-light" href={buttonLink} onClick={this.handleAnchorClick} target="_blank"><img alt={previewIcon.alt} src={previewIcon.src} /><span>{buttonText}</span></a> : null;
     /* eslint-enable react/jsx-no-target-blank */
-    const selectButton = <button className="quill-button-archived fun contained primary focus-on-light" onClick={selectCard} type="button">Select</button>
-    const lockedButton = <Tooltip tooltipText={lockedText} tooltipTriggerText={<button className="quill-button-archived small disabled contained" type="button"><img alt={lockedIcon.alt} src={lockedIcon.src} /> Locked</button>} />
+    const selectButton = <button className="quill-button fun contained primary focus-on-light" onClick={selectCard} type="button">Select</button>
+    let lockedButton = <Tooltip tooltipText={lockedText} tooltipTriggerText={<button className="quill-button small disabled contained" type="button"><img alt={lockedIcon.alt} src={lockedIcon.src} /> Locked</button>} />
+    if(isDisabled) {
+      lockedButton = <button className="quill-button small disabled contained" type="button">Coming Aug 1</button>
+    }
     if (button) {
       return (
         <div className="button-container">
-          {button}
-          {lockedText ? lockedButton : selectButton}
+          {!isDisabled && button}
+          {lockedText || isDisabled ? lockedButton : selectButton}
         </div>
       );
     } else {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assignment_card.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assignment_card.tsx
@@ -28,9 +28,8 @@ export default class AssignmentCard extends React.Component<AssignmentCardProps,
 
   handleAnchorClick = (e) => e.stopPropagation();
 
-  renderButtons = () => {
+  renderButtons = (isDisabled) => {
     const { buttonText, buttonLink, selectCard, lockedText, header} = this.props;
-    const isDisabled = DISABLED_DIAGNOSTICS.includes(header)
     /* eslint-disable react/jsx-no-target-blank */
     const button = buttonText && buttonLink ? <a className="interactive-wrapper focus-on-light" href={buttonLink} onClick={this.handleAnchorClick} target="_blank"><img alt={previewIcon.alt} src={previewIcon.src} /><span>{buttonText}</span></a> : null;
     /* eslint-enable react/jsx-no-target-blank */
@@ -53,6 +52,7 @@ export default class AssignmentCard extends React.Component<AssignmentCardProps,
 
   render() {
     const { imgSrc, imgAlt, imgClassName, showNewTag, header, bodyArray, showRecommendedToStartTag, } = this.props
+    const isDisabled = DISABLED_DIAGNOSTICS.includes(header)
     const bodyElements = bodyArray.map(obj => (
       <div className="body-element" key={obj.key}>
         <p className="key">{obj.key}</p>
@@ -65,7 +65,7 @@ export default class AssignmentCard extends React.Component<AssignmentCardProps,
     const leftClassName = showRecommendedToStartTag ? "left include-recommended-to-start-tag" : "left"
 
     return (
-      <div className={`${newTag ? 'show-new-tag' : ''} assignment-card quill-card`} onClick={this.handleClick}>
+      <div className={`${newTag ? 'show-new-tag' : ''} assignment-card quill-card`} onClick={isDisabled ? null : this.handleClick}>
         {newTag}
         <div className="top-row">
           <div className={leftClassName}>
@@ -75,7 +75,7 @@ export default class AssignmentCard extends React.Component<AssignmentCardProps,
               <h2>{header}</h2>
             </div>
           </div>
-          {this.renderButtons()}
+          {this.renderButtons(isDisabled)}
         </div>
         <div className="body">
           {bodyElements}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendations.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/recommendations.tsx
@@ -36,6 +36,8 @@ import {
 import ActivityDisclaimerBanner from '../../../shared/activityDisclaimerBanner';
 import DemoOnboardingTour, { DEMO_ONBOARDING_DIAGNOSTIC_RECOMMENDATIONS, } from '../../../shared/demo_onboarding_tour';
 import LoadingSpinner from '../../../shared/loading_indicator.jsx';
+import { DisabledDiagnosticsBanner } from '../../../../helpers/unitTemplates';
+import { DISABLED_DIAGNOSTIC_RECOMMENDATIONS_IDS } from '../../../assignment_flow/assignmentFlowConstants';
 
 const craneIllustration = <img alt="Grayscale construction crane" src={`${baseDiagnosticImageSrc}/crane-grayscale.svg`} />
 
@@ -501,7 +503,7 @@ export const Recommendations = ({ passedPreviouslyAssignedRecommendations, passe
     return assignedPacks.every(pack => pack.activity_count === pack.diagnostic_progress[sr.id])
   })
 
-  const showPostTestAssignmentColumn = studentsWhoCompletedDiagnostic.length && postDiagnosticUnitTemplateId && !isPostDiagnostic
+  const showPostTestAssignmentColumn = studentsWhoCompletedDiagnostic.length && postDiagnosticUnitTemplateId && !isPostDiagnostic && !DISABLED_DIAGNOSTIC_RECOMMENDATIONS_IDS.includes(Number(activityId))
 
   const widthClass = showPostTestAssignmentColumn ? "smaller-width" : ""
 
@@ -522,6 +524,7 @@ export const Recommendations = ({ passedPreviouslyAssignedRecommendations, passe
         <div className="section-header">
           <h2>Independent practice</h2>{recommendedKey}
         </div>
+        <DisabledDiagnosticsBanner className="recommendations" />
         <div className="recommendations-table-container">
           <div className={`recommendations-table-wrapper ${widthClass}`}>
             <IndependentRecommendationsButtons

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/unitTemplates.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/unitTemplates.tsx
@@ -206,6 +206,6 @@ export const renderPreviouslyAssignedActivitiesTooltipElement = (data) => {
 export const DisabledDiagnosticsBanner = ({ className }) => (
   <div className={`disabled-diagnostic-banner ${className}`}>
     <p>New diagnostics for the 2024-2025 school year are coming August 1st.</p>
-    <a className="focus-on-dark" href="https://www.quill.org/teacher-center/important-update-to-diagnostics" target="_blank" rel='noopener noreferrer'>Learn more</a>
+    <a className="focus-on-dark" href="https://www.quill.org/teacher-center/important-update-to-diagnostics" rel='noopener noreferrer' target="_blank">Learn more</a>
   </div>
 )

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/unitTemplates.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/unitTemplates.tsx
@@ -202,3 +202,10 @@ export const renderPreviouslyAssignedActivitiesTooltipElement = (data) => {
   )
   return renderToString(table)
 }
+
+export const DisabledDiagnosticsBanner = ({ className }) => (
+  <div className={`disabled-diagnostic-banner ${className}`}>
+    <p>New diagnostics for the 2024-2025 school year are coming August 1st.</p>
+    <a className="focus-on-dark" href="https://www.quill.org/teacher-center/important-update-to-diagnostics" target="_blank" rel='noopener noreferrer'>Learn more</a>
+  </div>
+)


### PR DESCRIPTION
## WHAT
disable ability to assign old Diagnostics

## WHY
we are introducing new ones and need to disable these

## HOW
update logic for button rendering, disabled status and add banners

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1435" alt="Screen Shot 2024-07-09 at 12 08 30 PM" src="https://github.com/empirical-org/Empirical-Core/assets/25959584/c46fe198-31ad-4f06-b045-e2b3da8d6755">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Disable-the-ability-to-assign-old-Diagnostics-7fc075079620459fa201a0d7c31a6558?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
verified on staging that banners render as expected and recommendations test assignment element does not render for old diagnostics

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
