### PR TITLE
Language picker on connect

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/actions.js
+++ b/services/QuillLMS/client/app/bundles/Connect/actions.js
@@ -14,6 +14,7 @@ export const START_QUESTION = 'START_QUESTION'
 export const UPDATE_CURRENT_QUESTION = 'UPDATE_CURRENT_QUESTION'
 export const SET_CURRENT_QUESTION = 'SET_CURRENT_QUESTION'
 export const RESUME_PREVIOUS_SESSION = 'RESUME_PREVIOUS_SESSION'
+export const SET_LANGUAGE = 'SET_LANGUAGE'
 
 export const SubmitActions = {
   SUBMIT_RESPONSE,
@@ -28,7 +29,8 @@ export const SubmitActions = {
   START_QUESTION,
   UPDATE_CURRENT_QUESTION,
   SET_CURRENT_QUESTION,
-  RESUME_PREVIOUS_SESSION
+  RESUME_PREVIOUS_SESSION,
+  SET_LANGUAGE
 }
 
 /*
@@ -85,4 +87,8 @@ export function resumePreviousSession(data) {
 
 export function setCurrentQuestion(data) {
   return { type: SET_CURRENT_QUESTION, data };
+}
+
+export function setLanguage(data) {
+  return { type: SET_LANGUAGE, data };
 }

--- a/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useQuery } from 'react-query';
+import { connect } from 'react-redux';
 import { renderRoutes } from "react-router-config";
 
 import { NavBar } from './navbar/navbar';
@@ -7,10 +8,11 @@ import { NavBar } from './navbar/navbar';
 import { addKeyDownListener } from '../../Shared/hooks/addKeyDownListener';
 import { ScreenreaderInstructions, TeacherPreviewMenu, } from '../../Shared/index';
 import { fetchUserRole } from '../../Shared/utils/userAPIs';
+import { setLanguage } from '../actions.js';
 import { getParameterByName } from '../libs/getParameterByName';
 import { routes } from "../routes";
 
-export const Home = () => {
+export const Home = ({playLesson, dispatch}) => {
   const studentSession = getParameterByName('student', window.location.href);
   const turkSession = window.location.href.includes('turk');
   const studentOrTurk = studentSession || turkSession;
@@ -57,15 +59,27 @@ export const Home = () => {
     setSkippedToQuestionFromIntro(true);
   }
 
+  function handleUpdateLanguage(language: string) {
+    const action = setLanguage(language)
+    dispatch(action)
+  }
+
   let className = "ant-layout "
   className = showFocusState ? '' : 'hide-focus-outline'
   const showPreview = previewShowing && isTeacherOrAdmin && isPlaying;
   const isOnMobile = window.innerWidth < 1100;
   let header;
   if(isTeacherOrAdmin && isPlaying) {
-    header = <NavBar isOnMobile={isOnMobile} isTeacher={isTeacherOrAdmin} onTogglePreview={handleTogglePreviewMenu} previewShowing={previewShowing} />;
+    header = (<NavBar
+      isOnMobile={isOnMobile}
+      isTeacher={isTeacherOrAdmin}
+      language={playLesson?.language}
+      onTogglePreview={handleTogglePreviewMenu}
+      previewShowing={previewShowing}
+      updateLanguage={handleUpdateLanguage}
+    />);
   } else if (!isTeacherOrAdmin && isPlaying) {
-    header = <NavBar />;
+    header = <NavBar language={playLesson?.language} updateLanguage={handleUpdateLanguage} />;
   }
   return(
     <div className={className}>
@@ -102,4 +116,10 @@ export const Home = () => {
   );
 }
 
-export default Home;
+const select = (state: any, props: any) => {
+  return {
+    playLesson: state.playLesson
+  };
+}
+
+export default connect(select)(Home);

--- a/services/QuillLMS/client/app/bundles/Connect/components/navbar/__tests__/__snapshots__/navbar.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Connect/components/navbar/__tests__/__snapshots__/navbar.test.tsx.snap
@@ -15,11 +15,15 @@ exports[`NavBar Component should match snapshot 1`] = `
         src="undefined/images/logos/quill-logo-white-2022.svg"
       />
     </a>
-    <a
-      className="focus-on-dark"
+    <div
+      className="header-buttons-container"
     >
-      Save and exit
-    </a>
+      <a
+        className="quill-button medium contained white focus-on-dark"
+      >
+        Save and exit
+      </a>
+    </div>
   </div>
 </div>
 `;

--- a/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
@@ -12,17 +12,22 @@ interface NavBarProps {
   updateLanguage: (language: string) => void;
 }
 
+
 export const NavBar: React.SFC<NavBarProps> = ({ isOnMobile, isTeacher, previewShowing, onTogglePreview, language, updateLanguage }) => {
   const handleTogglePreview = () => {
     onTogglePreview();
   }
+
+  // Temporary feature flag until we are ready to ship this.
+  const urlParams = new URLSearchParams(window.location.search)
+  const showTranslations = urlParams.get('showTranslations') === 'true'
   return (
     <div className="header">
       <div className="activity-navbar-content">
         {isTeacher && !previewShowing && !isOnMobile && <TeacherPreviewMenuButton handleTogglePreview={handleTogglePreview} />}
         <a className="focus-on-dark" href={process.env.DEFAULT_URL}><img alt="Quill logo" src={quillLogoSrc} /></a>
         <div className='header-buttons-container'>
-          <LanguagePicker language={language} updateLanguage={updateLanguage} />
+          {showTranslations && <LanguagePicker language={language} updateLanguage={updateLanguage} />}
           <a className="quill-button medium contained white focus-on-dark" href={process.env.DEFAULT_URL}>Save and exit</a>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { TeacherPreviewMenuButton } from '../../../Shared/index';
+import { LanguagePicker, TeacherPreviewMenuButton } from '../../../Shared/index';
 const quillLogoSrc = `${process.env.CDN_URL}/images/logos/quill-logo-white-2022.svg`;
 
 interface NavBarProps {
@@ -8,9 +8,11 @@ interface NavBarProps {
   isTeacher?: boolean;
   previewShowing?: boolean;
   onTogglePreview?: () => void;
+  language: string;
+  updateLanguage: (language: string) => void;
 }
 
-export const NavBar: React.SFC<NavBarProps> = ({ isOnMobile, isTeacher, previewShowing, onTogglePreview }) => {
+export const NavBar: React.SFC<NavBarProps> = ({ isOnMobile, isTeacher, previewShowing, onTogglePreview, language, updateLanguage }) => {
   const handleTogglePreview = () => {
     onTogglePreview();
   }
@@ -19,7 +21,10 @@ export const NavBar: React.SFC<NavBarProps> = ({ isOnMobile, isTeacher, previewS
       <div className="activity-navbar-content">
         {isTeacher && !previewShowing && !isOnMobile && <TeacherPreviewMenuButton handleTogglePreview={handleTogglePreview} />}
         <a className="focus-on-dark" href={process.env.DEFAULT_URL}><img alt="Quill logo" src={quillLogoSrc} /></a>
-        <a className="focus-on-dark" href={process.env.DEFAULT_URL}>Save and exit</a>
+        <div className='header-buttons-container'>
+          <LanguagePicker language={language} updateLanguage={updateLanguage} />
+          <a className="quill-button medium contained white focus-on-dark" href={process.env.DEFAULT_URL}>Save and exit</a>
+        </div>
       </div>
     </div>
   );

--- a/services/QuillLMS/client/app/bundles/Connect/reducers/questionReducer.js
+++ b/services/QuillLMS/client/app/bundles/Connect/reducers/questionReducer.js
@@ -1,9 +1,11 @@
 import { getCurrentQuestion, getFilteredQuestions, getQuestionsWithAttempts } from '../../Shared/index';
+import { ENGLISH } from '../../Shared/utils/languageList';
 import { SubmitActions } from '../actions';
 /// make this playLessonsReducer.
 const initialState = {
   answeredQuestions: [],
-  unansweredQuestions: []
+  unansweredQuestions: [],
+  language: ENGLISH
 }
 
 function question(state = initialState, action) {
@@ -54,6 +56,8 @@ function question(state = initialState, action) {
     case SubmitActions.UPDATE_NAME:
       var changes = {name: action.data}
       return Object.assign({}, state, changes)
+    case SubmitActions.SET_LANGUAGE:
+      return Object.assign({}, state, {language: action.data})
     case SubmitActions.UPDATE_CURRENT_QUESTION:
       var changes = {currentQuestion:
       Object.assign({}, state.currentQuestion, {

--- a/services/QuillLMS/client/app/bundles/Shared/styles/activity_container.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/activity_container.scss
@@ -11,7 +11,7 @@
     justify-content: space-between;
     align-items: center;
   }
-  .activity-navbar-content, .student-nav {
+  .activity-navbar-content, .student-nav, .header {
     .header-buttons-container {
       display: flex;
       justify-content: flex-end;
@@ -57,7 +57,10 @@
       font-weight: 600;
     }
   }
-  .student-nav .header-buttons-container .ell-language-selector {
-    height: 40px;
+
+  .student-nav, .header {
+    .header-buttons-container .ell-language-selector {
+      height: 40px;
+    }
   }
 }


### PR DESCRIPTION
## WHAT
Add the language picker to the connect activities (behind a feature flag). 

## WHY
So that students have a way to choose their language for a translated activity. 

## HOW
Used the shared component from diagnostics and added it to the connect activities. 
Also used a feature flag in the URL 

### Screenshots
![2024-07-24 at 2 39 PM](https://github.com/user-attachments/assets/4e613f84-2ad8-40ae-ac5f-301f6999b5e8)
![2024-07-24 at 2 40 PM](https://github.com/user-attachments/assets/5904f0be-5823-47eb-be17-4c029e04cd8b)
![2024-07-24 at 2 40 PM](https://github.com/user-attachments/assets/8e2f8337-2fd1-4031-bcfc-256e8bda6d42)

### Notion Card Links
https://www.notion.so/quill/Add-a-feature-flag-in-the-URL-for-showing-all-the-translation-UI-ec454c5b46bf460695d551f6519319ff?pvs=4
https://www.notion.so/quill/Add-language-picker-to-the-top-bar-on-activities-where-there-are-translations-for-Connect-and-Gramma-0c449f70511b4ae599beb67294cce102?pvs=4

### What have you done to QA this feature?
Tested on development

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
