### PR TITLE
Fix closing parentheses indentation.

### DIFF
--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -15,12 +15,6 @@ Bundler/OrderedGems:
     - 'Gemfile'
 
 
-# Offense count: 58
-# This cop supports safe autocorrection (--autocorrect).
-Layout/ClosingParenthesisIndentation:
-  Enabled: false
-
-
 # Offense count: 163
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -14,13 +14,6 @@ Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
 
-
-# Offense count: 163
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
-Layout/ExtraSpacing:
-  Enabled: false
-
 # Offense count: 25
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/services/QuillLMS/Guardfile
+++ b/services/QuillLMS/Guardfile
@@ -30,7 +30,7 @@ guard :rspec, cmd: 'spring rspec' do
 
   # Turnip features and steps
   watch(%r{^spec/acceptance/(.+)\.feature$})
-  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
 end
 
 # Add files and commands to this file, like the example:

--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -145,6 +145,6 @@ class ActivitiesController < ApplicationController
   end
 
   protected def search_params
-    params.require(:search).permit([:search_query, { sort: [:field, :asc_or_desc] },  { filters: [:field, :selected] }])
+    params.require(:search).permit([:search_query, { sort: [:field, :asc_or_desc] }, { filters: [:field, :selected] }])
   end
 end

--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -122,7 +122,7 @@ class ActivitySessionsController < ApplicationController
   end
 
   private def activity_session_authorize_teacher!
-    return if  AuthorizedTeacherForActivity.new(current_user, @activity_session).call
+    return if AuthorizedTeacherForActivity.new(current_user, @activity_session).call
 
     render_error(404)
   end

--- a/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
+++ b/services/QuillLMS/app/controllers/canvas_integration/lti_controller.rb
@@ -13,7 +13,7 @@ module CanvasIntegration
       @link_text = LAUNCH_TEXT
       @link_url = canvas_integration_lti_sso_path(canvas_instance_url: params[:custom_canvas_instance_url])
 
-      render layout: false   # canvas doesn't allow script tags in iframes
+      render layout: false # canvas doesn't allow script tags in iframes
     end
 
     def launch_config

--- a/services/QuillLMS/app/controllers/cms/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/activities_controller.rb
@@ -116,6 +116,6 @@ class Cms::ActivitiesController < Cms::CmsController
       activity_category_ids: [],
       content_partner_ids: [],
       flags: []
-                                   )
+    )
   end
 end

--- a/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/blog_posts_controller.rb
@@ -68,7 +68,7 @@ class Cms::BlogPostsController < Cms::CmsController
               :press_name,
               :featured_order_number,
               :footer_content
-                  )
+            )
   end
 
   private def set_blog_post

--- a/services/QuillLMS/app/controllers/cms/concepts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/concepts_controller.rb
@@ -26,7 +26,7 @@ class Cms::ConceptsController < Cms::CmsController
     return unless stored_concepts_in_use
 
     concepts_in_use = JSON.parse(stored_concepts_in_use)
-    csv_str = concepts_in_use.inject([]) { |csv, rows|  csv << CSV.generate_line(rows) }.join
+    csv_str = concepts_in_use.inject([]) { |csv, rows| csv << CSV.generate_line(rows) }.join
     respond_to do |format|
       format.html
       format.csv { render csv: csv_str, filename: 'concepts_in_use' }

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -148,7 +148,7 @@ class Cms::UsersController < Cms::CmsController
 
   protected def user_params
     params.require(:user).permit([:name, :email, :flagset, :username, :title, :role, :admin_sub_role, :classcode, :password, :password_confirmation, :email_verification_status, :flags =>[]] + default_params
-    )
+                                )
   end
 
   protected def user_query_params

--- a/services/QuillLMS/app/controllers/milestones_controller.rb
+++ b/services/QuillLMS/app/controllers/milestones_controller.rb
@@ -34,7 +34,7 @@ class MilestonesController < ApplicationController
   end
 
   def create_or_touch_dismiss_teacher_info_modal
-    milestone =  Milestone.find_by_name(Milestone::TYPES[:dismiss_teacher_info_modal])
+    milestone = Milestone.find_by_name(Milestone::TYPES[:dismiss_teacher_info_modal])
 
     user_milestone = UserMilestone.find_or_create_by!(milestone: milestone, user: current_user)
     user_milestone.touch

--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -60,9 +60,9 @@ class SchoolsController < ApplicationController
         .joins('LEFT JOIN schools_users ON schools_users.school_id = schools.id')
         .where(
           "zipcode in #{array_to_postgres_array_helper(zip_arr)} OR mail_zipcode in #{array_to_postgres_array_helper(zip_arr)}"
-         ).where(
-           'lower(name) LIKE :prefix', prefix: "%#{@prefix.downcase}%"
-         ).group('schools.id')
+        ).where(
+          'lower(name) LIKE :prefix', prefix: "%#{@prefix.downcase}%"
+        ).group('schools.id')
          .limit(@limit)
         $redis.set("#{cache_id}_RADIUS_TO_SCHOOL_#{@lat}_#{@lng}_#{@radius}", @schools.map { |s| s.id }.to_json)
         # short cache, highly specific
@@ -77,7 +77,7 @@ class SchoolsController < ApplicationController
       .joins('LEFT JOIN schools_users ON schools_users.school_id = schools.id')
       .where(
         'lower(name) LIKE :prefix', prefix: "%#{@prefix.downcase}%"
-       ).group('schools.id')
+      ).group('schools.id')
        .limit(@limit)
       $redis.set("PREFIX_TO_SCHOOL_#{@prefix}", @schools.map { |s| s.id }.to_json)
       # longer cache, more general

--- a/services/QuillLMS/app/controllers/sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/sessions_controller.rb
@@ -23,7 +23,7 @@ class SessionsController < ApplicationController
   # rubocop:disable Metrics/CyclomaticComplexity
   def login_through_ajax
     email_or_username = params[:user][:email].downcase.strip unless params[:user][:email].nil?
-    @user =  User.find_by_username_or_email(email_or_username)
+    @user = User.find_by_username_or_email(email_or_username)
     if @user.nil? || @user.sales_contact?
       render json: { message: 'An account with this email or username does not exist. Try again.', type: 'email' }, status: :unauthorized
     elsif @user.google_id && @user.password_digest.nil?

--- a/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classroom_manager_controller.rb
@@ -35,7 +35,7 @@ class Teachers::ClassroomManagerController < ApplicationController
     @clever_link = clever_link
     @google_link = Auth::Google::REAUTHORIZATION_PATH
     @number_of_activities_assigned = current_user.units.map(&:unit_activities).flatten.map(&:activity_id).uniq.size
-    @user =  UserWithProviderSerializer.new(current_user).as_json(root: false)
+    @user = UserWithProviderSerializer.new(current_user).as_json(root: false)
     find_or_create_checkbox(Objective::EXPLORE_OUR_LIBRARY, current_user)
     return unless params[:tab] == 'diagnostic'
 

--- a/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/classrooms_controller.rb
@@ -11,7 +11,7 @@ class Teachers::ClassroomsController < ApplicationController
 
   # The excepted/only methods below are ones that should be accessible to coteachers.
   # TODO This authing could probably be refactored.
-  before_action :authorize_owner!, only: [:update,  :transfer_ownership]
+  before_action :authorize_owner!, only: [:update, :transfer_ownership]
   before_action :authorize_teacher!, only: [:scores, :units, :scorebook, :generate_login_pdf]
 
   INDEX = 'index'
@@ -26,7 +26,7 @@ class Teachers::ClassroomsController < ApplicationController
     @canvas_link = Auth::Canvas::REAUTHORIZATION_PATH
     @clever_link = clever_link
     @google_link = Auth::Google::REAUTHORIZATION_PATH
-    @user =  UserWithProviderSerializer.new(current_user).as_json(root: false)
+    @user = UserWithProviderSerializer.new(current_user).as_json(root: false)
 
     respond_to do |format|
       format.html

--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -239,7 +239,7 @@ class Teachers::UnitsController < ApplicationController
   private def formatted_classrooms_data(unit_id)
     # potential refactor into SQL
     cus = ClassroomUnit.where(unit_id: unit_id).select(:classroom_id, :assigned_student_ids)
-    one_cu_per_classroom =  cus.group_by{ |class_unit| class_unit[:classroom_id] }.values.map{ |cu| cu.first }
+    one_cu_per_classroom = cus.group_by{ |class_unit| class_unit[:classroom_id] }.values.map{ |cu| cu.first }
     one_cu_per_classroom.map{ |cu| { id: cu.classroom_id, student_ids: cu.assigned_student_ids } }
   end
 

--- a/services/QuillLMS/app/controllers/teachers_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers_controller.rb
@@ -28,7 +28,7 @@ class TeachersController < ApplicationController
 
   def premium_hub
     if current_user.present? && current_user.admin? && !admin_impersonating_user?(current_user)
-      @user =  UserWithProviderSerializer.new(current_user).as_json(root: false)
+      @user = UserWithProviderSerializer.new(current_user).as_json(root: false)
       render 'admin'
     else
       redirect_to profile_path

--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -22,7 +22,7 @@ class RuleFeedbackHistory
       count(DISTINCT CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_CONSECUTIVE}' THEN feedback_history_flags.id END) AS repeated_consecutive,
       count(DISTINCT CASE WHEN feedback_history_flags.flag = '#{FeedbackHistoryFlag::FLAG_REPEATED_RULE_NON_CONSECUTIVE}' THEN feedback_history_flags.id END) AS repeated_non_consecutive
     SELECT
-    )
+                                 )
     .joins('INNER JOIN comprehension_prompts_rules as prompts_rules ON comprehension_rules.id = prompts_rules.rule_id')
     .joins('INNER JOIN comprehension_prompts as prompts ON prompts_rules.prompt_id = prompts.id')
     .joins('LEFT JOIN feedback_histories ON feedback_histories.rule_uid = comprehension_rules.uid AND feedback_histories.prompt_id = prompts.id')

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -32,7 +32,7 @@ class UserMailer < ActionMailer::Base
 
   def invitation_to_existing_user invitation_email_hash
     invitation_email_hash.stringify_keys!
-    @email_hash = invitation_email_hash.merge(support_article_link: COTEACHER_SUPPORT_ARTICLE,  accept_link: teachers_classrooms_url).stringify_keys
+    @email_hash = invitation_email_hash.merge(support_article_link: COTEACHER_SUPPORT_ARTICLE, accept_link: teachers_classrooms_url).stringify_keys
     mail from: 'The Quill Team <hello@quill.org>', 'reply-to': @email_hash['inviter_email'], to: @email_hash['invitee_email'], subject: "#{@email_hash['inviter_name']} has invited you to co-teach on Quill.org!"
   end
 
@@ -83,7 +83,7 @@ class UserMailer < ActionMailer::Base
   def new_admin_email(user, school)
     @user = user
     @school = school
-    mail from: 'The Quill Team <hello@quill.org>',  to: user.email, subject: "#{user.first_name}, you are now an admin on Quill!"
+    mail from: 'The Quill Team <hello@quill.org>', to: user.email, subject: "#{user.first_name}, you are now an admin on Quill!"
   end
 
   def activated_referral_email(referrer_hash, referral_hash)

--- a/services/QuillLMS/app/models/activity_category.rb
+++ b/services/QuillLMS/app/models/activity_category.rb
@@ -21,7 +21,7 @@ class ActivityCategory < ApplicationRecord
   def set_order_number
     return if order_number.present?
 
-    self.order_number =  ActivityCategory.count
+    self.order_number = ActivityCategory.count
   end
 
   def clear_activity_search_cache

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -107,7 +107,7 @@ class ActivitySession < ApplicationRecord
   scope :completed,  -> { where.not(completed_at: nil) }
   scope :incomplete, -> { where(completed_at: nil, is_retry: false) }
   # this is a default scope, adding this for unscoped use.
-  scope :visible,  -> { where(visible: true) }
+  scope :visible, -> { where(visible: true) }
 
   scope :for_teacher, lambda { |teacher_id|
     joins(classroom_unit: { classroom: :teachers })

--- a/services/QuillLMS/app/models/blog_post.rb
+++ b/services/QuillLMS/app/models/blog_post.rb
@@ -94,7 +94,7 @@ class BlogPost < ApplicationRecord
   def set_order_number
     return if order_number.present?
 
-    self.order_number =  BlogPost.where(topic: topic).count
+    self.order_number = BlogPost.where(topic: topic).count
   end
 
   def increment_read_count

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -13,7 +13,7 @@ module PublicProgressReports
   PROOFREADER_SUBOPTIMAL_FINAL_ATTEMPT_FEEDBACK = 'Incorrect'
   CONNECT_OPTIMAL_FINAL_ATTEMPT_FEEDBACK = "That's a strong sentence!"
   CONNECT_SUBOPTIMAL_FINAL_ATTEMPT_SENTENCE_COMBINING_FEEDBACK = "Nice try. Let's try a multiple choice question."
-  CONNECT_SUBOPTIMAL_FINAL_ATTEMPT_FILL_IN_BLANKS_FEEDBACK =  'Good try! Compare your response to the strong responses, and then go to on to the next question.'
+  CONNECT_SUBOPTIMAL_FINAL_ATTEMPT_FILL_IN_BLANKS_FEEDBACK = 'Good try! Compare your response to the strong responses, and then go to on to the next question.'
 
   def last_completed_diagnostic
     diagnostic_activity_ids = Activity.diagnostic_activity_ids

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -42,7 +42,7 @@ module Student
               AND students_classrooms.student_id = activity_sessions.user_id
               AND activities.id = activity_sessions.activity_id
         SQL
-        )
+              )
     end
 
     def finished_activities(classroom)

--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -336,7 +336,7 @@ class FeedbackHistory < ApplicationRecord
           THEN true ELSE false END
         ) AS complete
       SQL
-      )
+    )
       .joins('LEFT OUTER JOIN feedback_history_flags ON feedback_histories.id = feedback_history_flags.feedback_history_id')
       .joins('LEFT OUTER JOIN comprehension_prompts ON feedback_histories.prompt_id = comprehension_prompts.id')
       .joins('LEFT OUTER JOIN feedback_history_ratings ON feedback_histories.id = feedback_history_ratings.feedback_history_id')
@@ -404,7 +404,7 @@ class FeedbackHistory < ApplicationRecord
       <<-SQL
         feedback_histories.feedback_session_uid AS session_uid
       SQL
-      )
+    )
       .joins('LEFT OUTER JOIN feedback_history_flags ON feedback_histories.id = feedback_history_flags.feedback_history_id')
       .joins('LEFT OUTER JOIN comprehension_prompts ON feedback_histories.prompt_id = comprehension_prompts.id')
       .joins('LEFT OUTER JOIN feedback_history_ratings ON feedback_histories.id = feedback_history_ratings.feedback_history_id')
@@ -431,7 +431,7 @@ class FeedbackHistory < ApplicationRecord
         feedback_histories.feedback_type,
         comprehension_rules.name
       SQL
-      )
+    )
       .joins('LEFT OUTER JOIN comprehension_prompts ON feedback_histories.prompt_id = comprehension_prompts.id')
       .joins('LEFT OUTER JOIN comprehension_rules ON comprehension_rules.uid = feedback_histories.rule_uid')
       .where(used: true)

--- a/services/QuillLMS/app/models/feedback_history.rb
+++ b/services/QuillLMS/app/models/feedback_history.rb
@@ -54,16 +54,16 @@ class FeedbackHistory < ApplicationRecord
   ]
   FILTER_TYPES = [
     FILTER_ALL = 'all',
-    FILTER_SCORED =  'scored',
-    FILTER_UNSCORED =  'unscored',
-    FILTER_WEAK =  'weak',
-    FILTER_COMPLETE =  'complete',
-    FILTER_INCOMPLETE =  'incomplete'
+    FILTER_SCORED = 'scored',
+    FILTER_UNSCORED = 'unscored',
+    FILTER_WEAK = 'weak',
+    FILTER_COMPLETE = 'complete',
+    FILTER_INCOMPLETE = 'incomplete'
   ]
   CONJUNCTIONS = [
     BECAUSE =  'because',
-    BUT =  'but',
-    SO =  'so'
+    BUT = 'but',
+    SO = 'so'
   ]
 
   after_commit :initiate_flag_worker, on: :create
@@ -93,8 +93,8 @@ class FeedbackHistory < ApplicationRecord
   validates :time, presence: true
   validates :used, inclusion: { in: [true, false] }
 
-  scope :used,  -> { where(used: true) }
-  scope :optimal,  -> { where(optimal: true) }
+  scope :used, -> { where(used: true) }
+  scope :optimal, -> { where(optimal: true) }
   scope :suboptimal,  -> { where(optimal: false) }
   scope :autoML, -> { where(feedback_type: AUTO_ML) }
   scope :confidence_greater_than, ->(lower_limit) { where("CAST(metadata->'api'->'confidence' AS DOUBLE PRECISION) > ?", lower_limit) }

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -190,7 +190,7 @@ class Question < ApplicationRecord
   private def set_data_for(type:, id:, new_data:)
     data[type] ||= {}
     id = id.to_i if stored_as_array?(type)
-    new_data  = { 'uid' => new_uuid }.merge(new_data) if stored_as_array?(type)
+    new_data = { 'uid' => new_uuid }.merge(new_data) if stored_as_array?(type)
     data[type][id] = new_data
     save
   end

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -244,7 +244,7 @@ class UnitActivity < ApplicationRecord
           ua.due_date ASC,
           ua.id ASC
      SQL
-    )
+   )
 
     # we could also do this with a HAVING clause, but it is pretty difficult to read because the logic for computing those values is complex
     data.filter { |ua| ua['finished'] || !ua['closed'] }

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -217,7 +217,7 @@ class User < ApplicationRecord
   validates :name,
     presence: true,
     format: { without: /\t/, message: 'cannot contain tabs' },
-    length: { maximum:  CHAR_FIELD_MAX_LENGTH }
+    length: { maximum: CHAR_FIELD_MAX_LENGTH }
 
   validates :password,
     presence: { if: :requires_password? },
@@ -260,7 +260,7 @@ class User < ApplicationRecord
   # This is a little weird, but in our current conception, all Admins are Teachers
   scope :teacher, -> { where(role: [ADMIN, TEACHER]) }
   scope :student, -> { where(role: STUDENT) }
-  scope :admin, ->  { where(role: ADMIN) }
+  scope :admin, -> { where(role: ADMIN) }
 
   scope :teachers_in_schools, lambda { |school_ids|
     distinct

--- a/services/QuillLMS/app/pusher_modules/pusher_admin_users_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_admin_users_completed.rb
@@ -12,6 +12,6 @@ module PusherAdminUsersCompleted
       admin_id.to_s,
       'admin-users-found',
       message: "Admin users found for #{admin_id}."
-   )
+    )
   end
 end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_activity_scores_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_activity_scores_completed.rb
@@ -12,6 +12,6 @@ module PusherDistrictActivityScoresCompleted
       admin_id.to_s,
       'district-activity-scores-found',
       message: "District activity scores found for #{admin_id}."
-   )
+    )
   end
 end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_concept_reports_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_concept_reports_completed.rb
@@ -12,6 +12,6 @@ module PusherDistrictConceptReportsCompleted
       admin_id.to_s,
       'district-concept-reports-found',
       message: "District concept reports found for #{admin_id}."
-   )
+    )
   end
 end

--- a/services/QuillLMS/app/pusher_modules/pusher_district_standards_reports_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_district_standards_reports_completed.rb
@@ -12,6 +12,6 @@ module PusherDistrictStandardsReportsCompleted
       admin_id.to_s,
       'district-standards-reports-found',
       message: "District standards reports found for #{admin_id}."
-   )
+    )
   end
 end

--- a/services/QuillLMS/app/pusher_modules/pusher_recommendation_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_recommendation_completed.rb
@@ -13,7 +13,7 @@ module PusherRecommendationCompleted
         classroom.id.to_s,
         'lessons-recommendations-assigned',
         message: "Lessons recommendations assigned to #{classroom.name}."
-     )
+      )
     else
       pusher_client.trigger(
         classroom.id.to_s,

--- a/services/QuillLMS/app/pusher_modules/pusher_trigger.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_trigger.rb
@@ -13,6 +13,6 @@ module PusherTrigger
       channel.to_s,
       event,
       message: message
-     )
+    )
   end
 end

--- a/services/QuillLMS/app/queries/progress_reports/concepts/concept_result.rb
+++ b/services/QuillLMS/app/queries/progress_reports/concepts/concept_result.rb
@@ -7,7 +7,7 @@ class ProgressReports::Concepts::ConceptResult
       activity_sessions.user_id,
       concept_results.concept_id
     SELECT
-  ).joins({ activity_session: { classroom_unit: :classroom } })
+                                  ).joins({ activity_session: { classroom_unit: :classroom } })
      .joins('INNER JOIN classrooms_teachers ON classrooms.id = classrooms_teachers.classroom_id')
       .where('activity_sessions.state = ? AND classrooms_teachers.user_id = ?', 'finished', teacher.id)
 

--- a/services/QuillLMS/app/queries/prompt_feedback_history.rb
+++ b/services/QuillLMS/app/queries/prompt_feedback_history.rb
@@ -20,7 +20,7 @@ class PromptFeedbackHistory
       COUNT(DISTINCT CASE WHEN attempt = 1 AND optimal = false THEN feedback_histories.feedback_session_uid END) AS num_first_attempt_not_optimal,
       AVG(CAST((feedback_histories.metadata->>'api')::json->>'confidence' AS float)) AS avg_confidence
     SELECT
-    )
+                                  )
       .joins('JOIN comprehension_prompts ON feedback_histories.prompt_id = comprehension_prompts.id')
       .joins('LEFT JOIN feedback_history_flags ON feedback_histories.id = feedback_history_flags.feedback_history_id')
       .joins('LEFT JOIN feedback_sessions ON feedback_histories.feedback_session_uid = feedback_sessions.uid')
@@ -43,7 +43,7 @@ class PromptFeedbackHistory
         ELSE '0'
       END AS int) AS time_spent
     SELECT
-    )
+                                                 )
       .joins('RIGHT JOIN feedback_sessions ON feedback_sessions.activity_session_uid = activity_sessions.uid')
       .joins('RIGHT JOIN feedback_histories ON feedback_histories.feedback_session_uid = feedback_sessions.uid')
       .joins('RIGHT JOIN comprehension_prompts ON feedback_histories.prompt_id = comprehension_prompts.id')

--- a/services/QuillLMS/app/serializers/progress_reports/activity_session_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/activity_session_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProgressReports::ActivitySessionSerializer  < ApplicationSerializer
+class ProgressReports::ActivitySessionSerializer < ApplicationSerializer
   attributes :id,
     :activity_classification_name,
     :activity_classification_id,

--- a/services/QuillLMS/app/serializers/progress_reports/concepts/concept_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/concepts/concept_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProgressReports::Concepts::ConceptSerializer  < ApplicationSerializer
+class ProgressReports::Concepts::ConceptSerializer < ApplicationSerializer
   attributes :concept_name,
     :concept_id,
     :total_result_count,

--- a/services/QuillLMS/app/serializers/progress_reports/concepts/student_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/concepts/student_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProgressReports::Concepts::StudentSerializer  < ApplicationSerializer
+class ProgressReports::Concepts::StudentSerializer < ApplicationSerializer
   include Rails.application.routes.url_helpers
 
   attributes :name,

--- a/services/QuillLMS/app/serializers/progress_reports/standards/classroom_serializer.rb
+++ b/services/QuillLMS/app/serializers/progress_reports/standards/classroom_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProgressReports::Standards::ClassroomSerializer  < ApplicationSerializer
+class ProgressReports::Standards::ClassroomSerializer < ApplicationSerializer
   include Rails.application.routes.url_helpers
 
   attributes :name,

--- a/services/QuillLMS/app/services/admin_diagnostic_reports/students_csv_generator.rb
+++ b/services/QuillLMS/app/services/admin_diagnostic_reports/students_csv_generator.rb
@@ -2,7 +2,7 @@
 
 module AdminDiagnosticReports
   class StudentsCsvGenerator < ::CsvGenerator
-    ORDERED_COLUMNS =  {
+    ORDERED_COLUMNS = {
       student_name: {
         csv_header: 'Student Name',
         csv_tooltip: '', # Intentionally empty

--- a/services/QuillLMS/app/services/diagnostics_organized_by_classroom_fetcher.rb
+++ b/services/QuillLMS/app/services/diagnostics_organized_by_classroom_fetcher.rb
@@ -95,7 +95,7 @@ class DiagnosticsOrganizedByClassroomFetcher < ApplicationService
     record = records[0]
     return if !record
 
-    record['eligible_for_question_scoring'] = activity_sessions.empty? || activity_sessions.last.completed_at  > QUESTION_SCORING_ELIGIBILITY_CUTOFF_DATE
+    record['eligible_for_question_scoring'] = activity_sessions.empty? || activity_sessions.last.completed_at > QUESTION_SCORING_ELIGIBILITY_CUTOFF_DATE
     record['completed_count'] = activity_sessions.size
     record['assigned_count'] = assigned_student_ids.size
     record.except('unit_id', 'unit_name', 'classroom_unit_id', 'assigned_student_ids')

--- a/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
+++ b/services/QuillLMS/app/services/stripe_integration/webhooks/subscription_creator.rb
@@ -43,7 +43,7 @@ module StripeIntegration
           purchaser.subscription&.plan == plan
         when Plan.stripe_school_plan
           purchaser.associated_schools.any? do |school|
-            school.subscriptions.active.any?  do |subscription|
+            school.subscriptions.active.any? do |subscription|
               subscription.schools.pluck(:id).sort == school_ids
             end
           end

--- a/services/QuillLMS/app/workers/fast_assign_worker.rb
+++ b/services/QuillLMS/app/workers/fast_assign_worker.rb
@@ -6,7 +6,7 @@ class FastAssignWorker
   sidekiq_options queue: SidekiqQueue::CRITICAL
 
   def perform(teacher_id, unit_template_id)
-    unit_template  = UnitTemplate.find(unit_template_id)
+    unit_template = UnitTemplate.find(unit_template_id)
     unit = User.find(teacher_id).units_with_same_name(unit_template.name).first
 
     if unit

--- a/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
+++ b/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
@@ -37,8 +37,8 @@ class GetConceptsInUseIndividualConceptWorker
         index = @organized_concepts.find_index(existing_oc)
         @organized_concepts[index] = new_oc
       else
-        grandparent_name = c['grandparent_name'] ?  "#{c['grandparent_name']} | " : ''
-        parent_name = c['parent_name'] ?  "#{c['parent_name']} | " : ''
+        grandparent_name = c['grandparent_name'] ? "#{c['grandparent_name']} | " : ''
+        parent_name = c['parent_name'] ? "#{c['parent_name']} | " : ''
         new_oc = {
           grades_connect_activities: [],
           grades_diagnostic_activities: [],

--- a/services/QuillLMS/app/workers/rematch_updated_questions_worker.rb
+++ b/services/QuillLMS/app/workers/rematch_updated_questions_worker.rb
@@ -9,7 +9,7 @@ class RematchUpdatedQuestionsWorker
   JSON_HEADERS = { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
   DELAY_PER_QUESTION = 1.minutes.to_i
 
-  def perform(start_time = 1.day.ago, end_time = Time.current, delay =  DELAY_PER_QUESTION)
+  def perform(start_time = 1.day.ago, end_time = Time.current, delay = DELAY_PER_QUESTION)
     questions = Question
       .production
       .where(updated_at: start_time..end_time)

--- a/services/QuillLMS/config.ru
+++ b/services/QuillLMS/config.ru
@@ -2,5 +2,5 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/services/QuillLMS/config/environments/development.rb
+++ b/services/QuillLMS/config/environments/development.rb
@@ -12,7 +12,7 @@ EmpiricalGrammar::Application.configure do
   config.eager_load = false
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
 
   config.action_dispatch.show_detailed_exceptions = false
   config.action_controller.perform_caching = false
@@ -49,7 +49,7 @@ EmpiricalGrammar::Application.configure do
   config.sass.line_numbers = true
   config.sass.debug_info = true
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
-  Rails.application.routes.default_url_options[:host] =  'localhost:3000'
+  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
 
   # Image Uploads (see paperclip gem)
   Paperclip.options[:command_path] = '/usr/local/bin/'

--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -16,7 +16,7 @@ RailsAdmin.config do |config|
     dashboard do
       statistics false
     end
-    index                         # mandatory
+    index # mandatory
     new
     export
     # Turn off bulk delete, seems dangerous

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -483,7 +483,7 @@ EmpiricalGrammar::Application.routes.draw do
         end
       end
 
-      resources :classroom_units,         only: [] do
+      resources :classroom_units, only: [] do
         collection do
           get 'student_names'
           put 'finish_lesson'

--- a/services/QuillLMS/db/migrate/20140202153308_create_doorkeeper_tables.rb
+++ b/services/QuillLMS/db/migrate/20140202153308_create_doorkeeper_tables.rb
@@ -32,11 +32,11 @@ class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
     create_table :oauth_access_tokens do |t|
       t.integer  :resource_owner_id
       t.integer  :application_id
-      t.string   :token,             null: false
+      t.string   :token, null: false
       t.string   :refresh_token
       t.integer  :expires_in
       t.datetime :revoked_at
-      t.datetime :created_at,        null: false
+      t.datetime :created_at, null: false
       t.string   :scopes
     end
 

--- a/services/QuillLMS/db/migrate/20150805224448_create_concept_results.rb
+++ b/services/QuillLMS/db/migrate/20150805224448_create_concept_results.rb
@@ -4,7 +4,7 @@ class CreateConceptResults < ActiveRecord::Migration[4.2]
   def change
     create_table :concept_results do |t|
       t.integer 'activity_session_id'
-      t.integer 'concept_id',      null: false
+      t.integer 'concept_id', null: false
       t.json    'metadata'
     end
   end

--- a/services/QuillLMS/db/migrate/20210319160956_create_feedback_history_ratings.rb
+++ b/services/QuillLMS/db/migrate/20210319160956_create_feedback_history_ratings.rb
@@ -3,7 +3,7 @@
 class CreateFeedbackHistoryRatings < ActiveRecord::Migration[4.2]
   def change
     create_table :feedback_history_ratings do |t|
-      t.boolean :rating,  null: false
+      t.boolean :rating, null: false
       t.references :feedback_history, null: false
       t.references :user, null: false, foreign_key: true
       t.timestamps null: false

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/comparison.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/comparison.rb
@@ -22,7 +22,7 @@ module Evidence
         validates :dataset_id, presence: true
 
         scope :llms, -> { where(independent_variable: LLM).order(id: :desc) }
-        scope :llm_prompts, -> { where(independent_variable: LLM_PROMPT).order(id: :desc)  }
+        scope :llm_prompts, -> { where(independent_variable: LLM_PROMPT).order(id: :desc) }
 
         store_accessor :results, :accuracy_optimal_sub_optimal, :confusion_matrix
       end

--- a/services/QuillLMS/engines/evidence/lib/evidence/change_log.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/change_log.rb
@@ -113,7 +113,7 @@ module Evidence
           ],
         automl_models: [:change_logs]
         ]
-                    ).find(id)
+      ).find(id)
       change_logs = activity_change_logs + passages_change_logs + prompts_change_logs + universal_change_logs
       change_logs.map(&:serializable_hash)
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/feedback_assembler.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/feedback_assembler.rb
@@ -27,7 +27,7 @@ module Evidence
     def self.default_payload
       {
         'feedback_type': '',
-        'labels': '',       # not currently used, but part of Evidence payload spec
+        'labels': '', # not currently used, but part of Evidence payload spec
         'concept_uid': '',
         'feedback': '<p></p>',
         'optimal': true,

--- a/services/QuillLMS/engines/evidence/spec/lib/automl_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/automl_check_spec.rb
@@ -39,7 +39,7 @@ module Evidence
         AutomlModel.stub_any_instance(:classify_text, [label.name, automl_confidence]) do
           entry = 'entry'
           automl_check = Evidence::AutomlCheck.new(entry, prompt)
-          expect(:feedback => feedback.text, :feedback_type => 'autoML', :optimal => rule.optimal,  :entry => entry, :concept_uid => ((rule&.concept_uid or '')), :rule_uid => (rule&.uid), :highlight => ([]), :hint => nil, :api => { :confidence => automl_confidence }).to(eq(automl_check.feedback_object))
+          expect(:feedback => feedback.text, :feedback_type => 'autoML', :optimal => rule.optimal, :entry => entry, :concept_uid => ((rule&.concept_uid or '')), :rule_uid => (rule&.uid), :highlight => ([]), :hint => nil, :api => { :confidence => automl_confidence }).to(eq(automl_check.feedback_object))
         end
       end
 
@@ -50,7 +50,7 @@ module Evidence
           expected_payload = {
             :feedback => low_confidence_feedback.text,
             :feedback_type => 'low-confidence',
-            :optimal => low_confidence_rule.optimal,  :entry => entry,
+            :optimal => low_confidence_rule.optimal, :entry => entry,
             :concept_uid => ((low_confidence_rule&.concept_uid or '')),
             :rule_uid => (low_confidence_rule&.uid),
             :highlight => ([]),

--- a/services/QuillLMS/engines/evidence/spec/lib/synthetic/manual_types_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/synthetic/manual_types_spec.rb
@@ -11,7 +11,7 @@ describe Evidence::Synthetic::ManualTypes do
   end
 
   let(:activity) { create(:evidence_activity, :with_prompt_and_passage) }
-  let(:prompt)  { activity.prompts.first }
+  let(:prompt) { activity.prompts.first }
 
   let(:not_enough_labeled_data) { [['text string', label1], ['other text', label2]] }
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -219,7 +219,7 @@ module Evidence
       let(:activity) { create(:evidence_activity, :with_prompt_and_passage) }
       let(:rule) { create(:evidence_rule, prompts: [activity.prompts.first]) }
       let(:feedback) { create(:evidence_feedback, rule: rule) }
-      let(:highlight) { create(:evidence_highlight, feedback: feedback,  highlight_type: 'passage', text: activity.passages.first.text) }
+      let(:highlight) { create(:evidence_highlight, feedback: feedback, highlight_type: 'passage', text: activity.passages.first.text) }
 
       it 'should return an empty array if there are no invalid highlights or plagiarism_texts at all' do
         expect(activity.invalid_highlights).to eq([])

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/highlight_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/highlight_spec.rb
@@ -36,7 +36,7 @@ module Evidence
       let(:activity) { create(:evidence_activity, :with_prompt_and_passage) }
       let(:rule) { create(:evidence_rule, prompts: [activity.prompts.first]) }
       let(:feedback) { create(:evidence_feedback, rule: rule) }
-      let(:highlight) { create(:evidence_highlight, feedback: feedback,  highlight_type: 'passage', text: activity.passages.first.text) }
+      let(:highlight) { create(:evidence_highlight, feedback: feedback, highlight_type: 'passage', text: activity.passages.first.text) }
 
       it 'should return nil if the highlight_type is not "passage"' do
         highlight.update(highlight_type: 'prompt')

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_spec.rb
@@ -44,19 +44,19 @@ module Evidence
             context 'when version is GPT_3_5_TURBO_0125' do
               let(:version) { described_class::GPT_3_5_TURBO_0125 }
 
-              it { is_expected.to eq described_class::OPEN_AI_JSON_FORMAT_RESPONSES  }
+              it { is_expected.to eq described_class::OPEN_AI_JSON_FORMAT_RESPONSES }
             end
 
             context 'when version is GPT_4_TURBO_2024_04_09' do
               let(:version) { described_class::GPT_4_TURBO_2024_04_09 }
 
-              it { is_expected.to eq described_class::OPEN_AI_JSON_FORMAT_RESPONSES  }
+              it { is_expected.to eq described_class::OPEN_AI_JSON_FORMAT_RESPONSES }
             end
 
             context 'when version is GPT_4_O' do
               let(:version) { described_class::GPT_4_O }
 
-              it { is_expected.to eq described_class::OPEN_AI_JSON_FORMAT_RESPONSES  }
+              it { is_expected.to eq described_class::OPEN_AI_JSON_FORMAT_RESPONSES }
             end
           end
 
@@ -66,13 +66,13 @@ module Evidence
             context 'when version is GEMINI_1_5_PRO_LATEST' do
               let(:version) { described_class::GEMINI_1_5_PRO_LATEST }
 
-              it { is_expected.to eq described_class::GOOGLE_JSON_FORMAT_RESPONSES  }
+              it { is_expected.to eq described_class::GOOGLE_JSON_FORMAT_RESPONSES }
             end
 
             context 'version is GEMINI_1_5_FLASH_LATEST' do
               let(:version) { described_class::GEMINI_1_5_FLASH_LATEST }
 
-              it { is_expected.to eq described_class::GOOGLE_JSON_FORMAT_RESPONSES  }
+              it { is_expected.to eq described_class::GOOGLE_JSON_FORMAT_RESPONSES }
             end
 
             context 'version is not GEMINI_1_5_PRO_LATEST or GEMINI_1_5_FLASH_LATEST' do

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
@@ -49,25 +49,25 @@ module Evidence
 
         context 'contents with substitutions' do
           context 'stem' do
-            let(:contents)  { delimit('stem') }
+            let(:contents) { delimit('stem') }
 
             it { is_expected.to eq stem }
           end
 
           context 'conjunction' do
-            let(:contents)  { delimit('conjunction') }
+            let(:contents) { delimit('conjunction') }
 
             it { is_expected.to eq conjunction }
           end
 
           context 'because_text' do
-            let(:contents)  { delimit('because_text') }
+            let(:contents) { delimit('because_text') }
 
             it { is_expected.to eq because_text }
           end
 
           context 'but_text' do
-            let(:contents)  { delimit('but_text') }
+            let(:contents) { delimit('but_text') }
 
             it { is_expected.to eq but_text }
           end
@@ -79,7 +79,7 @@ module Evidence
           end
 
           context 'full_text' do
-            let(:contents)  { delimit('full_text') }
+            let(:contents) { delimit('full_text') }
 
             it { is_expected.to eq full_text }
           end

--- a/services/QuillLMS/engines/evidence/spec/workers/evidence/synthetic_labeled_data_worker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/workers/evidence/synthetic_labeled_data_worker_spec.rb
@@ -6,7 +6,7 @@ module Evidence
   describe SyntheticLabeledDataWorker, type: :worker do
     let(:email) { 'test@quill.org' }
     let(:activity) { create(:evidence_activity, :with_prompt_and_passage) }
-    let(:prompt)  { activity.prompts.first }
+    let(:prompt) { activity.prompts.first }
 
     before do
       stub_const('Evidence::Synthetic::EMAIL', email)

--- a/services/QuillLMS/lib/eg_form_builder.rb
+++ b/services/QuillLMS/lib/eg_form_builder.rb
@@ -92,7 +92,7 @@ class EgFormBuilder < CMS::FormBuilder
   end
 
   def choices(attribute, choices, *args)
-    field :choices, *_apply_default_options(args << attribute,  choices: choices)
+    field :choices, *_apply_default_options(args << attribute, choices: choices)
   end
 
   # slider is weird enough that we will not use the default field helper.

--- a/services/QuillLMS/lib/tasks/build_objectives.rake
+++ b/services/QuillLMS/lib/tasks/build_objectives.rake
@@ -20,7 +20,7 @@ namespace :objectives do
          { name: Objective::EXPLORE_OUR_DIAGNOSTICS, section: 'Getting Started', help_info: '', action_url: '/assign/diagnostic', section_placement: 4 },
          { name: 'Assign Featured Activity Pack', section: 'Other', help_info: 'https://support.quill.org/quill-org/getting-started-for-teachers/assigning-activities/how-can-i-assign-a-featured-activity-pack', action_url: '/activities/packs', section_placement: 3 },
          { name: 'Assign Entry Diagnostic', section: 'Other', help_info: 'https://support.quill.org/getting-started-for-teachers/assigning-activities/how-can-i-assign-a-quill-diagnostic', action_url: '/teachers/classrooms/activity_planner/diagnostic', section_placement: 4 },
-         { name: 'Add School', section: 'Other', help_info: 'http://support.quill.org/getting-started-for-teachers/manage-classes/how-can-i-add-my-school',  action_url: '/teachers/my_account', section_placement: 5 },
+         { name: 'Add School', section: 'Other', help_info: 'http://support.quill.org/getting-started-for-teachers/manage-classes/how-can-i-add-my-school', action_url: '/teachers/my_account', section_placement: 5 },
          { name: 'Build Your Own Activity Pack', section: 'Other', help_info: 'http://support.quill.org/getting-started-for-teachers/assigning-activities/create-and-assign-your-own-activity-pack', action_url: '/teachers/classrooms/lesson_planner', section_placement: 6 }
        ]
     end

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -82,7 +82,7 @@ namespace :users do
       ).first['ids'].split(',')
 
     puts "#{user_ids.count} users to delete"
-    misses = User.where(id: user_ids).select { |u| !u.student? || u.activity_sessions.count != 0 || u.classrooms.count != 0 || User.where(email: u.email).count <  2;  }.map { |u| [u.id, u.activity_sessions.count, u.classrooms.count, User.where(email: u.email).count] }
+    misses = User.where(id: user_ids).select { |u| !u.student? || u.activity_sessions.count != 0 || u.classrooms.count != 0 || User.where(email: u.email).count < 2; }.map { |u| [u.id, u.activity_sessions.count, u.classrooms.count, User.where(email: u.email).count] }
     return if misses.count > 0
 
     puts "Going to delete #{user_ids.count} users"

--- a/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
+++ b/services/QuillLMS/lib/tasks/temporary/vertex_ai_migration.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-namespace :vertex_ai  do
+namespace :vertex_ai do
   desc 'Populate prompt endpoint and model IDs (note these need to be run locally as files are not available on the server))'
   task populate_prompt_endpoint_and_model_ids: :environment do
     pipe_data = $stdin.read unless $stdin.tty?

--- a/services/QuillLMS/lib/tasks/update_scoring_for_demo_account_activity_sessions.rake
+++ b/services/QuillLMS/lib/tasks/update_scoring_for_demo_account_activity_sessions.rake
@@ -11,7 +11,7 @@ namespace :update_scoring_for_demo_account_activity_sessions do
 
     fetch_activity_sessions(ACTIVITY_USER_PAIRS)
       .reject { |activity_session| ActivityClassification::UNSCORED_KEYS.include?(activity_session.classification.key) }
-      .each { |activity_session|  update_activity_session_percentage(activity_session) }
+      .each { |activity_session| update_activity_session_percentage(activity_session) }
   end
 
   def fetch_activity_sessions(id_pairs)

--- a/services/QuillLMS/script/map_concepts_to_activities_across_apps.rb
+++ b/services/QuillLMS/script/map_concepts_to_activities_across_apps.rb
@@ -129,8 +129,8 @@ concepts.each do |c|
     index = organized_concepts.find_index(existing_oc)
     organized_concepts[index] = new_oc
   else
-    grandparent_name = c['grandparent_name'] ?  "#{c['grandparent_name']} | " : ''
-    parent_name = c['parent_name'] ?  "#{c['parent_name']} | " : ''
+    grandparent_name = c['grandparent_name'] ? "#{c['grandparent_name']} | " : ''
+    parent_name = c['parent_name'] ? "#{c['parent_name']} | " : ''
     new_oc = {}
     new_oc['grades_connect_activities'] = [],
     new_oc['grades_grammar_activities'] = [],

--- a/services/QuillLMS/script/rails
+++ b/services/QuillLMS/script/rails
@@ -3,6 +3,6 @@
 
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
-require File.expand_path('../../config/boot',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
+require File.expand_path('../../config/boot', __FILE__)
 require 'rails/commands'

--- a/services/QuillLMS/spec/controllers/admins_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/admins_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AdminsController  do
+describe AdminsController do
   before { allow(controller).to receive(:current_user) { admin } }
 
   it { should use_before_action :admin! }
@@ -198,7 +198,7 @@ describe AdminsController  do
   describe '#make_admin' do
     it 'should create a schools admins record, fire an email worker, and return a message' do
       expect(PremiumHub::MadeSchoolAdminEmailWorker).to receive(:perform_async)
-      post :make_admin, params: { id: teacher.id, school_id: school.id  }
+      post :make_admin, params: { id: teacher.id, school_id: school.id }
       expect(SchoolsAdmins.find_by(user_id: teacher.id, school_id: school.id)).to be
       expect(response.body).to eq({ message: I18n.t('admin.make_admin') }.to_json)
     end
@@ -210,7 +210,7 @@ describe AdminsController  do
     end
 
     it 'should destroy the schools admins record and return a message' do
-      post :remove_as_admin, params: { id: teacher.id, school_id: school.id  }
+      post :remove_as_admin, params: { id: teacher.id, school_id: school.id }
       expect(SchoolsAdmins.find_by(user_id: teacher.id, school_id: school.id)).not_to be
       expect(response.body).to eq({ message: I18n.t('admin.remove_admin') }.to_json)
     end
@@ -224,7 +224,7 @@ describe AdminsController  do
           admin_approval_request = create(:admin_approval_request, admin_info: admin_info, requestee: admin, request_made_during_sign_up: request_made_during_sign_up)
           expect(TeacherApprovedToBecomeAdminAnalyticsWorker).to receive(:perform_async).with(teacher.id, admin_approval_request.request_made_during_sign_up)
 
-          post :approve_admin_request, params: { id: teacher.id, school_id: school.id  }
+          post :approve_admin_request, params: { id: teacher.id, school_id: school.id }
 
           teacher.admin_info.reload
           expect(teacher.admin_info.approval_status).to eq(AdminInfo::APPROVED)
@@ -243,7 +243,7 @@ describe AdminsController  do
 
       expect(TeacherDeniedToBecomeAdminAnalyticsWorker).to receive(:perform_async).with(teacher.id, admin_approval_request.request_made_during_sign_up)
 
-      post :deny_admin_request, params: { id: teacher.id  }
+      post :deny_admin_request, params: { id: teacher.id }
 
       teacher.admin_info.reload
       expect(teacher.admin_info.approval_status).to eq(AdminInfo::DENIED)

--- a/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activities_controller_spec.rb
@@ -14,11 +14,11 @@ describe Api::V1::ActivitiesController, type: :controller do
     before { get :show, params: { id: activity_id }, as: :json }
 
     context 'valid activity' do
-      let(:activity_id) { create(:activity).uid  }
+      let(:activity_id) { create(:activity).uid }
 
       it_behaves_like 'an api request'
 
-      it  { expect(response.status).to eq(200) }
+      it { expect(response.status).to eq(200) }
     end
 
     context 'invalid activity' do
@@ -224,7 +224,7 @@ describe Api::V1::ActivitiesController, type: :controller do
       ENV['DEFAULT_URL'] = 'https://quill.org'
       ENV['CMS_URL'] = 'https://cms.quill.org'
       stub_request(:get, "#{ENV['CMS_URL']}/questions/#{question.uid}/question_dashboard_data")
-        .to_return(status: 200, body: { percent_common_unmatched: 50,  percent_specified_algos: 75 }.to_json, headers: {})
+        .to_return(status: 200, body: { percent_common_unmatched: 50, percent_specified_algos: 75 }.to_json, headers: {})
     end
 
     it 'should return a list of all questions and their health' do

--- a/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/classroom_units_controller_spec.rb
@@ -24,7 +24,7 @@ describe Api::V1::ClassroomUnitsController, type: :controller do
   end
   let(:teacher) { classroom.owner }
 
-  before {  request.accept = 'application/json' }
+  before { request.accept = 'application/json' }
 
   context '#student_names' do
     it 'does not authenticate a teacher who is not associated with the classroom activity' do

--- a/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
@@ -24,7 +24,7 @@ describe Api::V1::ConceptsController, type: :controller do
 
       it { expect(response).to have_http_status(:ok) }
       it { expect(parsed_body['concept'].keys).to match_array(%w(id uid name parent_id)) }
-      it { expect(parsed_body['concept']['name']).to eq concept_name  }
+      it { expect(parsed_body['concept']['name']).to eq concept_name }
       it { expect(parsed_body['concept']['uid']).to_not be_nil }
     end
 

--- a/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/rule_feedback_histories_controller_spec.rb
@@ -58,7 +58,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
           conjunction: 'so',
           activity: main_activity,
           max_attempts: 3
-         )
+        )
 
         as1 = create(:activity_session, activity_id: main_activity.id)
 
@@ -90,7 +90,7 @@ describe Api::V1::RuleFeedbackHistoriesController, type: :controller do
           conjunction: 'so',
           activity: main_activity,
           max_attempts: 3
-         )
+        )
 
         as1 = create(:activity_session, state: 'finished', activity_id: main_activity.id, timespent: 61)
 

--- a/services/QuillLMS/spec/controllers/api/v1/users_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/users_controller_spec.rb
@@ -57,7 +57,7 @@ describe Api::V1::UsersController do
     end
 
     context 'students' do
-      let(:user)  { create(:student) }
+      let(:user) { create(:student) }
 
       it 'should return student for student users' do
         get :current_user_role, as: :json

--- a/services/QuillLMS/spec/controllers/canvas_integration/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/canvas_integration/teachers_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CanvasIntegration::TeachersController do
     end
   end
 
-  describe '#import_students'  do
+  describe '#import_students' do
     subject { put :import_students, params: params, as: :json }
 
     let(:classroom) { create(:classroom, :from_canvas, :with_no_teacher) }
@@ -98,7 +98,7 @@ RSpec.describe CanvasIntegration::TeachersController do
     context 'user is canvas authorized' do
       before { allow(teacher).to receive(:canvas_authorized?).and_return(true) }
 
-      it  do
+      it do
         subject
         expect(response_body).to eq(quill_retrieval_processing: true)
       end

--- a/services/QuillLMS/spec/controllers/clever_integration/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/clever_integration/teachers_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CleverIntegration::TeachersController do
     end
   end
 
-  describe '#import_students'  do
+  describe '#import_students' do
     subject { put :import_students, params: params, as: :json }
 
     let(:classroom) { create(:classroom, :from_clever, :with_no_teacher) }
@@ -87,7 +87,7 @@ RSpec.describe CleverIntegration::TeachersController do
     context 'user is clever authorized' do
       before { expect(teacher).to receive(:clever_authorized?).and_return(true) }
 
-      it  do
+      it do
         subject
         expect(response_body).to eq(quill_retrieval_processing: true)
       end
@@ -97,7 +97,7 @@ RSpec.describe CleverIntegration::TeachersController do
 
         before { CleverIntegration::TeacherClassroomsCache.write(teacher.id, data.to_json) }
 
-        it  do
+        it do
           subject
           expect(response_body).to eq(classrooms: data)
         end

--- a/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/districts_controller_spec.rb
@@ -86,7 +86,7 @@ describe Cms::DistrictsController do
             user_id: admin.user_id
         }
       end
-      )
+                                    )
       expect(assigns(:district_subscription_info)).to eq({
         'District Premium Type' => district.subscription.account_type,
         'Expiration' => district.subscription.expiration.strftime('%b %d, %Y')

--- a/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/cms/schools_controller_spec.rb
@@ -110,7 +110,7 @@ describe Cms::SchoolsController do
                                            user_id: admin.user_id
                                        }
                                      end
-      )
+                                    )
     end
   end
 

--- a/services/QuillLMS/spec/controllers/google_integration/teachers_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/google_integration/teachers_controller_spec.rb
@@ -39,7 +39,7 @@ module GoogleIntegration
       end
     end
 
-    describe '#import_students'  do
+    describe '#import_students' do
       subject { put :import_students, params: params, as: :json }
 
       let(:classroom) { create(:classroom, :from_google, :with_no_teacher) }
@@ -91,7 +91,7 @@ module GoogleIntegration
       context 'user is google authorized' do
         before { allow(teacher).to receive(:google_authorized?).and_return(true) }
 
-        it  do
+        it do
           subject
           expect(response_body).to eq(quill_retrieval_processing: true)
         end

--- a/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/invitations_controller_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe InvitationsController, type: :controller do
           invitee_email: 'test@test.com',
           archived: false,
           inviter: user
-      )
+        )
       }
 
       it 'should destroy the given invitation' do
@@ -136,7 +136,7 @@ RSpec.describe InvitationsController, type: :controller do
           invitee_email: user.email,
           archived: false,
           inviter: another_user
-      )
+        )
       }
 
       it 'should destroy the given invitation' do

--- a/services/QuillLMS/spec/controllers/learn_worlds_integration/webhooks_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/learn_worlds_integration/webhooks_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe LearnWorldsIntegration::WebhooksController, type: :controller do
       let(:signature_header) { "v2=#{webhook_signature}" }
 
       context 'enrolled_free_course_event' do
-        let(:params) {  enrolled_free_course_event }
+        let(:params) { enrolled_free_course_event }
 
         it { should_call_event_handler(LearnWorldsIntegration::Webhooks::EnrolledFreeCourseEventHandler) }
       end

--- a/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classroom_manager_controller_spec.rb
@@ -244,7 +244,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should return the correct json' do
-      json =  teacher.classrooms_i_own.map { |classroom|
+      json = teacher.classrooms_i_own.map { |classroom|
         {
             classroom: classroom,
             students: classroom.students.sort_by(&:sorting_name)
@@ -267,7 +267,7 @@ describe Teachers::ClassroomManagerController, type: :controller do
     end
 
     it 'should return the correct json' do
-      json =  teacher.classrooms_i_teach.map { |classroom|
+      json = teacher.classrooms_i_teach.map { |classroom|
         {
             classroom: classroom,
             students: classroom.students.sort_by(&:sorting_name)

--- a/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/units_controller_spec.rb
@@ -16,7 +16,7 @@ describe Teachers::UnitsController, type: :controller do
       unit: unit,
       classroom: classroom,
       assigned_student_ids: [student.id]
-   )
+    )
   end
 
   let!(:classroom_unit2) do
@@ -24,7 +24,7 @@ describe Teachers::UnitsController, type: :controller do
       unit: unit2,
       classroom: classroom,
       assigned_student_ids: [student.id]
-   )
+    )
   end
 
   let!(:diagnostic) { create(:diagnostic) }
@@ -472,7 +472,7 @@ describe Teachers::UnitsController, type: :controller do
         is_final_score: true,
         percentage: 0.17,
         visible: true
-    )
+      )
     }
 
     it 'no classroom_unit_id should return empty hash' do

--- a/services/QuillLMS/spec/factories/activity_classifications.rb
+++ b/services/QuillLMS/spec/factories/activity_classifications.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
     module_url     { 'https://www.fake-url.com/' }
     form_url       { 'https://www.fake-url.com/' }
     sequence(:order_number)
-    uid            { SecureRandom.urlsafe_base64 } # mock a uid
+    uid { SecureRandom.urlsafe_base64 } # mock a uid
 
     # Because some of our activity classification code is currently hardcoded,
     # and because activity classifications are very static in our codebase,

--- a/services/QuillLMS/spec/factories/announcements.rb
+++ b/services/QuillLMS/spec/factories/announcements.rb
@@ -17,7 +17,7 @@
 #
 FactoryBot.define do
   factory :announcement do
-    announcement_type  { Announcement::TYPES[:webinar] }
+    announcement_type { Announcement::TYPES[:webinar] }
 
     add_attribute(:start) { 1.day.ago }
     add_attribute(:end) { 1.day.from_now }

--- a/services/QuillLMS/spec/factories/standard_levels.rb
+++ b/services/QuillLMS/spec/factories/standard_levels.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
     factory :grade_3_standard_level do
       name      { '3rd Grade CCSS' }
       position  { 4 }
-      uid        { '9XKMizwyMg9mWt1JO-YRdw' }
+      uid { '9XKMizwyMg9mWt1JO-YRdw' }
     end
 
     factory :grade_4_standard_level do

--- a/services/QuillLMS/spec/factories/unit_templates.rb
+++ b/services/QuillLMS/spec/factories/unit_templates.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
     unit_template_category  { create(:unit_template_category) }
 
     factory :unit_template_with_activities do
-      activities              { build_list(:activity, 3) }
+      activities { build_list(:activity, 3) }
     end
   end
 end

--- a/services/QuillLMS/spec/helpers/about_us_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/about_us_helper_spec.rb
@@ -15,7 +15,7 @@ describe AboutUsHelper do
         { id: 'Contact Us', name: 'Contact Us', url: '/contact' }
       ]
     }
-    let(:small_tabs)  {
+    let(:small_tabs) {
       [
         { id: 'About Us', name: 'About', url: '/about' },
         { id: 'Impact', name: 'Impact', url: '/impact' },

--- a/services/QuillLMS/spec/helpers/mobile_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/mobile_helper_spec.rb
@@ -23,7 +23,7 @@ describe MobileHelper do
         </p>
       </video>
     </div>"
-    )
+  )
     end
 
     it 'should return nil if device and type arguments do not match' do

--- a/services/QuillLMS/spec/helpers/tools_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/tools_helper_spec.rb
@@ -38,7 +38,7 @@ describe ToolsHelper do
         }
       ]
     }
-    let(:small_tabs)  {
+    let(:small_tabs) {
       [
         {
           name: 'Connect',

--- a/services/QuillLMS/spec/lib/snapshots/cache_keys_spec.rb
+++ b/services/QuillLMS/spec/lib/snapshots/cache_keys_spec.rb
@@ -32,7 +32,7 @@ module Snapshots
           current_start,
           current_end,
           school_ids)
-        ).to eq([
+              ).to eq([
           report,
           query,
           timeframe_value,
@@ -50,7 +50,7 @@ module Snapshots
           current_end,
           school_ids,
           additional_filters: additional_filters)
-        ).to eq([
+              ).to eq([
           report,
           query,
           timeframe_value,
@@ -75,7 +75,7 @@ module Snapshots
           custom_end,
           school_ids,
           additional_filters: additional_filters)
-        ).to eq([
+              ).to eq([
           report,
           query,
           calculated_previous_start,
@@ -96,17 +96,17 @@ module Snapshots
           current_end,
           school_ids,
           additional_filters: additional_filters)
-        ).to eq(Snapshots::CacheKeys.generate_key(report,
-          query,
-          timeframe_value,
-          current_start,
-          current_end,
-          school_ids.reverse,
-          additional_filters: {
-            grades: grades.reverse,
-            teacher_ids: teacher_ids.reverse,
-            classroom_ids: classroom_ids.reverse
-          }))
+              ).to eq(Snapshots::CacheKeys.generate_key(report,
+                query,
+                timeframe_value,
+                current_start,
+                current_end,
+                school_ids.reverse,
+                additional_filters: {
+                  grades: grades.reverse,
+                  teacher_ids: teacher_ids.reverse,
+                  classroom_ids: classroom_ids.reverse
+                }))
       end
     end
   end

--- a/services/QuillLMS/spec/lib/utils/numeric_spec.rb
+++ b/services/QuillLMS/spec/lib/utils/numeric_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe Utils::Numeric do
     it 'should format times under one minute correctly' do
       expect(Utils::Numeric.human_readable_time_to_seconds('00:02')).to eq(
        2
-      )
+     )
 
       expect(Utils::Numeric.human_readable_time_to_seconds('00:59')).to eq(
        59
-      )
+     )
     end
 
     it 'should format times over one minute correctly' do

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -278,7 +278,7 @@ describe ActivitySession, type: :model, redis: true do
     describe '#invalidate_activity_session_count_if_completed' do
       let!(:student){ create(:student, :in_one_classroom) }
       let!(:classroom_unit) { create(:classroom_unit, classroom_id: student.classrooms.first.id, assigned_student_ids: [student.id]) }
-      let!(:activity_session){   create(:activity_session, classroom_unit: classroom_unit, state: 'not validated') }
+      let!(:activity_session){ create(:activity_session, classroom_unit: classroom_unit, state: 'not validated') }
 
       before do
         $redis.set("classroom_id:#{student.classrooms.first.id}_completed_activity_count", 10)
@@ -302,7 +302,7 @@ describe ActivitySession, type: :model, redis: true do
       let!(:student){ create(:student, :in_one_classroom) }
       let!(:classroom_unit) { create(:classroom_unit, assigned_student_ids: [student.id], classroom_id: student.classrooms.first.id) }
       let!(:unit_activity) { create(:unit_activity, activity: activity, unit: classroom_unit.unit) }
-      let(:activity_session){   build(:activity_session, classroom_unit: classroom_unit)                     }
+      let(:activity_session){ build(:activity_session, classroom_unit: classroom_unit) }
 
       it "must return the unit activity's activity" do
         activity_session.activity_id=nil
@@ -655,7 +655,7 @@ describe ActivitySession, type: :model, redis: true do
     let(:student) { create(:student) }
     let(:activity) { create(:activity) }
 
-    let(:classroom_unit)   { create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id]) }
+    let(:classroom_unit) { create(:classroom_unit, classroom: classroom, assigned_student_ids: [student.id]) }
     let(:previous_final_score) { create(:activity_session, completed_at: Time.current, percentage: 0.9, is_final_score: true, user: student, classroom_unit: classroom_unit, activity: activity, updated_at: starting_updated_at) }
 
     before { allow(DateTime).to receive(:current).and_return(now) }

--- a/services/QuillLMS/spec/models/classroom_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_spec.rb
@@ -231,7 +231,7 @@ describe Classroom, type: :model do
       before { allow(DateTime).to receive(:current).and_return(1.day.from_now) }
 
       it { expect { subject }.to change { classroom_unit.reload.updated_at } }
-      it { expect { subject }.to change  { activity_session.reload.updated_at } }
+      it { expect { subject }.to change { activity_session.reload.updated_at } }
       it { expect { subject }.to change { unit.reload.updated_at } }
     end
   end

--- a/services/QuillLMS/spec/models/concept_result_spec.rb
+++ b/services/QuillLMS/spec/models/concept_result_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe ConceptResult, type: :model do
 
       it 'should create NormalizedText records when new text is provided' do
         expect do
-          cr =  ConceptResult.create_from_json(json)
+          cr = ConceptResult.create_from_json(json)
           expect(cr.extra_metadata).to be(nil)
         end.to change(ConceptResultDirections, :count).by(1)
           .and change(ConceptResultPreviousFeedback, :count).by(1)

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -403,7 +403,7 @@ describe PublicProgressReports, type: :model do
 
     it 'should return the evidence default key target skill concept if the first concept result has no extra metadata and it was an evidence session' do
       evidence_activity_session = create(:evidence_activity_session)
-      concept_result =  create(:concept_result, activity_session: evidence_activity_session)
+      concept_result = create(:concept_result, activity_session: evidence_activity_session)
 
       expect(FakeReports.new.get_key_target_skill_concept_for_question([concept_result], concept_result.activity_session)).to eq(evidence_default)
     end
@@ -421,9 +421,9 @@ describe PublicProgressReports, type: :model do
     end
 
     it 'should return a key target skill concept with the parent of the question\'s concept that is correct if the student reached an optimal response' do
-      concept =  create(:concept_with_grandparent)
-      incorrect_concept_result =  create(:concept_result, correct: false, concept_id: concept.id, question_score: 1, extra_metadata: { question_concept_uid: concept.uid })
-      correct_concept_result =  create(:concept_result, correct: true, concept_id: concept.id, question_score: 1, extra_metadata: { question_concept_uid: concept.uid })
+      concept = create(:concept_with_grandparent)
+      incorrect_concept_result = create(:concept_result, correct: false, concept_id: concept.id, question_score: 1, extra_metadata: { question_concept_uid: concept.uid })
+      correct_concept_result = create(:concept_result, correct: true, concept_id: concept.id, question_score: 1, extra_metadata: { question_concept_uid: concept.uid })
 
       expected = {
         id: concept.parent.id,
@@ -436,8 +436,8 @@ describe PublicProgressReports, type: :model do
     end
 
     it 'should return a key target skill concept with the parent of the question\'s concept that is incorrect if the student did not reach an optimal response' do
-      concept =  create(:concept_with_grandparent)
-      incorrect_concept_result =  create(:concept_result, correct: false, concept_id: concept.id, extra_metadata: { question_concept_uid: concept.uid })
+      concept = create(:concept_with_grandparent)
+      incorrect_concept_result = create(:concept_result, correct: false, concept_id: concept.id, extra_metadata: { question_concept_uid: concept.uid })
 
       expected = {
         id: concept.parent.id,

--- a/services/QuillLMS/spec/models/concerns/teacher_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/teacher_spec.rb
@@ -102,7 +102,7 @@ describe User, type: :model do
 
     describe '#has_outstanding_coteacher_invitation?' do
       it 'returns true if an outstanding invitation exists for the current user' do
-        pending_coteacher_invitation =  create(:pending_coteacher_invitation, invitee_email: teacher.email)
+        pending_coteacher_invitation = create(:pending_coteacher_invitation, invitee_email: teacher.email)
         create(:coteacher_classroom_invitation, invitation: pending_coteacher_invitation)
         expect(teacher.has_outstanding_coteacher_invitation?).to eq(true)
       end

--- a/services/QuillLMS/spec/models/one_off_banner_spec.rb
+++ b/services/QuillLMS/spec/models/one_off_banner_spec.rb
@@ -4,32 +4,32 @@ require 'rails_helper'
 
 describe OneOffBanner, type: :model do
   it 'does return false for show? when the key does not have an associated webinar' do
-    time =  DateTime.new(2020,1,1,11,0,0)
+    time = DateTime.new(2020,1,1,11,0,0)
     banner = OneOffBanner.new(time)
     expect(banner.show?).to eq(false)
   end
 
   it 'does return no link or title when the key does not have an associated webinar' do
-    time =  DateTime.new(2020,1,1,11,0,0)
+    time = DateTime.new(2020,1,1,11,0,0)
     banner = OneOffBanner.new(time)
     expect(banner.link).to eq(nil)
     expect(banner.title).to eq(nil)
   end
 
   it 'does return true for show? when the key does have an associated webinar' do
-    time =  DateTime.new(2022,8,10,11,1,0)
+    time = DateTime.new(2022,8,10,11,1,0)
     banner = OneOffBanner.new(time)
     expect(banner.show?).to eq(true)
   end
 
   it 'does not return true for show? when the key falls on a skipped day' do
-    time =  DateTime.new(2021,1,18,16,1,0)
+    time = DateTime.new(2021,1,18,16,1,0)
     banner = OneOffBanner.new(time)
     expect(banner.show?).to eq(false)
   end
 
   it 'does return correct link and title when the key does have an associated recurring webinar' do
-    time =  DateTime.new(2022,8,10,11,1,0)
+    time = DateTime.new(2022,8,10,11,1,0)
     banner = OneOffBanner.new(time)
     expect(banner.title).to eq('The webinar <strong>Back to School with Quill: Learn the Basics</strong> is live now!')
     expect(banner.link).to eq('https://quill-org.zoom.us/webinar/register/WN_2LfW2CGRSfyfJzv79kF_2Q#/registration')

--- a/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
@@ -79,7 +79,7 @@ describe QuestionHealthDashboard, type: :model do
       ENV['CMS_URL'] = 'https://cms.quill.org'
       question_uid = SecureRandom.uuid
       stub_request(:get, "#{ENV['CMS_URL']}/questions/#{question_uid}/question_dashboard_data")
-        .to_return(status: 200, body: { percent_common_unmatched: 50,  percent_specified_algos: 75 }.to_json, headers: {})
+        .to_return(status: 200, body: { percent_common_unmatched: 50, percent_specified_algos: 75 }.to_json, headers: {})
       dashboard_stats = QuestionHealthDashboard.new(activity.id, 1, question_uid).cms_dashboard_stats
       expect(dashboard_stats['percent_common_unmatched']).to eq(50)
       expect(dashboard_stats['percent_specified_algos']).to eq(75)

--- a/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_dashboard_spec.rb
@@ -21,7 +21,7 @@ describe QuestionHealthDashboard, type: :model do
       activity_session: activity_session2,
       question_number: 1,
       question_score: 0.75
-   )
+    )
   end
 
   let!(:concept_result3) do

--- a/services/QuillLMS/spec/models/question_health_obj_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_obj_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe QuestionHealthObj, type: :model do
         activity_session: activity_session1,
         question_number: 1,
         question_score: 1
-     )
+      )
     end
 
     let!(:concept_result2) do
@@ -24,7 +24,7 @@ RSpec.describe QuestionHealthObj, type: :model do
         activity_session: activity_session2,
         question_number: 1,
         question_score: 0.75
-     )
+      )
     end
 
     let!(:concept_result3) do

--- a/services/QuillLMS/spec/models/question_health_obj_spec.rb
+++ b/services/QuillLMS/spec/models/question_health_obj_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe QuestionHealthObj, type: :model do
       ENV['DEFAULT_URL'] = 'https://quill.org'
       ENV['CMS_URL'] = 'https://cms.quill.org'
       stub_request(:get, "#{ENV['CMS_URL']}/questions/#{question.uid}/question_dashboard_data")
-        .to_return(status: 200, body: { percent_common_unmatched: 50,  percent_specified_algos: 75 }.to_json, headers: {})
+        .to_return(status: 200, body: { percent_common_unmatched: 50, percent_specified_algos: 75 }.to_json, headers: {})
     end
 
     it 'should return an object with that questions health info' do

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Question, type: :model do
       expect(question.incorrectSequences).to contain_exactly(
         { 'uid' => 'uid1', 'text'=>'text', 'feedback'=>'bar' },
         { 'uid' => 'uid3', 'text'=>'text', 'feedback'=>'bar' }
-        )
+      )
     end
   end
 

--- a/services/QuillLMS/spec/models/recurring_banner_spec.rb
+++ b/services/QuillLMS/spec/models/recurring_banner_spec.rb
@@ -4,26 +4,26 @@ require 'rails_helper'
 
 describe RecurringBanner, type: :model do
   it 'does return false for show? when the key does not have an associated webinar' do
-    time =  DateTime.new(2020,1,1,11,0,0)
+    time = DateTime.new(2020,1,1,11,0,0)
     banner = RecurringBanner.new(time)
     expect(banner.show?).to eq(false)
   end
 
   it 'does return false for show? when the user has no subscription and the banner is subscription only' do
-    time =  DateTime.new(2021,3,11,16,1,0)
+    time = DateTime.new(2021,3,11,16,1,0)
     banner = RecurringBanner.new(time)
     expect(banner.show?('Teacher Trial')).to eq(false)
   end
 
   it 'does return no link or title when the key does not have an associated webinar' do
-    time =  DateTime.new(2020,1,1,11,0,0)
+    time = DateTime.new(2020,1,1,11,0,0)
     banner = RecurringBanner.new(time)
     expect(banner.link).to eq(nil)
     expect(banner.title).to eq(nil)
   end
 
   it 'does not return true for show? when the key falls on a skipped day' do
-    time =  DateTime.new(2021,1,18,16,1,0)
+    time = DateTime.new(2021,1,18,16,1,0)
     banner = RecurringBanner.new(time)
     expect(banner.show?(true)).to eq(false)
   end

--- a/services/QuillLMS/spec/models/school_spec.rb
+++ b/services/QuillLMS/spec/models/school_spec.rb
@@ -224,7 +224,7 @@ describe School, type: :model do
       context 'district admin is already admin for school' do
         before { create(:schools_admins, user: admin, school: school) }
 
-        it {  expect { school.update(district: district) }.to not_change(SchoolsAdmins, :count) }
+        it { expect { school.update(district: district) }.to not_change(SchoolsAdmins, :count) }
       end
     end
 
@@ -249,7 +249,7 @@ describe School, type: :model do
     end
   end
 
-  describe 'vitally_data'  do
+  describe 'vitally_data' do
     let(:school) { create(:school) }
 
     it 'sends a payload that contains the correct data for vitally' do

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -1044,7 +1044,7 @@ RSpec.describe User, type: :model do
 
       it 'is does save for records below the uniqueness constraint minimum' do
         create(:user, id: described_class::EMAIL_UNIQUENESS_CONSTRAINT_MINIMUM_ID - 1, email: 'test@test.lan')
-        user = build(:user,  email: 'test@test.lan')
+        user = build(:user, email: 'test@test.lan')
         expect { user.save!(validate: false) }.to change(User, :count).from(1).to(2)
       end
 
@@ -1054,7 +1054,7 @@ RSpec.describe User, type: :model do
       end
 
       it 'is invalid when there is a space in it' do
-        user = build(:user,  email: 'test@test.lan ')
+        user = build(:user, email: 'test@test.lan ')
         user.save
         expect(user.errors[:email]).to include('That email is not valid because it has a space. Try another.')
       end
@@ -2315,13 +2315,13 @@ RSpec.describe User, type: :model do
       end
 
       context 'auth_credential is not expired' do
-        before { create(:google_auth_credential, user: user)  }
+        before { create(:google_auth_credential, user: user) }
 
         it { is_expected.to eq false }
       end
 
       context 'auth_credential is expired' do
-        before { create(:google_auth_credential, :expired, user: user)  }
+        before { create(:google_auth_credential, :expired, user: user) }
 
         it { is_expected.to eq true }
       end

--- a/services/QuillLMS/spec/queries/lesson_recommendations_query.rb
+++ b/services/QuillLMS/spec/queries/lesson_recommendations_query.rb
@@ -315,7 +315,7 @@ describe LessonRecommendationsQuery do
                   ]
               }
           ]
-        )
+          )
         end
       end
     end

--- a/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
+++ b/services/QuillLMS/spec/queries/progress_reports/standards/all_classrooms_standard_spec.rb
@@ -23,7 +23,7 @@ describe ProgressReports::Standards::AllClassroomsStandard do
     end
 
     it 'should return the correctly shaped payload' do
-      expected_keys =  [
+      expected_keys = [
         'id',
         'name',
         'standard_level_name',

--- a/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/period_query_spec.rb
@@ -42,7 +42,7 @@ module Snapshots
       context 'classroom with co teachers' do
         let(:coteacher_classrooms_teachers) { classrooms.map { |classroom| create(:classrooms_teacher, classroom: classroom, role: ClassroomsTeacher::ROLE_TYPES[:coteacher]) } }
         let(:coteachers) { coteacher_classrooms_teachers.map { |ct| ct.user } }
-        let(:coteacher_schools_users) { coteachers.map { |coteacher| create(:schools_users, user: coteacher, school: schools.first)  } }
+        let(:coteacher_schools_users) { coteachers.map { |coteacher| create(:schools_users, user: coteacher, school: schools.first) } }
 
         let(:teacher_ids) { nil }
         let(:cte_records) { base_cte_records + [coteacher_classrooms_teachers, coteachers, coteacher_schools_users] }

--- a/services/QuillLMS/spec/queries/staff/rules_analysis_query_spec.rb
+++ b/services/QuillLMS/spec/queries/staff/rules_analysis_query_spec.rb
@@ -94,7 +94,7 @@ module Staff
             }
           end
 
-          it 'should aggregate feedbacks for a given rule'  do
+          it 'should aggregate feedbacks for a given rule' do
             expect(results.count).to eq 1
             expect(results.first[:api_name]).to eq 'autoML'
           end
@@ -137,7 +137,7 @@ module Staff
             }
           end
 
-          it 'should filter by activity_version if specified'  do
+          it 'should filter by activity_version if specified' do
             expect(results.count).to eq 2
             expect(results.select { |rf| rf[:rule_uid] == so_rule4.uid }.empty?).to be
             expect(results.first[:api_name]).to eq 'autoML'

--- a/services/QuillLMS/spec/queries/teacher_dashboard_metrics_spec.rb
+++ b/services/QuillLMS/spec/queries/teacher_dashboard_metrics_spec.rb
@@ -18,7 +18,7 @@ describe TeacherDashboardMetrics do
   let(:july_second_of_this_year) { Date.parse("02-07-#{today.year}") }
 
   let(:last_july_second) do
-    today.month > 7 ?  july_second_of_this_year : july_second_of_this_year - 1.year
+    today.month > 7 ? july_second_of_this_year : july_second_of_this_year - 1.year
   end
 
   around do |example|

--- a/services/QuillLMS/spec/queries/teachers_data_spec.rb
+++ b/services/QuillLMS/spec/queries/teachers_data_spec.rb
@@ -29,7 +29,7 @@ describe 'TeachersData' do
       started_at: time1,
       completed_at: time2,
       classroom_unit: classroom_unit
-                                                )
+    )
   }
 
   let!(:activity_session2) {
@@ -39,7 +39,7 @@ describe 'TeachersData' do
       started_at: time1,
       completed_at: time2,
       classroom_unit: classroom_unit
-                                                )
+    )
   }
 
   let!(:concept1) { create(:concept) }

--- a/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/canvas_integration/lti_controller_spec.rb
@@ -64,7 +64,7 @@ module CanvasIntegration
       let(:canvas_instance) { create(:canvas_instance) }
 
       let(:url) { canvas_instance.url }
-      let(:email)  { Faker::Internet.email }
+      let(:email) { Faker::Internet.email }
       let(:external_id) { Faker::Number.number }
       let(:name) { Faker::Name.custom_name }
       let(:ext_roles) { CanvasIntegration::RoleExtractor::INSTRUCTOR_ROLE }
@@ -94,7 +94,7 @@ module CanvasIntegration
         it { expect(response).to have_http_status(:success) }
         it { expect(response.content_type).to eq 'text/html; charset=utf-8' }
         it { expect(response.body).to include(described_class::LAUNCH_TEXT) }
-        it { expect(response.body).not_to include('<script') }  # LTI does not allow scripts
+        it { expect(response.body).not_to include('<script') } # LTI does not allow scripts
       end
     end
   end

--- a/services/QuillLMS/spec/serializers/standard_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/standard_serializer_spec.rb
@@ -21,7 +21,7 @@
 require 'rails_helper'
 
 describe StandardSerializer, type: :serializer do
-  let(:standard)      { create(:standard) }
+  let(:standard) { create(:standard) }
   let(:serializer) { StandardSerializer.new(standard) }
 
   describe '#to_json output' do

--- a/services/QuillLMS/spec/serializers/user_with_provider_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/user_with_provider_serializer_spec.rb
@@ -20,8 +20,8 @@ describe UserWithProviderSerializer, type: :serializer do
 
       before { user.update(google_id: google_id) }
 
-      it { expect(parsed_user['provider']).to eq User::GOOGLE_PROVIDER  }
-      it { expect(parsed_user['user_external_id']).to eq google_id  }
+      it { expect(parsed_user['provider']).to eq User::GOOGLE_PROVIDER }
+      it { expect(parsed_user['user_external_id']).to eq google_id }
     end
 
     context 'when user is a clever user' do
@@ -29,8 +29,8 @@ describe UserWithProviderSerializer, type: :serializer do
 
       before { user.update(clever_id: clever_id) }
 
-      it { expect(parsed_user['provider']).to eq User::CLEVER_PROVIDER  }
-      it { expect(parsed_user['user_external_id']).to eq clever_id  }
+      it { expect(parsed_user['provider']).to eq User::CLEVER_PROVIDER }
+      it { expect(parsed_user['user_external_id']).to eq clever_id }
     end
 
     # The canvas user construction is different since we can't uniquely identify

--- a/services/QuillLMS/spec/services/admin_diagnostic_reports/assemble_overview_report_spec.rb
+++ b/services/QuillLMS/spec/services/admin_diagnostic_reports/assemble_overview_report_spec.rb
@@ -226,7 +226,7 @@ module AdminDiagnosticReports
                     post_students_completed: post_completed_aggregate_row1[:post_students_completed],
                     overall_skill_growth: post_completed_aggregate_row1[:overall_skill_growth]
                   }
-              )
+                )
             end
           end
         end

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_updater_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_updater_spec.rb
@@ -56,13 +56,13 @@ RSpec.describe CanvasIntegration::ClassroomUpdater do
     before { ClassroomsTeacher.where(classroom: classroom).delete_all }
 
     context 'classroom has no owner or coteachers' do
-      it  { expect(subject.owner).to eq teacher }
+      it { expect(subject.owner).to eq teacher }
     end
 
     context 'teacher owns classroom' do
       before { create(:classrooms_teacher, classroom: classroom, user: teacher) }
 
-      it  { expect(subject.owner).to eq teacher }
+      it { expect(subject.owner).to eq teacher }
     end
 
     context 'another teacher owns classroom' do

--- a/services/QuillLMS/spec/services/clever_integration/classroom_updater_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/classroom_updater_spec.rb
@@ -75,13 +75,13 @@ RSpec.describe CleverIntegration::ClassroomUpdater do
     before { ClassroomsTeacher.where(classroom: classroom).delete_all }
 
     context 'classroom has no owner or coteachers' do
-      it  { expect(subject.owner).to eq teacher }
+      it { expect(subject.owner).to eq teacher }
     end
 
     context 'teacher owns classroom' do
       before { create(:classrooms_teacher, classroom: classroom, user: teacher) }
 
-      it  { expect(subject.owner).to eq teacher }
+      it { expect(subject.owner).to eq teacher }
     end
 
     context 'another teacher owns classroom' do

--- a/services/QuillLMS/spec/services/clever_integration/creators/teacher_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/creators/teacher_spec.rb
@@ -23,19 +23,19 @@ describe CleverIntegration::Creators::Teacher do
     context 'as an admin' do
       let(:factory) { :admin }
 
-      it  { expect(subject.role).to eq User::ADMIN }
+      it { expect(subject.role).to eq User::ADMIN }
     end
 
     context 'as a teacher' do
       let(:factory) { :teacher }
 
-      it  { expect(subject.role).to eq User::TEACHER }
+      it { expect(subject.role).to eq User::TEACHER }
     end
 
     context 'as a student' do
       let(:factory) { :student }
 
-      it  { expect(subject.role).to eq User::TEACHER }
+      it { expect(subject.role).to eq User::TEACHER }
     end
   end
 

--- a/services/QuillLMS/spec/services/clever_integration/library_client_spec.rb
+++ b/services/QuillLMS/spec/services/clever_integration/library_client_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CleverIntegration::LibraryClient do
     context 'classroom 1' do
       let(:code) { 200 }
       let(:parsed_response) { classroom1_students_data }
-      let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
+      let(:classroom_external_id) { classroom1_attrs[:classroom_external_id] }
       let(:students_attrs) { [student1_attrs, student2_attrs] }
 
       it { is_expected.to eq students_attrs }
@@ -30,7 +30,7 @@ RSpec.describe CleverIntegration::LibraryClient do
     context 'classroom 2' do
       let(:code) { 200 }
       let(:parsed_response) { classroom2_students_data }
-      let(:classroom_external_id)  { classroom2_attrs[:classroom_external_id] }
+      let(:classroom_external_id) { classroom2_attrs[:classroom_external_id] }
       let(:students_attrs) { [student3_attrs] }
 
       it { is_expected.to eq students_attrs }
@@ -39,7 +39,7 @@ RSpec.describe CleverIntegration::LibraryClient do
     context 'unauthorized token' do
       let(:code) { 401 }
       let(:parsed_response) { { 'error' => 'Unrecognized token string' } }
-      let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
+      let(:classroom_external_id) { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
       it { not_expected_to_report_error? }
@@ -48,7 +48,7 @@ RSpec.describe CleverIntegration::LibraryClient do
     context 'resource not found' do
       let(:code) { 404 }
       let(:parsed_response) { { 'error' => 'Resource not found' } }
-      let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
+      let(:classroom_external_id) { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
       it { not_expected_to_report_error? }
@@ -57,7 +57,7 @@ RSpec.describe CleverIntegration::LibraryClient do
     context 'unknown error' do
       let(:code) { 500 }
       let(:parsed_response) { { 'error' => 'Unknown error' } }
-      let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
+      let(:classroom_external_id) { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
       it { expected_to_report_error? }
@@ -81,7 +81,7 @@ RSpec.describe CleverIntegration::LibraryClient do
     context 'unauthorized token' do
       let(:code) { 401 }
       let(:parsed_response) { { 'error' => 'Unrecognized token string' } }
-      let(:classroom_external_id)  { classroom1_attrs[:classroom_external_id] }
+      let(:classroom_external_id) { classroom1_attrs[:classroom_external_id] }
 
       it { is_expected.to eq [] }
       it { not_expected_to_report_error? }

--- a/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
+++ b/services/QuillLMS/spec/services/demo/create_admin_report_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Demo::CreateAdminReport do
       .map { |template| Demo::ReportDemoCreator.activity_ids_for_config(template) }
       .flatten
       .uniq
-      .each { |activity_id|  create(:activity, id: activity_id) }
+      .each { |activity_id| create(:activity, id: activity_id) }
 
     Demo::SessionData.new
       .concept_results

--- a/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
+++ b/services/QuillLMS/spec/services/demo/report_demo_creator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Demo::ReportDemoCreator do
         .map { |template| described_class.activity_ids_for_config(template) }
         .flatten
         .uniq
-        .each { |activity_id|  create(:activity, id: activity_id) }
+        .each { |activity_id| create(:activity, id: activity_id) }
 
       Demo::SessionData.new
         .concept_results
@@ -56,7 +56,7 @@ RSpec.describe Demo::ReportDemoCreator do
     let!(:activity) { create(:activity, id: activity_id) }
 
     let(:concept_ids) { [566, 506, 508, 641, 640, 671, 239, 551, 488, 385, 524, 540, 664, 83, 673, 450] }
-    let!(:concepts) { concept_ids.map { |id|  create(:concept, id: id) } }
+    let!(:concepts) { concept_ids.map { |id| create(:concept, id: id) } }
 
     let(:demo_config) do
       [

--- a/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
@@ -82,7 +82,7 @@ describe 'SerializeActivityHealth' do
     ENV['DEFAULT_URL'] = 'https://quill.org'
     ENV['CMS_URL'] = 'https://cms.quill.org'
     stub_request(:get, "#{ENV['CMS_URL']}/questions/#{question.uid}/question_dashboard_data")
-      .to_return(status: 200, body: { percent_common_unmatched: 50,  percent_specified_algos: 75 }.to_json, headers: {})
+      .to_return(status: 200, body: { percent_common_unmatched: 50, percent_specified_algos: 75 }.to_json, headers: {})
     stub_request(:get, "#{ENV['CMS_URL']}/questions/#{another_question.uid}/question_dashboard_data")
       .to_return(status: 200, body: { percent_common_unmatched: 100,  percent_specified_algos: 75 }.to_json, headers: {})
     stub_request(:get, "#{ENV['CMS_URL']}/questions/#{a_bad_question.uid}/question_dashboard_data")

--- a/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
+++ b/services/QuillLMS/spec/services/serialize_activity_health_spec.rb
@@ -51,7 +51,7 @@ describe 'SerializeActivityHealth' do
       activity_session: activity_session1,
       question_number: 1,
       question_score: 1
-   )
+    )
   end
 
   let!(:concept_result2) do

--- a/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
+++ b/services/QuillLMS/spec/services/stripe_integration/webhooks/subscription_creator_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe StripeIntegration::Webhooks::SubscriptionCreator do
   end
 
   context 'amount paid different than plan price' do
-    let!(:stripe_invoice_amount_paid) { stripe_plan.plan.amount - 1  }
+    let!(:stripe_invoice_amount_paid) { stripe_plan.plan.amount - 1 }
 
     it { expect { subject }.to raise_error described_class::AmountPaidMismatchError }
 

--- a/services/QuillLMS/spec/services/valid_name_builder_spec.rb
+++ b/services/QuillLMS/spec/services/valid_name_builder_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ValidNameBuilder do
   end
 
   context 'name is longer than MAX_LENGTH' do
-    let(:name) { 'a' * (described_class::MAX_LENGTH + 1)  }
+    let(:name) { 'a' * (described_class::MAX_LENGTH + 1) }
     let(:existing_names) { [] }
     let(:truncated_name) { name.truncate(described_class::MAX_LENGTH - described_class::RANDOM_STRING_SUFFIX_LENGTH) }
 

--- a/services/QuillLMS/spec/services/vitally_integration/analytics_api_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/analytics_api_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe VitallyIntegration::AnalyticsApi do
-  let(:api)  { described_class.new }
+  let(:api) { described_class.new }
 
   let(:sample_response) { { body: '{}', headers: { content_type: 'application/json' } } }
   let(:mock_payload) { {} }

--- a/services/QuillLMS/spec/services/vitally_integration/rest_api_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/rest_api_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe VitallyIntegration::RestApi do
-  let(:api)  { described_class.new }
+  let(:api) { described_class.new }
   let(:api_key) { 'test api key' }
   let(:id) { 1 }
   let(:type) { 'type' }

--- a/services/QuillLMS/spec/support/pages/sign_up_page.rb
+++ b/services/QuillLMS/spec/support/pages/sign_up_page.rb
@@ -32,7 +32,7 @@ class SignUpPage < Page
     # so that the form appears to be filled out from
     # top to bottom
 
-    fill_in 'first_name', with:  first_name
+    fill_in 'first_name', with: first_name
     fill_in 'last_name', with: last_name
     fill_in 'username', with: username if type == :student
     fill_in 'password', with: password

--- a/services/QuillLMS/spec/support/pages/teachers/class_manager/class_manager_page.rb
+++ b/services/QuillLMS/spec/support/pages/teachers/class_manager/class_manager_page.rb
@@ -22,8 +22,8 @@ module Teachers
     end
 
     [['Activity Planner', :activity_planner],
-     ['Classes',    :classes],
-     ['Student Reports',        :student_reports]].each do |pair|
+     ['Classes', :classes],
+     ['Student Reports', :student_reports]].each do |pair|
       text, sym = pair
 
       module_eval_str __LINE__, %{

--- a/services/QuillLMS/spec/support/shared/concept_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/concept_progress_report.rb
@@ -23,7 +23,7 @@ shared_context 'Concept Progress Report' do
     create(:unit_activity,
       unit: unit,
       activity: activity
-  )
+    )
   }
 
   let!(:writing_grandparent_concept) { create(:concept, name: 'Writing Grandparent') }
@@ -38,7 +38,7 @@ shared_context 'Concept Progress Report' do
       activity: activity,
       state: 'finished',
       percentage: 0.75
-                                        )
+    )
   }
 
   let!(:correct_writing_result1) do
@@ -106,7 +106,7 @@ shared_context 'Concept Progress Report' do
       user: other_student,
       state: 'finished',
       percentage: 0.75
-   )
+    )
   end
 
   let!(:other_grammar_result) do

--- a/services/QuillLMS/spec/support/shared/standard_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/standard_progress_report.rb
@@ -66,7 +66,7 @@ shared_context 'Standard Progress Report' do
     session
   end
 
-  let!(:alice_first_grade_standard_session)  do
+  let!(:alice_first_grade_standard_session) do
     session = ActivitySession.create(user_id: alice.id, activity: activity_for_first_grade_standard, classroom_unit: classroom_unit1, state: 'finished', percentage: 0.70, timespent: 180, completed_at: 28.days.ago)
     session
   end

--- a/services/QuillLMS/spec/support/shared/student_concept_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/student_concept_progress_report.rb
@@ -26,7 +26,7 @@ shared_context 'Student Concept Progress Report' do
       assign_on_join: true,
       unit: unit,
       assigned_student_ids: [alice.id, fred.id, zojirushi.id]
-                                          )
+    )
   }
   let(:unit_activity) {
     create(:unit_activity,

--- a/services/QuillLMS/spec/support/shared/unit_assignments_variables.rb
+++ b/services/QuillLMS/spec/support/shared/unit_assignments_variables.rb
@@ -2,7 +2,7 @@
 
 shared_context 'Unit Assignments Variables' do
   let!(:author) { create(:author) }
-  let!(:classroom) { create(:classroom)  }
+  let!(:classroom) { create(:classroom) }
   let!(:teacher) { classroom.owner }
   let!(:student) { create(:student) }
   let!(:student1) { create(:student) }

--- a/services/QuillLMS/spec/workers/finish_activity_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/finish_activity_worker_spec.rb
@@ -7,7 +7,7 @@ describe FinishActivityWorker, type: :worker do
   let(:classroom) { create(:classroom) }
   let!(:unit) { create(:unit) }
   let(:classroom_unit) { create(:classroom_unit, classroom: classroom, unit: unit) }
-  let(:activity_session) { create(:activity_session,  classroom_unit: classroom_unit) }
+  let(:activity_session) { create(:activity_session, classroom_unit: classroom_unit) }
   let(:analyzer) { double(:analyzer) }
 
   before { allow(Analytics::SegmentAnalytics).to receive(:new) { analyzer } }

--- a/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
@@ -89,9 +89,9 @@ describe PopulateActivityHealthWorker do
       ENV['DEFAULT_URL'] = 'https://quill.org'
       ENV['CMS_URL'] = 'https://cms.quill.org'
       stub_request(:get, "#{ENV['CMS_URL']}/questions/#{question.uid}/question_dashboard_data")
-        .to_return(status: 200, body: { percent_common_unmatched: 50,  percent_specified_algos: 75 }.to_json, headers: {})
+        .to_return(status: 200, body: { percent_common_unmatched: 50, percent_specified_algos: 75 }.to_json, headers: {})
       stub_request(:get, "#{ENV['CMS_URL']}/questions/#{another_question.uid}/question_dashboard_data")
-        .to_return(status: 200, body: { percent_common_unmatched: 100,  percent_specified_algos: 75 }.to_json, headers: {})
+        .to_return(status: 200, body: { percent_common_unmatched: 100, percent_specified_algos: 75 }.to_json, headers: {})
     end
 
     it 'should create a new Activity Health object' do

--- a/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/populate_activity_health_worker_spec.rb
@@ -18,7 +18,7 @@ describe PopulateActivityHealthWorker do
             { key: another_question.uid }
           ]
         }
-     )
+      )
     end
 
     let!(:content_partner) { create(:content_partner, activities: [activity]) }

--- a/services/QuillLMS/spec/workers/teacher_activity_feed_refill_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/teacher_activity_feed_refill_worker_spec.rb
@@ -28,7 +28,7 @@ describe TeacherActivityFeedRefillWorker, type: :worker do
   end
 
   context 'teacher with classrooms, but no activities' do
-    let(:classroom) { create(:classroom)  }
+    let(:classroom) { create(:classroom) }
     let(:teacher) { classroom.owner }
 
     it 'should not reset and refill activity feed' do
@@ -40,7 +40,7 @@ describe TeacherActivityFeedRefillWorker, type: :worker do
   end
 
   context 'teacher with classrooms and activities' do
-    let(:classroom) { create(:classroom)  }
+    let(:classroom) { create(:classroom) }
     let(:teacher) { classroom.owner }
     let!(:student1) { create(:student) }
     let!(:student2) { create(:student) }

--- a/services/QuillLMS/spec/workers/update_student_last_active_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/update_student_last_active_worker_spec.rb
@@ -9,7 +9,7 @@ describe UpdateStudentLastActiveWorker do
     let!(:user) { create(:user) }
     let(:new_date) { Time.at(100).utc }
 
-    it 'should update the users last seen with the given date time'  do
+    it 'should update the users last seen with the given date time' do
       subject.perform(user.id, new_date)
       expect(user.reload.last_active).to eq new_date
     end


### PR DESCRIPTION
## WHAT
Add rules for closing parentheses indentation and extraneous spacing
## WHY
To make our code more consistent
## HOW
Remove `enabled: false` from rubocop_todo.yml
lines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO
Have you deployed to Staging? | NO
Self-Review: Have you done an initial self-review of the code below on Github? | YES
