### PR TITLE
Add a filter for languages on the admin translations page.

### DIFF
--- a/services/QuillLMS/app/controllers/translated_texts_controller.rb
+++ b/services/QuillLMS/app/controllers/translated_texts_controller.rb
@@ -5,12 +5,14 @@ class TranslatedTextsController < ApplicationController
 
   def index
     @translated_texts = TranslatedText
-      .all
       .includes(:english_text, :translation_mappings)
+      .order(created_at: :asc)
       .page(params[:page])
       .per(200)
 
+    @translated_texts = @translated_texts.where(locale: params[:locale]) if params[:locale].present?
     @js_file = "entrypoints/snippets/translated_text.ts"
+    @locales = TranslatedText.select(:locale).distinct.pluck(:locale)
   end
 
   def update

--- a/services/QuillLMS/app/views/translated_texts/index.html.erb
+++ b/services/QuillLMS/app/views/translated_texts/index.html.erb
@@ -22,8 +22,8 @@
     text-decoration: underline;
     font-size: 1.25em;
   }
-
 </style>
+
 <section>
 <h3> Filter locale </h3>
   <ul>

--- a/services/QuillLMS/app/views/translated_texts/index.html.erb
+++ b/services/QuillLMS/app/views/translated_texts/index.html.erb
@@ -7,7 +7,33 @@
     margin: 0px 20px;
   }
 
+  ul {
+    overflow: hidden;
+    padding: 0px;
+  }
+
+  li {
+    float: left;
+    display: block;
+    margin-right: 10px;
+  }
+
+  a {
+    text-decoration: underline;
+    font-size: 1.25em;
+  }
+
 </style>
+<section>
+<h3> Filter locale </h3>
+  <ul>
+  <% @locales.each do |locale| %>
+    <li>
+      <%= link_to(locale, translated_texts_url(locale:)) %>
+    </li>
+  <% end %>
+  </ul>
+</section>
 <h1>Translated Texts</h1>
 
 <table class='table'>

--- a/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe TranslatedTextsController, type: :controller do
         locales = ["es-la", "zh-cn"]
         locales.each { |locale| create(:translated_text, locale:) }
         get :index
-        expect(assigns(:locales).to match_array(locales)
+        expect(assigns(:locales)).to match_array(locales)
       end
 
       context 'a locale parameter is passed in' do

--- a/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe TranslatedTextsController, type: :controller do
       end
 
       it 'assigns @locales' do
-        create(:translated_text, locale: "es-la")
-        create(:translated_text, locale: "zh-cn")
+        locales = ["es-la", "zh-cn"]
+        locales.each { |locale| create(:translated_text, locale:) }
         get :index
-        expect(assigns(:locales)).to match_array(["es-la", "zh-cn"])
+        expect(assigns(:locales).to match_array(locales)
       end
 
       context 'a locale parameter is passed in' do

--- a/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
@@ -43,9 +43,10 @@ RSpec.describe TranslatedTextsController, type: :controller do
       end
 
       context 'a locale parameter is passed in' do
-        let(:locale) { 'es-la'}
+        let(:locale) { 'es-la' }
         let!(:es_text) { create(:translated_text, locale:) }
         let!(:zh_text) { create(:translated_text, locale: "zh-cn") }
+
         before do
           get :index, params: { locale: }
         end

--- a/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
@@ -34,6 +34,30 @@ RSpec.describe TranslatedTextsController, type: :controller do
       it 'assigns @js_file' do
         expect(assigns(:js_file)).to eq("entrypoints/snippets/translated_text.ts")
       end
+
+      it 'assigns @locales' do
+        create(:translated_text, locale: "es-la")
+        create(:translated_text, locale: "zh-cn")
+        get :index
+        expect(assigns(:locales)).to match_array(["es-la", "zh-cn"])
+      end
+
+      context 'a locale parameter is passed in' do
+        let(:locale) { 'es-la'}
+        let!(:es_text) { create(:translated_text, locale:) }
+        let!(:zh_text) { create(:translated_text, locale: "zh-cn") }
+        before do
+          get :index, params: { locale: }
+        end
+
+        it 'assigns translated_texts for that locale' do
+          expect(assigns(:translated_texts)).to include(es_text)
+        end
+
+        it 'does not add translated_texts for other locales' do
+          expect(assigns(:translated_texts)).not_to include(zh_text)
+        end
+      end
     end
 
     context 'when user is not staff' do


### PR DESCRIPTION
## WHAT
Add a list of available locales to the admin translations page 


## WHY
So that someone checking over translations doesn't get bogged down by all the languages once we've added them

## HOW
Added a section to the top of the admin page with a list of locales. 

### Screenshots
![2024-07-24 at 1 32 PM](https://github.com/user-attachments/assets/86b64dbe-f03b-49c2-a407-4fdaea6f657c)

### Notion Card Links
[Admins can filter by language](https://www.notion.so/quill/Admins-can-filter-by-language-on-the-translations-page-05c823eb9952420fb281855442490aac?pvs=4
)
### What have you done to QA this feature?
Tested the filter on development 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO, small change (and I am waiting on another PR that has a staging deploy) 
Self-Review: Have you done an initial self-review of the code below on Github? | YES
 