### PR TITLE
Remove rubocop rules that are automatically enforced.

### DIFF
--- a/services/.rubocop_base.yml
+++ b/services/.rubocop_base.yml
@@ -130,15 +130,6 @@ Layout/SpaceBeforeComment:
 Layout/SpaceBeforeFirstArg:
   Enabled: true
 
-Layout/SpaceInsideParens:
-  Enabled: true
-
-Layout/SpaceInsideBlockBraces:
-  Enabled: true
-
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: true
-
 Layout/SpaceInsideReferenceBrackets:
   Enabled: true
 


### PR DESCRIPTION
## WHAT
Remove some rules from the rubocop_base file that are automatically applied
## WHY
We get the behavior without explicitly adding them. 


### What have you done to QA this feature?
Checked that rubocop still caught the same stuff without the rules in the file

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO--small change
Have you deployed to Staging? | NO--non-code change 
Self-Review: Have you done an initial self-review of the code below on Github? | YES
