### PR TITLE
Concept feedback api (#12111)

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/lessons_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/lessons_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::LessonsController < Api::ApiController
   end
 
   def show
-    render(json: @lesson.translated_json)
+    render(json: @lesson.json_with_translations)
   end
 
   def create

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -257,7 +257,7 @@ class Activity < ApplicationRecord
   # translatable
   def self.default_translatable_field = 'landingPageHtml'
 
-  def translated_json(options = {})
+  def json_with_translations
     translations = translated_texts.pluck(:locale, :translation).to_h
     return data unless translations.present?
 

--- a/services/QuillLMS/app/models/concept_feedback.rb
+++ b/services/QuillLMS/app/models/concept_feedback.rb
@@ -38,11 +38,17 @@ class ConceptFeedback < ApplicationRecord
   def cache_key = "#{ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}"
 
   def as_json(options = nil)
-    translated_json(options || {})
+    data
   end
 
-
+  # translatable
   def self.default_translatable_field = 'description'
+
+  def translations_json(locale:)
+    return {} unless translation(locale:)
+
+    { uid => { default_translatable_field => translation(locale:) } }
+  end
 
   private def data_must_be_hash
     errors.add(:data, 'must be a hash') unless data.is_a?(Hash)

--- a/services/QuillLMS/app/models/concerns/translatable.rb
+++ b/services/QuillLMS/app/models/concerns/translatable.rb
@@ -18,14 +18,6 @@ module Translatable
     class_attribute :default_translatable_field, default: nil
   end
 
-  def translated_json(options = {})
-    source_api = options&.dig(:source_api) || Translatable::OPEN_AI_SOURCE
-    translation_text = translation(source_api: source_api)
-    return data unless translation_text.present?
-
-    data.merge({"translated#{default_translatable_field.capitalize}" => translation_text})
-  end
-
   def create_translation_mappings
     create_translation_mappings_with_text(translatable_text:)
   end
@@ -39,7 +31,7 @@ module Translatable
   end
 
   def translation(locale: DEFAULT_LOCALE, source_api: OPEN_AI_SOURCE)
-    translations(locale: locale, source_api: source_api)&.first&.translation
+    @translation ||= translations(locale: locale, source_api: source_api)&.first&.translation
   end
 
   def translations(locale:, source_api:)

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -79,7 +79,7 @@ class Question < ApplicationRecord
   scope :production, -> {where("data->>'flag' = ?", FLAG_PRODUCTION)}
 
   def as_json(options=nil)
-    translated_json(options)
+    data
   end
 
   def self.all_questions_json(question_type)

--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -46,18 +46,6 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
     }
   }
 
-  toggleTranslation() {
-    this.setState(prevState => ({ translated: !prevState.translated }))
-  }
-
-  renderTranslationButton(data) {
-    const { translated } = this.state
-    if(data.translatedDescription) {
-      const buttonText = translated ? "Hide translation" : "Show translation"
-      return <button className="button is-info" id='toggle-translation' onClick={this.toggleTranslation}>{buttonText}</button>
-    }
-  }
-
   submitNewFeedback(conceptFeedbackID: string, data: ConceptFeedback) {
     this.props.dispatch(actions.submitConceptsFeedbackEdit(conceptFeedbackID, data))
   }
@@ -89,11 +77,10 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
         return (
           <div key={conceptFeedbackID}>
             {conceptName}
-            <ConceptExplanation {...data[conceptFeedbackID]} translated={this.state.translated} />
+            <ConceptExplanation {...data[conceptFeedbackID]} />
             <p className="concept-feedback-control">
               <button className="button is-info" onClick={this.toggleEdit}>Edit Feedback</button>
               <button className="button is-danger" onClick={this.deleteConceptsFeedback}>Delete Concept Feedback</button>
-              {this.renderTranslationButton(data[conceptFeedbackID])}
             </p>
           </div>
         )

--- a/services/QuillLMS/client/app/bundles/Shared/__tests__/components/feedback/__snapshots__/conceptExplanation.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Shared/__tests__/components/feedback/__snapshots__/conceptExplanation.test.tsx.snap
@@ -22,11 +22,6 @@ exports[`ConceptExplanation it should render 1`] = `
       Combine two describing words using and.
     </div>
     <div
-      class="concept-explanation-translation"
-    >
-      Combinar dos palabras usando and.
-    </div>
-    <div
       class="concept-explanation-see-write"
     >
       <div

--- a/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/feedback/conceptExplanation.tsx
@@ -9,14 +9,10 @@ function getClassName(description, leftBox, rightBox) {
 
 const ConceptExplanation = ({ description, leftBox, rightBox, translatedDescription, adminShowTranslation}) => {
   const urlParams = new URLSearchParams(window.location.search)
-  // This is a temporary way to show translations until we add a language selector in the top bar.
-  const showTranslationsFromQueryString = urlParams.get('showTranslations') === 'true'
-  const showsTranslation = (translatedDescription != null) && (adminShowTranslation || showTranslationsFromQueryString)
   return (
     <div className={getClassName(description, leftBox, rightBox)}>
       <div className="concept-explanation-title"><img alt="Light Bulb Icon" src="https://assets.quill.org/images/icons/hint.svg" /><span>Hint</span></div>
       <div className="concept-explanation-description" dangerouslySetInnerHTML={{__html: description}} />
-      { showsTranslation && <div className="concept-explanation-translation" dangerouslySetInnerHTML={{__html: translatedDescription}} /> }
 
       <div className="concept-explanation-see-write">
         <div className="concept-explanation-see" dangerouslySetInnerHTML={{__html: leftBox}} />

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -530,7 +530,11 @@ EmpiricalGrammar::Application.routes.draw do
       end
       resources :shared_cache, only: [:show, :update, :destroy]
       scope 'activity_type/:activity_type' do
-        resources :concept_feedback
+        resources :concept_feedback do
+          collection do
+            get 'translations/:locale', action: :translations
+          end
+        end
       end
 
       resources :questions, only: [:index, :show, :new, :create, :edit, :update] do

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -6,7 +6,6 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
   let!(:concept_feedback) { create(:concept_feedback) }
 
   describe '#index' do
-
     it 'should return a list of ConceptFeedbacks' do
       get :index, params: { activity_type: concept_feedback.activity_type }, as: :json
       expect(JSON.parse(response.body).keys.length).to eq(1)
@@ -27,6 +26,88 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
           .reduce({}) { |agg, q| agg.update({q.uid => q.as_json}) }
       )
     end
+
+  end
+
+  describe "#translations" do
+    let(:locale) { Translatable::DEFAULT_LOCALE }
+    let!(:concept_feedback_untranslated) { create(:concept_feedback)}
+    let(:cache_key) {
+      "#{ConceptFeedback::ALL_CONCEPT_FEEDBACKS_KEY}_#{concept_feedback_untranslated.activity_type}_#{locale}"
+    }
+
+    context 'there is a translation available for the language' do
+      let!(:concept_feedback1) { create(:concept_feedback, :with_translated_text)}
+      let!(:concept_feedback2) { create(:concept_feedback, :with_translated_text)}
+
+      context 'there is no cache set' do
+        before do
+          $redis.del(cache_key)
+          get :translations, params: {
+              locale:,
+              activity_type: concept_feedback1.activity_type
+          }, as: :json
+        end
+
+        it 'returns all the concept feedback translated fields for that language' do
+          body = JSON.parse(response.body)
+          expect(body[concept_feedback1.uid]['description']).to eq(concept_feedback1.translation(locale:))
+          expect(body[concept_feedback2.uid]['description']).to eq(concept_feedback2.translation(locale:))
+          expect(body.keys).not_to include(concept_feedback_untranslated.uid)
+        end
+
+        it 'sets the redis cache' do
+          expect($redis.get(cache_key)).to eq(response.body)
+        end
+      end
+
+      context 'the cache is set' do
+        let(:cache_value) { {foo: 'bar'}.to_json }
+
+        before do
+          $redis.set(cache_key, cache_value)
+        end
+
+        it 'returns the cache value' do
+          get :translations, params: {
+              locale:,
+              activity_type: concept_feedback1.activity_type
+          }, as: :json
+          expect(response.body).to eq(cache_value)
+        end
+      end
+    end
+
+    context 'there is no translation for that language' do
+      context 'there is no cache set' do
+        before do
+          $redis.del(cache_key)
+        end
+
+        it 'returns an empty hash' do
+          get :translations, params: {
+              locale:,
+              activity_type: concept_feedback_untranslated.activity_type
+          }, as: :json
+          body = JSON.parse(response.body)
+          expect(body).to eq({})
+        end
+      end
+
+      context 'the cache is set' do
+        let(:cache_value) { {foo: 'bar'}.to_json }
+
+        it 'returns the cache value' do
+          $redis.set(cache_key, cache_value)
+          get :translations, params: {
+              locale:,
+              activity_type: concept_feedback_untranslated.activity_type
+          }, as: :json
+          expect(response.body).to eq(cache_value)
+        end
+      end
+    end
+
   end
 
   describe '#show' do

--- a/services/QuillLMS/spec/factories/concept_feedbacks.rb
+++ b/services/QuillLMS/spec/factories/concept_feedbacks.rb
@@ -27,5 +27,15 @@ FactoryBot.define do
     uid { SecureRandom.uuid }
     activity_type { 'connect' }
     data { data }
+
+    trait :with_translated_text do
+      after(:create) do |concept_feedback|
+        create(:translation_mapping_with_translation,
+          source: concept_feedback,
+          field_name: concept_feedback.default_translatable_field
+        )
+      end
+    end
+
   end
 end

--- a/services/QuillLMS/spec/factories/english_texts.rb
+++ b/services/QuillLMS/spec/factories/english_texts.rb
@@ -13,5 +13,11 @@ FactoryBot.define do
   factory :english_text do
     text { Faker::Quotes::Shakespeare.romeo_and_juliet_quote }
 
+    trait :with_translated_text do
+      after(:create) do |english_text|
+        create(:translated_text, english_text: english_text)
+      end
+    end
+
   end
 end

--- a/services/QuillLMS/spec/factories/translation_mappings.rb
+++ b/services/QuillLMS/spec/factories/translation_mappings.rb
@@ -18,4 +18,8 @@ FactoryBot.define do
     english_text { create(:english_text) }
     field_name { 'description' }
   end
+
+  factory :translation_mapping_with_translation, parent: :translation_mapping do
+    english_text { create(:english_text, :with_translated_text)}
+  end
 end

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -841,8 +841,8 @@ describe Activity, type: :model, redis: true do
     end
   end
 
-  describe 'translated_json' do
-    subject {activity.translated_json}
+  describe 'json_with_translations' do
+    subject {activity.json_with_translations}
 
     let(:activity) { create(:activity)}
 

--- a/services/QuillLMS/spec/models/concept_feedback_spec.rb
+++ b/services/QuillLMS/spec/models/concept_feedback_spec.rb
@@ -55,16 +55,6 @@ RSpec.describe ConceptFeedback, type: :model do
     end
   end
 
-  describe '#as_json' do
-    let(:concept_feedback) { create(:concept_feedback, data: { 'description' => 'Test description' }) }
-    let(:options) { { source_api: 'test_api' } }
-
-    it 'delegates to the translated_json method from Translatable concern' do
-      expect(concept_feedback).to receive(:translated_json).with(options)
-      concept_feedback.as_json(options)
-    end
-  end
-
   describe '#callbacks' do
     let!(:concept_feedback) { create(:concept_feedback) }
 
@@ -84,4 +74,25 @@ RSpec.describe ConceptFeedback, type: :model do
     end
   end
 
+  describe '#translations_json(language:)' do
+    subject { concept_feedback.translations_json(locale: )}
+
+    let(:locale) { Translatable::DEFAULT_LOCALE}
+
+    context 'there is a translation for the language' do
+      let(:concept_feedback) { create(:concept_feedback, :with_translated_text)}
+
+      it 'returns a json hash of with the uid as the key and the translation as the value' do
+        expect(subject).to eq({
+          concept_feedback.uid => { 'description' => concept_feedback.translation }
+        })
+      end
+    end
+
+    context 'there is no translation for the language' do
+      let(:concept_feedback) { create(:concept_feedback)}
+
+      it { expect(subject).to eq({})}
+    end
+  end
 end

--- a/services/QuillLMS/spec/models/concerns/translatable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/translatable_spec.rb
@@ -289,42 +289,4 @@ RSpec.describe Translatable do
     end
   end
 
-  describe '#translated_json' do
-    subject { translatable_object.translated_json(options) }
-
-    let(:options) { {} }
-    let(:data) { translatable_object.data }
-
-    context 'when there are no translations' do
-      it { is_expected.to eq(data) }
-    end
-
-    context 'when there are translations available' do
-      let(:translation) { 'test translation' }
-      let(:translated_text) { create(:translated_text, translation: translation) }
-
-      before do
-        translatable_object.create_translation_mappings
-        translatable_object.english_texts.first.translated_texts << translated_text
-      end
-
-      it 'adds the translations to the data' do
-        expect(subject['translatedTest_text']).to eq(translation)
-      end
-
-      context 'when a specific source_api is provided' do
-        let(:options) { { source_api: Translatable::GENGO_SOURCE } }
-        let(:gengo_translation) { 'gengo translation' }
-        let(:gengo_translated_text) { create(:translated_text, translation: gengo_translation, source_api: Translatable::GENGO_SOURCE) }
-
-        before do
-          translatable_object.english_texts.first.translated_texts << gengo_translated_text
-        end
-
-        it 'uses the specified source_api for translation' do
-          expect(subject['translatedTest_text']).to eq(gengo_translation)
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
* Remove translated_json method and rename method for activity.

* Remove translations from ConceptFeedback JSON for now.

* Add new factories to more easily create a translated object.

* Put back in as_json for question

* Add method to concept_feedback to get translated json

* Add route for translated hints.

* DRY out code.

* Rubocop

* Make test more robust for cache and no cache cases.

* Standardize test syntax

---------

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
