### PR TITLE
Scope questions for grammar

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/test/actions/sentenceFragments.test.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/test/actions/sentenceFragments.test.ts
@@ -26,7 +26,7 @@ describe('Questions actions', () => {
   })
 
   describe('submitNewQuestion', () => {
-    it('should call QuestionApi.getAll()', () => {
+    it('should call create()', () => {
       const MOCK_CONTENT = { mock: 'content', answers: [] }
       dispatch(questionActions.submitNewSentenceFragment(MOCK_CONTENT, {}, "123abc"))
       expect(mockQuestionApi.create).toHaveBeenLastCalledWith(SENTENCE_FRAGMENTS_TYPE, MOCK_CONTENT)

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -16,9 +16,13 @@ import {
   QuestionApi
 } from '../libs/questions_api';
 
-export const startListeningToQuestions = (sessionID?) => {
+export const startListeningToQuestions = (activityUID?: string, sessionID?: string) => {
   return (dispatch: Function) => {
-    QuestionApi.getAll(GRAMMAR_QUESTION_TYPE).then((questions: Questions) => {
+    const fetchQuestions = activityUID
+      ? QuestionApi.getAll(activityUID)
+      : QuestionApi.getAllForType(GRAMMAR_QUESTION_TYPE);
+
+    fetchQuestions.then((questions: Questions) => {
       if (questions) {
         if (sessionID) {
           populateQuestions(questions)

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -19,7 +19,7 @@ import {
 export const startListeningToQuestions = (activityUID?: string, sessionID?: string) => {
   return (dispatch: Function) => {
     const fetchQuestions = activityUID
-      ? QuestionApi.getAll(activityUID)
+      ? QuestionApi.getAllForActivity(activityUID)
       : QuestionApi.getAllForType(GRAMMAR_QUESTION_TYPE);
 
     fetchQuestions.then((questions: Array<Question>) => {

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -22,7 +22,7 @@ export const startListeningToQuestions = (activityUID?: string, sessionID?: stri
       ? QuestionApi.getAll(activityUID)
       : QuestionApi.getAllForType(GRAMMAR_QUESTION_TYPE);
 
-    fetchQuestions.then((questions: Questions) => {
+    fetchQuestions.then((questions: Array<Question>) => {
       if (questions) {
         if (sessionID) {
           populateQuestions(questions)

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -6,6 +6,7 @@ import * as responseActions from './responses';
 
 import { hashToCollection } from '../../Shared/index';
 import { permittedFlag } from '../helpers/flagArray';
+import getParameterByName from '../helpers/getParameterByName';
 import { shuffle } from '../helpers/shuffle';
 import { Question } from '../interfaces/questions';
 import { GRAMMAR_QUESTION_TYPE, QuestionApi } from '../libs/questions_api';
@@ -15,7 +16,7 @@ import { SessionState } from '../reducers/sessionReducer';
 export const allQuestions = {};
 let questionsInitialized = false;
 
-export const populateQuestions = (questions: object, forceRefresh: boolean) => {
+export const populateQuestions = (questions: object, forceRefresh?: boolean) => {
   if (questionsInitialized && !forceRefresh) return;
   Object.keys(questions).forEach((uid) => {
     questions[uid].uid = uid
@@ -126,11 +127,12 @@ const normalizeQuestionWithAttempts = (question: object): object => {
     attempts: question.attempts,
   }
 }
+const activityUID = getParameterByName('uid', window.location.href)
 
 const handleGrammarSession = (session) => {
   return dispatch => {
     if (session && Object.keys(session).length > 1 && !session.error) {
-      QuestionApi.getAll(GRAMMAR_QUESTION_TYPE).then((allQuestions) => {
+      QuestionApi.getAll(activityUID).then((allQuestions) => {
         if (session.currentQuestion) {
           if (!session.currentQuestion.prompt || !session.currentQuestion.answers) {
             const currentQuestion = allQuestions[session.currentQuestion.uid]
@@ -209,7 +211,7 @@ export const getQuestionsForConcepts = (concepts: any, flag: string) => {
   return (dispatch, getState) => {
     dispatch(setSessionPending(true))
     const conceptUIDs = Object.keys(concepts)
-    QuestionApi.getAll(GRAMMAR_QUESTION_TYPE).then((questions) => {
+    QuestionApi.getAllForType(GRAMMAR_QUESTION_TYPE).then((questions) => {
       const questionsForConcepts = {}
       Object.keys(questions).map(q => {
         if (conceptUIDs.includes(questions[q].concept_uid) && questions[q].prompt && questions[q].answers && permittedFlag(flag, questions[q].flag)) {
@@ -250,7 +252,7 @@ export const getQuestionsForConcepts = (concepts: any, flag: string) => {
 export const getQuestions = (questions: any, flag: string) => {
   return dispatch => {
     dispatch(setSessionPending(true))
-    QuestionApi.getAll(GRAMMAR_QUESTION_TYPE).then((allQuestions) => {
+    QuestionApi.getAll(activityUID).then((allQuestions) => {
       const arrayOfQuestions = questions.map(q => {
         const question = allQuestions[q.key]
         question.uid = q.key

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -127,7 +127,7 @@ const normalizeQuestionWithAttempts = (question: object): object => {
     attempts: question.attempts,
   }
 }
-const activityUID = getParameterByName('uid', window.location.href)
+const activityUID = (): string => { return getParameterByName('uid', window.location.href) }
 
 const handleGrammarSession = (session) => {
   return dispatch => {
@@ -252,7 +252,7 @@ export const getQuestionsForConcepts = (concepts: any, flag: string) => {
 export const getQuestions = (questions: any, flag: string) => {
   return dispatch => {
     dispatch(setSessionPending(true))
-    QuestionApi.getAll(activityUID).then((allQuestions) => {
+    QuestionApi.getAll(activityUID()).then((allQuestions) => {
       const arrayOfQuestions = questions.map(q => {
         const question = allQuestions[q.key]
         question.uid = q.key

--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -132,7 +132,7 @@ const activityUID = (): string => { return getParameterByName('uid', window.loca
 const handleGrammarSession = (session) => {
   return dispatch => {
     if (session && Object.keys(session).length > 1 && !session.error) {
-      QuestionApi.getAll(activityUID).then((allQuestions) => {
+      QuestionApi.getAllForActivity(activityUID).then((allQuestions) => {
         if (session.currentQuestion) {
           if (!session.currentQuestion.prompt || !session.currentQuestion.answers) {
             const currentQuestion = allQuestions[session.currentQuestion.uid]
@@ -252,7 +252,7 @@ export const getQuestionsForConcepts = (concepts: any, flag: string) => {
 export const getQuestions = (questions: any, flag: string) => {
   return dispatch => {
     dispatch(setSessionPending(true))
-    QuestionApi.getAll(activityUID()).then((allQuestions) => {
+    QuestionApi.getAllForActivity(activityUID()).then((allQuestions) => {
       const arrayOfQuestions = questions.map(q => {
         const question = allQuestions[q.key]
         question.uid = q.key

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -91,9 +91,9 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
     dispatch(getActivity(activityUID))
 
     if (sessionIdentifier && !previewMode) {
-      dispatch(startListeningToQuestions(sessionIdentifier));
+      dispatch(startListeningToQuestions(activityUID, sessionIdentifier));
     } else {
-      dispatch(startListeningToQuestions());
+      dispatch(startListeningToQuestions(activityUID));
       dispatch(startNewSession())
     }
 

--- a/services/QuillLMS/client/app/bundles/Grammar/helpers/getParameterByName.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/helpers/getParameterByName.ts
@@ -1,4 +1,4 @@
-export default function getParameterByName(name: string, url: string) {
+export default function getParameterByName(name: string, url: string): string {
   if (!url) { url = window.location.href; }
   name = name.replace(/[\[\]]/g, '\\$&');
   const regex = new RegExp(`[?&]${name}(=([^&#]*)|&|#|$)`),

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/questions_api.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/questions_api.ts
@@ -4,10 +4,15 @@ import { FocusPoint, IncorrectSequence, Question } from '../interfaces/questions
 const GRAMMAR_QUESTION_TYPE = 'grammar'
 
 const questionApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/questions`;
+const activityApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/activities`;
 
 class QuestionApi {
-  static getAll(questionType: string): Promise<Array<Question>> {
+  static getAllForType(questionType: string): Promise<Array<Question>> {
     return requestGet(`${questionApiBaseUrl}.json?question_type=${questionType}`, null, (error) => {throw(error)});
+  }
+
+  static getAll(activity_uid: string): Promise<Array<Question>> {
+    return requestGet(`${activityApiBaseUrl}/${activity_uid}/questions.json`, null, (error) => {throw(error)});
   }
 
   static get(uid: string): Promise<Question> {
@@ -83,7 +88,4 @@ class IncorrectSequenceApi {
   }
 }
 
-export {
-  FocusPointApi, GRAMMAR_QUESTION_TYPE, IncorrectSequenceApi, QuestionApi, questionApiBaseUrl
-};
-
+export { activityApiBaseUrl, FocusPointApi, GRAMMAR_QUESTION_TYPE, IncorrectSequenceApi, QuestionApi, questionApiBaseUrl };

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/questions_api.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/questions_api.ts
@@ -11,7 +11,7 @@ class QuestionApi {
     return requestGet(`${questionApiBaseUrl}.json?question_type=${questionType}`, null, (error) => {throw(error)});
   }
 
-  static getAll(activity_uid: string): Promise<Array<Question>> {
+  static getAllForActivity(activity_uid: string): Promise<Array<Question>> {
     return requestGet(`${activityApiBaseUrl}/${activity_uid}/questions.json`, null, (error) => {throw(error)});
   }
 

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/__mocks__/question_api.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/__mocks__/question_api.ts
@@ -1,4 +1,5 @@
 export const mockQuestionApi = {
+  getAllForType: jest.fn().mockImplementation(() => Promise.resolve({})),
   getAll: jest.fn().mockImplementation(() => Promise.resolve({})),
   get: jest.fn().mockImplementation(() => Promise.resolve({})),
   create: jest.fn().mockImplementation(() => Promise.resolve({})),

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/__mocks__/question_api.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/__mocks__/question_api.ts
@@ -1,6 +1,6 @@
 export const mockQuestionApi = {
   getAllForType: jest.fn().mockImplementation(() => Promise.resolve({})),
-  getAll: jest.fn().mockImplementation(() => Promise.resolve({})),
+  getAllForActivity: jest.fn().mockImplementation(() => Promise.resolve({})),
   get: jest.fn().mockImplementation(() => Promise.resolve({})),
   create: jest.fn().mockImplementation(() => Promise.resolve({})),
   update: jest.fn().mockImplementation(() => Promise.resolve({})),

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/actions/questions.test.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/actions/questions.test.ts
@@ -35,10 +35,10 @@ describe('Questions actions', () => {
       expect(mockQuestionApi.getAllForType).toHaveBeenLastCalledWith(GRAMMAR_QUESTION_TYPE)
     })
 
-    it('should call QuestionApi.getAll if an activity ID is passd in', () => {
+    it('should call QuestionApi.getAllForActivity if an activity ID is passd in', () => {
       const MOCK_UID = "23"
       dispatch(startListeningToQuestions(MOCK_UID))
-      expect(mockQuestionApi.getAll).toHaveBeenLastCalledWith(MOCK_UID)
+      expect(mockQuestionApi.getAllForActivity).toHaveBeenLastCalledWith(MOCK_UID)
     })
   })
 
@@ -51,7 +51,7 @@ describe('Questions actions', () => {
   })
 
   describe('submitNewQuestion', () => {
-    it('should call QuestionApi.getAll()', () => {
+    it('should call QuestionApi.create()', () => {
       const MOCK_CONTENT = { mock: 'content', answers: [] }
       dispatch(submitNewQuestion(MOCK_CONTENT))
       expect(mockQuestionApi.create).toHaveBeenLastCalledWith(GRAMMAR_QUESTION_TYPE, MOCK_CONTENT)

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/actions/questions.test.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/actions/questions.test.ts
@@ -30,9 +30,15 @@ import {
 
 describe('Questions actions', () => {
   describe('startListeningToQuestions', () => {
-    it('should call QuestionApi.getAll()', () => {
+    it('should call QuestionApi.getAllForType()', () => {
       dispatch(startListeningToQuestions())
-      expect(mockQuestionApi.getAll).toHaveBeenLastCalledWith(GRAMMAR_QUESTION_TYPE)
+      expect(mockQuestionApi.getAllForType).toHaveBeenLastCalledWith(GRAMMAR_QUESTION_TYPE)
+    })
+
+    it('should call QuestionApi.getAll if an activity ID is passd in', () => {
+      const MOCK_UID = "23"
+      dispatch(startListeningToQuestions(MOCK_UID))
+      expect(mockQuestionApi.getAll).toHaveBeenLastCalledWith(MOCK_UID)
     })
   })
 

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/libs/questions_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/libs/questions_api.test.ts
@@ -20,11 +20,11 @@ import {
 } from '../../libs/questions_api'
 
 describe('QuestionApi calls', () => {
-  describe('getAll', () => {
+  describe('getAllForActivity', () => {
     it('should call requestGet', () => {
       const MOCK_UID = 'uid'
       const url = `${activityApiBaseUrl}/${MOCK_UID}/questions.json`
-      QuestionApi.getAll(MOCK_UID)
+      QuestionApi.getAllForActivity(MOCK_UID)
       expect(mockRequestGet).toHaveBeenLastCalledWith(url, null, expect.anything())
     })
   })

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/libs/questions_api.test.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/libs/questions_api.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../../../modules/request/index', () => ({
 }))
 
 import {
+  activityApiBaseUrl,
   FocusPointApi,
   IncorrectSequenceApi,
   QuestionApi,
@@ -21,9 +22,18 @@ import {
 describe('QuestionApi calls', () => {
   describe('getAll', () => {
     it('should call requestGet', () => {
+      const MOCK_UID = 'uid'
+      const url = `${activityApiBaseUrl}/${MOCK_UID}/questions.json`
+      QuestionApi.getAll(MOCK_UID)
+      expect(mockRequestGet).toHaveBeenLastCalledWith(url, null, expect.anything())
+    })
+  })
+
+  describe('getAllForType', () => {
+    it('should call requestGet', () => {
       const MOCK_TYPE = 'TYPE'
       const url = `${questionApiBaseUrl}.json?question_type=${MOCK_TYPE}`
-      QuestionApi.getAll(MOCK_TYPE)
+      QuestionApi.getAllForType(MOCK_TYPE)
       expect(mockRequestGet).toHaveBeenLastCalledWith(url, null, expect.anything())
     })
   })


### PR DESCRIPTION
## WHAT
Don't load *all* the grammar questions every time somebody does a grammar activity. 
## WHY
The payload is very large leading to slow response times. It's one of our top most time-consuming requests. 

## HOW
In the grammar module switch to use the new activity-scoped question api. 

### Notion Card Links
[Scope Question to a single activity](https://www.notion.so/quill/Scope-question-json-API-to-the-current-activity-rather-than-loading-all-questions-for-grammar-50d2bbb6ae46491faf88551d8df993b6?pvs=4)

### What have you done to QA this feature?
Tested that grammar activities still work properly in admin and for students.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
