### PR TITLE
Add a rubocop rule to align parameters with a fixed width

### DIFF
--- a/services/.rubocop_base.yml
+++ b/services/.rubocop_base.yml
@@ -55,6 +55,11 @@ Gemspec/RequireMFA:
 Layout/ArrayAlignment:
   Enabled: true
 
+Layout/ArgumentAlignment:
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+  IndentationWidth: 2
+
 Layout/AssignmentIndentation:
   Enabled: true
 

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -14,12 +14,6 @@ Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
 
-# Offense count: 382
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: with_first_argument, with_fixed_indentation
-Layout/ArgumentAlignment:
-  Enabled: false
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).

--- a/services/QuillLMS/app/controllers/accounts_controller.rb
+++ b/services/QuillLMS/app/controllers/accounts_controller.rb
@@ -58,15 +58,15 @@ class AccountsController < ApplicationController
 
   protected def user_params
     params.require(:user).permit(
-                                 :account_type,
-                                 :classcode,
-                                 :email,
-                                 :name,
-                                 :password,
-                                 :school_ids,
-                                 :send_newsletter,
-                                 :terms_of_service,
-                                 :username)
+      :account_type,
+      :classcode,
+      :email,
+      :name,
+      :password,
+      :school_ids,
+      :send_newsletter,
+      :terms_of_service,
+      :username)
   end
 
   protected def update_user_params

--- a/services/QuillLMS/app/controllers/api/api_controller.rb
+++ b/services/QuillLMS/app/controllers/api/api_controller.rb
@@ -15,7 +15,7 @@ class Api::ApiController < ActionController::Base
 
   rescue_from AccessForbidden do
     render json: { meta: { message: 'You are not authorized to access this resource', status: :forbidden } },
-           status: 403
+      status: 403
   end
 
   rescue_from ActiveRecord::RecordInvalid do |e|
@@ -24,7 +24,7 @@ class Api::ApiController < ActionController::Base
 
   protected def not_found
     render json: { meta: { message: 'The resource you were looking for does not exist', status: :not_found } },
-           status: 404
+      status: 404
   end
 
   protected def staff_only

--- a/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
@@ -119,11 +119,11 @@ class Api::V1::ActivitiesController < Api::ApiController
     @data = params.delete(:data) # the thing likely to be persisted
 
     params.except(:id).permit(:name,
-                              :description,
-                              :activity_classification_uid,
-                              :standard_uid,
-                              :uid,
-                              flags: [])
+      :description,
+      :activity_classification_uid,
+      :standard_uid,
+      :uid,
+      flags: [])
                       .merge(data: @data)
                       .reject { |k,v| v.nil? }
   end

--- a/services/QuillLMS/app/controllers/api/v1/activity_questions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_questions_controller.rb
@@ -11,7 +11,6 @@ class Api::V1::ActivityQuestionsController < ApplicationController
     end
   end
 
-
   private def cached_questions(activity)
     Rails.cache.fetch(cache_key(activity), expires_in: 1.hour) do
       activity.questions.each_with_object({}) do |question, hash|

--- a/services/QuillLMS/app/controllers/cms/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/activities_controller.rb
@@ -100,22 +100,22 @@ class Cms::ActivitiesController < Cms::CmsController
 
   protected def activity_params
     params.require(:activity).permit(:name,
-                                     :description,
-                                     :uid,
-                                     :data,
-                                     :activity_classification_id,
-                                     :standard_id,
-                                     :flag,
-                                     :repeatable,
-                                     :follow_up_activity_id,
-                                     :supporting_info,
-                                     :raw_score_id,
-                                     :minimum_grade_level,
-                                     :maximum_grade_level,
-                                     topic_ids: [],
-                                     activity_category_ids: [],
-                                     content_partner_ids: [],
-                                     flags: []
+      :description,
+      :uid,
+      :data,
+      :activity_classification_id,
+      :standard_id,
+      :flag,
+      :repeatable,
+      :follow_up_activity_id,
+      :supporting_info,
+      :raw_score_id,
+      :minimum_grade_level,
+      :maximum_grade_level,
+      topic_ids: [],
+      activity_category_ids: [],
+      content_partner_ids: [],
+      flags: []
                                    )
   end
 end

--- a/services/QuillLMS/app/controllers/cms/activity_classifications_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/activity_classifications_controller.rb
@@ -46,18 +46,18 @@ class Cms::ActivityClassificationsController < Cms::CmsController
 
   protected def activity_classification_params
     params.require(:activity_classification).permit(:name,
-                                                    :key,
-                                                    :form_url,
-                                                    :uid,
-                                                    :module_url,
-                                                    :app_name,
-                                                    :order_number,
-                                                    :instructor_mode,
-                                                    :locked_by_default,
-                                                    :scored,
-                                                    :id,
-                                                    :created_at,
-                                                    :updated_at)
+      :key,
+      :form_url,
+      :uid,
+      :module_url,
+      :app_name,
+      :order_number,
+      :instructor_mode,
+      :locked_by_default,
+      :scored,
+      :id,
+      :created_at,
+      :updated_at)
   end
 
   protected def filtered_activity_classification_params

--- a/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
@@ -52,22 +52,22 @@ class Cms::BlogPostsController < Cms::CmsController
   private def blog_post_params
     params.require(:blog_post)
             .permit(:id,
-                    :body,
-                    :title,
-                    :subtitle,
-                    :author_id,
-                    :topic,
-                    :read_count,
-                    :preview_card_content,
-                    :draft,
-                    :premium,
-                    :external_link,
-                    :published_at,
-                    :center_images,
-                    :image_link,
-                    :press_name,
-                    :featured_order_number,
-                    :footer_content
+              :body,
+              :title,
+              :subtitle,
+              :author_id,
+              :topic,
+              :read_count,
+              :preview_card_content,
+              :draft,
+              :premium,
+              :external_link,
+              :published_at,
+              :center_images,
+              :image_link,
+              :press_name,
+              :featured_order_number,
+              :footer_content
                   )
   end
 

--- a/services/QuillLMS/app/controllers/sales_form_submission_controller.rb
+++ b/services/QuillLMS/app/controllers/sales_form_submission_controller.rb
@@ -35,6 +35,6 @@ class SalesFormSubmissionController < ApplicationController
 
   private def sales_form_submission_params
     params.require(:sales_form_submission).permit(:first_name, :last_name, :email, :phone_number,:zipcode, :collection_type, :school_name, :district_name,
-                   :school_premium_count_estimate, :teacher_premium_count_estimate, :student_premium_count_estimate, :submission_type, :comment)
+      :school_premium_count_estimate, :teacher_premium_count_estimate, :student_premium_count_estimate, :submission_type, :comment)
   end
 end

--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -61,7 +61,7 @@ class SchoolsController < ApplicationController
         .where(
           "zipcode in #{array_to_postgres_array_helper(zip_arr)} OR mail_zipcode in #{array_to_postgres_array_helper(zip_arr)}"
          ).where(
-         'lower(name) LIKE :prefix', prefix: "%#{@prefix.downcase}%"
+           'lower(name) LIKE :prefix', prefix: "%#{@prefix.downcase}%"
          ).group('schools.id')
          .limit(@limit)
         $redis.set("#{cache_id}_RADIUS_TO_SCHOOL_#{@lat}_#{@lng}_#{@radius}", @schools.map { |s| s.id }.to_json)
@@ -76,7 +76,7 @@ class SchoolsController < ApplicationController
       @schools = School.select('schools.id, name, zipcode, mail_zipcode, street, mail_street, city, mail_city, state, mail_state, COUNT(schools_users.id) AS number_of_teachers')
       .joins('LEFT JOIN schools_users ON schools_users.school_id = schools.id')
       .where(
-         'lower(name) LIKE :prefix', prefix: "%#{@prefix.downcase}%"
+        'lower(name) LIKE :prefix', prefix: "%#{@prefix.downcase}%"
        ).group('schools.id')
        .limit(@limit)
       $redis.set("PREFIX_TO_SCHOOL_#{@prefix}", @schools.map { |s| s.id }.to_json)

--- a/services/QuillLMS/app/controllers/teachers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/students_controller.rb
@@ -92,22 +92,22 @@ class Teachers::StudentsController < ApplicationController
 
   protected def user_params
     params.require(:user).permit(:name,
-                                 :first_name,
-                                 :last_name,
-                                 :password,
-                                 :password_digest,
-                                 :classcode,
-                                 :active,
-                                 :username,
-                                 :token,
-                                 :ip_address,
-                                 :clever_id,
-                                 :signed_up_with_google,
-                                 :google_id,
-                                 :flags,
-                                 :title,
-                                 :time_zone,
-                                 :account_type)
+      :first_name,
+      :last_name,
+      :password,
+      :password_digest,
+      :classcode,
+      :active,
+      :username,
+      :token,
+      :ip_address,
+      :clever_id,
+      :signed_up_with_google,
+      :google_id,
+      :flags,
+      :title,
+      :time_zone,
+      :account_type)
   end
 
   protected def edit_page_variables

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -70,7 +70,7 @@ class School < ApplicationRecord
   after_save :attach_new_district_school_admins, if: :saved_change_to_district_id?
 
   validate :lower_grade_within_bounds, :upper_grade_within_bounds,
-           :lower_grade_greater_than_upper_grade
+    :lower_grade_greater_than_upper_grade
   validates :zipcode, length: { minimum: 5 }, allow_blank: true
 
   # Lambda has to be wrapped in parens to avoid syntax error in this construction.

--- a/services/QuillLMS/app/pusher_modules/pusher_admin_users_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_admin_users_completed.rb
@@ -3,15 +3,15 @@
 module PusherAdminUsersCompleted
   def self.run(admin_id)
     pusher_client = Pusher::Client.new(
-        app_id: ENV['PUSHER_APP_ID'],
-        key: ENV['PUSHER_KEY'],
-        secret: ENV['PUSHER_SECRET'],
-        use_tls: true
+      app_id: ENV['PUSHER_APP_ID'],
+      key: ENV['PUSHER_KEY'],
+      secret: ENV['PUSHER_SECRET'],
+      use_tls: true
     )
     pusher_client.trigger(
       admin_id.to_s,
-     'admin-users-found',
-     message: "Admin users found for #{admin_id}."
+      'admin-users-found',
+      message: "Admin users found for #{admin_id}."
    )
   end
 end

--- a/services/QuillLMS/app/pusher_modules/pusher_csv_export_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_csv_export_completed.rb
@@ -3,10 +3,10 @@
 module PusherCSVExportCompleted
   def self.run(current_user_id, csv_url)
     pusher_client = Pusher::Client.new(
-        app_id: ENV['PUSHER_APP_ID'],
-        key: ENV['PUSHER_KEY'],
-        secret: ENV['PUSHER_SECRET'],
-        use_tls: true
+      app_id: ENV['PUSHER_APP_ID'],
+      key: ENV['PUSHER_KEY'],
+      secret: ENV['PUSHER_SECRET'],
+      use_tls: true
     )
     pusher_client.trigger(current_user_id.to_s, 'csv-export-completed', message: csv_url)
   end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_activity_scores_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_activity_scores_completed.rb
@@ -3,15 +3,15 @@
 module PusherDistrictActivityScoresCompleted
   def self.run(admin_id)
     pusher_client = Pusher::Client.new(
-        app_id: ENV['PUSHER_APP_ID'],
-        key: ENV['PUSHER_KEY'],
-        secret: ENV['PUSHER_SECRET'],
-        use_tls: true
+      app_id: ENV['PUSHER_APP_ID'],
+      key: ENV['PUSHER_KEY'],
+      secret: ENV['PUSHER_SECRET'],
+      use_tls: true
     )
     pusher_client.trigger(
       admin_id.to_s,
-     'district-activity-scores-found',
-     message: "District activity scores found for #{admin_id}."
+      'district-activity-scores-found',
+      message: "District activity scores found for #{admin_id}."
    )
   end
 end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_concept_reports_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_concept_reports_completed.rb
@@ -3,15 +3,15 @@
 module PusherDistrictConceptReportsCompleted
   def self.run(admin_id)
     pusher_client = Pusher::Client.new(
-        app_id: ENV['PUSHER_APP_ID'],
-        key: ENV['PUSHER_KEY'],
-        secret: ENV['PUSHER_SECRET'],
-        use_tls: true
+      app_id: ENV['PUSHER_APP_ID'],
+      key: ENV['PUSHER_KEY'],
+      secret: ENV['PUSHER_SECRET'],
+      use_tls: true
     )
     pusher_client.trigger(
       admin_id.to_s,
-     'district-concept-reports-found',
-     message: "District concept reports found for #{admin_id}."
+      'district-concept-reports-found',
+      message: "District concept reports found for #{admin_id}."
    )
   end
 end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_standards_reports_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_standards_reports_completed.rb
@@ -3,15 +3,15 @@
 module PusherDistrictStandardsReportsCompleted
   def self.run(admin_id)
     pusher_client = Pusher::Client.new(
-        app_id: ENV['PUSHER_APP_ID'],
-        key: ENV['PUSHER_KEY'],
-        secret: ENV['PUSHER_SECRET'],
-        use_tls: true
+      app_id: ENV['PUSHER_APP_ID'],
+      key: ENV['PUSHER_KEY'],
+      secret: ENV['PUSHER_SECRET'],
+      use_tls: true
     )
     pusher_client.trigger(
       admin_id.to_s,
-     'district-standards-reports-found',
-     message: "District standards reports found for #{admin_id}."
+      'district-standards-reports-found',
+      message: "District standards reports found for #{admin_id}."
    )
   end
 end

--- a/services/QuillLMS/app/pusher_modules/pusher_lesson_launched.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_lesson_launched.rb
@@ -3,10 +3,10 @@
 module PusherLessonLaunched
   def self.run(classroom)
     pusher_client = Pusher::Client.new(
-        app_id: ENV['PUSHER_APP_ID'],
-        key: ENV['PUSHER_KEY'],
-        secret: ENV['PUSHER_SECRET'],
-        use_tls: true
+      app_id: ENV['PUSHER_APP_ID'],
+      key: ENV['PUSHER_KEY'],
+      secret: ENV['PUSHER_SECRET'],
+      use_tls: true
     )
     pusher_client.trigger(classroom.id.to_s, 'lesson-launched', message: "Lesson launched for #{classroom.name}.")
   end

--- a/services/QuillLMS/app/pusher_modules/pusher_recommendation_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_recommendation_completed.rb
@@ -3,16 +3,16 @@
 module PusherRecommendationCompleted
   def self.run(classroom, unit_template_id, lesson)
     pusher_client = Pusher::Client.new(
-        app_id: ENV['PUSHER_APP_ID'],
-        key: ENV['PUSHER_KEY'],
-        secret: ENV['PUSHER_SECRET'],
-        use_tls: true
+      app_id: ENV['PUSHER_APP_ID'],
+      key: ENV['PUSHER_KEY'],
+      secret: ENV['PUSHER_SECRET'],
+      use_tls: true
     )
     if lesson
       pusher_client.trigger(
         classroom.id.to_s,
-       'lessons-recommendations-assigned',
-       message: "Lessons recommendations assigned to #{classroom.name}."
+        'lessons-recommendations-assigned',
+        message: "Lessons recommendations assigned to #{classroom.name}."
      )
     else
       pusher_client.trigger(

--- a/services/QuillLMS/app/serializers/activity_session_serializer.rb
+++ b/services/QuillLMS/app/serializers/activity_session_serializer.rb
@@ -35,5 +35,5 @@
 #
 class ActivitySessionSerializer < ApplicationSerializer
   attributes :uid, :percentage, :state, :completed_at, :data, :temporary,
-              :activity_uid, :anonymous
+    :activity_uid, :anonymous
 end

--- a/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
+++ b/services/QuillLMS/app/serializers/admin/teacher_serializer.rb
@@ -8,8 +8,8 @@ class Admin::TeacherSerializer < ApplicationSerializer
   TEACHER = 'Teacher'
 
   attributes :id, :name, :email, :last_sign_in, :schools, :admin_info,
-            :number_of_students,
-            :has_valid_subscription
+    :number_of_students,
+    :has_valid_subscription
 
   type :teacher
 

--- a/services/QuillLMS/app/serializers/progress_reports/activity_session_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/activity_session_serializer.rb
@@ -2,18 +2,18 @@
 
 class ProgressReports::ActivitySessionSerializer  < ApplicationSerializer
   attributes :id,
-             :activity_classification_name,
-             :activity_classification_id,
-             :activity_name,
-             :completed_at,
-             :percentage,
-             :display_score,
-             :display_completed_at,
-             :classroom_id,
-             :unit_id,
-             :student_name,
-             :student_id,
-             :standard
+    :activity_classification_name,
+    :activity_classification_id,
+    :activity_name,
+    :completed_at,
+    :percentage,
+    :display_score,
+    :display_completed_at,
+    :classroom_id,
+    :unit_id,
+    :student_name,
+    :student_id,
+    :standard
 
   def activity_classification_name
     object.activity.classification.name

--- a/services/QuillLMS/app/serializers/progress_reports/concepts/concept_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/concepts/concept_serializer.rb
@@ -2,12 +2,12 @@
 
 class ProgressReports::Concepts::ConceptSerializer  < ApplicationSerializer
   attributes :concept_name,
-             :concept_id,
-             :total_result_count,
-             :correct_result_count,
-             :incorrect_result_count,
-             :level_2_concept_name,
-             :percentage
+    :concept_id,
+    :total_result_count,
+    :correct_result_count,
+    :incorrect_result_count,
+    :level_2_concept_name,
+    :percentage
 
   def percentage
     (object.correct_result_count.to_f * 100 / object.total_result_count).round

--- a/services/QuillLMS/app/serializers/progress_reports/concepts/student_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/concepts/student_serializer.rb
@@ -4,12 +4,12 @@ class ProgressReports::Concepts::StudentSerializer  < ApplicationSerializer
   include Rails.application.routes.url_helpers
 
   attributes :name,
-             :concepts_href,
-             :total_result_count,
-             :correct_result_count,
-             :incorrect_result_count,
-             :percentage,
-             :id
+    :concepts_href,
+    :total_result_count,
+    :correct_result_count,
+    :incorrect_result_count,
+    :percentage,
+    :id
 
   type :student
 

--- a/services/QuillLMS/app/serializers/progress_reports/standards/classroom_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/classroom_serializer.rb
@@ -4,12 +4,12 @@ class ProgressReports::Standards::ClassroomSerializer  < ApplicationSerializer
   include Rails.application.routes.url_helpers
 
   attributes :name,
-             :total_student_count,
-             :proficient_student_count,
-             :not_proficient_student_count,
-             :total_standard_count,
-             :students_href,
-             :standards_href
+    :total_student_count,
+    :proficient_student_count,
+    :not_proficient_student_count,
+    :total_standard_count,
+    :students_href,
+    :standards_href
 
   def total_standard_count
     object.unique_standard_count

--- a/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/standard_serializer.rb
@@ -6,17 +6,17 @@ class ProgressReports::Standards::StandardSerializer < ApplicationSerializer
   attr_accessor :classroom_id
 
   attributes :name,
-             :id,
-             :standard_level_name,
-             :total_student_count,
-             :proficient_student_count,
-             :not_proficient_student_count,
-             :total_activity_count,
-             :timespent,
-             :average_score,
-             :standard_students_href,
-             :mastery_status,
-             :is_evidence
+    :id,
+    :standard_level_name,
+    :total_student_count,
+    :proficient_student_count,
+    :not_proficient_student_count,
+    :total_activity_count,
+    :timespent,
+    :average_score,
+    :standard_students_href,
+    :mastery_status,
+    :is_evidence
 
   # rubocop:disable Naming/PredicateName
   def is_evidence

--- a/services/QuillLMS/app/serializers/progress_reports/standards/student_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/student_serializer.rb
@@ -8,16 +8,16 @@ class ProgressReports::Standards::StudentSerializer < ApplicationSerializer
   type :student
 
   attributes :name,
-             :id,
-             :sorting_name,
-             :total_standard_count,
-             :proficient_standard_count,
-             :not_proficient_standard_count,
-             :total_activity_count,
-             :timespent,
-             :average_score,
-             :student_standards_href,
-             :mastery_status
+    :id,
+    :sorting_name,
+    :total_standard_count,
+    :proficient_standard_count,
+    :not_proficient_standard_count,
+    :total_activity_count,
+    :timespent,
+    :average_score,
+    :student_standards_href,
+    :mastery_status
 
   def average_score
     object.average_score&.round(2) || 0

--- a/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
@@ -185,9 +185,9 @@ module Demo::ReportDemoAPCreator
 
   def self.create_classroom_units(classroom, unit)
     ClassroomUnit.create(
-        classroom: classroom,
-        unit: unit,
-        assign_on_join: true)
+      classroom: classroom,
+      unit: unit,
+      assign_on_join: true)
   end
 
   def self.create_unit_activities(unit, activities)

--- a/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -9,11 +9,11 @@ class InternalTool::EmailFeedbackHistorySessionDataWorker
 
   def perform(activity_id, start_date, end_date, filter_type, responses_for_scoring, email)
     feedback_histories = FeedbackHistory.session_data_for_csv(
-        activity_id: activity_id,
-        start_date: start_date,
-        end_date: end_date,
-        filter_type: filter_type,
-        responses_for_scoring: responses_for_scoring
+      activity_id: activity_id,
+      start_date: start_date,
+      end_date: end_date,
+      filter_type: filter_type,
+      responses_for_scoring: responses_for_scoring
     )
     results = []
     feedback_histories.find_each(batch_size: 10_000) { |feedback_history| results << feedback_history.serialize_csv_data }

--- a/services/QuillLMS/db/migrate/20140811132110_create_schools.rb
+++ b/services/QuillLMS/db/migrate/20140811132110_create_schools.rb
@@ -4,12 +4,12 @@ class CreateSchools < ActiveRecord::Migration[4.2]
   def change
     create_table :schools do |t|
       t.string  :nces_id, :lea_id, :leanm, :name, :phone, :mail_street, :mail_city,
-                :mail_state, :mail_zipcode, :street, :city, :state, :zipcode,
-                :nces_type_code, :nces_status_code, :magnet, :charter,
-                :ethnic_group
+        :mail_state, :mail_zipcode, :street, :city, :state, :zipcode,
+        :nces_type_code, :nces_status_code, :magnet, :charter,
+        :ethnic_group
       t.decimal :longitude, :latitude, precision: 9, scale: 6
       t.integer :ulocal, :fte_classroom_teacher, :lower_grade, :upper_grade,
-                :school_level, :free_lunches, :total_students
+        :school_level, :free_lunches, :total_students
       t.timestamps
     end
 

--- a/services/QuillLMS/db/migrate/20201026185613_create_feedback_history.rb
+++ b/services/QuillLMS/db/migrate/20201026185613_create_feedback_history.rb
@@ -19,7 +19,7 @@ class CreateFeedbackHistory < ActiveRecord::Migration[4.2]
     end
     add_index :feedback_histories, :activity_session_uid
     add_index :feedback_histories, [:prompt_type, :prompt_id],
-              name: 'index_feedback_histories_on_prompt_type_and_id'
+      name: 'index_feedback_histories_on_prompt_type_and_id'
     add_index :feedback_histories, :concept_uid
   end
 end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/rules_controller.rb
@@ -82,12 +82,12 @@ module Evidence
 
     private def rule_params
       params.require(:rule).permit(:name, :note, :universal, :rule_type, :optimal, :state, :suborder, :concept_uid, :hint_id,
-         prompt_ids: [],
-         plagiarism_texts_attributes: [:id, :text, :_destroy],
-         regex_rules_attributes: [:id, :regex_text, :case_sensitive, :sequence_type, :conditional],
-         label_attributes: [:id, :name, :state],
-         hint_attributes: [:id, :explanation, :image_link, :image_alt_text, :_destroy],
-         feedbacks_attributes: [:id, :text, :description, :order, highlights_attributes: [:id, :text, :highlight_type, :starting_index, :_destroy]]
+        prompt_ids: [],
+        plagiarism_texts_attributes: [:id, :text, :_destroy],
+        regex_rules_attributes: [:id, :regex_text, :case_sensitive, :sequence_type, :conditional],
+        label_attributes: [:id, :name, :state],
+        hint_attributes: [:id, :explanation, :image_link, :image_alt_text, :_destroy],
+        feedbacks_attributes: [:id, :text, :description, :order, highlights_attributes: [:id, :text, :highlight_type, :starting_index, :_destroy]]
       )
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/change_log.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/change_log.rb
@@ -100,19 +100,19 @@ module Evidence
 
     def change_logs_for_activity
       @activity = Evidence::Activity.includes(
-                      :change_logs,
-                      passages: [:change_logs],
-                      prompts: [
-                        :change_logs,
-                        rules: [
-                          :change_logs,
-                          feedbacks:
-                            [:change_logs, highlights: [:change_logs]],
-                          regex_rules: [:change_logs],
-                          plagiarism_texts: [:change_logs]
-                        ],
-                      automl_models: [:change_logs]
-                      ]
+        :change_logs,
+        passages: [:change_logs],
+        prompts: [
+          :change_logs,
+          rules: [
+            :change_logs,
+            feedbacks:
+              [:change_logs, highlights: [:change_logs]],
+            regex_rules: [:change_logs],
+            plagiarism_texts: [:change_logs]
+          ],
+        automl_models: [:change_logs]
+        ]
                     ).find(id)
       change_logs = activity_change_logs + passages_change_logs + prompts_change_logs + universal_change_logs
       change_logs.map(&:serializable_hash)

--- a/services/QuillLMS/engines/evidence/lib/tasks/add_grammar_api_rules_and_feedback.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/add_grammar_api_rules_and_feedback.rake
@@ -25,16 +25,16 @@ namespace :grammar_api_rules_and_feedback do
         created_rule.save!
 
         feedback = Evidence::Feedback.find_or_initialize_by(
-            rule_id: created_rule.id,
-            order: 0,
-            text: r['Feedback V3 [HM 4/21]']
+          rule_id: created_rule.id,
+          order: 0,
+          text: r['Feedback V3 [HM 4/21]']
         )
 
         feedback.save!
 
         all_prompts.each do |p|
           p_r = Evidence::PromptsRule.find_or_initialize_by(
-              prompt_id: p.id, rule_id: created_rule.id
+            prompt_id: p.id, rule_id: created_rule.id
           )
           p_r.save!
         end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/g_eval_runner_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/g_eval_runner_spec.rb
@@ -16,9 +16,9 @@ module Evidence
 
         let(:llm_example) do
           create(
-           :evidence_research_gen_ai_llm_example,
-           test_example: test_example,
-           llm_feedback: test_example.staff_feedback
+            :evidence_research_gen_ai_llm_example,
+            test_example: test_example,
+            llm_feedback: test_example.staff_feedback
           )
         end
 

--- a/services/QuillLMS/lib/tasks/create_concepts.rake
+++ b/services/QuillLMS/lib/tasks/create_concepts.rake
@@ -12,10 +12,10 @@ namespace :concepts do
         level_2_concept = Concept.find_or_create_by!(name: level_2_name)
         ap level_2_concept
         level_1_concept = Concept.find_or_create_by!(name: level_1_name,
-                                                     parent_id: level_2_concept.id)
+          parent_id: level_2_concept.id)
         ap level_1_concept
         level_0_concept = Concept.find_or_create_by!(name: level_0_name,
-                                                     parent_id: level_1_concept.id)
+          parent_id: level_1_concept.id)
         ap level_0_concept
       end
     end

--- a/services/QuillLMS/lib/tasks/leap.rake
+++ b/services/QuillLMS/lib/tasks/leap.rake
@@ -68,7 +68,7 @@ namespace :leap do
       user = User.find_by(email: email)
       if user
         district_id = ThirdPartyUserId.find_or_create_by(user: user,
-                                                         source: @id_source)
+          source: @id_source)
         district_id.third_party_id = row[@district_id_column_name].strip
         district_id.save!
       else

--- a/services/QuillLMS/lib/tasks/quill_writer.rake
+++ b/services/QuillLMS/lib/tasks/quill_writer.rake
@@ -6,8 +6,8 @@ namespace :quillwriter do
     # classification
     ac = ActivityClassification.where(key: 'writer').first_or_create!
     ac.update(name: 'Quill Writer', key: 'writer', app_name: :writer,
-                   module_url: 'http://quill-writer.firebaseapp.com/',
-                     form_url: 'http://quill-writer.firebaseapp.com/?form=true')
+      module_url: 'http://quill-writer.firebaseapp.com/',
+      form_url: 'http://quill-writer.firebaseapp.com/?form=true')
 
     # taxonomy
     # CAUTION: Creating a section fails if the db has 0 workbooks.

--- a/services/QuillLMS/spec/controllers/api/v1/activity_questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_questions_controller_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Api::V1::ActivityQuestionsController, type: :controller do
         get :index, params: { activity_id: activity.uid, locale: }
       end
 
-
       it "uses a different cache key for different locales" do
         expect(Rails.cache).to receive(:fetch).with("activity_questions/#{activity.uid}/es", expires_in: 1.hour).and_call_original
         get :index, params: { activity_id: activity.uid, locale: }

--- a/services/QuillLMS/spec/controllers/api/v1/incorrect_sequences_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/incorrect_sequences_controller_spec.rb
@@ -54,11 +54,11 @@ describe Api::V1::IncorrectSequencesController, type: :controller do
       data = { 'text' => 'text', 'feedback'=>'feedback' }
       incorrect_sequence_uid = question.incorrectSequences.keys.first
       put :update,
-       params: {
-         question_id: question.uid,
-         id: incorrect_sequence_uid,
-         incorrect_sequence: data
-        },
+        params: {
+          question_id: question.uid,
+          id: incorrect_sequence_uid,
+          incorrect_sequence: data
+         },
         as: :json
 
       question.reload

--- a/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
@@ -129,10 +129,10 @@ RSpec.describe InvitationsController, type: :controller do
     context 'when invitation exists' do
       let(:another_user) { create(:user) }
       let!(:invitation) { create(:invitation,
-                                 invitation_type: 'some type',
-                                 invitee_email: user.email,
-                                 archived: false,
-                                 inviter: another_user
+        invitation_type: 'some type',
+        invitee_email: user.email,
+        archived: false,
+        inviter: another_user
       )}
 
       it 'should destroy the given invitation' do

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -160,30 +160,30 @@ describe Teachers::ClassroomManagerController, type: :controller do
               }
             ]
           },
-          {
-            id: intermediate_pre_test.id,
-            post_test_id: intermediate_post_test.id,
-            assigned_classroom_ids: [],
-            all_classrooms: [
-              {
-                id: user.classrooms_i_teach.last.id,
-                completed_pre_test_student_ids: [],
-                completed_post_test_student_ids: []
-              }
-            ]
-          },
-          {
-            id: advanced_pre_test.id,
-            post_test_id: advanced_post_test.id,
-            assigned_classroom_ids: [],
-            all_classrooms: [
-              {
-                id: user.classrooms_i_teach.last.id,
-                completed_pre_test_student_ids: [],
-                completed_post_test_student_ids: []
-              }
-            ]
-          })
+            {
+              id: intermediate_pre_test.id,
+              post_test_id: intermediate_post_test.id,
+              assigned_classroom_ids: [],
+              all_classrooms: [
+                {
+                  id: user.classrooms_i_teach.last.id,
+                  completed_pre_test_student_ids: [],
+                  completed_post_test_student_ids: []
+                }
+              ]
+            },
+            {
+              id: advanced_pre_test.id,
+              post_test_id: advanced_post_test.id,
+              assigned_classroom_ids: [],
+              all_classrooms: [
+                {
+                  id: user.classrooms_i_teach.last.id,
+                  completed_pre_test_student_ids: [],
+                  completed_post_test_student_ids: []
+                }
+              ]
+            })
         end
       end
 

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -130,13 +130,13 @@ describe Teachers::ClassroomsController, type: :controller do
     # associations which break these specs
     let!(:classrooms_teacher) do
       create(:classrooms_teacher,
-              user_id: current_owner.id,
-              classroom: classroom,
-              role: ClassroomsTeacher::ROLE_TYPES[:owner])
+        user_id: current_owner.id,
+        classroom: classroom,
+        role: ClassroomsTeacher::ROLE_TYPES[:owner])
       create(:classrooms_teacher,
-              user_id: subsequent_owner.id,
-              classroom: classroom,
-              role: ClassroomsTeacher::ROLE_TYPES[:coteacher])
+        user_id: subsequent_owner.id,
+        classroom: classroom,
+        role: ClassroomsTeacher::ROLE_TYPES[:coteacher])
     end
 
     let!(:unaffiliated_user) { create(:teacher) }

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -13,17 +13,17 @@ describe Teachers::UnitsController, type: :controller do
 
   let!(:classroom_unit) do
     create(:classroom_unit,
-     unit: unit,
-     classroom: classroom,
-     assigned_student_ids: [student.id]
+      unit: unit,
+      classroom: classroom,
+      assigned_student_ids: [student.id]
    )
   end
 
   let!(:classroom_unit2) do
     create(:classroom_unit,
-     unit: unit2,
-     classroom: classroom,
-     assigned_student_ids: [student.id]
+      unit: unit2,
+      classroom: classroom,
+      assigned_student_ids: [student.id]
    )
   end
 

--- a/services/QuillLMS/spec/factories/questions.rb
+++ b/services/QuillLMS/spec/factories/questions.rb
@@ -145,7 +145,6 @@ FactoryBot.define do
           source: question,
           field_name: question.default_translatable_field
         )
-
       end
     end
 

--- a/services/QuillLMS/spec/models/concerns/translatable_question_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/translatable_question_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe TranslatableQuestion do
 
       it "includes translations for all #{field_key}" do
         field_mappings.each do |mapping|
-
           translated_text = mapping.translated_texts.find_by(locale:)
 
           expect(translated_field).to have_key(mapping.field_name)

--- a/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
@@ -18,9 +18,9 @@ describe QuestionHealthDashboard, type: :model do
 
   let!(:concept_result2) do
     create(:concept_result,
-     activity_session: activity_session2,
-     question_number: 1,
-     question_score: 0.75
+      activity_session: activity_session2,
+      question_number: 1,
+      question_score: 0.75
    )
   end
 

--- a/services/QuillLMS/spec/models/question_health_obj_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_obj_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe QuestionHealthObj, type: :model do
 
     let!(:concept_result1) do
       create(:concept_result,
-       activity_session: activity_session1,
-       question_number: 1,
-       question_score: 1
+        activity_session: activity_session1,
+        question_number: 1,
+        question_score: 1
      )
     end
 
     let!(:concept_result2) do
       create(:concept_result,
-       activity_session: activity_session2,
-       question_number: 1,
-       question_score: 0.75
+        activity_session: activity_session2,
+        question_number: 1,
+        question_score: 0.75
      )
     end
 

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -416,8 +416,6 @@ RSpec.describe Question, type: :model do
     end
   end
 
-
-
   describe '#refresh_cache' do
     let!(:question) { create(:question, uid: '1234', data: { 'foo' => 'initial_value' }) }
 

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1258,7 +1258,7 @@ RSpec.describe User, type: :model do
       let(:last_name)  { 'Doe' }
       let(:user) do
         build(:user, first_name: first_name,
-                     last_name: last_name)
+          last_name: last_name)
       end
 
       it 'returns "last, first"' do

--- a/services/QuillLMS/spec/queries/teachers_data_spec.rb
+++ b/services/QuillLMS/spec/queries/teachers_data_spec.rb
@@ -19,21 +19,21 @@ describe 'TeachersData' do
   let!(:time1) { time2 - (10.minutes) }
 
   let!(:classroom_unit) { create(:classroom_unit, classroom_id: classroom.id,
-                                                        unit: unit)}
+    unit: unit)}
   let!(:activity_session1) { create(:activity_session_without_concept_results,
-                                                user: student1,
-                                                state: 'finished',
-                                                started_at: time1,
-                                                completed_at: time2,
-                                                classroom_unit: classroom_unit
+    user: student1,
+    state: 'finished',
+    started_at: time1,
+    completed_at: time2,
+    classroom_unit: classroom_unit
                                                 ) }
 
   let!(:activity_session2) { create(:activity_session_without_concept_results,
-                                                user: student1,
-                                                state: 'finished',
-                                                started_at: time1,
-                                                completed_at: time2,
-                                                classroom_unit: classroom_unit
+    user: student1,
+    state: 'finished',
+    started_at: time1,
+    completed_at: time2,
+    classroom_unit: classroom_unit
                                                 ) }
 
   let!(:concept1) { create(:concept) }

--- a/services/QuillLMS/spec/services/admin_diagnostic_reports/assemble_overview_report_spec.rb
+++ b/services/QuillLMS/spec/services/admin_diagnostic_reports/assemble_overview_report_spec.rb
@@ -215,17 +215,17 @@ module AdminDiagnosticReports
                 .first[:aggregate_rows]
                 .select { |aggregate_row| aggregate_row[:aggregate_id] == pre_assigned_aggregate_row1[:aggregate_id] }
                 .first).to include(
-                {
-                  pre_students_assigned: pre_assigned_aggregate_row1[:pre_students_assigned],
-                  pre_students_completed: pre_completed_aggregate_row1[:pre_students_completed],
-                  pre_average_score: pre_completed_aggregate_row1[:pre_average_score],
-                  students_completed_practice: recommendations_aggregate_row1[:students_completed_practice],
-                  average_practice_activities_count: recommendations_aggregate_row1[:average_practice_activities_count],
-                  average_time_spent_seconds: recommendations_aggregate_row1[:average_time_spent_seconds],
-                  post_students_assigned: post_assigned_aggregate_row1[:post_students_assigned],
-                  post_students_completed: post_completed_aggregate_row1[:post_students_completed],
-                  overall_skill_growth: post_completed_aggregate_row1[:overall_skill_growth]
-                }
+                  {
+                    pre_students_assigned: pre_assigned_aggregate_row1[:pre_students_assigned],
+                    pre_students_completed: pre_completed_aggregate_row1[:pre_students_completed],
+                    pre_average_score: pre_completed_aggregate_row1[:pre_average_score],
+                    students_completed_practice: recommendations_aggregate_row1[:students_completed_practice],
+                    average_practice_activities_count: recommendations_aggregate_row1[:average_practice_activities_count],
+                    average_time_spent_seconds: recommendations_aggregate_row1[:average_time_spent_seconds],
+                    post_students_assigned: post_assigned_aggregate_row1[:post_students_assigned],
+                    post_students_completed: post_completed_aggregate_row1[:post_students_completed],
+                    overall_skill_growth: post_completed_aggregate_row1[:overall_skill_growth]
+                  }
               )
             end
           end

--- a/services/QuillLMS/spec/services/provider_classrooms_with_unsynced_students_finder_spec.rb
+++ b/services/QuillLMS/spec/services/provider_classrooms_with_unsynced_students_finder_spec.rb
@@ -138,10 +138,10 @@ RSpec.describe ProviderClassroomsWithUnsyncedStudentsFinder do
 
     let(:classroom_i_coteach) do
       create(
-       :classroom,
-       :from_canvas,
-       canvas_instance: canvas_instance,
-       students: [unsynced_student2, another_student]
+        :classroom,
+        :from_canvas,
+        canvas_instance: canvas_instance,
+        students: [unsynced_student2, another_student]
       )
     end
 

--- a/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
@@ -48,9 +48,9 @@ describe 'SerializeActivityHealth' do
 
   let!(:concept_result1) do
     create(:concept_result,
-     activity_session: activity_session1,
-     question_number: 1,
-     question_score: 1
+      activity_session: activity_session1,
+      question_number: 1,
+      question_score: 1
    )
   end
 

--- a/services/QuillLMS/spec/support/shared/concept_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/concept_progress_report.rb
@@ -15,8 +15,8 @@ shared_context 'Concept Progress Report' do
   let!(:classroom) { create(:classroom, students: [student]) }
   let!(:unit) { create(:unit) }
   let!(:classroom_unit) { create(:classroom_unit,
-                                          classroom: classroom,
-                                          unit: unit) }
+    classroom: classroom,
+    unit: unit) }
   let!(:unit_activity) { create(:unit_activity,
     unit: unit,
     activity: activity
@@ -28,11 +28,11 @@ shared_context 'Concept Progress Report' do
   let!(:grammar_tag) { create(:concept, name: 'Grammar Tag') }
 
   let!(:activity_session) { create(:activity_session,
-                                        classroom_unit: classroom_unit,
-                                        user: student,
-                                        activity: activity,
-                                        state: 'finished',
-                                        percentage: 0.75
+    classroom_unit: classroom_unit,
+    user: student,
+    activity: activity,
+    state: 'finished',
+    percentage: 0.75
                                         ) }
 
   let!(:correct_writing_result1) do
@@ -96,10 +96,10 @@ shared_context 'Concept Progress Report' do
 
   let!(:other_activity_session) do
     create(:activity_session,
-     classroom_unit: other_classroom_unit,
-     user: other_student,
-     state: 'finished',
-     percentage: 0.75
+      classroom_unit: other_classroom_unit,
+      user: other_student,
+      state: 'finished',
+      percentage: 0.75
    )
   end
 

--- a/services/QuillLMS/spec/support/shared/profile/profile.rb
+++ b/services/QuillLMS/spec/support/shared/profile/profile.rb
@@ -17,24 +17,24 @@ shared_context 'profile' do
   let!(:activity_1b) { create(:activity, classification: game2) }
   let(:unit1) { create(:unit) }
   let!(:classroom_activity) { create(:classroom_activity,
-                                                  classroom: classroom2,
-                                                  activity: activity,
-                                                  unit: unit1) }
+    classroom: classroom2,
+    activity: activity,
+    unit: unit1) }
 
   let!(:classroom_activity_1a) { create(:classroom_activity,
-                                                    classroom: classroom2,
-                                                    activity: activity_1a,
-                                                    unit: unit1)}
+    classroom: classroom2,
+    activity: activity_1a,
+    unit: unit1)}
 
   let!(:classroom_activity_1aa) { create(:classroom_activity,
-                                                    classroom: classroom2,
-                                                    activity: activity_1aa,
-                                                    unit: unit1)}
+    classroom: classroom2,
+    activity: activity_1aa,
+    unit: unit1)}
 
   let!(:classroom_activity_1b) { create(:classroom_activity,
-                                                    classroom: classroom2,
-                                                    activity: activity_1b,
-                                                    unit: unit1)}
+    classroom: classroom2,
+    activity: activity_1b,
+    unit: unit1)}
 
   let(:activity2) { create(:activity, classification: game2) }
   let(:activity_2a) { create(:activity, classification: game1) }

--- a/services/QuillLMS/spec/support/shared/section_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/section_progress_report.rb
@@ -21,14 +21,14 @@ shared_context 'StandardLevel Progress Report' do
       standards << standard
       activity = create(:activity, standard: standard)
       classroom_unit = create(:classroom_unit,
-                                              classroom: classroom,
-                                              unit: unit)
+        classroom: classroom,
+        unit: unit)
       3.times do |j|
         activity_session = create(:activity_session,
-                                              classroom_unit: classroom_unit,
-                                              user: student,
-                                              activity: activity,
-                                              percentage: i / 3.0)
+          classroom_unit: classroom_unit,
+          user: student,
+          activity: activity,
+          percentage: i / 3.0)
       end
     end
   end

--- a/services/QuillLMS/spec/support/shared/standard_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/standard_progress_report.rb
@@ -27,20 +27,20 @@ shared_context 'Standard Progress Report' do
   let!(:activity_for_second_grade_standard) { create(:activity,
     name: '2nd Grade Activity', standard: second_grade_standard) }
   let!(:classroom_unit1) { create(:classroom_unit,
-                                            classroom: full_classroom,
-                                            assign_on_join: true,
-                                            unit: unit1) }
+    classroom: full_classroom,
+    assign_on_join: true,
+    unit: unit1) }
   let!(:unit_activity1) {
     create(:unit_activity,
-    activity: activity_for_second_grade_standard,
-    unit: unit1)
+      activity: activity_for_second_grade_standard,
+      unit: unit1)
   }
   let!(:activity_for_first_grade_standard) { create(:activity,
     name: '1st Grade Activity', standard: first_grade_standard) }
   let!(:unit_activity2) {
     create(:unit_activity,
-    activity: activity_for_first_grade_standard,
-    unit: unit1)
+      activity: activity_for_first_grade_standard,
+      unit: unit1)
   }
 
   # NOTE: ClassroomActivity.create does not create new activity sessions for every student in the classroom.

--- a/services/QuillLMS/spec/support/shared/student_concept_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/student_concept_progress_report.rb
@@ -19,35 +19,35 @@ shared_context 'Student Concept Progress Report' do
   let(:activity) { create(:activity) }
   let(:unit) { create(:unit, user: teacher) }
   let(:classroom_unit) { create(:classroom_unit,
-                                          classroom: classroom,
-                                          assign_on_join: true,
-                                          unit: unit,
-                                          assigned_student_ids: [alice.id, fred.id, zojirushi.id]
+    classroom: classroom,
+    assign_on_join: true,
+    unit: unit,
+    assigned_student_ids: [alice.id, fred.id, zojirushi.id]
                                           ) }
   let(:unit_activity) { create(:unit_activity,
-                                activity: activity,
-                                unit: unit)}
+    activity: activity,
+    unit: unit)}
 
   # Create 2 activity session for each student, one with the concept tags, one without
   let(:alice_session) { create(:activity_session,
-                                      classroom_unit: classroom_unit,
-                                      user: alice,
-                                      activity: activity,
-                                      percentage: 0.75) }
+    classroom_unit: classroom_unit,
+    user: alice,
+    activity: activity,
+    percentage: 0.75) }
 
   let(:fred_session) { create(:activity_session,
-                                      classroom_unit: classroom_unit,
-                                      user: fred,
-                                      activity: activity,
-                                      percentage: 0.75) }
+    classroom_unit: classroom_unit,
+    user: fred,
+    activity: activity,
+    percentage: 0.75) }
 
   # Zojirushi has no concept tag results, so should not display
   # in the progress report
   let(:zojirushi_session) { create(:activity_session,
-                                      classroom_unit: classroom_unit,
-                                      user: zojirushi,
-                                      activity: activity,
-                                      percentage: 0.75) }
+    classroom_unit: classroom_unit,
+    user: zojirushi,
+    activity: activity,
+    percentage: 0.75) }
 
   let(:visible_students) { [alice, fred] }
   let(:classrooms) { [classroom] }

--- a/services/QuillLMS/spec/workers/account_creation_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/account_creation_worker_spec.rb
@@ -16,8 +16,8 @@ describe AccountCreationWorker do
 
         it 'should track the account creation' do
           expect(analyzer).to receive(:track_chain).with(
-              teacher,
-              [Analytics::SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION]
+            teacher,
+            [Analytics::SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION]
           )
           subject.perform(teacher.id)
         end
@@ -28,11 +28,11 @@ describe AccountCreationWorker do
 
         it 'should track the creation and sign up for newsletter' do
           expect(analyzer).to receive(:track_chain).with(
-              teacher,
-              [
-                Analytics::SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION,
-                Analytics::SegmentIo::BackgroundEvents::TEACHER_SIGNED_UP_FOR_NEWSLETTER
-              ]
+            teacher,
+            [
+              Analytics::SegmentIo::BackgroundEvents::TEACHER_ACCOUNT_CREATION,
+              Analytics::SegmentIo::BackgroundEvents::TEACHER_SIGNED_UP_FOR_NEWSLETTER
+            ]
           )
           subject.perform(teacher.id)
         end

--- a/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
@@ -11,13 +11,13 @@ describe PopulateActivityHealthWorker do
     let!(:connect) { create(:activity_classification, key: ActivityClassification::CONNECT_KEY) }
     let!(:activity) do
       create(:activity,
-       activity_classification_id: connect.id,
-       data: {
-         questions: [
-           { key: question.uid },
-           { key: another_question.uid }
-         ]
-       }
+        activity_classification_id: connect.id,
+        data: {
+          questions: [
+            { key: question.uid },
+            { key: another_question.uid }
+          ]
+        }
      )
     end
 


### PR DESCRIPTION
## WHAT
Add the rubocop rule to align parameters with a fixed width

## WHY
So that we have more consistency in our code

## HOW
Delete the exception from the todo 

## Notes: 
I chose the option for a fixed indentation of 2 spaces. There's another option to align with the first parameter, but I think it doesn't look as nice. 

When I ran rubocop with the fixed width alignment there were 378 changes. When I ran it with parameters alignments there were 563 changes, so this seems to be our preferred alignment. 

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO
Have you deployed to Staging? | NO- non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
