### PR TITLE
Add a test for register component

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/__tests__/components/__snapshots__/register.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Shared/__tests__/components/__snapshots__/register.test.tsx.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Register it should render with translations 1`] = `
+<DocumentFragment>
+  <section
+    class="student"
+    style="padding-top: 20px;"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="landing-page-html"
+      >
+        Joining sentences
+      </div>
+      <hr />
+      <div
+        class="landing-page-html"
+      >
+        Conjunto oraciones
+      </div>
+      <button
+        class="quill-button-archived focus-on-light large primary contained"
+        type="button"
+      >
+        Start activity
+      </button>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`Register it should render without translations 1`] = `
+<DocumentFragment>
+  <section
+    class="student"
+    style="padding-top: 20px;"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="landing-page-html"
+      >
+        Joining sentences
+      </div>
+      <button
+        class="quill-button-archived focus-on-light large primary contained"
+        type="button"
+      >
+        Start activity
+      </button>
+    </div>
+  </section>
+</DocumentFragment>
+`;

--- a/services/QuillLMS/client/app/bundles/Shared/__tests__/components/register.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/__tests__/components/register.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import * as React from "react";
+
+import { Register } from "../../components/studentLessons/register";
+
+const props = {
+  language: 'english',
+  lesson: {
+    flag: "production",
+    landingPageHtml: "Joining sentences",
+    modelConceptUID: "GiUZ6KPkH958AT8S413nJg",
+    name: "And - Deserts",
+    questionType: "questions",
+    questions: [],
+  },
+  previewMode: true,
+  resumeActivity: () => {},
+  startActivity:  () => {}
+}
+
+describe('Register', () => {
+  test('it should render without translations', () => {
+    const { asFragment } = render(<Register {...props} />);
+    expect(asFragment()).toMatchSnapshot();
+  })
+
+  // Note--once we take out the feature flag, this will show the translations and we'll have to redo the snapshot
+  test('it should render with translations', () => {
+    props.lesson['translations'] = {"spanish" : "Conjunto oraciones"}
+    props.language = 'spanish'
+    const { asFragment } = render(<Register {...props} />);
+    expect(asFragment()).toMatchSnapshot();
+  })
+
+})


### PR DESCRIPTION
## WHAT
Add a test for the register component
## WHY
We got [this error](https://quillorg-5s.sentry.io/issues/5648018552/?alert_rule_id=292298&alert_timestamp=1722019278375&alert_type=email&environment=production&notification_uuid=c72fd601-d50c-4f20-944d-3be0fc19e224&project=210579) from the component. It's been fixed, but I thought there should be a test to show it 
## HOW
Add a snapshot test that renders this with and without translations 

### What have you done to QA this feature?
Ran the tests
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | Non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES