### PR TITLE
Questions api

### DIFF
--- a/services/QuillLMS/app/controllers/api/v1/activity_questions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_questions_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::ActivityQuestionsController < ApplicationController
   def index
-    activity = Activity.find_by(uid: params[:activity_id])
+    activity = Activity.find_by(uid: permitted_params[:activity_id])
 
     if activity.nil?
       render json: { error: 'Activity not found' }, status: :not_found
@@ -15,12 +15,16 @@ class Api::V1::ActivityQuestionsController < ApplicationController
   private def cached_questions(activity)
     Rails.cache.fetch(cache_key(activity), expires_in: 1.hour) do
       activity.questions.each_with_object({}) do |question, hash|
-        hash[question.uid] = question.as_json(locale: params[:locale])
+        hash[question.uid] = question.as_json(locale: permitted_params[:locale])
       end
     end
   end
 
   private def cache_key(activity)
-    "activity_questions/#{activity.uid}/#{params[:locale]}"
+    "activity_questions/#{activity.uid}/#{permitted_params[:locale]}"
+  end
+
+  private def permitted_params
+    params.permit(:activity_id, :locale)
   end
 end

--- a/services/QuillLMS/app/controllers/api/v1/activity_questions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_questions_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Api::V1::ActivityQuestionsController < ApplicationController
+  def index
+    activity = Activity.find_by(uid: params[:activity_id])
+
+    if activity.nil?
+      render json: { error: 'Activity not found' }, status: :not_found
+    else
+      render json: cached_questions(activity)
+    end
+  end
+
+
+  private def cached_questions(activity)
+    Rails.cache.fetch(cache_key(activity), expires_in: 1.hour) do
+      activity.questions.each_with_object({}) do |question, hash|
+        hash[question.uid] = question.as_json(locale: params[:locale])
+      end
+    end
+  end
+
+  private def cache_key(activity)
+    "activity_questions/#{activity.uid}/#{params[:locale]}"
+  end
+end

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -79,7 +79,8 @@ class Question < ApplicationRecord
   scope :production, -> { where("data->>'flag' = ?", FLAG_PRODUCTION) }
 
   def as_json(options=nil)
-    data
+    locale = options&.[](:locale)
+    locale.present? ? translated_data(locale:) : data
   end
 
   def self.all_questions_json(question_type)
@@ -156,7 +157,6 @@ class Question < ApplicationRecord
   def delete_incorrect_sequence(id)
     delete_data_for(id:, type: INCORRECT_SEQUENCES)
   end
-
 
   # this attribute is used by the CMS's Rematch All process
   def rematch_type

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -79,7 +79,7 @@ class Question < ApplicationRecord
   scope :production, -> { where("data->>'flag' = ?", FLAG_PRODUCTION) }
 
   def as_json(options=nil)
-    locale = options&.[](:locale)
+    locale = options&.fetch(:locale, nil)
     locale.present? ? translated_data(locale:) : data
   end
 

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -465,7 +465,9 @@ EmpiricalGrammar::Application.routes.draw do
       get 'activity_health' => 'rule_feedback_histories#activity_health'
       post 'email_csv_data' => 'session_feedback_histories#email_csv_data'
 
-      resources :activities, only: [:create, :show, :update, :destroy]
+      resources :activities, only: [:create, :show, :update, :destroy] do
+        resources :questions, only: [:index], controller: 'activity_questions'
+      end
       resources :activity_flags, only: [:index]
       resources :activity_sessions, only: [:create, :show, :update, :destroy]
       resources :feedback_histories, only: [:index, :show, :create]

--- a/services/QuillLMS/spec/controllers/api/v1/activity_questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_questions_controller_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::ActivityQuestionsController, type: :controller do
+  let(:redis) { Redis.new }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::RedisCacheStore.new(redis: redis))
+  end
+
+  describe "GET #index" do
+    let(:activity) { create(:activity) }
+    let(:questions) { create_list(:question, 3) }
+    let(:locale) { 'en' }
+    let(:cache_key) { "activity_questions/#{activity.uid}/#{locale}" }
+
+    before do
+      allow(Activity).to receive(:find_by).with(uid: activity.uid).and_return(activity)
+      allow(activity).to receive(:questions).and_return(questions)
+      questions.each do |question|
+        allow(question).to receive(:as_json).with(locale: locale).and_return({ "id" => question.id, "content" => "Question content" })
+      end
+    end
+
+    it "returns http success" do
+      get :index, params: { activity_id: activity.uid, locale: locale }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "returns questions as a hash with UIDs as keys" do
+      get :index, params: { activity_id: activity.uid, locale: locale }
+
+      json_response = JSON.parse(response.body)
+      expect(json_response.keys).to match_array(questions.map(&:uid))
+    end
+
+    it "calls as_json with the correct locale for each question" do
+      expect(questions).to all(receive(:as_json).with(locale:))
+      get :index, params: { activity_id: activity.uid, locale: locale }
+    end
+
+    it "caches the result" do
+      expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 1.hour).and_call_original
+
+      get :index, params: { activity_id: activity.uid, locale: locale }
+    end
+
+    it "returns cached result on subsequent requests" do
+      get :index, params: { activity_id: activity.uid, locale: locale }
+
+      # Clear any existing stub to ensure we're testing the actual caching
+      allow(Activity).to receive(:find_by).and_call_original
+
+      # This should now come from cache
+      get :index, params: { activity_id: activity.uid, locale: locale }
+      expect(response).to have_http_status(:success)
+    end
+
+    context "when activity is not found" do
+      before do
+        allow(Activity).to receive(:find_by).and_return(nil)
+      end
+
+      it "returns http not_found" do
+        get :index, params: { activity_id: 'non_existent_uid', locale: locale }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "does not attempt to cache" do
+        expect(Rails.cache).not_to receive(:fetch)
+
+        get :index, params: { activity_id: 'non_existent_uid', locale: locale }
+      end
+    end
+
+    context "with different locales" do
+      let(:locale) { 'es' }
+
+      it "passes the correct locale to as_json" do
+        expect(questions).to all(receive(:as_json).with(locale: 'es'))
+        get :index, params: { activity_id: activity.uid, locale: locale }
+      end
+
+
+      it "uses a different cache key for different locales" do
+        expect(Rails.cache).to receive(:fetch).with("activity_questions/#{activity.uid}/es", expires_in: 1.hour).and_call_original
+        get :index, params: { activity_id: activity.uid, locale: locale }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/spec/controllers/api/v1/activity_questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_questions_controller_spec.rb
@@ -19,17 +19,17 @@ RSpec.describe Api::V1::ActivityQuestionsController, type: :controller do
       allow(Activity).to receive(:find_by).with(uid: activity.uid).and_return(activity)
       allow(activity).to receive(:questions).and_return(questions)
       questions.each do |question|
-        allow(question).to receive(:as_json).with(locale: locale).and_return({ "id" => question.id, "content" => "Question content" })
+        allow(question).to receive(:as_json).with(locale:).and_return({ "id" => question.id, "content" => "Question content" })
       end
     end
 
     it "returns http success" do
-      get :index, params: { activity_id: activity.uid, locale: locale }
+      get :index, params: { activity_id: activity.uid, locale: }
       expect(response).to have_http_status(:success)
     end
 
     it "returns questions as a hash with UIDs as keys" do
-      get :index, params: { activity_id: activity.uid, locale: locale }
+      get :index, params: { activity_id: activity.uid, locale: }
 
       json_response = JSON.parse(response.body)
       expect(json_response.keys).to match_array(questions.map(&:uid))
@@ -37,23 +37,23 @@ RSpec.describe Api::V1::ActivityQuestionsController, type: :controller do
 
     it "calls as_json with the correct locale for each question" do
       expect(questions).to all(receive(:as_json).with(locale:))
-      get :index, params: { activity_id: activity.uid, locale: locale }
+      get :index, params: { activity_id: activity.uid, locale: }
     end
 
     it "caches the result" do
       expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 1.hour).and_call_original
 
-      get :index, params: { activity_id: activity.uid, locale: locale }
+      get :index, params: { activity_id: activity.uid, locale: }
     end
 
     it "returns cached result on subsequent requests" do
-      get :index, params: { activity_id: activity.uid, locale: locale }
+      get :index, params: { activity_id: activity.uid, locale: }
 
       # Clear any existing stub to ensure we're testing the actual caching
       allow(Activity).to receive(:find_by).and_call_original
 
       # This should now come from cache
-      get :index, params: { activity_id: activity.uid, locale: locale }
+      get :index, params: { activity_id: activity.uid, locale: }
       expect(response).to have_http_status(:success)
     end
 
@@ -63,14 +63,14 @@ RSpec.describe Api::V1::ActivityQuestionsController, type: :controller do
       end
 
       it "returns http not_found" do
-        get :index, params: { activity_id: 'non_existent_uid', locale: locale }
+        get :index, params: { activity_id: 'non_existent_uid', locale: }
         expect(response).to have_http_status(:not_found)
       end
 
       it "does not attempt to cache" do
         expect(Rails.cache).not_to receive(:fetch)
 
-        get :index, params: { activity_id: 'non_existent_uid', locale: locale }
+        get :index, params: { activity_id: 'non_existent_uid', locale: }
       end
     end
 
@@ -79,13 +79,13 @@ RSpec.describe Api::V1::ActivityQuestionsController, type: :controller do
 
       it "passes the correct locale to as_json" do
         expect(questions).to all(receive(:as_json).with(locale: 'es'))
-        get :index, params: { activity_id: activity.uid, locale: locale }
+        get :index, params: { activity_id: activity.uid, locale: }
       end
 
 
       it "uses a different cache key for different locales" do
         expect(Rails.cache).to receive(:fetch).with("activity_questions/#{activity.uid}/es", expires_in: 1.hour).and_call_original
-        get :index, params: { activity_id: activity.uid, locale: locale }
+        get :index, params: { activity_id: activity.uid, locale: }
       end
     end
   end

--- a/services/QuillLMS/spec/factories/questions.rb
+++ b/services/QuillLMS/spec/factories/questions.rb
@@ -17,27 +17,8 @@
 #  index_questions_on_uid            (uid) UNIQUE
 #
 FactoryBot.define do
-  data = {
-    'conceptID' => 'Jl4ByYtUfo4VhIKpMt23yA',
-    'cues' => [''],
-    'cuesLabel' => '',
-    'flag' => 'production',
-    Question::FOCUS_POINTS => {
-      '-LNLfzKfwaoZUVeSIH8o' => {
-        'conceptResults' => {
-          'Jl4ByYtUfo4VhIKpMt23yA' => {
-            'conceptUID' => 'Jl4ByYtUfo4VhIKpMt23yA',
-            'correct' => false,
-            'name' => 'Structure | Compound Subjects, Objects, and Predicates | Compound Subjects'
-          }
-        },
-        'feedback' => '<p>Revise your work. Use the hint as an example of how to combine the sentences.</p>',
-        'order' => 1,
-        'text' => 'and'
-      }
-    },
-    Question::INCORRECT_SEQUENCES => {
-      '0' => {
+  incorrect_sequences = {
+    '0' => {
         'conceptResults' => {
           'GiUZ6KPkH958AT8S413nJg' => {
             'conceptUID' => 'GiUZ6KPkH958AT8S413nJg',
@@ -125,15 +106,85 @@ FactoryBot.define do
         'feedback' => '<p>Revise your work. Make your sentence more concise by only saying <em>reefs </em>once.</p>',
         'text' => 'but (some|most) ree&&ral re'
       }
-    },
+  }
+  focus_points = {
+    '-LNLfzKfwaoZUVeSIH8o' => {
+      'conceptResults' => {
+        'Jl4ByYtUfo4VhIKpMt23yA' => {
+          'conceptUID' => 'Jl4ByYtUfo4VhIKpMt23yA',
+          'correct' => false,
+          'name' => 'Structure | Compound Subjects, Objects, and Predicates | Compound Subjects'
+        }
+      },
+      'feedback' => '<p>Revise your work. Use the hint as an example of how to combine the sentences.</p>',
+      'order' => 1,
+      'text' => 'and'
+    }
+  }
+  data = {
+    'conceptID' => 'Jl4ByYtUfo4VhIKpMt23yA',
+    'cues' => [''],
+    'cuesLabel' => '',
+    'flag' => 'production',
+    Question::FOCUS_POINTS => focus_points,
+    Question::INCORRECT_SEQUENCES => incorrect_sequences,
     'instructions' => '',
     'itemLevel' => '',
     'modelConceptUID' => 'Jl4ByYtUfo4VhIKpMt23yA',
     'prompt' => '<p>The moon is smaller than the sun.</p><p>Earth is smaller than the sun.</p>'
   }
+
   factory :question do
     uid { SecureRandom.uuid }
     data { data }
     question_type { 'connect_sentence_combining' }
+
+    trait :with_translated_text do
+      after(:create) do |question|
+        create(:translation_mapping_with_translation,
+          source: question,
+          field_name: question.default_translatable_field
+        )
+
+      end
+    end
+
+    trait :with_translated_focus_points do
+      after(:create) do |question|
+        focus_points.each do |key, value|
+          create(:translation_mapping_with_translation,
+            source: question,
+            field_name: "#{Question::FOCUS_POINTS}.#{key}"
+          )
+        end
+      end
+    end
+
+    trait :with_translated_incorrect_sequences do
+      after(:create) do |question|
+        incorrect_sequences.each do |key, value|
+          create(:translation_mapping_with_translation,
+            source: question,
+            field_name: "#{Question::INCORRECT_SEQUENCES}.#{key}"
+          )
+        end
+      end
+    end
+
+    trait :with_translated_cms_response do
+      after(:create) do |question|
+        create(:translation_mapping_with_translation,
+          source: question,
+          field_name: "#{Question::CMS_RESPONSES}.283992"
+        )
+      end
+    end
+  end
+
+  trait :with_all_translations do
+    with_translated_text
+    with_translated_focus_points
+    with_translated_incorrect_sequences
+    with_translated_cms_response
   end
 end

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -398,10 +398,26 @@ RSpec.describe Question, type: :model do
   end
 
   describe '#as_json' do
+    subject { question.as_json(options) }
+
+    let(:options) { nil }
+
     it 'should just be the data attribute' do
-      expect(question.as_json).to eq(question.data)
+      expect(subject).to eq(question.data)
+    end
+
+    context 'a locale is passed in' do
+      let(:locale) { "ch-zn" }
+      let(:options) { { locale: } }
+
+      it 'should return translated_data(locale:)' do
+        expect(question).to receive(:translated_data).with(locale:)
+        subject
+      end
     end
   end
+
+
 
   describe '#refresh_cache' do
     let!(:question) { create(:question, uid: '1234', data: { 'foo' => 'initial_value' }) }


### PR DESCRIPTION
## WHAT
Added a new API to get questions for a single activity--either in english, or translated
## WHY
So that we can display the question and feedback in a new language
## HOW
added a new controller and action to get all questions. 

### Notion Card Links
[Add API endpoint for questions translation](https://www.notion.so/quill/Add-an-API-endpoint-to-get-translated-question-feedback-for-an-activity-c82111c419d649c1b2efac810e132265?pvs=4)

### What have you done to QA this feature?
Tested the API URL on local to see if it works for translated and untranslated questions. 
 
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
