### PR TITLE
Bug fix/ Activity Analysis classroom dropdown

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/reports_header.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/reports_header.scss
@@ -3,7 +3,7 @@
   border-bottom: 1px solid $quill-grey-5;
   .name-and-classroom-dropdown {
     padding-top: 32px;
-    min-height: 72px;
+    min-height: 77px;
     display: flex;
     justify-content: space-between;
     h1 {

--- a/services/QuillLMS/client/app/bundles/Shared/styles/input.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/input.scss
@@ -14,7 +14,7 @@
         align-items: center;
         height: 100%;
         .dropdown__single-value {
-          line-height: 0;
+          line-height: normal;
           margin-top: 2px;
         }
         .html-dropdown-option {


### PR DESCRIPTION
## WHAT
fix classroom dropdown in Activity Analysis report

## WHY
we want the classroom to show

## HOW
CSS tweak

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Classroom-dropdown-not-showing-anything-when-closed-d977a3f97ec7422abe52e70e5fab2be2?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
verified on staging that the Classroom shows

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | no-- css change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
