### PR TITLE
Add the activity translations to the lessons API

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/lessons_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/lessons_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::LessonsController < Api::ApiController
   end
 
   def show
-    render(json: @lesson.data_as_json)
+    render(json: @lesson.translated_json)
   end
 
   def create

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -254,7 +254,15 @@ class Activity < ApplicationRecord
     data
   end
 
+  # translatable
   def self.translatable_field_name = 'landingPageHtml'
+
+  def translated_json(options = {})
+    translations = translated_texts.pluck(:locale, :translation).to_h
+    return data unless translations.present?
+
+    data.merge('translations' => translations)
+  end
 
   def add_question(question)
     return if !validate_question(question)

--- a/services/QuillLMS/app/models/concerns/translatable.rb
+++ b/services/QuillLMS/app/models/concerns/translatable.rb
@@ -31,7 +31,7 @@ module Translatable
     return unless translation_mappings.empty?
 
     english_text = EnglishText.find_or_create_by(text: translatable_text)
-    translation_mappings.create(english_text: english_text)
+    translation_mappings.create(english_text:)
   end
 
   def translation(locale: DEFAULT_LOCALE, source_api: OPEN_AI_SOURCE)

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -840,4 +840,33 @@ describe Activity, type: :model, redis: true do
       it { expect(subject.count).to eq(0) }
     end
   end
+
+  describe 'translated_json' do
+    subject {activity.translated_json}
+
+    let(:activity) { create(:activity)}
+
+    context 'there are translations' do
+      it 'is data + all available languages' do
+        activity.data.merge!({'landingPageHtml' => "html"})
+        activity.create_translation_mappings
+        chinese_locale = "zh-CN"
+        english_text = activity.english_texts.first
+        chinese = create(:translated_text, english_text:, locale: chinese_locale)
+        spanish = create(:translated_text, english_text:, locale: Translatable::SPANISH_LOCALE)
+        expected_data = activity.data.merge(
+          'translations' => {
+            chinese_locale => chinese.translation,
+            Translatable::SPANISH_LOCALE => spanish.translation
+          }
+        )
+        expect(subject).to eq(expected_data)
+      end
+    end
+
+    context 'the activity has no translations' do
+      it { expect(subject).to eq( activity.data )}
+    end
+
+  end
 end


### PR DESCRIPTION
## WHAT
Update the API for an individual activity to include translation. 
## WHY
This data will be used to display the translated activity landing page when a user selects a new language. It will also be used to determine which languages are available for a given activity. 
## HOW
Return the `translated_json` for the activity in the `api/v1/lessons/[uid].json` api call. Updated the method to return a hash of languages. 

### Notion Card Links
[Add hash of languages to activity API](https://www.notion.so/quill/Add-a-hash-of-languages-to-the-landingPageHTML-for-each-activity-json-payload-269f2024a320485ea59ffc59f9262c4c?pvs=4)

### What have you done to QA this feature?
looked at the network tab when loading activities with and without translations to see that the expected payload was there. 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
