### PR TITLE
Refactor Vitally functions to use global attributes instead of parameters

### DIFF
--- a/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
+++ b/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
@@ -3,7 +3,9 @@
 module VitallySchoolStats
   extend ActiveSupport::Concern
 
-  private def active_students_query(school)
+  attr_accessor :school
+
+  private def active_students_query
     # use raw SQL to bypass scope limits (visible: true) on classrooms
     ActivitySession.unscoped.select(:user_id)
       .distinct
@@ -15,7 +17,7 @@ module VitallySchoolStats
       .where(state: 'finished').where('schools.id = ?', school.id)
   end
 
-  private def activities_finished_query(school)
+  private def activities_finished_query
     ClassroomsTeacher.joins('JOIN users ON users.id=classrooms_teachers.user_id')
       .joins('JOIN schools_users ON schools_users.user_id=users.id')
       .joins('JOIN schools ON schools.id=schools_users.school_id')
@@ -27,7 +29,7 @@ module VitallySchoolStats
       .where('activity_sessions.state = ?', 'finished')
   end
 
-  def activities_assigned_query(school)
+  def activities_assigned_query
     ClassroomUnit.joins(classroom: {teachers: :school}, unit: :activities)
       .where('schools.id = ?', school.id)
       .select('assigned_student_ids', 'activities.id', 'unit_activities.created_at')

--- a/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
+++ b/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
@@ -3,7 +3,7 @@
 module VitallySchoolStats
   extend ActiveSupport::Concern
 
-  attr_accessor :school
+  attr_reader :school
 
   private def active_students_query
     # use raw SQL to bypass scope limits (visible: true) on classrooms

--- a/services/QuillLMS/app/models/concerns/vitally_shared_functions.rb
+++ b/services/QuillLMS/app/models/concerns/vitally_shared_functions.rb
@@ -3,7 +3,7 @@
 module VitallySharedFunctions
   extend ActiveSupport::Concern
 
-  attr_accessor :vitally_entity, :school_year_start, :school_year_end
+  attr_reader :vitally_entity, :school_year_start, :school_year_end
 
   def activities_per_student(active_students, activities_finished)
     return 0 unless active_students.nonzero?

--- a/services/QuillLMS/app/models/concerns/vitally_shared_functions.rb
+++ b/services/QuillLMS/app/models/concerns/vitally_shared_functions.rb
@@ -3,6 +3,8 @@
 module VitallySharedFunctions
   extend ActiveSupport::Concern
 
+  attr_accessor :vitally_entity, :school_year_start, :school_year_end
+
   def activities_per_student(active_students, activities_finished)
     return 0 unless active_students.nonzero?
 
@@ -22,19 +24,19 @@ module VitallySharedFunctions
     activities.select {|r| r.created_at >= school_year_start && r.created_at < school_year_end }
   end
 
-  def evidence_assigned_in_year_count(entity, school_year_start, school_year_end)
-    sum_students(filter_evidence(in_school_year(activities_assigned_query(entity), school_year_start, school_year_end)))
+  def evidence_assigned_in_year_count
+    sum_students(filter_evidence(in_school_year(activities_assigned_query, school_year_start, school_year_end)))
   end
 
-  private def evidence_assigned_count(entity)
-    sum_students(filter_evidence(activities_assigned_query(entity)))
+  private def evidence_assigned_count
+    sum_students(filter_evidence(activities_assigned_query))
   end
 
-  private def evidence_finished(entity)
-    activities_finished_query(entity).where('activities.activity_classification_id=?', ActivityClassification.evidence.id)
+  private def evidence_finished
+    activities_finished_query.where('activities.activity_classification_id=?', ActivityClassification.evidence.id)
   end
 
-  private def evidence_completed_in_year_count(entity, school_year_start, school_year_end)
-    evidence_finished(entity).where('activity_sessions.completed_at >=? AND activity_sessions.completed_at < ?', school_year_start, school_year_end).count
+  private def evidence_completed_in_year_count
+    evidence_finished.where('activity_sessions.completed_at >=? AND activity_sessions.completed_at < ?', school_year_start, school_year_end).count
   end
 end

--- a/services/QuillLMS/app/services/vitally_integration/previous_year_school_datum.rb
+++ b/services/QuillLMS/app/services/vitally_integration/previous_year_school_datum.rb
@@ -6,25 +6,25 @@ module VitallyIntegration
     include VitallySharedFunctions
 
     def initialize(school, year)
-      @year = year
       @school = school
+      @vitally_entity = school
+      @school_year_start = Date.new(year, 7, 1)
+      @school_year_end = school_year_start + 1.year
     end
 
     def calculate_data
-      school_year_start = Date.new(@year, 7, 1)
-      school_year_end = school_year_start + 1.year
       raise 'Cannot calculate data for a school year that is still ongoing.' if school_year_end > Time.current
 
-      active_students_this_year = active_students_query(@school).where('activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
-      activities_finished_this_year = activities_finished_query(@school).where('activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
-      evidence_activities_completed_this_year = evidence_completed_in_year_count(@school, school_year_start, school_year_end)
+      active_students_this_year = active_students_query.where('activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
+      activities_finished_this_year = activities_finished_query.where('activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
+      evidence_activities_completed_this_year = evidence_completed_in_year_count
       {
         # this will not be accurate if calculated after the last day of the school year
         total_students: @school.students.where(last_sign_in: school_year_start..school_year_end).count,
         active_students: active_students_this_year,
         activities_finished: activities_finished_this_year,
         activities_per_student: activities_per_student(active_students_this_year, activities_finished_this_year),
-        evidence_activities_assigned: evidence_assigned_in_year_count(@school, school_year_start, school_year_end),
+        evidence_activities_assigned: evidence_assigned_in_year_count,
         evidence_activities_completed: evidence_activities_completed_this_year,
         completed_evidence_activities_per_student: activities_per_student(active_students_this_year, evidence_activities_completed_this_year)
       }

--- a/services/QuillLMS/app/services/vitally_integration/previous_year_teacher_datum.rb
+++ b/services/QuillLMS/app/services/vitally_integration/previous_year_teacher_datum.rb
@@ -6,25 +6,25 @@ module VitallyIntegration
     include VitallySharedFunctions
 
     def initialize(user, year)
-      @year = year
       @user = user
+      @vitally_entity = user
+      @school_year_start = Date.new(year, 7, 1)
+      @school_year_end = school_year_start + 1.year
     end
 
     def calculate_data
-      school_year_start = Date.new(@year, 7, 1)
-      school_year_end = school_year_start + 1.year
       raise 'Cannot calculate data for a school year that is still ongoing.' if school_year_end > Time.current
 
-      active_students = active_students_query(@user).where('activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
-      activities_assigned = activities_assigned_in_year_count(@user, school_year_start, school_year_end)
-      activities_finished = activities_finished_query(@user).where('activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
-      diagnostics_assigned_this_year = diagnostics_assigned_in_year_count(@user, school_year_start, school_year_end)
-      diagnostics_finished_this_year = diagnostics_finished(@user).where('activity_sessions.completed_at >=? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
-      evidence_activities_assigned_this_year = evidence_assigned_in_year_count(@user, school_year_start, school_year_end)
-      evidence_activities_completed_this_year = evidence_completed_in_year_count(@user, school_year_start, school_year_end)
+      active_students = active_students_query.where('activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
+      activities_assigned = activities_assigned_in_year_count
+      activities_finished = activities_finished_query.where('activity_sessions.completed_at >= ? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
+      diagnostics_assigned_this_year = diagnostics_assigned_in_year_count
+      diagnostics_finished_this_year = diagnostics_finished.where('activity_sessions.completed_at >=? and activity_sessions.completed_at < ?', school_year_start, school_year_end).count
+      evidence_activities_assigned_this_year = evidence_assigned_in_year_count
+      evidence_activities_completed_this_year = evidence_completed_in_year_count
       completed_evidence_activities_per_student_this_year = activities_per_student(active_students, evidence_activities_completed_this_year)
       {
-        total_students: total_students_in_year(@user, school_year_start, school_year_end),
+        total_students: total_students_in_year,
         active_students: active_students,
         activities_assigned: activities_assigned,
         completed_activities: activities_finished,

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -9,17 +9,20 @@ module VitallyIntegration
 
     def initialize(school)
       @school = school
+      @vitally_entity = school
+
+      current_time = Time.current
+      @school_year_start = School.school_year_start(current_time)
+      @school_year_end = school_year_start + 1.year
     end
 
     def data
       current_time = Time.current
-      school_year_start = School.school_year_start(current_time)
-      school_year_end = school_year_start + 1.year
 
-      active_students = active_students_query(@school).count
-      active_students_this_year = active_students_query(@school).where('activity_sessions.completed_at >= ?', school_year_start).count
-      activities_finished = activities_finished_query(@school).count('DISTINCT activity_sessions.id')
-      activities_finished_this_year = activities_finished_query(@school).where('activity_sessions.completed_at >= ?', school_year_start).count('DISTINCT activity_sessions.id')
+      active_students = active_students_query.count
+      active_students_this_year = active_students_query.where('activity_sessions.completed_at >= ?', school_year_start).count
+      activities_finished = activities_finished_query.count('DISTINCT activity_sessions.id')
+      activities_finished_this_year = activities_finished_query.where('activity_sessions.completed_at >= ?', school_year_start).count('DISTINCT activity_sessions.id')
 
       total_premium_months = @school.subscriptions.map(&:length_in_months).sum
 
@@ -78,12 +81,12 @@ module VitallyIntegration
       current_time = Time.current
       school_year_start = School.school_year_start(current_time)
       school_year_end = school_year_start + 1.year
-      active_students_this_year = active_students_query(@school).where('activity_sessions.completed_at >= ?', school_year_start).count
+      active_students_this_year = active_students_query.where('activity_sessions.completed_at >= ?', school_year_start).count
 
-      evidence_activities_assigned_all_time = evidence_assigned_count(@school)
-      evidence_activities_assigned_this_year = evidence_assigned_in_year_count(@school, school_year_start, school_year_end)
-      evidence_activities_completed_all_time = evidence_finished(@school).count
-      evidence_activities_completed_this_year = evidence_completed_in_year_count(@school, school_year_start, school_year_end)
+      evidence_activities_assigned_all_time = evidence_assigned_count
+      evidence_activities_assigned_this_year = evidence_assigned_in_year_count
+      evidence_activities_completed_all_time = evidence_finished.count
+      evidence_activities_completed_this_year = evidence_completed_in_year_count
       evidence_activities_completed_per_student_this_year = activities_per_student(active_students_this_year, evidence_activities_completed_this_year)
 
       {

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_organization.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_organization.rb
@@ -10,6 +10,11 @@ module VitallyIntegration
 
     def initialize(district)
       @district = district
+      @vitally_entity = district
+
+      current_time = Time.current
+      @school_year_start = School.school_year_start(current_time)
+      @school_year_end = school_year_start + 1.year
     end
 
     def data
@@ -35,8 +40,6 @@ module VitallyIntegration
     end
 
     def activities_and_students_rollups
-      current_time = Time.current
-      school_year_start = School.school_year_start(current_time)
       last_school_year_start = school_year_start - 1.year
 
       active_students_this_year = active_students(school_year_start)
@@ -61,8 +64,6 @@ module VitallyIntegration
     end
 
     def diagnostic_rollups
-      school_year_start = School.school_year_start(Time.current)
-
       diagnostics_assigned_this_year = diagnostics_assigned_between_count(school_year_start, school_year_start + 1.year)
       diagnostics_assigned_last_year = diagnostics_assigned_between_count(school_year_start - 1.year, school_year_start)
       diagnostics_completed_this_year = diagnostics_completed_between(school_year_start, school_year_start + 1.year)
@@ -81,19 +82,18 @@ module VitallyIntegration
     end
 
     private def evidence_rollups
-      school_year_start = School.school_year_start(Time.current)
       last_school_year_start = school_year_start - 1.year
-      school_year_end = school_year_start + 1.year
+
       active_students_this_year = active_students(school_year_start)
       active_students_last_year = active_students(last_school_year_start, school_year_start)
 
-      evidence_activities_assigned_all_time = evidence_assigned_count(district)
-      evidence_activities_assigned_this_year = evidence_assigned_in_year_count(district, school_year_start, school_year_end)
-      evidence_activities_assigned_last_year = evidence_assigned_in_year_count(district, last_school_year_start, school_year_start)
-      evidence_activities_completed_all_time = evidence_finished(district).count
-      evidence_activities_completed_this_year = evidence_completed_in_year_count(district, school_year_start, school_year_end)
+      evidence_activities_assigned_all_time = evidence_assigned_count
+      evidence_activities_assigned_this_year = sum_students(filter_evidence(in_school_year(activities_assigned_query, school_year_start, school_year_end)))
+      evidence_activities_assigned_last_year = sum_students(filter_evidence(in_school_year(activities_assigned_query, last_school_year_start, school_year_start)))
+      evidence_activities_completed_all_time = evidence_finished.count
+      evidence_activities_completed_this_year = evidence_finished.where('activity_sessions.completed_at >=? AND activity_sessions.completed_at < ?', school_year_start, school_year_end).count
       evidence_activities_completed_per_student_this_year = activities_per_student(active_students_this_year, evidence_activities_completed_this_year)
-      evidence_activities_completed_last_year = evidence_completed_in_year_count(district, last_school_year_start, school_year_start)
+      evidence_activities_completed_last_year = evidence_finished.where('activity_sessions.completed_at >=? AND activity_sessions.completed_at < ?', last_school_year_start, school_year_start).count
       evidence_activities_completed_per_student_last_year = activities_per_student(active_students_last_year, evidence_activities_completed_last_year)
 
       {
@@ -199,13 +199,13 @@ module VitallyIntegration
         .where('activity_sessions.state = ?', 'finished')
     end
 
-    def activities_assigned_query(district)
+    def activities_assigned_query
       ClassroomUnit.joins(classroom: {teachers: {school: :district}}, unit: :activities)
         .where('districts.id = ?', district.id)
         .select('assigned_student_ids', 'activities.id', 'unit_activities.created_at')
     end
 
-    def activities_finished_query(district)
+    def activities_finished_query
       ClassroomsTeacher.joins(user: {schools_users: {school: :district}}, classroom: [{classroom_units: {unit: :activities}}, {classroom_units: :activity_sessions}])
         .where('districts.id = ?', district.id)
         .where('activity_sessions.state = ?', 'finished')

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_user.rb
@@ -9,6 +9,11 @@ module VitallyIntegration
 
     def initialize(user)
       @user = user
+      @vitally_entity = user
+
+      current_time = Time.current
+      @school_year_start = School.school_year_start(current_time)
+      @school_year_end = school_year_start + 1.year
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
@@ -17,21 +22,20 @@ module VitallyIntegration
       current_time = Time.current
       school_year_start = School.school_year_start(current_time)
       school_year_end = school_year_start + 1.year
-      active_students = active_students_query(@user).count
-      active_students_this_year = active_students_query(@user).where('activity_sessions.completed_at >= ?', school_year_start).count
-      activities_finished = activities_finished_query(@user).count
-      activities_finished_this_year = activities_finished_query(@user).where('activity_sessions.completed_at >= ?', school_year_start).count
-      activities_assigned = activities_assigned_count(@user)
-      activities_assigned_this_year = activities_assigned_in_year_count(@user, school_year_start, school_year_end)
-      diagnostics_assigned = diagnostics_assigned_count(@user)
-      diagnostics_assigned_this_year = diagnostics_assigned_in_year_count(@user, school_year_start, school_year_end)
-      diagnostics_finished = diagnostics_finished(@user).count
-      diagnostics_finished_this_year = diagnostics_finished(@user).where('activity_sessions.completed_at >=?', school_year_start).count
-      evidence_activities_assigned_all_time = evidence_assigned_count(@user)
-      evidence_activities_assigned_this_year = evidence_assigned_in_year_count(@user, school_year_start, school_year_end)
-      evidence_activities_completed_all_time = evidence_finished(@user).count
-      evidence_activities_completed_this_year = evidence_completed_in_year_count(@user, school_year_start, school_year_end)
-      date_of_last_completed_evidence_activity = evidence_finished(@user).order('activity_sessions.completed_at DESC').select('activity_sessions.completed_at').first&.completed_at&.strftime('%F') || 'N/A'
+      active_students = active_students_query.count
+      active_students_this_year = active_students_query.where('activity_sessions.completed_at >= ?', school_year_start).count
+      activities_finished = activities_finished_query.count
+      activities_finished_this_year = activities_finished_query.where('activity_sessions.completed_at >= ?', school_year_start).count
+      activities_assigned = activities_assigned_count
+      activities_assigned_this_year = activities_assigned_in_year_count
+      diagnostics_assigned = diagnostics_assigned_count
+      diagnostics_assigned_this_year = diagnostics_assigned_in_year_count
+      diagnostics_finished_this_year = diagnostics_finished.where('activity_sessions.completed_at >=?', school_year_start).count
+      evidence_activities_assigned_all_time = evidence_assigned_count
+      evidence_activities_assigned_this_year = evidence_assigned_in_year_count
+      evidence_activities_completed_all_time = evidence_finished.count
+      evidence_activities_completed_this_year = evidence_completed_in_year_count
+      date_of_last_completed_evidence_activity = evidence_finished.order('activity_sessions.completed_at DESC').select('activity_sessions.completed_at').first&.completed_at&.strftime('%F') || 'N/A'
       learn_worlds_account = @user.learn_worlds_account
       learn_worlds_enrolled_courses = learn_worlds_account&.enrolled_courses
       learn_worlds_completed_courses = learn_worlds_account&.completed_courses
@@ -75,9 +79,9 @@ module VitallyIntegration
           percent_completed_activities: activities_assigned > 0 ? (activities_finished.to_f / activities_assigned).round(2) : 'N/A',
           completed_activities_per_student: activities_per_student(active_students, activities_finished),
           diagnostics_assigned: diagnostics_assigned,
-          diagnostics_finished: diagnostics_finished,
-          percent_completed_diagnostics: diagnostics_assigned > 0 ? (diagnostics_finished.to_f / diagnostics_assigned).round(2) : 'N/A',
-          total_students_this_year: total_students_in_year(@user, school_year_start, school_year_end),
+          diagnostics_finished: diagnostics_finished.count,
+          percent_completed_diagnostics: diagnostics_assigned > 0 ? (diagnostics_finished.count.to_f / diagnostics_assigned).round(2) : 'N/A',
+          total_students_this_year: total_students_in_year,
           total_students_last_year: get_from_cache('total_students'),
           active_students_this_year: active_students_this_year,
           active_students_last_year: get_from_cache('active_students'),
@@ -175,12 +179,12 @@ module VitallyIntegration
       end
     end
 
-    private def activities_assigned_count(user)
-      sum_students(activities_assigned_query(user))
+    private def activities_assigned_count
+      sum_students(activities_assigned_query)
     end
 
-    private def diagnostics_assigned_count(user)
-      sum_students(filter_diagnostics(activities_assigned_query(user)))
+    private def diagnostics_assigned_count
+      sum_students(filter_diagnostics(activities_assigned_query))
     end
 
     private def premium_status


### PR DESCRIPTION
## WHAT
Admin requested a lot of new Vitally attributes to be added to the sync. Before we do that, I want to refactor our Vitally-related functions to stop passing parameters back and forth between functions, and instead use global variables accessible by all the functions. 

## WHY
This is a much cleaner way to calculate data because we no longer need to pass parameters back and forth between functions. The code is more readable and easier to use. The cleanup will make the upcoming Vitally workload much easier.

## HOW
Stop passing these attributes back and forth between functions - `district, school, user, school_year_start, school_year_end`. Instead, make these variables global variables that each subclass must set upon initialization. 

Each shared function module defines only the global variables necessary for their scope. So for example, `VitallySharedFunctions` defines the `vitally_entity` variable which represents either schools, districts or users depending on the subclass. While `VitallySchoolStats` defines only the `school` variable because its implementation assumes that the entity is a `School` record.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
[(Please provide links to any relevant Notion card(s) relevant to this PR.)](https://www.notion.so/quill/Update-Vitally-Data-Sync-New-Diagnostic-Usage-Data-2fb92d4ba89847af9da661fc78710556?pvs=4)

### What have you done to QA this feature?
Ran all the rspec tests to ensure everything is working properly. 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
