### PR TITLE
set-new-diagnostic-follow-up-ids

### DIFF
--- a/services/QuillLMS/lib/tasks/temporary/activities.rake
+++ b/services/QuillLMS/lib/tasks/temporary/activities.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :activities do
+  desc 'Set follow_up_activity_id values on new Diagnostics'
+  task :set_new_follow_up_activity_ids => :environment do
+    pre_post_id_pairs = [
+      [2537,2538], # Starter
+      [2539,2540], # Intermediate
+      [2541,2542], # Advanced
+      [2550,2551], # ELL Starter
+      [2555,2557], # ELL Intermediate
+      [2563,2564] # ELL Advanced
+    ]
+    pre_post_id_pairs.each do |id, follow_up_activity_id|
+      Activity.where(id:)
+        .update(follow_up_activity_id:)
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
Add a rake task to set follow_up_activity_ids on new Diagnostics
## WHY
This value is required for a number of the places that pre and post diagnostics connect to function properly.
## HOW
Create a rake task to find pre diagnostics and set their `follow_up_activity_id` appropriately

### Notion Card Links
https://www.notion.so/quill/New-Diagnostic-Engineering-Tasks-ef849d3f473a4a11a675081a89556a75?pvs=4#e72f45edae0d4136ab9e6d441a5dfd9a

### What have you done to QA this feature?
Run script in staging, confirm the new pre diagnostics are associated with post diagnostics in the database.  Note that this code was pulled out of a broader branch in which I also tested that pre and post diagnostics are properly associated with each other on the Assign Diagnostics page once this data is in place.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, pure data update script
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes