### PR TITLE
remove sprockets

### DIFF
--- a/services/QuillLMS/Gemfile
+++ b/services/QuillLMS/Gemfile
@@ -132,7 +132,6 @@ gem 'vite_rails', '~> 3.0.14'
 # ASSET/UI
 gem 'uglifier', require: false
 gem 'kaminari', '~> 1.2.1'
-gem 'sprockets-rails', '~> 3.2.2'
 
 # MIDDLEWARE
 gem 'rack-cache', '~> 1.6.1', require: 'rack/cache'

--- a/services/QuillLMS/Gemfile.lock
+++ b/services/QuillLMS/Gemfile.lock
@@ -970,7 +970,6 @@ DEPENDENCIES
   slim-rails
   spring
   spring-commands-rspec
-  sprockets-rails (~> 3.2.2)
   stripe (~> 9.4)
   super_diff
   timecop (~> 0.9.8)


### PR DESCRIPTION
## WHAT
- removes the sprockets gem 

## WHY
- blocked previous attempted at Ruby 3.2 upgrade; no longer used 


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Sanity checked login, evidence/connect activities on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  n/a
Have you deployed to Staging? | (yes
Self-Review: Have you done an initial self-review of the code below on Github? |
