### PR TITLE
dont pull translations in the activity data_as_json

### DIFF
--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -251,7 +251,7 @@ class Activity < ApplicationRecord
   end
 
   def data_as_json
-    translated_json({})
+    data
   end
 
   def self.translatable_field_name = 'landingPageHtml'


### PR DESCRIPTION
## WHAT
Stop using the `translated_json`  when you pull data for `Activities`

## WHY
`translated_json` does a join on several tables, and it's inefficient to call it for each activity you pull down when you load them all in the admin interface.  

## HOW
revert back to returning `data` in the `data_as_json` method


### What have you done to QA this feature?
Checked that number of queries went way down on the dev console.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, small change that is reverting back to a previous state. 
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | yes
