### PR TITLE
Change translatable method prompt to open_ai_prompt

### DIFF
--- a/services/QuillLMS/app/models/concerns/translatable.rb
+++ b/services/QuillLMS/app/models/concerns/translatable.rb
@@ -53,7 +53,7 @@ module Translatable
       Gengo::RequestTranslations.run(english_texts, locale)
     when OPEN_AI_SOURCE
       texts = force ? english_texts : english_texts.reject {|e| e.translated?(locale:)}
-      texts.each{ |text| OpenAI::TranslateAndSaveText.run(text, prompt: prompt(locale:)) }
+      texts.each{ |text| OpenAI::TranslateAndSaveText.run(text, prompt: open_ai_prompt(locale:)) }
     end
     translation(locale:, source_api:)
   end
@@ -62,7 +62,7 @@ module Translatable
     gengo_jobs.each(&:fetch_translation!)
   end
 
-  def prompt(locale:)
+  def open_ai_prompt(locale:)
     "#{prompt_start(locale:)}#{custom_prompt}#{examples}\n text to translate: "
   end
 

--- a/services/QuillLMS/spec/models/concerns/translatable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/translatable_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Translatable do
 
     context 'when using OpenAI as the source' do
       let(:source_api) { Translatable::OPEN_AI_SOURCE }
-      let(:prompt) { translatable_object.prompt(locale:) }
+      let(:prompt) { translatable_object.open_ai_prompt(locale:) }
 
       context 'there is not an existing translation' do
         it 'calls OpenAI::TranslateAndSaveText for each English text' do
@@ -267,7 +267,7 @@ RSpec.describe Translatable do
     end
   end
 
-  describe '#prompt(locale:)' do
+  describe '#open_ai_prompt(locale:)' do
     let(:locale) { Translatable::DEFAULT_LOCALE }
 
     it 'returns the expected prompt' do
@@ -277,13 +277,13 @@ RSpec.describe Translatable do
         We are translating the instructions for an English-language grammar activity. The content of the activity itself is not translated.
       STRING
       expected += "\nTest prompt\n text to translate: "
-      expect(translatable_object.prompt(locale:)).to eq(expected)
+      expect(translatable_object.open_ai_prompt(locale:)).to eq(expected)
     end
 
     it 'adds in the example_json' do
       filename = 'question.yml'
       allow(translatable_object).to receive(:config_file).and_return(Rails.root.join('app/models/translation_config', filename))
-      prompt = translatable_object.prompt(locale:)
+      prompt = translatable_object.open_ai_prompt(locale:)
       expect(prompt).to match(translatable_object.send(:examples))
       expect(translatable_object.send(:examples)).to match('1. English: "Combine the sentences')
     end


### PR DESCRIPTION
## WHAT
Fix a name collision between `Question` and `Translatable` where both had `prompt` defined.
## WHY
[This PR](https://github.com/empirical-org/Empirical-Core/pull/12084) to use `data_accessors` for the `Question` model added a `data_accessor` for the property `prompt`. It led to a name collision with the [translatable method](https://github.com/empirical-org/Empirical-Core/blob/4d24685eb4480e2897cd4ed487884a04ab17ce88/services/QuillLMS/app/models/concerns/translatable.rb#L65-L67) `prompt(locale:)` which caused [an error](https://quillorg-5s.sentry.io/issues/5622212978/?project=11238) when trying to translate a `Question`. 
## HOW
change the method name in `Translatable` from `prompt` to `open_ai_prompt`


### Notion Card Links
[Translate feedback](https://www.notion.so/quill/Translate-question-feedback-for-activities-that-need-translation-29eb2286675e4a05a8841d1ee63f5f9b?pvs=4)

### What have you done to QA this feature?
Testing running translations for questions locally. 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
