### PR TITLE
Use data accessors for questions

### DIFF
--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -497,13 +497,13 @@ module PublicProgressReports
     questions = activity.data['questions'].map { |q| Question.find_by_uid(q['key']) }
 
     questions.compact.each do |q|
-      next if !q.data['prompt']
+      next if !q.prompt
 
       question_array.push({
         question_id: question_array.length + 1,
         question_uid: q.uid,
         score: nil,
-        prompt: q.data['prompt'],
+        prompt: q.prompt,
         instructions: q.data['instructions']
       })
     end

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -66,10 +66,11 @@ class Question < ApplicationRecord
   validate :validate_sequences
 
 
-  store_accessor :data, :incorrectSequences
-  store_accessor :data, :focusPoints
   store_accessor :data, :flag
+  store_accessor :data, :focusPoints
+  store_accessor :data, :incorrectSequences
   store_accessor :data, :modelConceptUID
+  store_accessor :data, :prompt
   attr_accessor :skip_refresh_caches
 
   after_save :refresh_caches, unless: -> { skip_refresh_caches }

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -69,6 +69,7 @@ class Question < ApplicationRecord
   store_accessor :data, :incorrectSequences
   store_accessor :data, :focusPoints
   store_accessor :data, :flag
+  store_accessor :data, :modelConceptUID
   attr_accessor :skip_refresh_caches
 
   after_save :refresh_caches, unless: -> { skip_refresh_caches }
@@ -104,7 +105,7 @@ class Question < ApplicationRecord
   end
 
   def update_model_concept(model_concept_id)
-    data['modelConceptUID'] = model_concept_id
+    self.modelConceptUID = model_concept_id
     save
   end
 

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -68,6 +68,7 @@ class Question < ApplicationRecord
 
   store_accessor :data, :incorrectSequences
   store_accessor :data, :focusPoints
+  store_accessor :data, :flag
   attr_accessor :skip_refresh_caches
 
   after_save :refresh_caches, unless: -> { skip_refresh_caches }
@@ -98,7 +99,7 @@ class Question < ApplicationRecord
   end
 
   def update_flag(flag_value)
-    data['flag'] = flag_value
+    self.flag = flag_value
     save
   end
 

--- a/services/QuillLMS/app/models/question_health_obj.rb
+++ b/services/QuillLMS/app/models/question_health_obj.rb
@@ -22,7 +22,7 @@ class QuestionHealthObj
     {
       url: "#{ENV['DEFAULT_URL']&.to_s}/#{@tool}/#/admin/#{question_url}/#{@question&.uid}/responses",
       text: data['prompt'],
-      flag: data['flag'],
+      flag: @question.flag,
       incorrect_sequences: @question.incorrectSequences&.length,
       focus_points: @question.focusPoints&.length,
       percent_common_unmatched: health_dashboard.cms_dashboard_stats['percent_common_unmatched']&.round(2),

--- a/services/QuillLMS/app/models/question_health_obj.rb
+++ b/services/QuillLMS/app/models/question_health_obj.rb
@@ -18,10 +18,9 @@ class QuestionHealthObj
   # rubocop:disable Metrics/CyclomaticComplexity
   def run
     health_dashboard = QuestionHealthDashboard.new(@activity.id, @question_number, @question.uid)
-    data = @question.data
     {
       url: "#{ENV['DEFAULT_URL']&.to_s}/#{@tool}/#/admin/#{question_url}/#{@question&.uid}/responses",
-      text: data['prompt'],
+      text: @question.prompt,
       flag: @question.flag,
       incorrect_sequences: @question.incorrectSequences&.length,
       focus_points: @question.focusPoints&.length,

--- a/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
@@ -23,8 +23,8 @@ class ConceptReplacementGrammarWorker
         data['concept_uid'] = new_concept_uid
       end
 
-      if q['modelConceptUID'] && q['modelConceptUID'] == original_concept_uid
-        data['modelConceptUID'] = new_concept_uid
+      if q.modelConceptUID && q.modelConceptUID == original_concept_uid
+        q.modelConceptUID = new_concept_uid
       end
 
       if q.focusPoints

--- a/services/QuillLMS/lib/tasks/connect.rake
+++ b/services/QuillLMS/lib/tasks/connect.rake
@@ -9,7 +9,7 @@ namespace :connect do
 
     questions = Question.where(question_type: question_type).where("data->>'flag' = ?", flag_to_replace)
     questions.each do |q|
-      q.data['flag'] = flag_to_set
+      q.flag = flag_to_set
       q.save
     end
   end

--- a/services/QuillLMS/lib/tasks/diagnostic_question_optimal_concepts.rake
+++ b/services/QuillLMS/lib/tasks/diagnostic_question_optimal_concepts.rake
@@ -129,7 +129,7 @@ namespace :diagnostic_question_optimal_concepts do
     def question_valid?(row)
       question = fetch_question_from_row(row)
 
-      sanitize_question(question.data['prompt']) == sanitize_question(row[QUESTION_INDEX])
+      sanitize_question(question.prompt) == sanitize_question(row[QUESTION_INDEX])
     end
 
     def concepts_valid?(row)

--- a/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
@@ -233,7 +233,7 @@ describe Api::V1::ActivitiesController, type: :controller do
 
       response_obj = parsed_body['question_health']
       expect(response_obj[0]['url']).to eq("https://quill.org/connect/#/admin/questions/#{question.uid}/responses")
-      expect(response_obj[0]['text']).to eq(question.data['prompt'])
+      expect(response_obj[0]['text']).to eq(question.prompt)
       expect(response_obj[0]['flag']).to eq(question.flag)
       expect(response_obj[0]['incorrect_sequences']).to eq(question.incorrectSequences.length)
       expect(response_obj[0]['focus_points']).to eq(question.focusPoints.length)

--- a/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
@@ -234,7 +234,7 @@ describe Api::V1::ActivitiesController, type: :controller do
       response_obj = parsed_body['question_health']
       expect(response_obj[0]['url']).to eq("https://quill.org/connect/#/admin/questions/#{question.uid}/responses")
       expect(response_obj[0]['text']).to eq(question.data['prompt'])
-      expect(response_obj[0]['flag']).to eq(question.data['flag'])
+      expect(response_obj[0]['flag']).to eq(question.flag)
       expect(response_obj[0]['incorrect_sequences']).to eq(question.incorrectSequences.length)
       expect(response_obj[0]['focus_points']).to eq(question.focusPoints.length)
       expect(response_obj[0]['percent_common_unmatched']).to eq(50)

--- a/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
@@ -86,7 +86,7 @@ describe Api::V1::QuestionsController, type: :controller do
       new_model_concept = SecureRandom.uuid
       put :update_model_concept, params: { id: question.uid, question: { modelConcept: new_model_concept } }, as: :json
       question.reload
-      expect(question.data['modelConceptUID']).to eq(new_model_concept)
+      expect(question.modelConceptUID).to eq(new_model_concept)
     end
 
     it 'should return a 404 if the requested Question is not found' do

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -785,8 +785,8 @@ describe Activity, type: :model, redis: true do
       it do
         expect do
           activity.update_questions_flag_status_if_necessary!
-        end.to change{ q1.reload.data['flag'] }.to('production')
-          .and change{ q2.reload.data['flag'] }.to('production')
+        end.to change{ q1.reload.flag }.to('production')
+          .and change{ q2.reload.flag }.to('production')
       end
     end
 
@@ -797,7 +797,7 @@ describe Activity, type: :model, redis: true do
       it do
         expect do
           activity.update_questions_flag_status_if_necessary!
-        end.not_to change{ q1.reload.data['flag'] }
+        end.not_to change{ q1.reload.flag }
       end
     end
   end

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -305,21 +305,21 @@ describe PublicProgressReports, type: :model do
           question_id: 1,
           question_uid: question1.uid,
           score: nil,
-          prompt: question1.data['prompt'],
+          prompt: question1.prompt,
           instructions: question1.data['instructions']
         },
         {
           question_id: 2,
           question_uid: question2.uid,
           score: nil,
-          prompt: question2.data['prompt'],
+          prompt: question2.prompt,
           instructions: question2.data['instructions']
         },
         {
           question_id: 3,
           question_uid: question3.uid,
           score: nil,
-          prompt: question3.data['prompt'],
+          prompt: question3.prompt,
           instructions: question3.data['instructions']
         }
       ]

--- a/services/QuillLMS/spec/models/question_health_obj_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_obj_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe QuestionHealthObj, type: :model do
       activity.update(data: {questions: [{key: question.uid}]})
       health_obj = QuestionHealthObj.new(activity, question, 1, connect.key).run
       expect(health_obj[:url]).to eq("https://quill.org/connect/#/admin/questions/#{question.uid}/responses")
-      expect(health_obj[:text]).to eq(question.data['prompt'])
+      expect(health_obj[:text]).to eq(question.prompt)
       expect(health_obj[:flag]).to eq(question.flag)
       expect(health_obj[:incorrect_sequences]).to eq(question.incorrectSequences.length)
       expect(health_obj[:focus_points]).to eq(question.focusPoints.length)
@@ -60,7 +60,7 @@ RSpec.describe QuestionHealthObj, type: :model do
     it 'should return without erroring if one of the url values is nil' do
       health_obj = QuestionHealthObj.new(activity, question, 1, nil).run
       expect(health_obj[:url]).to eq("https://quill.org//#/admin/questions/#{question.uid}/responses")
-      expect(health_obj[:text]).to eq(question.data['prompt'])
+      expect(health_obj[:text]).to eq(question.prompt)
       expect(health_obj[:flag]).to eq(question.flag)
       expect(health_obj[:incorrect_sequences]).to eq(question.incorrectSequences.length)
       expect(health_obj[:focus_points]).to eq(question.focusPoints.length)

--- a/services/QuillLMS/spec/models/question_health_obj_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_obj_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe QuestionHealthObj, type: :model do
       health_obj = QuestionHealthObj.new(activity, question, 1, connect.key).run
       expect(health_obj[:url]).to eq("https://quill.org/connect/#/admin/questions/#{question.uid}/responses")
       expect(health_obj[:text]).to eq(question.data['prompt'])
-      expect(health_obj[:flag]).to eq(question.data['flag'])
+      expect(health_obj[:flag]).to eq(question.flag)
       expect(health_obj[:incorrect_sequences]).to eq(question.incorrectSequences.length)
       expect(health_obj[:focus_points]).to eq(question.focusPoints.length)
       expect(health_obj[:percent_common_unmatched]).to eq(50)
@@ -61,7 +61,7 @@ RSpec.describe QuestionHealthObj, type: :model do
       health_obj = QuestionHealthObj.new(activity, question, 1, nil).run
       expect(health_obj[:url]).to eq("https://quill.org//#/admin/questions/#{question.uid}/responses")
       expect(health_obj[:text]).to eq(question.data['prompt'])
-      expect(health_obj[:flag]).to eq(question.data['flag'])
+      expect(health_obj[:flag]).to eq(question.flag)
       expect(health_obj[:incorrect_sequences]).to eq(question.incorrectSequences.length)
       expect(health_obj[:focus_points]).to eq(question.focusPoints.length)
       expect(health_obj[:percent_common_unmatched]).to eq(50)

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Question, type: :model do
       new_val = 'foo'
       question.update_flag(new_val)
       question.reload
-      expect(question.data['flag']).to eq(new_val)
+      expect(question.flag).to eq(new_val)
     end
   end
 

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Question, type: :model do
       new_val = 'foo'
       question.update_model_concept(new_val)
       question.reload
-      expect(question.data['modelConceptUID']).to eq(new_val)
+      expect(question.modelConceptUID).to eq(new_val)
     end
   end
 

--- a/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
@@ -109,9 +109,9 @@ describe PopulateActivityHealthWorker do
     it 'should create new Prompt Health objects' do
       subject.perform(activity.id)
       expect(PromptHealth.count).to eq(2)
-      expect(PromptHealth.first.text).to eq(question.data['prompt'])
+      expect(PromptHealth.first.text).to eq(question.prompt)
       expect(PromptHealth.first.percent_common_unmatched).to eq(50)
-      expect(PromptHealth.second.text).to eq(another_question.data['prompt'])
+      expect(PromptHealth.second.text).to eq(another_question.prompt)
       expect(PromptHealth.second.percent_common_unmatched).to eq(100)
     end
 


### PR DESCRIPTION
## WHAT
Use `data_accessor` so that we can access various properties that are inside `question.data` by name rather than relying on strings. 
## WHY
This is more robust and less error-prone than using strings. Plus the code looks nicer. 


### What have you done to QA this feature?
Checked that the site worked on dev

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
