### PR TITLE
fix-concept-creation-modal-close

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/CreateConceptBox.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/CreateConceptBox.tsx
@@ -99,6 +99,7 @@ class CreateConceptBox extends React.Component<CreateConceptBoxProps, CreateConc
       changeLogs
     }})
     this.setState({ concept: { name: '', parent: {}, description: '' }})
+    this.closeChangeLogModal()
   }
 
   closeChangeLogModal = () => {


### PR DESCRIPTION
## WHAT
Actually close the ChangeLog modal after it's saved
## WHY
If it doesn't close, it's unclear to users that the action that they've requested actually completes
## HOW
Add a call to the `save` function to close the modal at the end

### Screenshots
![image](https://github.com/user-attachments/assets/ba5fb1cb-3e17-48ae-88fb-19e41652d19a)
![image](https://github.com/user-attachments/assets/ec8df435-7322-4fa4-84c7-58a0b047e7be)

### Notion Card Links
https://www.notion.so/quill/Creating-Level-1-Concept-does-not-work-staging-e73614443f55441a9c895f0fd6420cd5

### What have you done to QA this feature?
- Created a new Level 1 Concept
- Added a message in the change-log modal
- Confirmed that the change-log modal closes after saving
- Confirmed that the Concept was persisted in the database
- Confirmed that the ChangeLog persisted in the database

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, super-minor change
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
