### PR TITLE
adgr-configure-materialized-view-for-fallback

### DIFF
--- a/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_student_view_query.rb
+++ b/services/QuillLMS/app/queries/admin_diagnostic_reports/diagnostic_performance_by_student_view_query.rb
@@ -18,6 +18,10 @@ module AdminDiagnosticReports
       super(aggregation: 'student', **options)
     end
 
+    def materialized_views = super + [active_user_names_view]
+
+    def active_user_names_view = materialized_view('active_user_names_view')
+
     def rollup_select_columns = 'student_id, student_name, pre_activity_session_completed_at, post_activity_session_completed_at, classroom_id'
 
     def specific_select_clause


### PR DESCRIPTION

## WHAT
Properly register materialized view with query class
## WHY
So that it can automatically trigger fallback code in cases where the view is erroring
## HOW
Register the materialized view with the class so that it understands how to construct a fallback query when a failure is caused by a missing materialized view.

### What have you done to QA this feature?
- Run query in console to ensure that it does not error
- Deploy to staging and confirm queries do not error

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No tests on this type of fallback code
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes