### PR TITLE
Validate that UID exists for `incorrectSequences` and `focusPoints`

### DIFF
--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -239,8 +239,13 @@ class Question < ApplicationRecord
     when Hash
       sequences.each { |key, value| validate_text_and_feedback(value) }
     when Array
-      sequences.each { |value| validate_text_and_feedback(value) }
+      sequences.each { |value| validate_text_feedback_and_uid(value) }
     end
+  end
+
+  private def validate_text_feedback_and_uid(value)
+    validate_text_and_feedback(value)
+    validate_uid(value)
   end
 
   private def validate_text_and_feedback(value)
@@ -250,6 +255,12 @@ class Question < ApplicationRecord
     end
 
     value['text'].split('|||').each { |regex| validate_regex(regex) }
+  end
+
+  private def validate_uid(value)
+    return if value['uid'].present?
+
+    errors.add(:data, 'Focus Points and Incorrect Sequences must have uid.')
   end
 
   private def validate_regex(regex)

--- a/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/focus_points_controller_spec.rb
@@ -10,8 +10,8 @@ describe Api::V1::FocusPointsController, type: :controller do
         Question::FOCUS_POINTS => {
           '0' => { 'text' => 'text', 'feedback'=>'fff' }
         },
-        Question::INCORRECT_SEQUENCES => [
-          { 'text'=>'foo', 'feedback'=>'bar' }
+        'incorrectSequences'=> [
+          { 'text'=>'foo', 'feedback'=>'bar', 'uid' => 'uid1'}
         ]
       }
     )

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -101,6 +101,17 @@ RSpec.describe Question, type: :model do
       expect(question.errors[:data]).to include('There is incorrectly formatted regex: (foo|')
     end
 
+    it 'should be invalid if the focus point in an array does not have a uid' do
+      data = {
+        Question::FOCUS_POINTS =>
+        [
+          {'text'=>'(foo|bar)', 'feedback'=>'bar'}
+        ]
+      }
+      question.data = data
+      expect(question.valid?).to be false
+    end
+
     it 'should be valid if focus point has valid regex and feedback' do
       question.data = {Question::FOCUS_POINTS=>{'0'=>{'text'=>'(foo|bar)', 'feedback'=>'bar'}}}
       expect(question.valid?).to be true
@@ -116,6 +127,17 @@ RSpec.describe Question, type: :model do
       question.data = {Question::INCORRECT_SEQUENCES=>{'0'=>{'text'=>'foo'}}}
       expect(question.valid?).to be false
       expect(question.errors[:data]).to include('Focus Points and Incorrect Sequences must have text and feedback.')
+    end
+
+    it 'should be invalid if the incorrectSequence in an array does not have a uid' do
+      data = {
+        Question::INCORRECT_SEQUENCES =>
+        [
+          {'text'=>'(foo|bar)', 'feedback'=>'bar'}
+        ]
+      }
+      question.data = data
+      expect(question.valid?).to be false
     end
 
     it 'should be invalid if an incorrect sequence is invalid regex' do
@@ -301,20 +323,20 @@ RSpec.describe Question, type: :model do
 
     context 'array' do
       before do
-        question.incorrectSequences = [
-          {'text'=>'text1','feedback'=>'feedback1'},
-          {'text'=>'text2','feedback'=>'feedback2'},
-          {'text'=>'text3','feedback'=>'feedback3'}
+        question.data['incorrectSequences'] = [
+          {'text'=>'text1','feedback'=>'feedback1', 'uid' => 'uid1'},
+          {'text'=>'text2','feedback'=>'feedback2', 'uid' => 'uid2'},
+          {'text'=>'text3','feedback'=>'feedback3', 'uid' => 'uid3'}
         ]
         question.save
       end
 
       it 'should set the value of the specified incorrectSequence' do
         replace_uid = 0
+        new_incorrect_sequence = {'text' => 't4', 'feedback' => 'f4', 'uid' => 'u4'}
         question.set_incorrect_sequence(replace_uid, new_incorrect_sequence)
         question.reload
         new_data = question.incorrectSequences[replace_uid]
-        new_data.delete('uid') # remove the added uid
         expect(new_data).to eq(new_incorrect_sequence)
       end
 

--- a/services/QuillLMS/spec/workers/add_uuid_to_question_data_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/add_uuid_to_question_data_worker_spec.rb
@@ -22,7 +22,7 @@ describe AddUuidToQuestionDataWorker do
 
       before do
         question.data[type] = data
-        question.save
+        question.save(validate: false)
       end
 
       it 'saves the uids for the question' do


### PR DESCRIPTION
## WHAT
Add a validation that all new `incorrectSequences` and `focusPoints` must have a `uid`

## WHY
So that we don't create invalid data that can't be translated. 

## HOW
Add to the existing validations on question. 

### Notion Card Links
[RFC for data migration](https://www.notion.so/quill/RFC-Give-all-incorrectSequences-unique-keys-8d492736b76e45c787fd3fdaa5cb880f)

### What have you done to QA this feature?
Will deploy to staging and QA this once [previous PR](https://github.com/empirical-org/Empirical-Core/pull/12058) to migrate existing data is complete. 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO
Self-Review: Have you done an initial self-review of the code below on Github? | YES
