### PR TITLE
fix tooltip clickability

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/styles/style.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/style.scss
@@ -110,6 +110,33 @@ button {
   }
 }
 
+// TODO: move modal scss from here https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/app/assets/stylesheets/shared/modals.scss#L415-L453 into Shared bundle and use that instead 
+.modal, .modal-background {
+  width: 100%;
+  height: 100%;
+  position: fixed !important;
+  top: 0;
+  left: 0;
+  z-index: 2;
+}
+
+.modal-background {
+  opacity: 0.5;
+  background-color: $quill-black;
+}
+
+.modal-container {
+  border-radius: 16px;
+  background-color: $quill-white;
+  z-index: 3;
+  position: fixed !important;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: block;
+  max-height: 100vh;
+}
+
 @media (min-width: 1100px) {
   .hide-on-desktop {
     display: none !important;

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/__snapshots__/Header.test.tsx.snap
@@ -51,20 +51,20 @@ exports[`StudentViewContainer component when the activity has loaded renders 1`]
             tooltipTriggerTextClass="hide-on-mobile beta-tag focus-on-dark"
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              tabIndex={0}
             >
               <span
                 className="hide-on-mobile beta-tag focus-on-dark"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
-                tabIndex={0}
               >
                 <div>
                   <img
@@ -85,6 +85,8 @@ exports[`StudentViewContainer component when the activity has loaded renders 1`]
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/readAndHighlightInstructions.test.tsx.snap
@@ -90,21 +90,19 @@ exports[`ReadAndHighlightInstructions component when the student has not started
           }
         >
           <span
-            aria-hidden={false}
+            aria-expanded={false}
+            aria-haspopup="true"
             className="quill-tooltip-trigger "
-            role="tooltip"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="button"
+            tabIndex={0}
           >
-            <span
-              className="undefined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex={0}
-            >
+            <span>
               <img
                 alt="Question mark icon"
                 src="undefined/images/icons/icons-help.svg"
@@ -116,6 +114,8 @@ exports[`ReadAndHighlightInstructions component when the student has not started
               <span
                 aria-live="polite"
                 className="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>
@@ -227,21 +227,19 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
           }
         >
           <span
-            aria-hidden={false}
+            aria-expanded={false}
+            aria-haspopup="true"
             className="quill-tooltip-trigger "
-            role="tooltip"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="button"
+            tabIndex={0}
           >
-            <span
-              className="undefined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex={0}
-            >
+            <span>
               <img
                 alt="Question mark icon"
                 src="undefined/images/icons/icons-help.svg"
@@ -253,6 +251,8 @@ exports[`ReadAndHighlightInstructions component when the student has started mak
               <span
                 aria-live="polite"
                 className="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/activity_scores.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/activity_scores.test.tsx.snap
@@ -15,15 +15,13 @@ exports[`ActivityScores it should render 1`] = `
           Activity Scores Report
         </h1>
         <span
-          aria-hidden="false"
+          aria-expanded="false"
+          aria-haspopup="true"
           class="quill-tooltip-trigger "
-          role="tooltip"
+          role="button"
+          tabindex="0"
         >
-          <span
-            class="undefined"
-            role="button"
-            tabindex="0"
-          >
+          <span>
             <img
               alt="Question mark icon"
               src="undefined/images/icons/icons-help.svg"
@@ -35,6 +33,8 @@ exports[`ActivityScores it should render 1`] = `
             <span
               aria-live="polite"
               class="quill-tooltip"
+              id="tooltip"
+              role="tooltip"
             />
           </span>
         </span>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/concept_reports.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/components/__tests__/__snapshots__/concept_reports.test.tsx.snap
@@ -15,15 +15,13 @@ exports[`ConceptReports it should render 1`] = `
           Concepts Report
         </h1>
         <span
-          aria-hidden="false"
+          aria-expanded="false"
+          aria-haspopup="true"
           class="quill-tooltip-trigger "
-          role="tooltip"
+          role="button"
+          tabindex="0"
         >
-          <span
-            class="undefined"
-            role="button"
-            tabindex="0"
-          >
+          <span>
             <img
               alt="Question mark icon"
               src="undefined/images/icons/icons-help.svg"
@@ -35,6 +33,8 @@ exports[`ConceptReports it should render 1`] = `
             <span
               aria-live="polite"
               class="quill-tooltip"
+              id="tooltip"
+              role="tooltip"
             />
           </span>
         </span>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DataExportContainer.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/DataExportContainer.test.tsx.snap
@@ -321,15 +321,13 @@ exports[`DataExportContainer full state it should render 1`] = `
           Preview
         </h3>
         <span
-          aria-hidden="false"
+          aria-expanded="false"
+          aria-haspopup="true"
           class="quill-tooltip-trigger "
-          role="tooltip"
+          role="button"
+          tabindex="0"
         >
-          <span
-            class="undefined"
-            role="button"
-            tabindex="0"
-          >
+          <span>
             <img
               alt="Question mark icon"
               src="undefined/images/icons/icons-help.svg"
@@ -341,6 +339,8 @@ exports[`DataExportContainer full state it should render 1`] = `
             <span
               aria-live="polite"
               class="quill-tooltip"
+              id="tooltip"
+              role="tooltip"
             />
           </span>
         </span>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/PremiumFilterableReportsContainer.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/PremiumFilterableReportsContainer.test.tsx.snap
@@ -51,15 +51,13 @@ exports[`PremiumFilterableReportsContainer it should render 1`] = `
               Timeframe
             </span>
             <span
-              aria-hidden="false"
+              aria-expanded="false"
+              aria-haspopup="true"
               class="quill-tooltip-trigger "
-              role="tooltip"
+              role="button"
+              tabindex="0"
             >
-              <span
-                class="undefined"
-                role="button"
-                tabindex="0"
-              >
+              <span>
                 <img
                   alt="Question mark icon"
                   src="undefined/images/icons/icons-help.svg"
@@ -71,6 +69,8 @@ exports[`PremiumFilterableReportsContainer it should render 1`] = `
                 <span
                   aria-live="polite"
                   class="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/overviewSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/overviewSection.test.tsx.snap
@@ -106,15 +106,13 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -126,6 +124,8 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -155,15 +155,13 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -175,6 +173,8 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -197,15 +197,13 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -217,6 +215,8 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -246,15 +246,13 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -266,6 +264,8 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -295,15 +295,13 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -315,6 +313,8 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -344,15 +344,13 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -364,6 +362,8 @@ exports[`OverviewSection loaded state clicking toggle button should expand aggre
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -692,15 +692,13 @@ exports[`OverviewSection loaded state it should render the expected data when da
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -712,6 +710,8 @@ exports[`OverviewSection loaded state it should render the expected data when da
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -741,15 +741,13 @@ exports[`OverviewSection loaded state it should render the expected data when da
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -761,6 +759,8 @@ exports[`OverviewSection loaded state it should render the expected data when da
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -783,15 +783,13 @@ exports[`OverviewSection loaded state it should render the expected data when da
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -803,6 +801,8 @@ exports[`OverviewSection loaded state it should render the expected data when da
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -832,15 +832,13 @@ exports[`OverviewSection loaded state it should render the expected data when da
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -852,6 +850,8 @@ exports[`OverviewSection loaded state it should render the expected data when da
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -881,15 +881,13 @@ exports[`OverviewSection loaded state it should render the expected data when da
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -901,6 +899,8 @@ exports[`OverviewSection loaded state it should render the expected data when da
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -930,15 +930,13 @@ exports[`OverviewSection loaded state it should render the expected data when da
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -950,6 +948,8 @@ exports[`OverviewSection loaded state it should render the expected data when da
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1278,15 +1278,13 @@ exports[`OverviewSection loaded state it should render the expected header compo
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1298,6 +1296,8 @@ exports[`OverviewSection loaded state it should render the expected header compo
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1327,15 +1327,13 @@ exports[`OverviewSection loaded state it should render the expected header compo
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1347,6 +1345,8 @@ exports[`OverviewSection loaded state it should render the expected header compo
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1369,15 +1369,13 @@ exports[`OverviewSection loaded state it should render the expected header compo
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1389,6 +1387,8 @@ exports[`OverviewSection loaded state it should render the expected header compo
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1418,15 +1418,13 @@ exports[`OverviewSection loaded state it should render the expected header compo
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1438,6 +1436,8 @@ exports[`OverviewSection loaded state it should render the expected header compo
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1467,15 +1467,13 @@ exports[`OverviewSection loaded state it should render the expected header compo
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1487,6 +1485,8 @@ exports[`OverviewSection loaded state it should render the expected header compo
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1516,15 +1516,13 @@ exports[`OverviewSection loaded state it should render the expected header compo
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1536,6 +1534,8 @@ exports[`OverviewSection loaded state it should render the expected header compo
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/skillSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/skillSection.test.tsx.snap
@@ -215,15 +215,13 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -235,6 +233,8 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -264,15 +264,13 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -284,6 +282,8 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -306,15 +306,13 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -326,6 +324,8 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -355,15 +355,13 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -375,6 +373,8 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -404,15 +404,13 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -424,6 +422,8 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -453,15 +453,13 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -473,6 +471,8 @@ exports[`SkillSection loaded state clicking toggle button should expand aggregat
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -918,15 +918,13 @@ exports[`SkillSection loaded state it should render the expected data when data 
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -938,6 +936,8 @@ exports[`SkillSection loaded state it should render the expected data when data 
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -967,15 +967,13 @@ exports[`SkillSection loaded state it should render the expected data when data 
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -987,6 +985,8 @@ exports[`SkillSection loaded state it should render the expected data when data 
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1009,15 +1009,13 @@ exports[`SkillSection loaded state it should render the expected data when data 
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1029,6 +1027,8 @@ exports[`SkillSection loaded state it should render the expected data when data 
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1058,15 +1058,13 @@ exports[`SkillSection loaded state it should render the expected data when data 
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1078,6 +1076,8 @@ exports[`SkillSection loaded state it should render the expected data when data 
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1107,15 +1107,13 @@ exports[`SkillSection loaded state it should render the expected data when data 
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1127,6 +1125,8 @@ exports[`SkillSection loaded state it should render the expected data when data 
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1156,15 +1156,13 @@ exports[`SkillSection loaded state it should render the expected data when data 
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1176,6 +1174,8 @@ exports[`SkillSection loaded state it should render the expected data when data 
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1621,15 +1621,13 @@ exports[`SkillSection loaded state it should render the expected header componen
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1641,6 +1639,8 @@ exports[`SkillSection loaded state it should render the expected header componen
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1670,15 +1670,13 @@ exports[`SkillSection loaded state it should render the expected header componen
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1690,6 +1688,8 @@ exports[`SkillSection loaded state it should render the expected header componen
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1712,15 +1712,13 @@ exports[`SkillSection loaded state it should render the expected header componen
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1732,6 +1730,8 @@ exports[`SkillSection loaded state it should render the expected header componen
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1761,15 +1761,13 @@ exports[`SkillSection loaded state it should render the expected header componen
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1781,6 +1779,8 @@ exports[`SkillSection loaded state it should render the expected header componen
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1810,15 +1810,13 @@ exports[`SkillSection loaded state it should render the expected header componen
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1830,6 +1828,8 @@ exports[`SkillSection loaded state it should render the expected header componen
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1859,15 +1859,13 @@ exports[`SkillSection loaded state it should render the expected header componen
               class="sort-tooltip-container"
             >
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
+                tabindex="0"
               >
-                <span
-                  class="undefined"
-                  role="button"
-                  tabindex="0"
-                >
+                <span>
                   <img
                     alt="Question mark icon"
                     src="undefined/images/icons/icons-help.svg"
@@ -1879,6 +1877,8 @@ exports[`SkillSection loaded state it should render the expected header componen
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>

--- a/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/studentSection.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/PremiumHub/containers/__tests__/__snapshots__/studentSection.test.tsx.snap
@@ -111,15 +111,13 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -131,6 +129,8 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -160,15 +160,13 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -180,6 +178,8 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -209,15 +209,13 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -229,6 +227,8 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -258,15 +258,13 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -278,6 +276,8 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -307,15 +307,13 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -327,6 +325,8 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -356,15 +356,13 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -376,6 +374,8 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -405,15 +405,13 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -425,6 +423,8 @@ exports[`StudentSection loaded state clicking toggle button should expand aggreg
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -846,15 +846,13 @@ exports[`StudentSection loaded state it should render the expected data when dat
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -866,6 +864,8 @@ exports[`StudentSection loaded state it should render the expected data when dat
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -895,15 +895,13 @@ exports[`StudentSection loaded state it should render the expected data when dat
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -915,6 +913,8 @@ exports[`StudentSection loaded state it should render the expected data when dat
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -944,15 +944,13 @@ exports[`StudentSection loaded state it should render the expected data when dat
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -964,6 +962,8 @@ exports[`StudentSection loaded state it should render the expected data when dat
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -993,15 +993,13 @@ exports[`StudentSection loaded state it should render the expected data when dat
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1013,6 +1011,8 @@ exports[`StudentSection loaded state it should render the expected data when dat
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1042,15 +1042,13 @@ exports[`StudentSection loaded state it should render the expected data when dat
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1062,6 +1060,8 @@ exports[`StudentSection loaded state it should render the expected data when dat
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1091,15 +1091,13 @@ exports[`StudentSection loaded state it should render the expected data when dat
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1111,6 +1109,8 @@ exports[`StudentSection loaded state it should render the expected data when dat
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1140,15 +1140,13 @@ exports[`StudentSection loaded state it should render the expected data when dat
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1160,6 +1158,8 @@ exports[`StudentSection loaded state it should render the expected data when dat
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1466,15 +1466,13 @@ exports[`StudentSection loaded state it should render the expected empty state m
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1486,6 +1484,8 @@ exports[`StudentSection loaded state it should render the expected empty state m
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1515,15 +1515,13 @@ exports[`StudentSection loaded state it should render the expected empty state m
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1535,6 +1533,8 @@ exports[`StudentSection loaded state it should render the expected empty state m
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1564,15 +1564,13 @@ exports[`StudentSection loaded state it should render the expected empty state m
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1584,6 +1582,8 @@ exports[`StudentSection loaded state it should render the expected empty state m
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1613,15 +1613,13 @@ exports[`StudentSection loaded state it should render the expected empty state m
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1633,6 +1631,8 @@ exports[`StudentSection loaded state it should render the expected empty state m
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1662,15 +1662,13 @@ exports[`StudentSection loaded state it should render the expected empty state m
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1682,6 +1680,8 @@ exports[`StudentSection loaded state it should render the expected empty state m
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1711,15 +1711,13 @@ exports[`StudentSection loaded state it should render the expected empty state m
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1731,6 +1729,8 @@ exports[`StudentSection loaded state it should render the expected empty state m
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1760,15 +1760,13 @@ exports[`StudentSection loaded state it should render the expected empty state m
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1780,6 +1778,8 @@ exports[`StudentSection loaded state it should render the expected empty state m
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1934,15 +1934,13 @@ exports[`StudentSection loaded state it should render the expected header compon
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1954,6 +1952,8 @@ exports[`StudentSection loaded state it should render the expected header compon
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1983,15 +1983,13 @@ exports[`StudentSection loaded state it should render the expected header compon
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2003,6 +2001,8 @@ exports[`StudentSection loaded state it should render the expected header compon
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2032,15 +2032,13 @@ exports[`StudentSection loaded state it should render the expected header compon
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2052,6 +2050,8 @@ exports[`StudentSection loaded state it should render the expected header compon
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2081,15 +2081,13 @@ exports[`StudentSection loaded state it should render the expected header compon
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2101,6 +2099,8 @@ exports[`StudentSection loaded state it should render the expected header compon
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2130,15 +2130,13 @@ exports[`StudentSection loaded state it should render the expected header compon
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2150,6 +2148,8 @@ exports[`StudentSection loaded state it should render the expected header compon
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2179,15 +2179,13 @@ exports[`StudentSection loaded state it should render the expected header compon
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2199,6 +2197,8 @@ exports[`StudentSection loaded state it should render the expected header compon
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2228,15 +2228,13 @@ exports[`StudentSection loaded state it should render the expected header compon
                 class="sort-tooltip-container"
               >
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2248,6 +2246,8 @@ exports[`StudentSection loaded state it should render the expected header compon
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -37,6 +37,8 @@ class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean
   }
 
   showTooltip() {
+    if (this.tooltip.classList.value.includes(VISIBLE)) { return }
+
     const { tooltipText, averageItemHeight } = this.props;
     const activeTooltips = document.getElementsByClassName('visible quill-tooltip');
     Array.from(activeTooltips).forEach(tooltip => tooltip.classList.remove('visible'));
@@ -107,31 +109,32 @@ class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean
   }
 
   render() {
-    const { tooltipTriggerText, tooltipTriggerTextClass, tooltipTriggerStyle, tooltipTriggerTextStyle, isTabbable } = this.props
-    const { tooltipVisible, } = this.state
-    const tabIndex = isTabbable ? 0 : null;
+    const { tooltipTriggerText, tooltipTriggerTextClass, tooltipTriggerStyle, tooltipTriggerTextStyle, isTabbable } = this.props;
+    const { tooltipVisible } = this.state;
+    const tabIndex = isTabbable ? 0 : undefined;
 
-    const triggerClass = `quill-tooltip-trigger ${tooltipVisible ? 'active' : ''}`
+    const triggerClass = `quill-tooltip-trigger ${tooltipVisible ? 'active' : ''}`;
 
     return (
       <span
-        aria-hidden={!isTabbable}
+        aria-describedby={tooltipVisible ? 'tooltip' : undefined}
+        aria-expanded={tooltipVisible}
+        aria-haspopup="true"
         className={triggerClass}
+        onBlur={this.hideTooltip}
+        onClick={this.handleTooltipClick}
+        onFocus={this.showTooltip}
+        onKeyDown={this.handleTooltipKeyDown}
+        onMouseEnter={this.showTooltip}
+        onMouseLeave={this.hideTooltip}
         ref={node => this.tooltipTrigger = node}
-        role="tooltip"
+        role="button"
         style={tooltipTriggerStyle}
+        tabIndex={tabIndex}
       >
         <span
-          className={`${tooltipTriggerTextClass}`}
-          onBlur={this.hideTooltip}
-          onClick={this.handleTooltipClick}
-          onFocus={this.showTooltip}
-          onKeyDown={this.handleTooltipKeyDown}
-          onMouseEnter={this.showTooltip}
-          onMouseLeave={this.hideTooltip}
-          role="button"
+          className={tooltipTriggerTextClass}
           style={tooltipTriggerTextStyle}
-          tabIndex={tabIndex}
         >
           {tooltipTriggerText}
         </span>
@@ -139,11 +142,13 @@ class Tooltip extends React.Component<TooltipProps, { clickedFromMobile: boolean
           <span
             aria-live="polite"
             className="quill-tooltip"
+            id="tooltip"
             ref={node => this.tooltip = node}
+            role="tooltip"
           />
         </span>
       </span>
-    )
+    );
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Shared/styles/tooltip.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/tooltip.scss
@@ -23,6 +23,9 @@
   display: flex;
   align-items: flex-start;
   justify-content: center;
+  margin-bottom: -10px;
+  padding-bottom: 10px;
+
   &:has(.visible) {
     z-index: 2;
   }

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/menus.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/menus.test.tsx.snap
@@ -536,15 +536,13 @@ exports[`Menus it should render 1`] = `
                   </div>
                 </div>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Information icon"
                       class="information-icon"
@@ -557,6 +555,8 @@ exports[`Menus it should render 1`] = `
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -3,15 +3,13 @@
 exports[`Tooltip component it should render when it is not searchable 1`] = `
 <DocumentFragment>
   <span
-    aria-hidden="false"
+    aria-expanded="false"
+    aria-haspopup="true"
     class="quill-tooltip-trigger "
-    role="tooltip"
+    role="button"
+    tabindex="0"
   >
-    <span
-      class="undefined"
-      role="button"
-      tabindex="0"
-    >
+    <span>
       I have a lot of text
     </span>
     <span
@@ -20,6 +18,8 @@ exports[`Tooltip component it should render when it is not searchable 1`] = `
       <span
         aria-live="polite"
         class="quill-tooltip"
+        id="tooltip"
+        role="tooltip"
       />
     </span>
   </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_new_activity.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/__tests__/__snapshots__/assign_a_new_activity.test.jsx.snap
@@ -705,16 +705,16 @@ exports[`AssignANewActivity component with suggested activities should render 1`
             </td>
             <td>
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
                 style="min-width: 319px; width: 319px;"
+                tabindex="0"
               >
                 <span
                   class="data-table-row-section topic-section"
-                  role="button"
                   style="min-width: 319px; width: 319px;"
-                  tabindex="0"
                 >
                   <div
                     class="topic"
@@ -762,6 +762,8 @@ exports[`AssignANewActivity component with suggested activities should render 1`
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -827,16 +829,16 @@ exports[`AssignANewActivity component with suggested activities should render 1`
             </td>
             <td>
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
                 style="min-width: 319px; width: 319px;"
+                tabindex="0"
               >
                 <span
                   class="data-table-row-section topic-section"
-                  role="button"
                   style="min-width: 319px; width: 319px;"
-                  tabindex="0"
                 >
                   <div
                     class="topic"
@@ -884,6 +886,8 @@ exports[`AssignANewActivity component with suggested activities should render 1`
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -949,16 +953,16 @@ exports[`AssignANewActivity component with suggested activities should render 1`
             </td>
             <td>
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
                 style="min-width: 319px; width: 319px;"
+                tabindex="0"
               >
                 <span
                   class="data-table-row-section topic-section"
-                  role="button"
                   style="min-width: 319px; width: 319px;"
-                  tabindex="0"
                 >
                   <div
                     class="topic"
@@ -978,6 +982,8 @@ exports[`AssignANewActivity component with suggested activities should render 1`
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1043,16 +1049,16 @@ exports[`AssignANewActivity component with suggested activities should render 1`
             </td>
             <td>
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
                 style="min-width: 319px; width: 319px;"
+                tabindex="0"
               >
                 <span
                   class="data-table-row-section topic-section"
-                  role="button"
                   style="min-width: 319px; width: 319px;"
-                  tabindex="0"
                 >
                   <div
                     class="topic"
@@ -1086,6 +1092,8 @@ exports[`AssignANewActivity component with suggested activities should render 1`
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1151,16 +1159,16 @@ exports[`AssignANewActivity component with suggested activities should render 1`
             </td>
             <td>
               <span
-                aria-hidden="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="quill-tooltip-trigger "
-                role="tooltip"
+                role="button"
                 style="min-width: 319px; width: 319px;"
+                tabindex="0"
               >
                 <span
                   class="data-table-row-section topic-section"
-                  role="button"
                   style="min-width: 319px; width: 319px;"
-                  tabindex="0"
                 >
                   <div
                     class="topic"
@@ -1180,6 +1188,8 @@ exports[`AssignANewActivity component with suggested activities should render 1`
                   <span
                     aria-live="polite"
                     class="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_category_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_category_filters.test.tsx.snap
@@ -5960,20 +5960,20 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             tooltipTriggerTextClass="tooltip-trigger-text"
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              tabIndex={0}
             >
               <span
                 className="tooltip-trigger-text"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
-                tabIndex={0}
               >
                 History: Causes of the American Revolution
               </span>
@@ -5983,6 +5983,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -15004,20 +15006,20 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             tooltipTriggerTextClass="tooltip-trigger-text"
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              tabIndex={0}
             >
               <span
                 className="tooltip-trigger-text"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
-                tabIndex={0}
               >
                 History: Causes of the American Revolution
               </span>
@@ -15027,6 +15029,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_row.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_row.test.tsx.snap
@@ -90,21 +90,19 @@ exports[`ActivityRow component with showCheckbox false and showRemoveButton true
           }
         >
           <span
-            aria-hidden={false}
+            aria-expanded={false}
+            aria-haspopup="true"
             className="quill-tooltip-trigger "
-            role="tooltip"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="button"
+            tabIndex={0}
           >
-            <span
-              className="undefined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex={0}
-            >
+            <span>
               <h2>
                 <img
                   alt="Target representing Quill Connect"
@@ -125,6 +123,8 @@ exports[`ActivityRow component with showCheckbox false and showRemoveButton true
               <span
                 aria-live="polite"
                 className="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>
@@ -512,21 +512,19 @@ exports[`ActivityRow component with showCheckbox false and showRemoveButton true
           }
         >
           <span
-            aria-hidden={false}
+            aria-expanded={false}
+            aria-haspopup="true"
             className="quill-tooltip-trigger "
-            role="tooltip"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="button"
+            tabIndex={0}
           >
-            <span
-              className="undefined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex={0}
-            >
+            <span>
               <h2>
                 <img
                   alt="Target representing Quill Connect"
@@ -547,6 +545,8 @@ exports[`ActivityRow component with showCheckbox false and showRemoveButton true
               <span
                 aria-live="polite"
                 className="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>
@@ -995,21 +995,19 @@ exports[`ActivityRow component with showCheckbox true and showRemoveButton false
           }
         >
           <span
-            aria-hidden={false}
+            aria-expanded={false}
+            aria-haspopup="true"
             className="quill-tooltip-trigger "
-            role="tooltip"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="button"
+            tabIndex={0}
           >
-            <span
-              className="undefined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex={0}
-            >
+            <span>
               <h2>
                 <img
                   alt="Target representing Quill Connect"
@@ -1030,6 +1028,8 @@ exports[`ActivityRow component with showCheckbox true and showRemoveButton false
               <span
                 aria-live="polite"
                 className="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>
@@ -1484,21 +1484,19 @@ exports[`ActivityRow component with showCheckbox true and showRemoveButton false
           }
         >
           <span
-            aria-hidden={false}
+            aria-expanded={false}
+            aria-haspopup="true"
             className="quill-tooltip-trigger "
-            role="tooltip"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="button"
+            tabIndex={0}
           >
-            <span
-              className="undefined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex={0}
-            >
+            <span>
               <h2>
                 <img
                   alt="Target representing Quill Connect"
@@ -1519,6 +1517,8 @@ exports[`ActivityRow component with showCheckbox true and showRemoveButton false
               <span
                 aria-live="polite"
                 className="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_table_container.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_table_container.test.tsx.snap
@@ -1713,21 +1713,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -1748,6 +1746,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -2182,21 +2182,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -2217,6 +2215,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -2630,21 +2630,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -2665,6 +2663,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -3099,21 +3099,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -3134,6 +3132,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -3547,21 +3547,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -3582,6 +3580,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -4016,21 +4016,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -4051,6 +4049,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -4452,21 +4452,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -4487,6 +4485,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -4888,21 +4888,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -4923,6 +4921,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -5336,21 +5336,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -5371,6 +5369,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -5817,21 +5817,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -5852,6 +5850,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -6298,21 +6298,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -6333,6 +6331,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -6767,21 +6767,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -6802,6 +6800,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -7203,21 +7203,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -7238,6 +7236,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -7639,21 +7639,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -7674,6 +7672,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -8087,21 +8087,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -8122,6 +8120,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -8556,21 +8556,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -8591,6 +8589,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -8992,21 +8992,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -9027,6 +9025,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -9428,21 +9428,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -9463,6 +9461,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -9876,21 +9876,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -9911,6 +9909,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -10357,21 +10357,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <h2>
                     <img
                       alt="Target representing Quill Connect"
@@ -10392,6 +10390,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/ccss_grade_level_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/ccss_grade_level_filters.test.tsx.snap
@@ -80,21 +80,18 @@ exports[`ccssGradeLevelFilters component should render 1`] = `
       }
     >
       <span
-        aria-hidden={true}
+        aria-expanded={false}
+        aria-haspopup="true"
         className="quill-tooltip-trigger "
-        role="tooltip"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="button"
       >
-        <span
-          className="undefined"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          role="button"
-          tabIndex={null}
-        >
+        <span>
           <div
             className="tooltip-trigger-filter-section-content"
           >
@@ -904,6 +901,8 @@ exports[`ccssGradeLevelFilters component should render 1`] = `
           <span
             aria-live="polite"
             className="quill-tooltip"
+            id="tooltip"
+            role="tooltip"
           />
         </span>
       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/early_access_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/early_access_filters.test.tsx.snap
@@ -2932,21 +2932,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
         }
       >
         <span
-          aria-hidden={true}
+          aria-expanded={false}
+          aria-haspopup="true"
           className="quill-tooltip-trigger "
-          role="tooltip"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          role="button"
         >
-          <span
-            className="undefined"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            role="button"
-            tabIndex={null}
-          >
+          <span>
             <div
               className="individual-row-tooltip-trigger"
             >
@@ -2980,6 +2977,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             <span
               aria-live="polite"
               className="quill-tooltip"
+              id="tooltip"
+              role="tooltip"
             />
           </span>
         </span>
@@ -4464,21 +4463,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
         }
       >
         <span
-          aria-hidden={true}
+          aria-expanded={false}
+          aria-haspopup="true"
           className="quill-tooltip-trigger "
-          role="tooltip"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          role="button"
         >
-          <span
-            className="undefined"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            role="button"
-            tabIndex={null}
-          >
+          <span>
             <div
               className="individual-row-tooltip-trigger"
             >
@@ -4512,6 +4508,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             <span
               aria-live="polite"
               className="quill-tooltip"
+              id="tooltip"
+              role="tooltip"
             />
           </span>
         </span>
@@ -7453,21 +7451,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
         }
       >
         <span
-          aria-hidden={true}
+          aria-expanded={false}
+          aria-haspopup="true"
           className="quill-tooltip-trigger "
-          role="tooltip"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          role="button"
         >
-          <span
-            className="undefined"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            role="button"
-            tabIndex={null}
-          >
+          <span>
             <div
               className="individual-row-tooltip-trigger"
             >
@@ -7501,6 +7496,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
             <span
               aria-live="polite"
               className="quill-tooltip"
+              id="tooltip"
+              role="tooltip"
             />
           </span>
         </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/ell_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/ell_filters.test.tsx.snap
@@ -2939,21 +2939,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
       }
     >
       <span
-        aria-hidden={true}
+        aria-expanded={false}
+        aria-haspopup="true"
         className="quill-tooltip-trigger "
-        role="tooltip"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="button"
       >
-        <span
-          className="undefined"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          role="button"
-          tabIndex={null}
-        >
+        <span>
           <div
             className="tooltip-trigger-filter-section-content"
           >
@@ -4484,6 +4481,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
           <span
             aria-live="polite"
             className="quill-tooltip"
+            id="tooltip"
+            role="tooltip"
           />
         </span>
       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/grade_level_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/grade_level_filters.test.tsx.snap
@@ -79,21 +79,18 @@ exports[`gradeLevelFilters component should render 1`] = `
       }
     >
       <span
-        aria-hidden={true}
+        aria-expanded={false}
+        aria-haspopup="true"
         className="quill-tooltip-trigger "
-        role="tooltip"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="button"
       >
-        <span
-          className="undefined"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          role="button"
-          tabIndex={null}
-        >
+        <span>
           <div
             className="tooltip-trigger-filter-section-content"
           >
@@ -490,6 +487,8 @@ exports[`gradeLevelFilters component should render 1`] = `
           <span
             aria-live="polite"
             className="quill-tooltip"
+            id="tooltip"
+            role="tooltip"
           />
         </span>
       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/index.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/index.test.tsx.snap
@@ -14828,21 +14828,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
               >
                 <span
-                  aria-hidden={true}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={null}
-                  >
+                  <span>
                     <div
                       className="tooltip-trigger-filter-section-content"
                     >
@@ -15239,6 +15236,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -15318,21 +15317,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
               >
                 <span
-                  aria-hidden={true}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={null}
-                  >
+                  <span>
                     <div
                       className="tooltip-trigger-filter-section-content"
                     >
@@ -15830,6 +15826,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -15915,21 +15913,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
               >
                 <span
-                  aria-hidden={true}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={null}
-                  >
+                  <span>
                     <div
                       className="tooltip-trigger-filter-section-content"
                     >
@@ -16739,6 +16734,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -19683,21 +19680,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
               >
                 <span
-                  aria-hidden={true}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={null}
-                  >
+                  <span>
                     <div
                       className="tooltip-trigger-filter-section-content"
                     >
@@ -21228,6 +21222,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -27193,20 +27189,20 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                       tooltipTriggerTextClass="tooltip-trigger-text"
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
                         <span
                           className="tooltip-trigger-text"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
                         >
                           History: Causes of the American Revolution
                         </span>
@@ -27216,6 +27212,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -36397,21 +36395,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -36432,6 +36428,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -36872,21 +36870,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -36907,6 +36903,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -37326,21 +37324,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -37361,6 +37357,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -37801,21 +37799,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -37836,6 +37832,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -38255,21 +38253,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -38290,6 +38286,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -38730,21 +38728,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -38765,6 +38761,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -39172,21 +39170,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -39207,6 +39203,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -39614,21 +39612,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -39649,6 +39645,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -40068,21 +40066,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -40103,6 +40099,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -40555,21 +40553,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -40590,6 +40586,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -41042,21 +41040,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -41077,6 +41073,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -41517,21 +41515,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -41552,6 +41548,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -41959,21 +41957,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -41994,6 +41990,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -42401,21 +42399,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -42436,6 +42432,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -42855,21 +42853,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -42890,6 +42886,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -43330,21 +43328,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -43365,6 +43361,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -43772,21 +43770,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -43807,6 +43803,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -44214,21 +44212,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -44249,6 +44245,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -44668,21 +44666,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -44703,6 +44699,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -45155,21 +45153,19 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <h2>
                           <img
                             alt="Target representing Quill Connect"
@@ -45190,6 +45186,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
@@ -16936,21 +16936,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
               >
                 <span
-                  aria-hidden={true}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={null}
-                  >
+                  <span>
                     <div
                       className="tooltip-trigger-filter-section-content"
                     >
@@ -17347,6 +17344,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -17426,21 +17425,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
               >
                 <span
-                  aria-hidden={true}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={null}
-                  >
+                  <span>
                     <div
                       className="tooltip-trigger-filter-section-content"
                     >
@@ -17938,6 +17934,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -18023,21 +18021,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
               >
                 <span
-                  aria-hidden={true}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={null}
-                  >
+                  <span>
                     <div
                       className="tooltip-trigger-filter-section-content"
                     >
@@ -18847,6 +18842,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -21791,21 +21788,18 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
               >
                 <span
-                  aria-hidden={true}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={null}
-                  >
+                  <span>
                     <div
                       className="tooltip-trigger-filter-section-content"
                     >
@@ -23336,6 +23330,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -29301,20 +29297,20 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                       tooltipTriggerTextClass="tooltip-trigger-text"
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
                         <span
                           className="tooltip-trigger-text"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
                         >
                           History: Causes of the American Revolution
                         </span>
@@ -29324,6 +29320,8 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/readability_grade_level_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/readability_grade_level_filters.test.tsx.snap
@@ -74,21 +74,18 @@ exports[`readabilityGradeLevelFilters component should render 1`] = `
       }
     >
       <span
-        aria-hidden={true}
+        aria-expanded={false}
+        aria-haspopup="true"
         className="quill-tooltip-trigger "
-        role="tooltip"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="button"
       >
-        <span
-          className="undefined"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          role="button"
-          tabIndex={null}
-        >
+        <span>
           <div
             className="tooltip-trigger-filter-section-content"
           >
@@ -586,6 +583,8 @@ exports[`readabilityGradeLevelFilters component should render 1`] = `
           <span
             aria-live="polite"
             className="quill-tooltip"
+            id="tooltip"
+            role="tooltip"
           />
         </span>
       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/overrideWarningModal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/overrideWarningModal.test.jsx.snap
@@ -39,21 +39,19 @@ exports[`OverrideWarningModal component should render 1`] = `
             tooltipTriggerText="1 student"
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              tabIndex={0}
             >
-              <span
-                className="undefined"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
-                tabIndex={0}
-              >
+              <span>
                 1 student
               </span>
               <span
@@ -62,6 +60,8 @@ exports[`OverrideWarningModal component should render 1`] = `
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/skipRecommendationsWarningModal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/stage2/__tests__/__snapshots__/skipRecommendationsWarningModal.test.jsx.snap
@@ -39,21 +39,19 @@ exports[`SkipRecommendationsWarningModal component should render 1`] = `
             tooltipTriggerText="1 student"
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              tabIndex={0}
             >
-              <span
-                className="undefined"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
-                tabIndex={0}
-              >
+              <span>
                 1 student
               </span>
               <span
@@ -62,6 +60,8 @@ exports[`SkipRecommendationsWarningModal component should render 1`] = `
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack.test.tsx.snap
@@ -422,21 +422,19 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <button
                     className="interactive-wrapper focus-on-light"
                     onClick={[Function]}
@@ -457,6 +455,8 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -481,21 +481,19 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
               }
             >
               <span
-                aria-hidden={false}
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="quill-tooltip-trigger "
-                role="tooltip"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                tabIndex={0}
               >
-                <span
-                  className="undefined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
+                <span>
                   <button
                     className="interactive-wrapper focus-on-light"
                     onClick={[Function]}
@@ -516,6 +514,8 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                   <span
                     aria-live="polite"
                     className="quill-tooltip"
+                    id="tooltip"
+                    role="tooltip"
                   />
                 </span>
               </span>
@@ -1422,21 +1422,19 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <span
                           className="publish-date-header"
                         >
@@ -1449,6 +1447,8 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1483,21 +1483,19 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <span
                           className="due-date-header"
                         >
@@ -1513,6 +1511,8 @@ exports[`ActivityPack component renders if the current user created the unit 1`]
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -12559,21 +12559,19 @@ exports[`ActivityPack component renders if the current user did not create the u
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <span
                           className="publish-date-header"
                         >
@@ -12586,6 +12584,8 @@ exports[`ActivityPack component renders if the current user did not create the u
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -12620,21 +12620,19 @@ exports[`ActivityPack component renders if the current user did not create the u
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <span
-                        className="undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
-                        tabIndex={0}
-                      >
+                      <span>
                         <span
                           className="due-date-header"
                         >
@@ -12650,6 +12648,8 @@ exports[`ActivityPack component renders if the current user did not create the u
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack_update_buttons.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_pack_update_buttons.test.tsx.snap
@@ -45,21 +45,19 @@ exports[`ActivityPackUpdateButtons component renders when the pack is closed 1`]
       }
     >
       <span
-        aria-hidden={false}
+        aria-expanded={false}
+        aria-haspopup="true"
         className="quill-tooltip-trigger "
-        role="tooltip"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="button"
+        tabIndex={0}
       >
-        <span
-          className="undefined"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          role="button"
-          tabIndex={0}
-        >
+        <span>
           <button
             className="interactive-wrapper focus-on-light"
             onClick={[MockFunction]}
@@ -80,6 +78,8 @@ exports[`ActivityPackUpdateButtons component renders when the pack is closed 1`]
           <span
             aria-live="polite"
             className="quill-tooltip"
+            id="tooltip"
+            role="tooltip"
           />
         </span>
       </span>
@@ -104,21 +104,19 @@ exports[`ActivityPackUpdateButtons component renders when the pack is closed 1`]
       }
     >
       <span
-        aria-hidden={false}
+        aria-expanded={false}
+        aria-haspopup="true"
         className="quill-tooltip-trigger "
-        role="tooltip"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="button"
+        tabIndex={0}
       >
-        <span
-          className="undefined"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          role="button"
-          tabIndex={0}
-        >
+        <span>
           <button
             className="interactive-wrapper focus-on-light"
             onClick={[MockFunction]}
@@ -139,6 +137,8 @@ exports[`ActivityPackUpdateButtons component renders when the pack is closed 1`]
           <span
             aria-live="polite"
             className="quill-tooltip"
+            id="tooltip"
+            role="tooltip"
           />
         </span>
       </span>
@@ -205,21 +205,19 @@ exports[`ActivityPackUpdateButtons component renders when the pack is open 1`] =
       }
     >
       <span
-        aria-hidden={false}
+        aria-expanded={false}
+        aria-haspopup="true"
         className="quill-tooltip-trigger "
-        role="tooltip"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="button"
+        tabIndex={0}
       >
-        <span
-          className="undefined"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          role="button"
-          tabIndex={0}
-        >
+        <span>
           <button
             className="interactive-wrapper focus-on-light"
             onClick={[MockFunction]}
@@ -240,6 +238,8 @@ exports[`ActivityPackUpdateButtons component renders when the pack is open 1`] =
           <span
             aria-live="polite"
             className="quill-tooltip"
+            id="tooltip"
+            role="tooltip"
           />
         </span>
       </span>
@@ -264,21 +264,19 @@ exports[`ActivityPackUpdateButtons component renders when the pack is open 1`] =
       }
     >
       <span
-        aria-hidden={false}
+        aria-expanded={false}
+        aria-haspopup="true"
         className="quill-tooltip-trigger "
-        role="tooltip"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="button"
+        tabIndex={0}
       >
-        <span
-          className="undefined"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          role="button"
-          tabIndex={0}
-        >
+        <span>
           <button
             className="interactive-wrapper focus-on-light"
             onClick={[MockFunction]}
@@ -299,6 +297,8 @@ exports[`ActivityPackUpdateButtons component renders when the pack is open 1`] =
           <span
             aria-live="polite"
             className="quill-tooltip"
+            id="tooltip"
+            role="tooltip"
           />
         </span>
       </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/manage_units/__tests__/__snapshots__/activity_table.test.tsx.snap
@@ -857,21 +857,19 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <span
                       className="publish-date-header"
                     >
@@ -884,6 +882,8 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -918,21 +918,19 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <span
                       className="due-date-header"
                     >
@@ -948,6 +946,8 @@ exports[`ActivityTable component renders if the current user created the unit 1`
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -11462,21 +11462,19 @@ exports[`ActivityTable component renders if the current user did not create the 
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <span
                       className="publish-date-header"
                     >
@@ -11489,6 +11487,8 @@ exports[`ActivityTable component renders if the current user did not create the 
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -11523,21 +11523,19 @@ exports[`ActivityTable component renders if the current user did not create the 
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <span
                       className="due-date-header"
                     >
@@ -11553,6 +11551,8 @@ exports[`ActivityTable component renders if the current user did not create the 
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unitTemplateMini.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unitTemplateMini.test.tsx.snap
@@ -185,21 +185,18 @@ exports[`UnitTemplateMini component should render activity_info has html 1`] = `
     }
   >
     <span
-      aria-hidden={true}
+      aria-expanded={false}
+      aria-haspopup="true"
       className="quill-tooltip-trigger "
-      role="tooltip"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      role="button"
     >
-      <span
-        className="undefined"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        role="button"
-        tabIndex={null}
-      >
+      <span>
         <button
           className="unit-template-mini interactive-wrapper focus-on-light"
           onClick={[Function]}
@@ -457,6 +454,8 @@ exports[`UnitTemplateMini component should render activity_info has html 1`] = `
         <span
           aria-live="polite"
           className="quill-tooltip"
+          id="tooltip"
+          role="tooltip"
         />
       </span>
     </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unitTemplateMinisTable.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unitTemplateMinisTable.test.tsx.snap
@@ -382,20 +382,20 @@ exports[`UnitTemplateMinisTable component should render activity_info has html 1
                   tooltipTriggerTextClass="activity-pack-name"
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
                     <span
                       className="activity-pack-name"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
                     >
                       Test Activity Pack
                     </span>
@@ -405,6 +405,8 @@ exports[`UnitTemplateMinisTable component should render activity_info has html 1
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/classroom_student_section.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/classroom_student_section.test.jsx.snap
@@ -4631,21 +4631,19 @@ exports[`ClassroomStudentSection component with students should render 1`] = `
         }
       >
         <span
-          aria-hidden={false}
+          aria-expanded={false}
+          aria-haspopup="true"
           className="quill-tooltip-trigger "
-          role="tooltip"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          role="button"
+          tabIndex={0}
         >
-          <span
-            className="undefined"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            role="button"
-            tabIndex={0}
-          >
+          <span>
             <img
               alt="Warning icon"
               src="undefined/images/icons/warning-icon.svg"
@@ -4657,6 +4655,8 @@ exports[`ClassroomStudentSection component with students should render 1`] = `
             <span
               aria-live="polite"
               className="quill-tooltip"
+              id="tooltip"
+              role="tooltip"
             />
           </span>
         </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/no_classrooms_to_import_modal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/classrooms/__tests__/__snapshots__/no_classrooms_to_import_modal.test.jsx.snap
@@ -90,15 +90,13 @@ exports[`NoClassroomsToImportModal component it should render when there is an a
             </a>
           </b>
           <span
-            aria-hidden="false"
+            aria-expanded="false"
+            aria-haspopup="true"
             class="quill-tooltip-trigger "
-            role="tooltip"
+            role="button"
+            tabindex="0"
           >
-            <span
-              class="undefined"
-              role="button"
-              tabindex="0"
-            >
+            <span>
               <img
                 alt="Question mark icon"
                 src="undefined/images/icons/icons-help.svg"
@@ -110,6 +108,8 @@ exports[`NoClassroomsToImportModal component it should render when there is an a
               <span
                 aria-live="polite"
                 class="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>
@@ -172,15 +172,13 @@ exports[`NoClassroomsToImportModal component it should render when there is an u
           </b>
            you have access to, but don't own
           <span
-            aria-hidden="false"
+            aria-expanded="false"
+            aria-haspopup="true"
             class="quill-tooltip-trigger "
-            role="tooltip"
+            role="button"
+            tabindex="0"
           >
-            <span
-              class="undefined"
-              role="button"
-              tabindex="0"
-            >
+            <span>
               <img
                 alt="Question mark icon"
                 src="undefined/images/icons/icons-help.svg"
@@ -192,6 +190,8 @@ exports[`NoClassroomsToImportModal component it should render when there is an u
               <span
                 aria-live="polite"
                 class="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>
@@ -258,15 +258,13 @@ exports[`NoClassroomsToImportModal component it should render when there is both
             </a>
           </b>
           <span
-            aria-hidden="false"
+            aria-expanded="false"
+            aria-haspopup="true"
             class="quill-tooltip-trigger "
-            role="tooltip"
+            role="button"
+            tabindex="0"
           >
-            <span
-              class="undefined"
-              role="button"
-              tabindex="0"
-            >
+            <span>
               <img
                 alt="Question mark icon"
                 src="undefined/images/icons/icons-help.svg"
@@ -278,6 +276,8 @@ exports[`NoClassroomsToImportModal component it should render when there is both
               <span
                 aria-live="polite"
                 class="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>
@@ -289,15 +289,13 @@ exports[`NoClassroomsToImportModal component it should render when there is both
           </b>
            you have access to, but don't own
           <span
-            aria-hidden="false"
+            aria-expanded="false"
+            aria-haspopup="true"
             class="quill-tooltip-trigger "
-            role="tooltip"
+            role="button"
+            tabindex="0"
           >
-            <span
-              class="undefined"
-              role="button"
-              tabindex="0"
-            >
+            <span>
               <img
                 alt="Question mark icon"
                 src="undefined/images/icons/icons-help.svg"
@@ -309,6 +307,8 @@ exports[`NoClassroomsToImportModal component it should render when there is both
               <span
                 aria-live="polite"
                 class="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/__tests__/__snapshots__/blog_post_table.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/__tests__/__snapshots__/blog_post_table.test.jsx.snap
@@ -4291,9 +4291,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -4301,16 +4308,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -4318,7 +4319,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -4326,6 +4326,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -4721,9 +4723,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -4731,16 +4740,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -4748,7 +4751,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -4756,6 +4758,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -5110,9 +5114,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -5120,16 +5131,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -5137,7 +5142,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     Michele Ellis uses Quill to Facilitate a Dialogue with her 7th Grade Language Arts Class
                                   </span>
@@ -5147,6 +5151,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -5211,9 +5217,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -5221,16 +5234,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -5238,7 +5245,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -5246,6 +5252,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -5641,9 +5649,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -5651,16 +5666,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -5668,7 +5677,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -5676,6 +5684,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -6030,9 +6040,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -6040,16 +6057,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -6057,7 +6068,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     📋 PDF | Introducing Quill Reading for Evidence: One-Pager 
                                   </span>
@@ -6067,6 +6077,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -6131,9 +6143,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -6141,16 +6160,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -6158,7 +6171,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -6166,6 +6178,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -6520,9 +6534,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -6530,16 +6551,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -6547,7 +6562,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     📋 PDF | Quill and Beyond: Recommended Tools to Support Remote Learning
                                   </span>
@@ -6557,6 +6571,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -6621,9 +6637,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -6631,16 +6654,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -6648,7 +6665,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -6656,6 +6672,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -7051,9 +7069,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -7061,16 +7086,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -7078,7 +7097,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -7086,6 +7104,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -7481,9 +7501,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -7491,16 +7518,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -7508,7 +7529,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -7516,6 +7536,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -7911,9 +7933,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -7921,16 +7950,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -7938,7 +7961,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -7946,6 +7968,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -8300,9 +8324,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -8310,16 +8341,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -8327,7 +8352,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     Best Practices: Using Quill to Support Mastery-Based Learning
                                   </span>
@@ -8337,6 +8361,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -8401,9 +8427,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -8411,16 +8444,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -8428,7 +8455,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -8436,6 +8462,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -8831,9 +8859,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -8841,16 +8876,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -8858,7 +8887,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -8866,6 +8894,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -9261,9 +9291,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -9271,16 +9308,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -9288,7 +9319,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -9296,6 +9326,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -9650,9 +9682,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -9660,16 +9699,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -9677,7 +9710,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     What activities will be recommended after students complete a Pre-AP® Writing Skills Survey?
                                   </span>
@@ -9687,6 +9719,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -9751,9 +9785,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -9761,16 +9802,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -9778,7 +9813,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -9786,6 +9820,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -10181,9 +10217,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -10191,16 +10234,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -10208,7 +10245,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -10216,6 +10252,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -10611,9 +10649,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -10621,16 +10666,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -10638,7 +10677,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -10646,6 +10684,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -11041,9 +11081,16 @@ exports[`BlogPostTable component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -11051,16 +11098,10 @@ exports[`BlogPostTable component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -11068,7 +11109,6 @@ exports[`BlogPostTable component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -11076,6 +11116,8 @@ exports[`BlogPostTable component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/__tests__/__snapshots__/featured_blog_posts.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/cms/blog_posts/__tests__/__snapshots__/featured_blog_posts.test.jsx.snap
@@ -4304,9 +4304,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -4314,16 +4321,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -4331,7 +4332,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -4339,6 +4339,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -4693,9 +4695,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -4703,16 +4712,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -4720,7 +4723,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     Michele Ellis uses Quill to Facilitate a Dialogue with her 7th Grade Language Arts Class
                                   </span>
@@ -4730,6 +4732,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -4794,9 +4798,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -4804,16 +4815,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -4821,7 +4826,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -4829,6 +4833,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -5224,9 +5230,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -5234,16 +5247,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -5251,7 +5258,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -5259,6 +5265,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -5613,9 +5621,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -5623,16 +5638,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -5640,7 +5649,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     📋 PDF | Introducing Quill Reading for Evidence: One-Pager 
                                   </span>
@@ -5650,6 +5658,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -5714,9 +5724,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -5724,16 +5741,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -5741,7 +5752,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -5749,6 +5759,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -6103,9 +6115,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -6113,16 +6132,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -6130,7 +6143,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     📋 PDF | Quill and Beyond: Recommended Tools to Support Remote Learning
                                   </span>
@@ -6140,6 +6152,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -6204,9 +6218,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -6214,16 +6235,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -6231,7 +6246,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -6239,6 +6253,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -6634,9 +6650,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -6644,16 +6667,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -6661,7 +6678,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -6669,6 +6685,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -7064,9 +7082,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -7074,16 +7099,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -7091,7 +7110,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -7099,6 +7117,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -7494,9 +7514,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -7504,16 +7531,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -7521,7 +7542,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -7529,6 +7549,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -7883,9 +7905,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -7893,16 +7922,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -7910,7 +7933,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     Best Practices: Using Quill to Support Mastery-Based Learning
                                   </span>
@@ -7920,6 +7942,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -7984,9 +8008,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -7994,16 +8025,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -8011,7 +8036,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -8019,6 +8043,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -8414,9 +8440,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -8424,16 +8457,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -8441,7 +8468,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -8449,6 +8475,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -8844,9 +8872,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -8854,16 +8889,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -8871,7 +8900,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -8879,6 +8907,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -9233,9 +9263,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "400px",
@@ -9243,16 +9280,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "400px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section undefined"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "400px",
@@ -9260,7 +9291,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "400px",
                                       }
                                     }
-                                    tabIndex={0}
                                   >
                                     What activities will be recommended after students complete a Pre-AP® Writing Skills Survey?
                                   </span>
@@ -9270,6 +9300,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -9334,9 +9366,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -9344,16 +9383,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -9361,7 +9394,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -9369,6 +9401,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -9764,9 +9798,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -9774,16 +9815,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -9791,7 +9826,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -9799,6 +9833,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -10194,9 +10230,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -10204,16 +10247,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -10221,7 +10258,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -10229,6 +10265,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -10624,9 +10662,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -10634,16 +10679,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -10651,7 +10690,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -10659,6 +10697,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>
@@ -11054,9 +11094,16 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                 }
                               >
                                 <span
-                                  aria-hidden={false}
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
                                   className="quill-tooltip-trigger "
-                                  role="tooltip"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
                                   style={
                                     Object {
                                       "minWidth": "50px",
@@ -11064,16 +11111,10 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                       "width": "50px",
                                     }
                                   }
+                                  tabIndex={0}
                                 >
                                   <span
                                     className="data-table-row-section left-align"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    role="button"
                                     style={
                                       Object {
                                         "minWidth": "50px",
@@ -11081,7 +11122,6 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                         "width": "50px",
                                       }
                                     }
-                                    tabIndex={0}
                                   />
                                   <span
                                     className="quill-tooltip-wrapper"
@@ -11089,6 +11129,8 @@ exports[`FeaturedBlogPosts component renders 1`] = `
                                     <span
                                       aria-live="polite"
                                       className="quill-tooltip"
+                                      id="tooltip"
+                                      role="tooltip"
                                     />
                                   </span>
                                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/activity_feed.test.jsx.snap
@@ -679,32 +679,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag not-yet-proficient"
@@ -718,6 +718,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -810,9 +812,16 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "284px",
@@ -820,16 +829,10 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                           "width": "284px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section undefined"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "284px",
@@ -837,7 +840,6 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                             "width": "284px",
                           }
                         }
-                        tabIndex={0}
                       >
                         Capitalize Names of People and the Pronoun "I"
                       </span>
@@ -847,6 +849,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -888,32 +892,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag proficient"
@@ -927,6 +931,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1045,32 +1051,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag proficient"
@@ -1084,6 +1090,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1202,32 +1210,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag nearly-proficient"
@@ -1241,6 +1249,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1359,32 +1369,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag proficient"
@@ -1398,6 +1408,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1516,32 +1528,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag nearly-proficient"
@@ -1555,6 +1567,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1673,32 +1687,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag proficient"
@@ -1712,6 +1726,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1831,32 +1847,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag completed"
@@ -1870,6 +1886,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1989,32 +2007,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag completed"
@@ -2028,6 +2046,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -2147,32 +2167,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag completed"
@@ -2186,6 +2206,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -2305,32 +2327,32 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                     }
                   >
                     <span
-                      aria-hidden={false}
+                      aria-expanded={false}
+                      aria-haspopup="true"
                       className="quill-tooltip-trigger "
-                      role="tooltip"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="button"
                       style={
                         Object {
                           "minWidth": "210px",
                           "width": "210px",
                         }
                       }
+                      tabIndex={0}
                     >
                       <span
                         className="data-table-row-section"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        role="button"
                         style={
                           Object {
                             "minWidth": "210px",
                             "width": "210px",
                           }
                         }
-                        tabIndex={0}
                       >
                         <span
                           className="score-tag completed"
@@ -2344,6 +2366,8 @@ exports[`ActivityFeed component not on mobile should render when there are activ
                         <span
                           aria-live="polite"
                           className="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -2620,32 +2644,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag not-yet-proficient"
@@ -2659,6 +2683,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -2744,32 +2770,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag proficient"
@@ -2783,6 +2809,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -2868,32 +2896,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag proficient"
@@ -2907,6 +2935,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -2992,32 +3022,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag nearly-proficient"
@@ -3031,6 +3061,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -3116,32 +3148,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag proficient"
@@ -3155,6 +3187,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -3240,32 +3274,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag nearly-proficient"
@@ -3279,6 +3313,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -3364,32 +3400,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag proficient"
@@ -3403,6 +3439,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -3490,32 +3528,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag completed"
@@ -3529,6 +3567,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -3616,32 +3656,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag completed"
@@ -3655,6 +3695,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -3742,32 +3784,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag completed"
@@ -3781,6 +3823,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -3868,32 +3912,32 @@ exports[`ActivityFeed component on mobile should render when there are activitie
             }
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
               style={
                 Object {
                   "minWidth": "210px",
                   "width": "210px",
                 }
               }
+              tabIndex={0}
             >
               <span
                 className="data-table-row-section"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
                 style={
                   Object {
                     "minWidth": "210px",
                     "width": "210px",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className="score-tag completed"
@@ -3907,6 +3951,8 @@ exports[`ActivityFeed component on mobile should render when there are activitie
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/diagnostic_mini.test.jsx.snap
@@ -412,9 +412,16 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
                     style={
                       Object {
                         "minWidth": "290px",
@@ -422,16 +429,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                         "width": "290px",
                       }
                     }
+                    tabIndex={0}
                   >
                     <span
                       className="data-table-row-section undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
                       style={
                         Object {
                           "minWidth": "290px",
@@ -439,7 +440,6 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                           "width": "290px",
                         }
                       }
-                      tabIndex={0}
                     >
                       Quill Classroom Extremely Long So Long SUper Duper
                     </span>
@@ -449,6 +449,8 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -620,9 +622,16 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
                     style={
                       Object {
                         "minWidth": "290px",
@@ -630,16 +639,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                         "width": "290px",
                       }
                     }
+                    tabIndex={0}
                   >
                     <span
                       className="data-table-row-section undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
                       style={
                         Object {
                           "minWidth": "290px",
@@ -647,7 +650,6 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                           "width": "290px",
                         }
                       }
-                      tabIndex={0}
                     >
                       Quill Classroom Extremely Long So Long SUper Duper
                     </span>
@@ -657,6 +659,8 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -750,9 +754,16 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
                     style={
                       Object {
                         "minWidth": "290px",
@@ -760,16 +771,10 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                         "width": "290px",
                       }
                     }
+                    tabIndex={0}
                   >
                     <span
                       className="data-table-row-section undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
                       style={
                         Object {
                           "minWidth": "290px",
@@ -777,7 +782,6 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                           "width": "290px",
                         }
                       }
-                      tabIndex={0}
                     >
                       Quill Classroom Extremely Long So Long SUper Duper
                     </span>
@@ -787,6 +791,8 @@ exports[`DiagnosticMini component not on mobile should render when there are dia
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/lessons_mini.test.jsx.snap
@@ -726,9 +726,16 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
                     style={
                       Object {
                         "minWidth": "290px",
@@ -736,16 +743,10 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                         "width": "290px",
                       }
                     }
+                    tabIndex={0}
                   >
                     <span
                       className="data-table-row-section undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
                       style={
                         Object {
                           "minWidth": "290px",
@@ -753,7 +754,6 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                           "width": "290px",
                         }
                       }
-                      tabIndex={0}
                     >
                       Advanced Combining: Complex Sentences with Modifiers
                     </span>
@@ -763,6 +763,8 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -1027,9 +1029,16 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
                     style={
                       Object {
                         "minWidth": "290px",
@@ -1037,16 +1046,10 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                         "width": "290px",
                       }
                     }
+                    tabIndex={0}
                   >
                     <span
                       className="data-table-row-section undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
                       style={
                         Object {
                           "minWidth": "290px",
@@ -1054,7 +1057,6 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                           "width": "290px",
                         }
                       }
-                      tabIndex={0}
                     >
                       Lesson 1: Conjunctions of Time (After, Until, Before, etc.)
                     </span>
@@ -1064,6 +1066,8 @@ exports[`LessonsMini component not on mobile should render when there are lesson
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/activities_progress_report.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/__tests__/__snapshots__/activities_progress_report.test.tsx.snap
@@ -15,15 +15,13 @@ exports[`ActivitiesProgressReport it should render 1`] = `
           Data Export
         </h1>
         <span
-          aria-hidden="false"
+          aria-expanded="false"
+          aria-haspopup="true"
           class="quill-tooltip-trigger "
-          role="tooltip"
+          role="button"
+          tabindex="0"
         >
-          <span
-            class="undefined"
-            role="button"
-            tabindex="0"
-          >
+          <span>
             <img
               alt="Question mark icon"
               src="undefined/images/icons/icons-help.svg"
@@ -35,6 +33,8 @@ exports[`ActivitiesProgressReport it should render 1`] = `
             <span
               aria-live="polite"
               class="quill-tooltip"
+              id="tooltip"
+              role="tooltip"
             />
           </span>
         </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/individualStudentResponses.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/individualStudentResponses.test.jsx.snap
@@ -361,15 +361,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 1
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -381,6 +379,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -409,16 +409,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -428,6 +428,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -600,15 +602,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 2
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -620,6 +620,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -648,16 +650,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -667,6 +669,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -839,15 +843,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 3
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -859,6 +861,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -887,16 +891,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -906,6 +910,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1098,15 +1104,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 4
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1118,6 +1122,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1146,16 +1152,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -1165,6 +1171,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1337,15 +1345,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 5
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1357,6 +1363,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1385,16 +1393,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -1404,6 +1412,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1596,15 +1606,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 6
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1616,6 +1624,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1644,16 +1654,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -1663,6 +1673,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1835,15 +1847,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 7
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -1855,6 +1865,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1883,16 +1895,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -1902,6 +1914,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2074,15 +2088,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 12
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2094,6 +2106,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2122,16 +2136,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -2141,6 +2155,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2313,15 +2329,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 13
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2333,6 +2347,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2361,16 +2377,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -2380,6 +2396,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2552,15 +2570,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 14
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2572,6 +2588,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2600,16 +2618,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -2619,6 +2637,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2791,15 +2811,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 17
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -2811,6 +2829,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -2839,16 +2859,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -2858,6 +2878,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -3030,15 +3052,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 18
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -3050,6 +3070,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -3078,16 +3100,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -3097,6 +3119,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -3289,15 +3313,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 8
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -3309,6 +3331,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -3337,16 +3361,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -3356,6 +3380,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -3528,15 +3554,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 9
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -3548,6 +3572,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -3576,16 +3602,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -3595,6 +3621,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -3787,15 +3815,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 10
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -3807,6 +3833,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -3835,16 +3863,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -3854,6 +3882,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -4026,15 +4056,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 11
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -4046,6 +4074,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -4074,16 +4104,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -4093,6 +4123,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -4285,15 +4317,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 15
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -4305,6 +4335,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -4333,16 +4365,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -4352,6 +4384,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -4524,15 +4558,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 16
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -4544,6 +4576,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -4572,16 +4606,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -4591,6 +4625,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -4783,15 +4819,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 19
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -4803,6 +4837,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -4831,16 +4867,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -4850,6 +4886,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -5022,15 +5060,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 20
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -5042,6 +5078,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -5070,16 +5108,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -5089,6 +5127,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -5261,15 +5301,13 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                   Question 21
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -5281,6 +5319,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -5309,16 +5349,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -5328,6 +5368,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -5358,16 +5400,16 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
               />
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 720px; min-width: 720px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 720px; min-width: 720px; text-align: left;"
-                    tabindex="0"
                   >
                     Flan is a dessert made with sugar. Flan is a dessert made with evaporated milk. Flan is a dessert made with eggs.
                   </span>
@@ -5377,6 +5419,8 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -5667,15 +5711,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 1
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -5687,6 +5729,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -5715,16 +5759,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -5734,6 +5778,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -5906,15 +5952,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 2
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -5926,6 +5970,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -5954,16 +6000,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -5973,6 +6019,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -6145,15 +6193,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 3
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -6165,6 +6211,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -6193,16 +6241,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -6212,6 +6260,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -6404,15 +6454,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 4
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -6424,6 +6472,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -6452,16 +6502,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -6471,6 +6521,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -6643,15 +6695,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 5
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -6663,6 +6713,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -6691,16 +6743,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -6710,6 +6762,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -6902,15 +6956,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 6
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -6922,6 +6974,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -6950,16 +7004,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -6969,6 +7023,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -7141,15 +7197,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 7
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -7161,6 +7215,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -7189,16 +7245,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -7208,6 +7264,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -7380,15 +7438,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 12
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -7400,6 +7456,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -7428,16 +7486,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -7447,6 +7505,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -7619,15 +7679,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 13
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -7639,6 +7697,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -7667,16 +7727,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -7686,6 +7746,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -7858,15 +7920,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 14
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -7878,6 +7938,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -7906,16 +7968,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -7925,6 +7987,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -8097,15 +8161,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 17
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -8117,6 +8179,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -8145,16 +8209,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -8164,6 +8228,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -8336,15 +8402,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 18
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -8356,6 +8420,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -8384,16 +8450,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -8403,6 +8469,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -8595,15 +8663,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 8
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -8615,6 +8681,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -8643,16 +8711,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -8662,6 +8730,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -8834,15 +8904,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 9
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -8854,6 +8922,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -8882,16 +8952,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -8901,6 +8971,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -9093,15 +9165,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 10
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -9113,6 +9183,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -9141,16 +9213,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -9160,6 +9232,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -9332,15 +9406,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 11
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -9352,6 +9424,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -9380,16 +9454,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -9399,6 +9473,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -9591,15 +9667,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 15
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -9611,6 +9685,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -9639,16 +9715,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -9658,6 +9734,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -9830,15 +9908,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 16
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -9850,6 +9926,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -9878,16 +9956,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -9897,6 +9975,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -10089,15 +10169,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 19
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -10109,6 +10187,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -10137,16 +10217,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -10156,6 +10236,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -10328,15 +10410,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 20
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -10348,6 +10428,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -10376,16 +10458,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -10395,6 +10477,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -10567,15 +10651,13 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                   Question 21
                 </span>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
+                  tabindex="0"
                 >
-                  <span
-                    class="undefined"
-                    role="button"
-                    tabindex="0"
-                  >
+                  <span>
                     <img
                       alt="Question mark icon"
                       src="undefined/images/icons/icons-help.svg"
@@ -10587,6 +10669,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -10615,16 +10699,16 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             >
               <td>
                 <span
-                  aria-hidden="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
                   class="quill-tooltip-trigger "
-                  role="tooltip"
+                  role="button"
                   style="width: 66px; min-width: 66px; text-align: left;"
+                  tabindex="0"
                 >
                   <span
                     class="data-table-row-section undefined"
-                    role="button"
                     style="width: 66px; min-width: 66px; text-align: left;"
-                    tabindex="0"
                   >
                     Directions
                   </span>
@@ -10634,6 +10718,8 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
                     <span
                       aria-live="polite"
                       class="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/questions.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/questions.test.jsx.snap
@@ -114,14 +114,14 @@ exports[`Questions component should render when there is no student data 1`] = `
                       Prompt
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Tornadoes can pick up trees while they spin. Tornadoes can rip off roofs while they spin.
                       </span>
@@ -131,6 +131,8 @@ exports[`Questions component should render when there is no student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -630,14 +632,14 @@ exports[`Questions component should render when there is no student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Combine the sentences. Use the joining word that best shows the relationship between the ideas.
                       </span>
@@ -647,6 +649,8 @@ exports[`Questions component should render when there is no student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -691,14 +695,14 @@ exports[`Questions component should render when there is no student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Combine the sentences. Use the joining word that best shows the relationship between the ideas.
                       </span>
@@ -708,6 +712,8 @@ exports[`Questions component should render when there is no student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -921,14 +927,14 @@ exports[`Questions component should render when there is no student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Use one of the joining words to connect the sentences. Your response may be one sentence or two.
                       </span>
@@ -938,6 +944,8 @@ exports[`Questions component should render when there is no student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -949,14 +957,14 @@ exports[`Questions component should render when there is no student data 1`] = `
                       Prompt
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Levees were built to keep New Orleans from flooding. They were not strong enough to withstand Hurricane Katrina.
                       </span>
@@ -966,6 +974,8 @@ exports[`Questions component should render when there is no student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1000,14 +1010,14 @@ exports[`Questions component should render when there is no student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Use one of the joining words to connect the ideas. Your response may be one sentence or two.
                       </span>
@@ -1017,6 +1027,8 @@ exports[`Questions component should render when there is no student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1028,14 +1040,14 @@ exports[`Questions component should render when there is no student data 1`] = `
                       Prompt
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         A cello is a large instrument with four strings. A violin has four strings that can be played by hand or with a bow.
                       </span>
@@ -1045,6 +1057,8 @@ exports[`Questions component should render when there is no student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1249,14 +1263,14 @@ exports[`Questions component should render when there is no student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Combine the sentences into one sentence that includes a list. You may change the form of the action words and remove unnecessary words.
                       </span>
@@ -1266,6 +1280,8 @@ exports[`Questions component should render when there is no student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -1494,14 +1510,14 @@ exports[`Questions component should render when there is no student data 1`] = `
                       Prompt
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         every summer, my dad teaches a biology class about sea turtles that live in the atlantic ocean.
                       </span>
@@ -1511,6 +1527,8 @@ exports[`Questions component should render when there is no student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -2796,14 +2814,14 @@ exports[`Questions component should render when there is student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Fill in the blank with the action word that matches the rest of the sentence. (Doesn't, Don't)
                       </span>
@@ -2813,6 +2831,8 @@ exports[`Questions component should render when there is student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -2863,14 +2883,14 @@ exports[`Questions component should render when there is student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Fill in the blank with the action word that matches the rest of the sentence. (Kicks, Kick)
                       </span>
@@ -2880,6 +2900,8 @@ exports[`Questions component should render when there is student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -2930,14 +2952,14 @@ exports[`Questions component should render when there is student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Fill in the blank with the action word that matches the rest of the sentence. (Are, Is)
                       </span>
@@ -2947,6 +2969,8 @@ exports[`Questions component should render when there is student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -3212,14 +3236,14 @@ exports[`Questions component should render when there is student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Choose which word fits best in each blank. You may use the same word twice. (You're, Your)
                       </span>
@@ -3229,6 +3253,8 @@ exports[`Questions component should render when there is student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -3279,14 +3305,14 @@ exports[`Questions component should render when there is student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Choose which word fits best in each blank. You may use the same word twice. (They’re, There, Their)
                       </span>
@@ -3296,6 +3322,8 @@ exports[`Questions component should render when there is student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -3518,14 +3546,14 @@ exports[`Questions component should render when there is student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Fill in the blank with the correct word or words. (More easier, More easy, Easiest, Easier)
                       </span>
@@ -3535,6 +3563,8 @@ exports[`Questions component should render when there is student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -3585,14 +3615,14 @@ exports[`Questions component should render when there is student data 1`] = `
                       Directions
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Fill in the blank with the correct word or words. (More brighter, More bright, Brightest, Brighter)
                       </span>
@@ -3602,6 +3632,8 @@ exports[`Questions component should render when there is student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -4883,14 +4915,14 @@ exports[`Questions component should render when there is student data 1`] = `
                       Prompt
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         He is going on vacation. He is going to a beach. The beach is beautiful. The beach is in San Diego.
                       </span>
@@ -4900,6 +4932,8 @@ exports[`Questions component should render when there is student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>
@@ -5220,14 +5254,14 @@ exports[`Questions component should render when there is student data 1`] = `
                       Prompt
                     </span>
                     <span
-                      aria-hidden="false"
+                      aria-expanded="false"
+                      aria-haspopup="true"
                       class="quill-tooltip-trigger "
-                      role="tooltip"
+                      role="button"
+                      tabindex="0"
                     >
                       <span
                         class="directions-or-prompt"
-                        role="button"
-                        tabindex="0"
                       >
                         Pho is a soup made with herbs. Pho is a soup made with bone broth. Pho is a soup made with noodles.
                       </span>
@@ -5237,6 +5271,8 @@ exports[`Questions component should render when there is student data 1`] = `
                         <span
                           aria-live="polite"
                           class="quill-tooltip"
+                          id="tooltip"
+                          role="tooltip"
                         />
                       </span>
                     </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/recommendationsTable.test.jsx.snap
@@ -400,21 +400,19 @@ exports[`RecommendationsTable component should render when no students have comp
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -433,6 +431,8 @@ exports[`RecommendationsTable component should render when no students have comp
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -498,21 +498,19 @@ exports[`RecommendationsTable component should render when no students have comp
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -531,6 +529,8 @@ exports[`RecommendationsTable component should render when no students have comp
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -596,21 +596,19 @@ exports[`RecommendationsTable component should render when no students have comp
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -629,6 +627,8 @@ exports[`RecommendationsTable component should render when no students have comp
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -694,21 +694,19 @@ exports[`RecommendationsTable component should render when no students have comp
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -727,6 +725,8 @@ exports[`RecommendationsTable component should render when no students have comp
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -792,21 +792,19 @@ exports[`RecommendationsTable component should render when no students have comp
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -825,6 +823,8 @@ exports[`RecommendationsTable component should render when no students have comp
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -890,21 +890,19 @@ exports[`RecommendationsTable component should render when no students have comp
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -923,6 +921,8 @@ exports[`RecommendationsTable component should render when no students have comp
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -5524,20 +5524,20 @@ exports[`RecommendationsTable component should render when no students have comp
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Gabriel De La Concordia Garcia
                           </span>
@@ -5547,6 +5547,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -8004,20 +8006,20 @@ exports[`RecommendationsTable component should render when no students have comp
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Judy Heier-hammond Name Keeps Going For A Long Long Tim
                           </span>
@@ -8027,6 +8029,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -9224,20 +9228,20 @@ exports[`RecommendationsTable component should render when no students have comp
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Dehab Lee Kassis-washington
                           </span>
@@ -9247,6 +9251,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -11497,20 +11503,20 @@ exports[`RecommendationsTable component should render when no students have comp
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Henry Wadsworth Longfellow
                           </span>
@@ -11520,6 +11526,8 @@ exports[`RecommendationsTable component should render when no students have comp
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -12264,21 +12272,19 @@ exports[`RecommendationsTable component should render when there are recommendat
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -12297,6 +12303,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -12362,21 +12370,19 @@ exports[`RecommendationsTable component should render when there are recommendat
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -12395,6 +12401,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -12460,21 +12468,19 @@ exports[`RecommendationsTable component should render when there are recommendat
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -12493,6 +12499,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -12558,21 +12566,19 @@ exports[`RecommendationsTable component should render when there are recommendat
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -12591,6 +12597,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -12656,21 +12664,19 @@ exports[`RecommendationsTable component should render when there are recommendat
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -12689,6 +12695,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -12754,21 +12762,19 @@ exports[`RecommendationsTable component should render when there are recommendat
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -12787,6 +12793,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -20916,20 +20924,20 @@ exports[`RecommendationsTable component should render when there are recommendat
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Gabriel De La Concordia Garcia
                           </span>
@@ -20939,6 +20947,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -25250,20 +25260,20 @@ exports[`RecommendationsTable component should render when there are recommendat
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Judy Heier-hammond Name Keeps Going For A Long Long Tim
                           </span>
@@ -25273,6 +25283,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -27319,20 +27331,20 @@ exports[`RecommendationsTable component should render when there are recommendat
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Dehab Lee Kassis-washington
                           </span>
@@ -27342,6 +27354,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -30996,20 +31010,20 @@ exports[`RecommendationsTable component should render when there are recommendat
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Henry Wadsworth Longfellow
                           </span>
@@ -31019,6 +31033,8 @@ exports[`RecommendationsTable component should render when there are recommendat
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -31938,21 +31954,19 @@ exports[`RecommendationsTable component should render when there is data to assi
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -31971,6 +31985,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -32036,21 +32052,19 @@ exports[`RecommendationsTable component should render when there is data to assi
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -32069,6 +32083,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -32134,21 +32150,19 @@ exports[`RecommendationsTable component should render when there is data to assi
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -32167,6 +32181,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -32232,21 +32248,19 @@ exports[`RecommendationsTable component should render when there is data to assi
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -32265,6 +32279,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -32330,21 +32346,19 @@ exports[`RecommendationsTable component should render when there is data to assi
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -32363,6 +32377,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -32428,21 +32444,19 @@ exports[`RecommendationsTable component should render when there is data to assi
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <button
                             aria-label="Select all column"
                             className="interactive-wrapper"
@@ -32461,6 +32475,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -40570,20 +40586,20 @@ exports[`RecommendationsTable component should render when there is data to assi
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Gabriel De La Concordia Garcia
                           </span>
@@ -40593,6 +40609,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -44904,20 +44922,20 @@ exports[`RecommendationsTable component should render when there is data to assi
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Judy Heier-hammond Name Keeps Going For A Long Long Tim
                           </span>
@@ -44927,6 +44945,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -46973,20 +46993,20 @@ exports[`RecommendationsTable component should render when there is data to assi
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Dehab Lee Kassis-washington
                           </span>
@@ -46996,6 +47016,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -50650,20 +50672,20 @@ exports[`RecommendationsTable component should render when there is data to assi
                         tooltipTriggerTextClass="student-name"
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
                           <span
                             className="student-name"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
                           >
                             Henry Wadsworth Longfellow
                           </span>
@@ -50673,6 +50695,8 @@ exports[`RecommendationsTable component should render when there is data to assi
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/releaseMethodModal.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/releaseMethodModal.test.jsx.snap
@@ -67,21 +67,19 @@ exports[`ReleaseMethodModal component with IMMEDIATE as the original release met
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -93,6 +91,8 @@ exports[`ReleaseMethodModal component with IMMEDIATE as the original release met
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -153,21 +153,19 @@ exports[`ReleaseMethodModal component with IMMEDIATE as the original release met
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -179,6 +177,8 @@ exports[`ReleaseMethodModal component with IMMEDIATE as the original release met
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -297,21 +297,19 @@ exports[`ReleaseMethodModal component with IMMEDIATE as the original release met
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -323,6 +321,8 @@ exports[`ReleaseMethodModal component with IMMEDIATE as the original release met
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -383,21 +383,19 @@ exports[`ReleaseMethodModal component with IMMEDIATE as the original release met
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -409,6 +407,8 @@ exports[`ReleaseMethodModal component with IMMEDIATE as the original release met
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -527,21 +527,19 @@ exports[`ReleaseMethodModal component with STAGGERED as the original release met
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -553,6 +551,8 @@ exports[`ReleaseMethodModal component with STAGGERED as the original release met
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -613,21 +613,19 @@ exports[`ReleaseMethodModal component with STAGGERED as the original release met
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -639,6 +637,8 @@ exports[`ReleaseMethodModal component with STAGGERED as the original release met
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -757,21 +757,19 @@ exports[`ReleaseMethodModal component with STAGGERED as the original release met
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -783,6 +781,8 @@ exports[`ReleaseMethodModal component with STAGGERED as the original release met
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -843,21 +843,19 @@ exports[`ReleaseMethodModal component with STAGGERED as the original release met
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -869,6 +867,8 @@ exports[`ReleaseMethodModal component with STAGGERED as the original release met
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -985,21 +985,19 @@ exports[`ReleaseMethodModal component with no original release method should ren
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -1011,6 +1009,8 @@ exports[`ReleaseMethodModal component with no original release method should ren
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1071,21 +1071,19 @@ exports[`ReleaseMethodModal component with no original release method should ren
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -1097,6 +1095,8 @@ exports[`ReleaseMethodModal component with no original release method should ren
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1212,21 +1212,19 @@ exports[`ReleaseMethodModal component with no original release method should ren
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -1238,6 +1236,8 @@ exports[`ReleaseMethodModal component with no original release method should ren
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1298,21 +1298,19 @@ exports[`ReleaseMethodModal component with no original release method should ren
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -1324,6 +1322,8 @@ exports[`ReleaseMethodModal component with no original release method should ren
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1439,21 +1439,19 @@ exports[`ReleaseMethodModal component with no original release method should ren
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -1465,6 +1463,8 @@ exports[`ReleaseMethodModal component with no original release method should ren
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>
@@ -1525,21 +1525,19 @@ exports[`ReleaseMethodModal component with no original release method should ren
                 }
               >
                 <span
-                  aria-hidden={false}
+                  aria-expanded={false}
+                  aria-haspopup="true"
                   className="quill-tooltip-trigger "
-                  role="tooltip"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <span
-                    className="undefined"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
+                  <span>
                     <img
                       alt=""
                       src="undefined/images/icons/info.svg"
@@ -1551,6 +1549,8 @@ exports[`ReleaseMethodModal component with no original release method should ren
                     <span
                       aria-live="polite"
                       className="quill-tooltip"
+                      id="tooltip"
+                      role="tooltip"
                     />
                   </span>
                 </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/results.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/results.test.jsx.snap
@@ -429,21 +429,19 @@ exports[`Results component should render when there are no results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -455,6 +453,8 @@ exports[`Results component should render when there are no results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -490,21 +490,19 @@ exports[`Results component should render when there are no results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -516,6 +514,8 @@ exports[`Results component should render when there are no results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -551,21 +551,19 @@ exports[`Results component should render when there are no results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -577,6 +575,8 @@ exports[`Results component should render when there are no results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -612,21 +612,19 @@ exports[`Results component should render when there are no results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -638,6 +636,8 @@ exports[`Results component should render when there are no results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -673,21 +673,19 @@ exports[`Results component should render when there are no results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -699,6 +697,8 @@ exports[`Results component should render when there are no results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -734,21 +734,19 @@ exports[`Results component should render when there are no results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -760,6 +758,8 @@ exports[`Results component should render when there are no results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -1909,20 +1909,20 @@ exports[`Results component should render when there are no results 1`] = `
                           tooltipTriggerTextClass="student-name"
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
                             <span
                               className="student-name"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
                             >
                               Gabriel De La Concordia Garcia
                             </span>
@@ -1932,6 +1932,8 @@ exports[`Results component should render when there are no results 1`] = `
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>
@@ -2418,20 +2420,20 @@ exports[`Results component should render when there are no results 1`] = `
                           tooltipTriggerTextClass="student-name"
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
                             <span
                               className="student-name"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
                             >
                               Dehab Lee Kassis-washington
                             </span>
@@ -2441,6 +2443,8 @@ exports[`Results component should render when there are no results 1`] = `
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>
@@ -2735,20 +2739,20 @@ exports[`Results component should render when there are no results 1`] = `
                           tooltipTriggerTextClass="student-name"
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
                             <span
                               className="student-name"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
                             >
                               Henry Wadsworth Longfellow
                             </span>
@@ -2758,6 +2762,8 @@ exports[`Results component should render when there are no results 1`] = `
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>
@@ -4012,20 +4018,20 @@ exports[`Results component should render when there are no results 1`] = `
                           tooltipTriggerTextClass="student-name"
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
                             <span
                               className="student-name"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
                             >
                               Judy Heier-hammond Name Keeps Going For A Long Long Tim
                             </span>
@@ -4035,6 +4041,8 @@ exports[`Results component should render when there are no results 1`] = `
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>
@@ -8408,21 +8416,19 @@ exports[`Results component should render when there are results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -8434,6 +8440,8 @@ exports[`Results component should render when there are results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -8479,21 +8487,19 @@ exports[`Results component should render when there are results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -8505,6 +8511,8 @@ exports[`Results component should render when there are results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -8550,21 +8558,19 @@ exports[`Results component should render when there are results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -8576,6 +8582,8 @@ exports[`Results component should render when there are results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -8621,21 +8629,19 @@ exports[`Results component should render when there are results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -8647,6 +8653,8 @@ exports[`Results component should render when there are results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -8692,21 +8700,19 @@ exports[`Results component should render when there are results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -8718,6 +8724,8 @@ exports[`Results component should render when there are results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -8763,21 +8771,19 @@ exports[`Results component should render when there are results 1`] = `
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <img
                               alt="Question mark icon"
                               src="undefined/images/icons/icons-help.svg"
@@ -8789,6 +8795,8 @@ exports[`Results component should render when there are results 1`] = `
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -24152,20 +24160,20 @@ exports[`Results component should render when there are results 1`] = `
                           tooltipTriggerTextClass="student-name"
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
                             <span
                               className="student-name"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
                             >
                               Gabriel De La Concordia Garcia
                             </span>
@@ -24175,6 +24183,8 @@ exports[`Results component should render when there are results 1`] = `
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>
@@ -26295,20 +26305,20 @@ exports[`Results component should render when there are results 1`] = `
                           tooltipTriggerTextClass="student-name"
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
                             <span
                               className="student-name"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
                             >
                               Dehab Lee Kassis-washington
                             </span>
@@ -26318,6 +26328,8 @@ exports[`Results component should render when there are results 1`] = `
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>
@@ -28292,20 +28304,20 @@ exports[`Results component should render when there are results 1`] = `
                           tooltipTriggerTextClass="student-name"
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
                             <span
                               className="student-name"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
                             >
                               Henry Wadsworth Longfellow
                             </span>
@@ -28315,6 +28327,8 @@ exports[`Results component should render when there are results 1`] = `
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>
@@ -30073,20 +30087,20 @@ exports[`Results component should render when there are results 1`] = `
                           tooltipTriggerTextClass="student-name"
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
                             <span
                               className="student-name"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
                             >
                               Judy Heier-hammond Name Keeps Going For A Long Long Tim
                             </span>
@@ -30096,6 +30110,8 @@ exports[`Results component should render when there are results 1`] = `
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/skillGroupTooltip.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/skillGroupTooltip.test.jsx.snap
@@ -16,21 +16,19 @@ exports[`SkillGroupTooltip component should render 1`] = `
     }
   >
     <span
-      aria-hidden={false}
+      aria-expanded={false}
+      aria-haspopup="true"
       className="quill-tooltip-trigger "
-      role="tooltip"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      role="button"
+      tabIndex={0}
     >
-      <span
-        className="undefined"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        role="button"
-        tabIndex={0}
-      >
+      <span>
         <img
           alt="Question mark icon"
           src="undefined/images/icons/icons-help.svg"
@@ -42,6 +40,8 @@ exports[`SkillGroupTooltip component should render 1`] = `
         <span
           aria-live="polite"
           className="quill-tooltip"
+          id="tooltip"
+          role="tooltip"
         />
       </span>
     </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentNameOrTooltip.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentNameOrTooltip.test.jsx.snap
@@ -11,20 +11,20 @@ exports[`StudentNameOrTooltip component should render if the name is long enough
     tooltipTriggerTextClass="student-name"
   >
     <span
-      aria-hidden={false}
+      aria-expanded={false}
+      aria-haspopup="true"
       className="quill-tooltip-trigger "
-      role="tooltip"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      role="button"
+      tabIndex={0}
     >
       <span
         className="student-name"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        role="button"
-        tabIndex={0}
       >
         Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia Gabriel De La Concordia Garcia
       </span>
@@ -34,6 +34,8 @@ exports[`StudentNameOrTooltip component should render if the name is long enough
         <span
           aria-live="polite"
           className="quill-tooltip"
+          id="tooltip"
+          role="tooltip"
         />
       </span>
     </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResultsTable.test.jsx.snap
@@ -127,21 +127,19 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -153,6 +151,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -188,21 +188,19 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -214,6 +212,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -249,21 +249,19 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -275,6 +273,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -310,21 +310,19 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -336,6 +334,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -371,21 +371,19 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -397,6 +395,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -432,21 +432,19 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -458,6 +456,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -493,21 +493,19 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -519,6 +517,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -554,21 +554,19 @@ exports[`StudentResultsTable component should render when there is no student da
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -580,6 +578,8 @@ exports[`StudentResultsTable component should render when there is no student da
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -1671,21 +1671,19 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -1697,6 +1695,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -1752,21 +1752,19 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -1778,6 +1776,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -1833,21 +1833,19 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -1859,6 +1857,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -1914,21 +1914,19 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -1940,6 +1938,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -1995,21 +1995,19 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -2021,6 +2019,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>
@@ -2076,21 +2076,19 @@ exports[`StudentResultsTable component should render when there is student data 
                   }
                 >
                   <span
-                    aria-hidden={false}
+                    aria-expanded={false}
+                    aria-haspopup="true"
                     className="quill-tooltip-trigger "
-                    role="tooltip"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="button"
+                    tabIndex={0}
                   >
-                    <span
-                      className="undefined"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
+                    <span>
                       <img
                         alt="Question mark icon"
                         src="undefined/images/icons/icons-help.svg"
@@ -2102,6 +2100,8 @@ exports[`StudentResultsTable component should render when there is student data 
                       <span
                         aria-live="polite"
                         className="quill-tooltip"
+                        id="tooltip"
+                        role="tooltip"
                       />
                     </span>
                   </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/__tests__/__snapshots__/student_profile_units.test.jsx.snap
@@ -648,21 +648,19 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -675,6 +673,8 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -761,21 +761,19 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -788,6 +786,8 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -874,21 +874,19 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -901,6 +899,8 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -2622,21 +2622,19 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -2649,6 +2647,8 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -2735,21 +2735,19 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -2762,6 +2760,8 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -2848,21 +2848,19 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -2875,6 +2873,8 @@ exports[`StudentProfileUnits component should not render the pinned activity mod
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -5814,21 +5814,19 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -5841,6 +5839,8 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -5927,21 +5927,19 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -5954,6 +5952,8 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -6040,21 +6040,19 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -6067,6 +6065,8 @@ exports[`StudentProfileUnits component should render only incomplete activities 
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -7996,21 +7996,19 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -8023,6 +8021,8 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -8109,21 +8109,19 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -8136,6 +8134,8 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -8222,21 +8222,19 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -8249,6 +8247,8 @@ exports[`StudentProfileUnits component should render the pinned activity bar if 
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -10178,21 +10178,19 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -10205,6 +10203,8 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -10291,21 +10291,19 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -10318,6 +10316,8 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>
@@ -10404,21 +10404,19 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                         }
                       >
                         <span
-                          aria-hidden={false}
+                          aria-expanded={false}
+                          aria-haspopup="true"
                           className="quill-tooltip-trigger "
-                          role="tooltip"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          role="button"
+                          tabIndex={0}
                         >
-                          <span
-                            className="undefined"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          >
+                          <span>
                             <span
                               className="needs-teacher"
                             >
@@ -10431,6 +10429,8 @@ exports[`StudentProfileUnits component should render the pinned activity modal i
                             <span
                               aria-live="polite"
                               className="quill-tooltip"
+                              id="tooltip"
+                              role="tooltip"
                             />
                           </span>
                         </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/subscriptions/__tests__/__snapshots__/current_subscription.test.jsx.snap
@@ -136,21 +136,19 @@ exports[`CurrentSubscription container when there is a current subscription shou
                           }
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
-                            <span
-                              className="undefined"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
-                            >
+                            <span>
                               <span>
                                 <img
                                   alt="Question mark icon"
@@ -165,6 +163,8 @@ exports[`CurrentSubscription container when there is a current subscription shou
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>
@@ -404,21 +404,19 @@ exports[`CurrentSubscription container when there is a current subscription shou
                           }
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
-                            <span
-                              className="undefined"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
-                            >
+                            <span>
                               <span>
                                 <img
                                   alt="Question mark icon"
@@ -433,6 +431,8 @@ exports[`CurrentSubscription container when there is a current subscription shou
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>
@@ -687,21 +687,19 @@ exports[`CurrentSubscription container when there is a current subscription shou
                           }
                         >
                           <span
-                            aria-hidden={false}
+                            aria-expanded={false}
+                            aria-haspopup="true"
                             className="quill-tooltip-trigger "
-                            role="tooltip"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
-                            <span
-                              className="undefined"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              role="button"
-                              tabIndex={0}
-                            >
+                            <span>
                               <span>
                                 <img
                                   alt="Question mark icon"
@@ -716,6 +714,8 @@ exports[`CurrentSubscription container when there is a current subscription shou
                               <span
                                 aria-live="polite"
                                 className="quill-tooltip"
+                                id="tooltip"
+                                role="tooltip"
                               />
                             </span>
                           </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/unitTemplate/__tests__/__snapshots__/unitTemplate.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/unitTemplate/__tests__/__snapshots__/unitTemplate.test.jsx.snap
@@ -135,15 +135,13 @@ exports[`<UnitTemplate /> matches the component snapshot 1`] = `
           for="pack-type-dropdown"
         >
           <span
-            aria-hidden="false"
+            aria-expanded="false"
+            aria-haspopup="true"
             class="quill-tooltip-trigger "
-            role="tooltip"
+            role="button"
+            tabindex="0"
           >
-            <span
-              class="undefined"
-              role="button"
-              tabindex="0"
-            >
+            <span>
               Pack Type
             </span>
             <span
@@ -152,6 +150,8 @@ exports[`<UnitTemplate /> matches the component snapshot 1`] = `
               <span
                 aria-live="polite"
                 class="quill-tooltip"
+                id="tooltip"
+                role="tooltip"
               />
             </span>
           </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/update_assigned_students/__tests__/__snapshots__/student.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/update_assigned_students/__tests__/__snapshots__/student.test.jsx.snap
@@ -158,21 +158,19 @@ exports[`Student should render when the student has been removed 1`] = `
         }
       >
         <span
-          aria-hidden={false}
+          aria-expanded={false}
+          aria-haspopup="true"
           className="quill-tooltip-trigger "
-          role="tooltip"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          role="button"
+          tabIndex={0}
         >
-          <span
-            className="undefined"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            role="button"
-            tabIndex={0}
-          >
+          <span>
             <button
               aria-label="Restore assigned pack"
               className="interactive-wrapper focus-on-light"
@@ -191,6 +189,8 @@ exports[`Student should render when the student has been removed 1`] = `
             <span
               aria-live="polite"
               className="quill-tooltip"
+              id="tooltip"
+              role="tooltip"
             />
           </span>
         </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/AdminAccess.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/AdminAccess.test.jsx.snap
@@ -169,20 +169,20 @@ exports[`AdminAccounts container when the user does not have a verified email an
             tooltipTriggerTextClass="disabled-link"
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              tabIndex={0}
             >
               <span
                 className="disabled-link"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
-                tabIndex={0}
               >
                 Contact
               </span>
@@ -192,6 +192,8 @@ exports[`AdminAccounts container when the user does not have a verified email an
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -210,20 +212,20 @@ exports[`AdminAccounts container when the user does not have a verified email an
             tooltipTriggerTextClass="disabled-link"
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              tabIndex={0}
             >
               <span
                 className="disabled-link"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
-                tabIndex={0}
               >
                 Contact
               </span>
@@ -233,6 +235,8 @@ exports[`AdminAccounts container when the user does not have a verified email an
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -438,20 +442,20 @@ exports[`AdminAccounts container when the user does not have a verified email an
             tooltipTriggerTextClass="disabled-link"
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              tabIndex={0}
             >
               <span
                 className="disabled-link"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
-                tabIndex={0}
               >
                 Contact
               </span>
@@ -461,6 +465,8 @@ exports[`AdminAccounts container when the user does not have a verified email an
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>
@@ -479,20 +485,20 @@ exports[`AdminAccounts container when the user does not have a verified email an
             tooltipTriggerTextClass="disabled-link"
           >
             <span
-              aria-hidden={false}
+              aria-expanded={false}
+              aria-haspopup="true"
               className="quill-tooltip-trigger "
-              role="tooltip"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+              tabIndex={0}
             >
               <span
                 className="disabled-link"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                role="button"
-                tabIndex={0}
               >
                 Contact
               </span>
@@ -502,6 +508,8 @@ exports[`AdminAccounts container when the user does not have a verified email an
                 <span
                   aria-live="polite"
                   className="quill-tooltip"
+                  id="tooltip"
+                  role="tooltip"
                 />
               </span>
             </span>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/Subscriptions.test.jsx.snap
@@ -245,21 +245,19 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -274,6 +272,8 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -518,21 +518,19 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -547,6 +545,8 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -958,21 +958,19 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -987,6 +985,8 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -1376,21 +1376,19 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -1405,6 +1403,8 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -1476,21 +1476,19 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -1505,6 +1503,8 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -1715,21 +1715,19 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -1744,6 +1742,8 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -2144,21 +2144,19 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -2173,6 +2171,8 @@ exports[`Subscriptions UI state iterations district paid via invoice the current
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -2562,21 +2562,19 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -2591,6 +2589,8 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -2820,21 +2820,19 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -2849,6 +2847,8 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -3258,21 +3258,19 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -3287,6 +3285,8 @@ exports[`Subscriptions UI state iterations premium credit renders when there is 
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -3676,21 +3676,19 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -3705,6 +3703,8 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -3934,21 +3934,19 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -3963,6 +3961,8 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -4372,21 +4372,19 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -4401,6 +4399,8 @@ exports[`Subscriptions UI state iterations school free renders when there is an 
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -4790,21 +4790,19 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -4819,6 +4817,8 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -5063,21 +5063,19 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -5092,6 +5090,8 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -5510,21 +5510,19 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -5539,6 +5537,8 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -5928,21 +5928,19 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -5957,6 +5955,8 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -6028,21 +6028,19 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -6057,6 +6055,8 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -6267,21 +6267,19 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -6296,6 +6294,8 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -6703,21 +6703,19 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -6732,6 +6730,8 @@ exports[`Subscriptions UI state iterations school paid via invoice the current u
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -7121,21 +7121,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -7150,6 +7148,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -7388,21 +7388,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -7417,6 +7415,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -7806,21 +7806,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -7835,6 +7833,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -8085,21 +8085,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -8114,6 +8112,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -8532,21 +8532,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -8561,6 +8559,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -8950,21 +8950,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -8979,6 +8977,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -9230,21 +9230,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -9259,6 +9257,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -9648,21 +9648,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -9677,6 +9675,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -9949,21 +9949,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -9978,6 +9976,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -10385,21 +10385,19 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -10414,6 +10412,8 @@ exports[`Subscriptions UI state iterations school paid via stripe the current us
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -10803,21 +10803,19 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -10832,6 +10830,8 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -11061,21 +11061,19 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -11090,6 +11088,8 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -11499,21 +11499,19 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -11528,6 +11526,8 @@ exports[`Subscriptions UI state iterations teacher free renders when there is an
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -11917,21 +11917,19 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -11946,6 +11944,8 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -12197,21 +12197,19 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -12226,6 +12224,8 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -12615,21 +12615,19 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -12644,6 +12642,8 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -12916,21 +12916,19 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -12945,6 +12943,8 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -13363,21 +13363,19 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -13392,6 +13390,8 @@ exports[`Subscriptions UI state iterations teacher paid renders when there is an
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -13781,21 +13781,19 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
                               }
                             >
                               <span
-                                aria-hidden={false}
+                                aria-expanded={false}
+                                aria-haspopup="true"
                                 className="quill-tooltip-trigger "
-                                role="tooltip"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
                               >
-                                <span
-                                  className="undefined"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  role="button"
-                                  tabIndex={0}
-                                >
+                                <span>
                                   <span>
                                     <img
                                       alt="Question mark icon"
@@ -13810,6 +13808,8 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
                                   <span
                                     aria-live="polite"
                                     className="quill-tooltip"
+                                    id="tooltip"
+                                    role="tooltip"
                                   />
                                 </span>
                               </span>
@@ -14039,21 +14039,19 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -14068,6 +14066,8 @@ exports[`Subscriptions UI state iterations trial renders when there is an active
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>
@@ -14477,21 +14477,19 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
                       }
                     >
                       <span
-                        aria-hidden={false}
+                        aria-expanded={false}
+                        aria-haspopup="true"
                         className="quill-tooltip-trigger "
-                        role="tooltip"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <span
-                          className="undefined"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          role="button"
-                          tabIndex={0}
-                        >
+                        <span>
                           <span>
                             <img
                               alt="Question mark icon"
@@ -14506,6 +14504,8 @@ exports[`Subscriptions UI state iterations trial renders when there is an expire
                           <span
                             aria-live="polite"
                             className="quill-tooltip"
+                            id="tooltip"
+                            role="tooltip"
                           />
                         </span>
                       </span>


### PR DESCRIPTION
## WHAT
Fix the tooltip so that it's possible to click links within the tooltip text and it's more accessible all around, and also add back some css in Evidence so the modal works.

## WHY
Jamie noticed that this wasn't working on the new course page, so I broke it out into a separate card because the file diff was so big due to all the tests.

## HOW
Update the tooltip itself so that all the `onX` handlers apply to the tooltip container, not just the tooltip trigger, so that we don't always blur when the user tries to move the mouse over the tooltip itself. Then update a big suite of tests and also the Evidence modal css, because once this was fixed it became apparent that that was also broken.

<img width="1480" alt="Screenshot 2024-07-29 at 2 10 07 PM" src="https://github.com/user-attachments/assets/aab6a4fa-7914-40e5-a9bf-2c57b0a96801">
<img width="416" alt="Screenshot 2024-07-29 at 2 10 17 PM" src="https://github.com/user-attachments/assets/0a4d9055-a7f9-4e81-8610-465429952d84">

### Screenshots
<img width="1480" alt="Screenshot 2024-07-29 at 2 10 07 PM" src="https://github.com/user-attachments/assets/91b09554-d512-4134-be40-b68ebf2c7f09">
<img width="416" alt="Screenshot 2024-07-29 at 2 10 17 PM" src="https://github.com/user-attachments/assets/24b971b2-7138-4dcb-8e7b-c24c66db651f">

### Notion Card Links
https://www.notion.so/quill/Fix-tooltip-links-9f69025c613a4f96ad2af1d49a227190?pvs=4

### What have you done to QA this feature?
Tested tooltips with links in Evidence and on a merge branch for the new content hub page, plus spot-checked various other places around the website to make sure tooltips in general haven't changed behavior.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
