### PR TITLE
Replace except with only

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/concept_feedback_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::ConceptFeedbackController < Api::ApiController
-  before_action :activity_type, except: [:index, :translations]
-  before_action :concept_feedback_by_uid, except: [:index, :create, :update, :translations]
+  before_action :activity_type, only: [:show, :create, :update, :destroy]
+  before_action :concept_feedback_by_uid, only: [:show, :destroy]
 
   CACHE_EXPIRY = 24.hours
 


### PR DESCRIPTION
## WHAT
Replace before_action with preferred usage of `only` instead of `except` 

## WHY
`only` is a little safer

### What have you done to QA this feature?
Ran the tests! Checked manually 
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
