### PR TITLE
Use the language options from the API to populate the language picker

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/app.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/app.tsx
@@ -48,7 +48,7 @@ function extractLessonUIDFromLocation() {
   return (matches) ? matches[2] : null;
 }
 
-const lessonUid = extractLessonUIDFromLocation();
+export const lessonUid = extractLessonUIDFromLocation();
 
 if (lessonUid) {
   setTimeout(() => {

--- a/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
@@ -29,17 +29,16 @@ export const Home = ({playLesson, lessons, dispatch}) => {
   const [skippedToQuestionFromIntro, setSkippedToQuestionFromIntro] = React.useState<boolean>(false);
   const [languageOptions, setLanguageOptions] = React.useState<any>(null);
   React.useEffect(() => {
-    if (lessons?.hasreceiveddata) {
-      const translations = lessons.data?.[lessonUid]?.translations ?? {};
-      const languageOptions = [
-        { value: ENGLISH, label: ENGLISH },
-        ...Object.keys(translations).map(language => ({
-          value: localeToLanguageMap[language],
-          label: localeToLanguageMap[language]
-        }))
-      ];
-      setLanguageOptions(languageOptions);
-    }
+    if (!lessons?.hasreceiveddata) { return }
+    const translations = lessons.data?.[lessonUid]?.translations ?? {};
+    const languageOptions = [
+      { value: ENGLISH, label: ENGLISH },
+      ...Object.keys(translations).map(language => ({
+        value: localeToLanguageMap[language],
+        label: localeToLanguageMap[language]
+      }))
+    ];
+    setLanguageOptions(languageOptions);
   }, [lessons]);
 
   function handleKeyDown (e: any) {

--- a/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
@@ -100,7 +100,7 @@ export const Home = ({playLesson, lessons, dispatch}) => {
       language={playLesson?.language}
       languageOptions={languageOptions}
       updateLanguage={handleUpdateLanguage}
-      />);
+    />);
   }
   return(
     <div className={className}>

--- a/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/home.tsx
@@ -7,12 +7,14 @@ import { NavBar } from './navbar/navbar';
 
 import { addKeyDownListener } from '../../Shared/hooks/addKeyDownListener';
 import { ScreenreaderInstructions, TeacherPreviewMenu, } from '../../Shared/index';
+import { ENGLISH, localeToLanguageMap } from '../../Shared/utils/languageList';
 import { fetchUserRole } from '../../Shared/utils/userAPIs';
 import { setLanguage } from '../actions.js';
+import { lessonUid } from '../app';
 import { getParameterByName } from '../libs/getParameterByName';
 import { routes } from "../routes";
 
-export const Home = ({playLesson, dispatch}) => {
+export const Home = ({playLesson, lessons, dispatch}) => {
   const studentSession = getParameterByName('student', window.location.href);
   const turkSession = window.location.href.includes('turk');
   const studentOrTurk = studentSession || turkSession;
@@ -25,6 +27,20 @@ export const Home = ({playLesson, dispatch}) => {
   const [questionToPreview, setQuestionToPreview] = React.useState<any>(null);
   const [switchedBackToPreview, setSwitchedBackToPreview] = React.useState<boolean>(false);
   const [skippedToQuestionFromIntro, setSkippedToQuestionFromIntro] = React.useState<boolean>(false);
+  const [languageOptions, setLanguageOptions] = React.useState<any>(null);
+  React.useEffect(() => {
+    if (lessons?.hasreceiveddata) {
+      const translations = lessons.data?.[lessonUid]?.translations ?? {};
+      const languageOptions = [
+        { value: ENGLISH, label: ENGLISH },
+        ...Object.keys(translations).map(language => ({
+          value: localeToLanguageMap[language],
+          label: localeToLanguageMap[language]
+        }))
+      ];
+      setLanguageOptions(languageOptions);
+    }
+  }, [lessons]);
 
   function handleKeyDown (e: any) {
     if (e.key !== 'Tab') { return }
@@ -74,12 +90,17 @@ export const Home = ({playLesson, dispatch}) => {
       isOnMobile={isOnMobile}
       isTeacher={isTeacherOrAdmin}
       language={playLesson?.language}
+      languageOptions={languageOptions}
       onTogglePreview={handleTogglePreviewMenu}
       previewShowing={previewShowing}
       updateLanguage={handleUpdateLanguage}
     />);
   } else if (!isTeacherOrAdmin && isPlaying) {
-    header = <NavBar language={playLesson?.language} updateLanguage={handleUpdateLanguage} />;
+    header = (<NavBar
+      language={playLesson?.language}
+      languageOptions={languageOptions}
+      updateLanguage={handleUpdateLanguage}
+      />);
   }
   return(
     <div className={className}>
@@ -118,7 +139,8 @@ export const Home = ({playLesson, dispatch}) => {
 
 const select = (state: any, props: any) => {
   return {
-    playLesson: state.playLesson
+    playLesson: state.playLesson,
+    lessons: state.lessons
   };
 }
 

--- a/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
@@ -13,22 +13,25 @@ interface NavBarProps {
   updateLanguage: (language: string) => void;
 }
 
-
 export const NavBar: React.SFC<NavBarProps> = ({ isOnMobile, isTeacher, previewShowing, onTogglePreview, language, languageOptions, updateLanguage }) => {
   const handleTogglePreview = () => {
     onTogglePreview();
   }
 
+  const showTranslations = (): boolean => {
+    if (urlParams.get('showTranslations') !== 'true') return false;
+    return !!languageOptions && Object.keys(languageOptions).length > 1;
+  };
+
   // Temporary feature flag until we are ready to ship this.
   const urlParams = new URLSearchParams(window.location.search)
-  const showTranslations = urlParams.get('showTranslations') === 'true'
   return (
     <div className="header">
       <div className="activity-navbar-content">
         {isTeacher && !previewShowing && !isOnMobile && <TeacherPreviewMenuButton handleTogglePreview={handleTogglePreview} />}
         <a className="focus-on-dark" href={process.env.DEFAULT_URL}><img alt="Quill logo" src={quillLogoSrc} /></a>
         <div className='header-buttons-container'>
-          {showTranslations && <LanguagePicker language={language} languageOptions={languageOptions} updateLanguage={updateLanguage} />}
+          {showTranslations() && <LanguagePicker language={language} languageOptions={languageOptions} updateLanguage={updateLanguage} />}
           <a className="quill-button medium contained white focus-on-dark" href={process.env.DEFAULT_URL}>Save and exit</a>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
@@ -9,11 +9,12 @@ interface NavBarProps {
   previewShowing?: boolean;
   onTogglePreview?: () => void;
   language: string;
+  languageOptions?: any;
   updateLanguage: (language: string) => void;
 }
 
 
-export const NavBar: React.SFC<NavBarProps> = ({ isOnMobile, isTeacher, previewShowing, onTogglePreview, language, updateLanguage }) => {
+export const NavBar: React.SFC<NavBarProps> = ({ isOnMobile, isTeacher, previewShowing, onTogglePreview, language, languageOptions, updateLanguage }) => {
   const handleTogglePreview = () => {
     onTogglePreview();
   }
@@ -27,7 +28,7 @@ export const NavBar: React.SFC<NavBarProps> = ({ isOnMobile, isTeacher, previewS
         {isTeacher && !previewShowing && !isOnMobile && <TeacherPreviewMenuButton handleTogglePreview={handleTogglePreview} />}
         <a className="focus-on-dark" href={process.env.DEFAULT_URL}><img alt="Quill logo" src={quillLogoSrc} /></a>
         <div className='header-buttons-container'>
-          {showTranslations && <LanguagePicker language={language} updateLanguage={updateLanguage} />}
+          {showTranslations && <LanguagePicker language={language} languageOptions={languageOptions} updateLanguage={updateLanguage}/>}
           <a className="quill-button medium contained white focus-on-dark" href={process.env.DEFAULT_URL}>Save and exit</a>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/navbar/navbar.tsx
@@ -28,7 +28,7 @@ export const NavBar: React.SFC<NavBarProps> = ({ isOnMobile, isTeacher, previewS
         {isTeacher && !previewShowing && !isOnMobile && <TeacherPreviewMenuButton handleTogglePreview={handleTogglePreview} />}
         <a className="focus-on-dark" href={process.env.DEFAULT_URL}><img alt="Quill logo" src={quillLogoSrc} /></a>
         <div className='header-buttons-container'>
-          {showTranslations && <LanguagePicker language={language} languageOptions={languageOptions} updateLanguage={updateLanguage}/>}
+          {showTranslations && <LanguagePicker language={language} languageOptions={languageOptions} updateLanguage={updateLanguage} />}
           <a className="quill-button medium contained white focus-on-dark" href={process.env.DEFAULT_URL}>Save and exit</a>
         </div>
       </div>

--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/languagePage.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/languagePage.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import { diagnosticLanguageOptions, ENGLISH, languages } from '../../../Shared/utils/languageList';
 import { TrackAnalyticsEvent } from '../../actions/analytics';
 import { Events } from '../../modules/analytics';
-import { ENGLISH, languages, languageOptions } from '../../../Shared/utils/languageList';
 
 export class LanguagePage extends React.Component {
 
@@ -29,7 +29,7 @@ export class LanguagePage extends React.Component {
         </div>
         <div className="language-button-container english">
           <button className="language-button" onClick={this.handleClickLanguage} type="button" value="english">
-            <img alt="flag" className="language-button-img" src={languageOptions[ENGLISH].flag} />
+            <img alt="flag" className="language-button-img" src={diagnosticLanguageOptions[ENGLISH].flag} />
             <p className="language-label">English</p>
           </button>
         </div>
@@ -46,8 +46,8 @@ export class LanguagePage extends React.Component {
             if(language !== ENGLISH) {
               return(
                 <button className="language-button" key={`${language}-button`} onClick={this.handleClickLanguage} type="button" value={language}>
-                  <img alt="flag" className="language-button-img" src={languageOptions[language].flag} />
-                  <p className="language-label">{languageOptions[language].label}</p>
+                  <img alt="flag" className="language-button-img" src={diagnosticLanguageOptions[language].flag} />
+                  <p className="language-label">{diagnosticLanguageOptions[language].label}</p>
                 </button>
               );
             }

--- a/services/QuillLMS/client/app/bundles/Shared/components/translations/languagePicker.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/translations/languagePicker.tsx
@@ -1,21 +1,20 @@
 import * as React from 'react';
 
 import { DropdownInput } from '../../index';
-import { languages, languageOptions } from "../../utils/languageList"
+import { diagnosticLanguageOptions, languages } from "../../utils/languageList";
 
 interface LanguagePickerProps {
   language: string,
+  languageOptions: any,
   updateLanguage(language: string): any
 }
 
-const options = (): Array<{value: string, label: string}> => {
-  return languages.map(language => ({
-    value: language,
-    label: languageOptions[language].label
-  }))
-}
-
-const LanguagePicker = ({ language, updateLanguage, }: LanguagePickerProps) => {
+const LanguagePicker = ({ language, updateLanguage, languageOptions }: LanguagePickerProps) => {
+  const options = (): Array<{value: string, label: string}> =>
+    languageOptions ?? languages.map(language => ({
+      value: language,
+      label: diagnosticLanguageOptions[language].label
+    }));
 
   const onChange = (option: { value: string}) => {
     const language = option.value;

--- a/services/QuillLMS/client/app/bundles/Shared/utils/languageList.js
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/languageList.js
@@ -15,10 +15,33 @@ export const THAI = 'thai';
 export const UKRAINIAN = 'ukrainian';
 export const TAGALOG = 'tagalog';
 export const DARI = 'dari';
+export const localeToLanguageMap = {
+  "en": ENGLISH,
+  "zh-cn": CHINESE,
+  "zh-tw": CHINESE,
+  "hi": HINDI,
+  "es": SPANISH,
+  "es-la": SPANISH,
+  "fr": FRENCH,
+  "ar": ARABIC,
+  "ru": RUSSIAN,
+  "pt": PORTUGUESE,
+  "pt-br": PORTUGUESE,
+  "ur": URDU,
+  "de": GERMAN,
+  "ja": JAPANESE,
+  "ko": KOREAN,
+  "vi": VIETNAMESE,
+  "th": THAI,
+  "uk": UKRAINIAN,
+  "tl": TAGALOG,
+  "fil": TAGALOG,
+  "prs": DARI
+};
 export const languages = [ENGLISH, CHINESE, HINDI, SPANISH, FRENCH, ARABIC, RUSSIAN, PORTUGUESE, URDU, GERMAN, JAPANESE, KOREAN, VIETNAMESE, THAI, UKRAINIAN, TAGALOG, DARI];
 export const rightToLeftLanguages = [ARABIC, URDU, DARI];
 
-export const languageOptions = {
+export const diagnosticLanguageOptions = {
   [ENGLISH]: {
     flag: 'https://assets.quill.org/images/flags/usa.png',
     label: 'English'


### PR DESCRIPTION
## WHAT
Make the language header populate based on the available languages available in the activity. If there is only english available, don't show it. 

## WHY
So we don't tempt students with languages we don't actually support 
## HOW
Use the `translations` key in the `activity` payload to determine which languages to show. 

### Screenshots
![2024-07-25 at 3 19 PM](https://github.com/user-attachments/assets/946772e9-5408-49a5-a014-8e92ab708e38)


### Notion Card Links
https://www.notion.so/quill/Add-language-picker-to-the-top-bar-on-activities-where-there-are-translations-for-Connect-and-Gramma-0c449f70511b4ae599beb67294cce102?pvs=4

### What have you done to QA this feature?
Tested it on development
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO-frontend change
Have you deployed to Staging? |  YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
