### PR TITLE
Bug fix/ Grammar CMS concept feedback

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/conceptsFeedback/conceptFeedback.tsx
@@ -22,7 +22,6 @@ class ConceptFeedbackComponent extends React.Component<ConceptFeedbackComponentP
 
     this.deleteConceptsFeedback = this.deleteConceptsFeedback.bind(this)
     this.toggleEdit = this.toggleEdit.bind(this)
-    this.toggleTranslation = this.toggleTranslation.bind(this)
     this.submitNewFeedback = this.submitNewFeedback.bind(this)
     this.cancelEdit = this.cancelEdit.bind(this)
     this.concept = this.concept.bind(this)


### PR DESCRIPTION
## WHAT
fix bug that was causing Grammar CMS concept feedback pages to crash

## WHY
we want these pages to work

## HOW
remove unneeded bind statement

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Can-t-open-any-concept-feedback-pages-in-Grammar-CMS-461b5183872349ba9a29cd818d5b194e?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
verified on local and staging that the concept feedback page loads

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
