### PR TITLE
Rename old diagnostic units that have same name as new diagnostic template name

### DIFF
--- a/services/QuillLMS/lib/tasks/temporary/unit_templates.rake
+++ b/services/QuillLMS/lib/tasks/temporary/unit_templates.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :unit_templates do
+  task backfill_2023_version_units: :environment do
+    prefix = '2023 Version - '
+    temp_file = Tempfile.new('unit_template_updates')
+
+    UnitTemplate.where('name LIKE ?', "#{prefix}%").each do |unit_template|
+      original_name = unit_template.name[prefix.length..]
+
+      units = unit_template.units.where(name: original_name)
+      next if units.empty?
+
+      temp_file.puts({ unit_template_id: unit_template.id, units: units.pluck(:id), original_name:}.to_json)
+      units.update_all(name: unit_template.name)
+    end
+
+    temp_file.rewind
+    puts temp_file.read
+    temp_file.close
+    temp_file.unlink
+  end
+end


### PR DESCRIPTION
## WHAT
Rename old diagnostic unit names that have the same name as a newer diagnostic unit template name.

## WHY
This fixes a [bug](https://quillorg-5s.sentry.io/issues/4442667705/?environment=production&project=11238&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=6) involving the assigning of recommendations.  If a user has an existing unit with the name that is the same as a newer diagnostic template, then a validation error will be raised since users are not allowed to have units with the same name. 

## HOW
By prepending the the older units with '2023 Version - ' there is no longer a collision when assigning recommendations.

See notion card for relevant log files.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Unable-to-assign-new-diagnostic-recommended-packs-eaf933a1d04b43d091541109e9e36f0f?pvs=4

### What have you done to QA this feature?
I have run this rake task locally and on staging.  

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
