### PR TITLE
Do a null check for translations

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
@@ -75,10 +75,9 @@ class Register extends React.Component<any, any> {
   }
 
   translatedText = (): string => {
-
     const { lesson, language} = this.props;
     const { translations, } = lesson;
-    return translations[language];
+    return translations && translations[language];
   }
 
 


### PR DESCRIPTION
## WHAT
Make sure we check the case where there are no translations

## WHY
We get this sentry error: https://quillorg-5s.sentry.io/issues/5648018552/?alert_rule_id=292298&alert_timestamp=1722019278375&alert_type=email&environment=production&notification_uuid=c72fd601-d50c-4f20-944d-3be0fc19e224&project=210579

## HOW
check that translations exist before trying to index into it.
### What have you done to QA this feature?
Tested locally 
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, because I wanted to get this out since a page is broken, but will add another PR to test this function
Have you deployed to Staging? | No, small change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
