### PR TITLE
Bug fix/ fix display for activity packs with long names

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_profile.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_profile.scss
@@ -24,6 +24,16 @@
       margin: 4px 0px 20px;
     }
 
+    .unit-template-profile-activities {
+      .activity-name {
+        white-space: nowrap;
+        width: 450px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        text-align: left;
+      }
+    }
+
     a:hover {
       text-decoration: none;
     }

--- a/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_profile.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_profile.scss
@@ -27,7 +27,7 @@
     .unit-template-profile-activities {
       .activity-name {
         white-space: nowrap;
-        width: 450px;
+        max-width: 450px;
         text-overflow: ellipsis;
         overflow: hidden;
         text-align: left;


### PR DESCRIPTION
## WHAT
fix display for activity packs with long names

## WHY
we don't want this text to overlap with the concept text

## HOW
add some CSS 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Display-overlap-issue-extremely-low-priority-52a73faddca84e1f9a829d7ec76e4dfe

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
verified that the text does not overlap on local and staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | no-- CSS change, manually verified
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
