### PR TITLE
Update connect to pull all questions for the activity in one request …

### DIFF
--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -79,7 +79,8 @@ class Question < ApplicationRecord
 
   def as_json(options=nil)
     locale = options&.fetch(:locale, nil)
-    locale.present? ? translated_data(locale:) : data
+    json = locale.present? ? translated_data(locale:) : data
+    json.merge(question_type:)
   end
 
   def self.all_questions_json(question_type)

--- a/services/QuillLMS/client/app/bundles/Connect/actions/fillInBlank.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/fillInBlank.ts
@@ -40,24 +40,6 @@ function loadQuestion(uid) {
   }
 }
 
-function loadSpecifiedQuestions(uids) {
-  return (dispatch, getState) => {
-    const requestPromises: Promise<any>[] = [];
-    uids.forEach((uid) => {
-      requestPromises.push(QuestionApi.get(uid));
-    });
-    const allPromises = Promise.all(requestPromises);
-    const questionData = {};
-    allPromises.then((results) => {
-      results.forEach((result, index) => {
-        questionData[uids[index]] = result;
-      });
-      dispatch({ type: C.RECEIVE_FILL_IN_BLANK_QUESTIONS_DATA, data: questionData, });
-    });
-  }
-}
-
-
 function startQuestionEdit(qid) {
   return { type: C.START_FILL_IN_BLANK_QUESTION_EDIT, qid, };
 }
@@ -186,7 +168,6 @@ export default {
   startListeningToQuestions,
   loadQuestions,
   loadQuestion,
-  loadSpecifiedQuestions,
   startQuestionEdit,
   cancelQuestionEdit,
   submitQuestionEdit,

--- a/services/QuillLMS/client/app/bundles/Connect/actions/lessons.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/lessons.ts
@@ -1,13 +1,12 @@
 import { pickBy } from 'lodash';
 import { push } from 'react-router-redux';
+import { CONNECT } from '../../Shared';
+import { reloadQuestionsIfNecessary } from '../../Shared/actions/questions';
 import C from '../constants';
 import { LessonApi, TYPE_CONNECT_LESSON } from '../libs/lessons_api';
-import fillInBlankActions from './fillInBlank';
+import { FILL_IN_BLANKS_TYPE, QuestionApi, SENTENCE_COMBINING_TYPE, SENTENCE_FRAGMENTS_TYPE } from '../libs/questions_api';
 import questionActions from './questions';
-import sentenceFragmentActions from './sentenceFragments';
-import titleCardActions from './titleCards.ts';
-import { reloadQuestionsIfNecessary } from '../../Shared/actions/questions';
-import { CONNECT } from '../../Shared';
+import { CONNECT_TITLE_CARD_TYPE } from '../libs/title_cards_api';
 
 // called when the app starts. this means we immediately download all quotes, and
 // then receive all quotes again as soon as anyone changes anything.
@@ -35,28 +34,37 @@ const loadLesson = (uid) => {
   }
 }
 
+const filterQuestionType = (data, key) => {
+  return Object.fromEntries(
+    Object.entries(data).filter(([_, value]) =>
+      value['question_type'] === key
+    )
+  );
+}
+
 const loadLessonWithQuestions = (uid) => {
   return (dispatch, getState) => {
     dispatch(loadLesson(uid)).then(() => {
-      const fetchedLesson = getState().lessons.data[uid];
-      const questionTypes = ['questions', 'fillInBlank', 'titleCards', 'sentenceFragments'];
-      questionTypes.forEach((questionType) => {
-        const questionUids = fetchedLesson.questions.filter((q) => q.questionType == questionType).map((q) => q.key);
-        switch (questionType) {
-          case 'questions':
-            dispatch(questionActions.loadSpecifiedQuestions(questionUids));
-            break
-          case 'fillInBlank':
-            dispatch(fillInBlankActions.loadSpecifiedQuestions(questionUids));
-            break
-          case 'titleCards':
-            dispatch(titleCardActions.loadSpecifiedTitleCards(questionUids));
-            break
-          case 'sentenceFragments':
-            dispatch(sentenceFragmentActions.loadSpecifiedSentenceFragments(questionUids));
-        }
-      });
-    });
+      const questions = QuestionApi.getAllForActivity(uid).then((questions) => {
+        if (!questions) { return }
+        dispatch({
+          type: C.RECEIVE_QUESTIONS_DATA,
+          data: filterQuestionType(questions, SENTENCE_COMBINING_TYPE)
+        })
+        dispatch({
+          type: C.RECEIVE_FILL_IN_BLANK_QUESTIONS_DATA,
+          data: filterQuestionType(questions, FILL_IN_BLANKS_TYPE)
+        })
+        dispatch({
+          type: C.RECEIVE_SENTENCE_FRAGMENTS_DATA,
+          data: filterQuestionType(questions, SENTENCE_FRAGMENTS_TYPE)
+        })
+        dispatch({
+          type: C.RECEIVE_TITLE_CARDS_DATA,
+          data: filterQuestionType(questions, CONNECT_TITLE_CARD_TYPE)
+        })
+      })
+    })
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Connect/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/questions.ts
@@ -40,23 +40,6 @@ function loadQuestion(uid) {
   }
 }
 
-function loadSpecifiedQuestions(uids) {
-  return (dispatch, getState) => {
-    const requestPromises: Promise<any>[] = [];
-    uids.forEach((uid) => {
-      requestPromises.push(QuestionApi.get(uid));
-    });
-    const allPromises = Promise.all(requestPromises);
-    const questionData = {};
-    allPromises.then((results) => {
-      results.forEach((result, index) => {
-        questionData[uids[index]] = result;
-      });
-      dispatch({ type: C.RECEIVE_QUESTIONS_DATA, data: questionData, });
-    });
-  }
-}
-
 function startQuestionEdit(qid) {
   return { type: C.START_QUESTION_EDIT, qid, };
 }
@@ -368,7 +351,6 @@ function incrementRequestCount() {
 export default {
   startListeningToQuestions,
   loadQuestions,
-  loadSpecifiedQuestions,
   startQuestionEdit,
   cancelQuestionEdit,
   submitQuestionEdit,

--- a/services/QuillLMS/client/app/bundles/Connect/actions/sentenceFragments.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/sentenceFragments.ts
@@ -30,23 +30,6 @@ function loadSentenceFragment(uid) {
   }
 }
 
-function loadSpecifiedSentenceFragments(uids) {
-  return (dispatch, getState) => {
-    const requestPromises: Promise<any>[] = [];
-    uids.forEach((uid) => {
-      requestPromises.push(QuestionApi.get(uid));
-    });
-    const allPromises = Promise.all(requestPromises);
-    const questionData = {};
-    allPromises.then((results) => {
-      results.forEach((result, index) => {
-        questionData[uids[index]] = result;
-      });
-      dispatch({ type: C.RECEIVE_SENTENCE_FRAGMENTS_DATA, data: questionData, });
-    });
-  }
-}
-
 function startSentenceFragmentEdit(sfid) {
   return { type: C.START_SENTENCE_FRAGMENT_EDIT, sfid, };
 }
@@ -198,7 +181,6 @@ export default {
   startListeningToSentenceFragments,
   loadSentenceFragments,
   loadSentenceFragment,
-  loadSpecifiedSentenceFragments,
   startSentenceFragmentEdit,
   cancelSentenceFragmentEdit,
   submitSentenceFragmentEdit,

--- a/services/QuillLMS/client/app/bundles/Connect/actions/titleCards.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/actions/titleCards.ts
@@ -22,23 +22,6 @@ function loadTitleCards(): (any) => void {
   };
 }
 
-function loadSpecifiedTitleCards(uids) {
-  return (dispatch, getState) => {
-    const requestPromises: Promise<TitleCardProps>[] = [];
-    uids.forEach((uid) => {
-      requestPromises.push(TitleCardApi.get(CONNECT_TITLE_CARD_TYPE, uid));
-    });
-    const allPromises: Promise<TitleCardProps[]> = Promise.all(requestPromises);
-    const questionData = {};
-    allPromises.then((results) => {
-      results.forEach((result) => {
-        questionData[result.uid] = result;
-      });
-      dispatch({ type: C.RECEIVE_TITLE_CARDS_DATA, data: questionData, });
-    });
-  }
-}
-
 function submitNewTitleCard(content, response, lessonID) {
   return (dispatch) => {
     TitleCardApi.create(CONNECT_TITLE_CARD_TYPE, content).then((body) => {
@@ -81,7 +64,6 @@ function submitTitleCardEdit(uid, content) {
 export default {
   submitNewTitleCard,
   loadTitleCards,
-  loadSpecifiedTitleCards,
   startListeningToTitleCards,
   submitTitleCardEdit,
 }

--- a/services/QuillLMS/client/app/bundles/Connect/libs/questions_api.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/libs/questions_api.ts
@@ -6,10 +6,15 @@ const SENTENCE_COMBINING_TYPE = 'connect_sentence_combining',
   FILL_IN_BLANKS_TYPE = 'connect_fill_in_blanks'
 
 const questionApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/questions`;
+const activityApiBaseUrl = `${process.env.DEFAULT_URL}/api/v1/activities`;
 
 class QuestionApi {
   static getAll(questionType: string): Promise<Array<Question>> {
     return requestGet(`${questionApiBaseUrl}.json?question_type=${questionType}`, null, (error) => {throw(error)});
+  }
+
+  static getAllForActivity(activityUID: string): Promise<Array<Question>> {
+    return requestGet(`${activityApiBaseUrl}/${activityUID}/questions.json`, null, (error) => {throw(error)});
   }
 
   static get(uid: string): Promise<Question> {
@@ -89,9 +94,6 @@ export {
   FILL_IN_BLANKS_TYPE,
   FocusPointApi,
   IncorrectSequenceApi,
-  QuestionApi,
-  SENTENCE_COMBINING_TYPE,
-  SENTENCE_FRAGMENTS_TYPE,
-  questionApiBaseUrl
+  QuestionApi, questionApiBaseUrl, SENTENCE_COMBINING_TYPE,
+  SENTENCE_FRAGMENTS_TYPE
 };
-

--- a/services/QuillLMS/client/app/bundles/Connect/test/__mocks__/question_api.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/test/__mocks__/question_api.ts
@@ -1,5 +1,6 @@
 export const mockQuestionApi = {
   getAll: jest.fn().mockImplementation(() => Promise.resolve({})),
+  getAllForActivity: jest.fn().mockImplementation(() => Promise.resolve({})),
   get: jest.fn().mockImplementation(() => Promise.resolve({})),
   updateFlag: jest.fn().mockImplementation(() => Promise.resolve({})),
   create: jest.fn().mockImplementation(() => Promise.resolve({question: {}})),

--- a/services/QuillLMS/client/app/bundles/Connect/test/actions/lessons.test.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/test/actions/lessons.test.ts
@@ -63,14 +63,6 @@ describe('Lessons actions', () => {
     })
   })
 
-  describe('loadLessonsWithQuestions', () => {
-    it('should call LessonApi.get()', () => {
-      const MOCK_ID = '1'
-      dispatch(lessonActions.loadLesson(MOCK_ID))
-      expect(mockLessonApi.get).toHaveBeenLastCalledWith(MOCK_LESSON_TYPE, MOCK_ID)
-    })
-  })
-
   describe('setLessonFlag', () => {
     const expectedActions = [{
       'type': 'SET_LESSON_FLAG',

--- a/services/QuillLMS/client/app/bundles/Connect/test/actions/questions.test.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/test/actions/questions.test.ts
@@ -32,17 +32,6 @@ describe('Questions actions', () => {
     })
   })
 
-  describe('loadSpecifiedQuestions', () => {
-    it('should call QuestionApi.get()', () => {
-      const MOCK_ID1 = '1'
-      const MOCK_ID2 = '2'
-      const MOCK_IDS = [MOCK_ID1, MOCK_ID2]
-      dispatch(questionActions.loadSpecifiedQuestions(MOCK_IDS))
-      expect(mockQuestionApi.get).toHaveBeenCalledWith(MOCK_ID1)
-      expect(mockQuestionApi.get).toHaveBeenCalledWith(MOCK_ID2)
-    })
-  })
-
   describe('updateFlag', () => {
     it('should call QuestionApi.updateFlag()', () => {
       const MOCK_ID = 'id'

--- a/services/QuillLMS/client/app/bundles/Connect/test/actions/titleCards.test.ts
+++ b/services/QuillLMS/client/app/bundles/Connect/test/actions/titleCards.test.ts
@@ -30,17 +30,6 @@ describe('TitleCards actions', () => {
     })
   })
 
-  describe('loadSpecifiedTitleCards', () => {
-    it('should call TitleCardApi.get()', () => {
-      const MOCK_ID1 = '1'
-      const MOCK_ID2 = '2'
-      const MOCK_IDS = [MOCK_ID1, MOCK_ID2]
-      dispatch(titleCardActions.loadSpecifiedTitleCards(MOCK_IDS))
-      expect(mockTitleCardApi.get).toHaveBeenCalledWith(CONNECT_TITLE_CARD_TYPE, MOCK_ID1)
-      expect(mockTitleCardApi.get).toHaveBeenCalledWith(CONNECT_TITLE_CARD_TYPE, MOCK_ID2)
-    })
-  })
-
   describe('submitNewTitleCard', () => {
     it('should call TitleCardApi.create()', () => {
       const MOCK_CONTENT = { mock: 'content' }

--- a/services/QuillLMS/client/app/bundles/Grammar/libs/questions_api.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/libs/questions_api.ts
@@ -11,8 +11,8 @@ class QuestionApi {
     return requestGet(`${questionApiBaseUrl}.json?question_type=${questionType}`, null, (error) => {throw(error)});
   }
 
-  static getAllForActivity(activity_uid: string): Promise<Array<Question>> {
-    return requestGet(`${activityApiBaseUrl}/${activity_uid}/questions.json`, null, (error) => {throw(error)});
+  static getAllForActivity(activityUID: string): Promise<Array<Question>> {
+    return requestGet(`${activityApiBaseUrl}/${activityUID}/questions.json`, null, (error) => {throw(error)});
   }
 
   static get(uid: string): Promise<Question> {

--- a/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/questions_controller_spec.rb
@@ -35,7 +35,7 @@ describe Api::V1::QuestionsController, type: :controller do
 
     it 'should return the specified question' do
       get :show, params: { id: question.uid }, as: :json
-      expect(JSON.parse(response.body)).to eq(question.data)
+      expect(JSON.parse(response.body)).to eq(question.as_json.stringify_keys)
     end
 
     it 'should return a 404 if the requested Question is not found' do

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -401,8 +401,8 @@ RSpec.describe Question, type: :model do
 
     let(:options) { nil }
 
-    it 'should just be the data attribute' do
-      expect(subject).to eq(question.data)
+    it 'should just be the data attribute + the question type' do
+      expect(subject).to eq(question.data.merge({ question_type: question.question_type }))
     end
 
     context 'a locale is passed in' do
@@ -410,8 +410,12 @@ RSpec.describe Question, type: :model do
       let(:options) { { locale: } }
 
       it 'should return translated_data(locale:)' do
-        expect(question).to receive(:translated_data).with(locale:)
+        expect(question).to receive(:translated_data).with(locale:).and_return({})
         subject
+      end
+
+      it 'adds the question type' do
+        expect(subject.keys).to include(:question_type)
       end
     end
   end


### PR DESCRIPTION
… (#12160)

* Update question API to add getAll method to connect.

* Add question_type to the API

* Get all questions for an activity in one API call rather than multiple.

* Remove test that wasn’t actually testing the method it said it was

* Remove unneeded test

* Rubocop

* Remove unneeded test

* Fix spec

* Put mock question api in the right spot

* Re-order the imports

* Undo reordering imports

* Remove incorrect type annotation

---------

## WHAT

## WHY

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | (Possible answers: YES, Not yet - deploying now!, NO - non-app change, NO - tiny change)
Self-Review: Have you done an initial self-review of the code below on Github? |
