### PR TITLE
Fix faker custom name

### DIFF
--- a/services/QuillLMS/spec/services/canvas_integration/student_updater_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/student_updater_spec.rb
@@ -11,13 +11,7 @@ describe CanvasIntegration::StudentUpdater do
   let(:email) { student.email }
   let(:name) { student.name }
 
-  let(:data) do
-    {
-      email: email,
-      name: name,
-      user_external_id: user_external_id
-    }
-  end
+  let(:data) { { email:, name:, user_external_id: } }
 
   context 'student has no email' do
     before { student.update(email: nil) }
@@ -81,7 +75,7 @@ describe CanvasIntegration::StudentUpdater do
   end
 
   context 'new name provided' do
-    let(:name) { Faker::Name.custom_name }
+    let(:name) { 'New Name' }
 
     it { expect { subject }.to change(student, :name).to(name) }
   end

--- a/services/QuillLMS/spec/support/faker.rb
+++ b/services/QuillLMS/spec/support/faker.rb
@@ -2,8 +2,18 @@
 
 module Faker
   class Name
-    def self.custom_name
-      [first_name, last_name].join(' ')
-    end
+    CUSTOM_FIRST_NAMES = %w[
+      Van
+      Maria
+    ].freeze
+
+    CUSTOM_LAST_NAMES = [
+      'Johsnon',
+      'von Trapp'
+    ].freeze
+
+    def self.custom_name = "#{custom_first_name} #{custom_last_name}"
+    def self.custom_first_name = CUSTOM_FIRST_NAMES.sample
+    def self.custom_last_name = CUSTOM_LAST_NAMES.sample
   end
 end


### PR DESCRIPTION
## WHAT
Fix an issue with a Faker name generation extension

## WHY
The method `custom_name` occasionally gives names that are subject to capitalization rules which end up changing the capitalization of a name within the test which can sometimes result in a test failure.

## HOW
Use a smaller list of first and last names for testing rather than the entire Faker set.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
This is a update to spec files only, so run this a few times just to make sure it passes.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
