### PR TITLE
fix bug with activity uid in Grammar

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -132,7 +132,7 @@ const activityUID = (): string => { return getParameterByName('uid', window.loca
 const handleGrammarSession = (session) => {
   return dispatch => {
     if (session && Object.keys(session).length > 1 && !session.error) {
-      QuestionApi.getAllForActivity(activityUID).then((allQuestions) => {
+      QuestionApi.getAllForActivity(activityUID()).then((allQuestions) => {
         if (session.currentQuestion) {
           if (!session.currentQuestion.prompt || !session.currentQuestion.answers) {
             const currentQuestion = allQuestions[session.currentQuestion.uid]


### PR DESCRIPTION
## WHAT
Fix bug where `activityUID` was getting sent as a function, not the result of that function, when sessions were resumed in Grammar.

## WHY
We want students to be able to resume their session.

## HOW
Just invoke the function.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Students-cannot-resume-Quill-Grammar-activities-6a5fbb48d3c74be99bffbf44f099333b

### What have you done to QA this feature?
Confirmed locally that resuming wasn't working before this change was made and was afterwards.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
