### PR TITLE
tweak demo account generation script

### DIFF
--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -3,7 +3,7 @@
 class Demo::CreateAdminReport
 
   RANGE_OF_NUMBER_OF_SESSIONS_TO_DESTROY = 1..20
-  BATCH_DELAY = 1.minute
+  BATCH_DELAY = 10.seconds
   NUMBER_OF_STUDENTS_PER_CLASSROOM = 25
 
   GRADE_MIN = 5
@@ -36,7 +36,7 @@ class Demo::CreateAdminReport
   end
 
   private def find_or_create_school(school_name)
-    School.find_or_create_by(name: school_name, mail_street: school_street)
+    School.find_or_create_by!(name: school_name, mail_street: school_street)
   end
 
   private def find_or_create_teacher_data(teacher_name, school, subscription)
@@ -68,7 +68,7 @@ class Demo::CreateAdminReport
     admin_teacher = User.create!(
       name: 'Toni Morrison',
       role: User::ADMIN,
-      email: teacher_email,
+      email: @teacher_email,
       username: '',
       password: SecureRandom.urlsafe_base64
     )

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -26,7 +26,7 @@ class Demo::CreateAdminReport
   end
 
   def reset
-    User.find_by_email(@teacher_email)&.destroy
+    User.find_by_email(teacher_email)&.destroy
     School.where(mail_street: school_street).destroy_all
     create_demo
   end
@@ -68,7 +68,7 @@ class Demo::CreateAdminReport
     admin_teacher = User.create!(
       name: 'Toni Morrison',
       role: User::ADMIN,
-      email: @teacher_email,
+      email: teacher_email,
       username: '',
       password: SecureRandom.urlsafe_base64
     )


### PR DESCRIPTION
## WHAT
Tweak the admin demo account generation script to run more quickly and fix what looked like a potential bug.

## WHY
Alex reported a different issue with the admin demo account today, and as I was investigating it I noticed the admin demo account only had one school associated with it. When I tried to replicate this on staging, I found that it was a) really slow and b) on at least one run it wasn't correctly associating new schools with the most recent instance of the admin demo user. I think that was due to some weird ghost in the machine because the previous user had the same email, but I made these tweaks to a) run more quickly, because I was no longer seeing the Redis memory errors we'd previously experienced on staging that necessitated these long delays in the first place, and b) use the instance variable that it seems like we should have been using in the first place, which appears to have solved the issue.

## HOW
Update default time, add bang operator to school creation so we can see errors more easily, 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Make-sure-all-schools-are-consistently-created-on-admin-demo-account-1630a1b7976041d992e1b949a580a477?pvs=4

### What have you done to QA this feature?
Tested on staging and confirmed that it runs in about 45 minutes and the data looks as it should.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
