### PR TITLE
Bug fix/ renaming concepts

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/ConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/ConceptBox.tsx
@@ -131,7 +131,7 @@ class ConceptBox extends React.Component<ConceptBoxProps, ConceptBoxState> {
     editConcept({ variables: {
       id: concept.id,
       name: concept.name,
-      parentId: concept.parent.id,
+      parentId: concept.parent?.id,
       visible: concept.visible,
       description: concept.description && concept.description.length && concept.description !== '<br/>' ? concept.description : null,
       explanation: concept.explanation && concept.explanation.length && concept.explanation !== '<br/>' ? concept.explanation : null,


### PR DESCRIPTION
## WHAT
fix issue preventing users from renaming Level 2 concepts

## WHY
this is blocking a project

## HOW
just add a presence check for concept `parent`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Renaming-Level-2-Concept-does-not-work-staging-e9a97170dd2e41a7bdbc08f5ea46ef62?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
verified on staging that a Level 2 concept can be renamed

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
