### PR TITLE
Bug fix/ dropdown helper text margin

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/styles/input.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/input.scss
@@ -5,6 +5,9 @@
   position: relative;
 
   &.dropdown-container {
+    .helper-text {
+      margin-top: 8px;
+    }
     .dropdown {
       .dropdown__control {
         display: flex;
@@ -87,10 +90,6 @@
 
     .dropdown {
       margin-bottom: 0px;
-    }
-
-    .helper-text {
-      margin-top: 8px;
     }
 
     &.active {


### PR DESCRIPTION
## WHAT
fix margin for helper text of dropdown inputs

## WHY
we want to have the correct margin between the input and the helper text element

## HOW
just move the CSS rule up in the hierarchy to apply to all dropdown types (not just bordered)

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Dropdown-subtext-incorrectly-aligned-b3c0e02f0b754ba99a3ebd15110520a0?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
checked on staging that dropdown inputs with helper text have the expected margin (also checked that text field inputs weren't changed)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | no-- CSS change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
