### PR TITLE
GenAI - Add student responses to prompt builder

### DIFF
--- a/services/QuillLMS/db/migrate/20240801134426_remove_quill_feedbacks_table.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240801134426_remove_quill_feedbacks_table.evidence.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240801134328)
+class RemoveQuillFeedbacksTable < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :evidence_research_gen_ai_quill_feedbacks
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3451,41 +3451,6 @@ ALTER SEQUENCE public.evidence_research_gen_ai_prompt_template_variables_id_seq 
 
 
 --
--- Name: evidence_research_gen_ai_quill_feedbacks; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.evidence_research_gen_ai_quill_feedbacks (
-    id bigint NOT NULL,
-    student_response_id integer NOT NULL,
-    text text NOT NULL,
-    label character varying NOT NULL,
-    paraphrase text,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    data_partition character varying
-);
-
-
---
--- Name: evidence_research_gen_ai_quill_feedbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.evidence_research_gen_ai_quill_feedbacks_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: evidence_research_gen_ai_quill_feedbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.evidence_research_gen_ai_quill_feedbacks_id_seq OWNED BY public.evidence_research_gen_ai_quill_feedbacks.id;
-
-
---
 -- Name: evidence_research_gen_ai_stem_vaults; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -7052,13 +7017,6 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_template_variables ALTER
 
 
 --
--- Name: evidence_research_gen_ai_quill_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.evidence_research_gen_ai_quill_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_quill_feedbacks_id_seq'::regclass);
-
-
---
 -- Name: evidence_research_gen_ai_stem_vaults id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -8372,14 +8330,6 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_examples
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_template_variables
     ADD CONSTRAINT evidence_research_gen_ai_prompt_template_variables_pkey PRIMARY KEY (id);
-
-
---
--- Name: evidence_research_gen_ai_quill_feedbacks evidence_research_gen_ai_quill_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.evidence_research_gen_ai_quill_feedbacks
-    ADD CONSTRAINT evidence_research_gen_ai_quill_feedbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -12137,8 +12087,10 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240626193615'),
 ('20240627001654'),
 ('20240627002601'),
-('20240710195857'),
 ('20240701180742'),
+('20240710195857'),
 ('20240713144717'),
-('20240714215711');
+('20240714215711'),
+('20240801134426');
+
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
@@ -29,11 +29,9 @@ module Evidence
 
         belongs_to :activity
 
-        has_many :trials, dependent: :destroy
-        has_many :student_responses, dependent: :destroy
-        has_many :quill_feedbacks, through: :student_responses
         has_many :guidelines, dependent: :destroy
         has_many :datasets, dependent: :destroy
+        has_many :trials, through: :datasets
 
         validates :stem, presence: true
         validates :conjunction, presence: true, inclusion: { in: CONJUNCTIONS }

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
@@ -31,7 +31,9 @@ module Evidence
           'optimal_examples' => ->(builder, _) { builder.optimal_examples },
           'suboptimal_examples' => ->(builder, _) { builder.suboptimal_examples },
           'optimal_guidelines' => ->(builder, _) { builder.optimal_guidelines },
-          'suboptimal_guidelines' => ->(builder, _) { builder.suboptimal_guidelines }
+          'suboptimal_guidelines' => ->(builder, _) { builder.suboptimal_guidelines },
+          'optimal_student_responses' => ->(builder, _) { builder.optimal_student_responses },
+          'suboptimal_student_responses' => ->(builder, _) { builder.suboptimal_student_responses }
         }.freeze
 
         GENERAL_SUBSTITUTIONS = PromptTemplateVariable::NAMES.index_with do |name|
@@ -74,6 +76,9 @@ module Evidence
 
         def optimal_guidelines = guidelines.optimal.map(&:text).join("\n")
         def suboptimal_guidelines = guidelines.suboptimal.map(&:text).join("\n")
+
+        def optimal_student_responses = prompt_examples.optimal.map { |eg| "- #{eg.student_response}" }.join("\n")
+        def suboptimal_student_responses = prompt_examples.suboptimal.map { |eg| "- #{eg.student_response}" }.join("\n")
 
         def prompt_template_variable(id) = PromptTemplateVariable.find(id).value
 

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/new.html.erb
@@ -128,7 +128,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @prompt_examples.unscoped.optimal.order(:student_response).each do |prompt_example| %>
+        <% @prompt_examples.optimal.sort_by(&:student_response).each do |prompt_example| %>
           <tr>
             <td>
               <%= f.check_box :prompt_example_ids, { multiple: true }, prompt_example.id, nil %>
@@ -165,7 +165,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @prompt_examples.unscoped.suboptimal.order(:student_response).each do |prompt_example| %>
+        <% @prompt_examples.suboptimal.sort_by(&:student_response).each do |prompt_example| %>
           <tr>
             <td>
               <%= f.check_box :prompt_example_ids, { multiple: true }, prompt_example.id, nil %>

--- a/services/QuillLMS/engines/evidence/db/migrate/20240801134328_remove_quill_feedbacks_table.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240801134328_remove_quill_feedbacks_table.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveQuillFeedbacksTable < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :evidence_research_gen_ai_quill_feedbacks
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1375,41 +1375,6 @@ ALTER SEQUENCE public.evidence_research_gen_ai_prompt_template_variables_id_seq 
 
 
 --
--- Name: evidence_research_gen_ai_quill_feedbacks; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.evidence_research_gen_ai_quill_feedbacks (
-    id bigint NOT NULL,
-    student_response_id integer NOT NULL,
-    text text NOT NULL,
-    label character varying NOT NULL,
-    paraphrase text,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    data_partition character varying
-);
-
-
---
--- Name: evidence_research_gen_ai_quill_feedbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.evidence_research_gen_ai_quill_feedbacks_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: evidence_research_gen_ai_quill_feedbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.evidence_research_gen_ai_quill_feedbacks_id_seq OWNED BY public.evidence_research_gen_ai_quill_feedbacks.id;
-
-
---
 -- Name: evidence_research_gen_ai_stem_vaults; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1921,13 +1886,6 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_template_variables ALTER
 
 
 --
--- Name: evidence_research_gen_ai_quill_feedbacks id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.evidence_research_gen_ai_quill_feedbacks ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_quill_feedbacks_id_seq'::regclass);
-
-
---
 -- Name: evidence_research_gen_ai_stem_vaults id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2289,14 +2247,6 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_template_variables
 
 
 --
--- Name: evidence_research_gen_ai_quill_feedbacks evidence_research_gen_ai_quill_feedbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.evidence_research_gen_ai_quill_feedbacks
-    ADD CONSTRAINT evidence_research_gen_ai_quill_feedbacks_pkey PRIMARY KEY (id);
-
-
---
 -- Name: evidence_research_gen_ai_stem_vaults evidence_research_gen_ai_stem_vaults_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2649,6 +2599,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240627002301'),
 ('20240701180438'),
 ('20240713141016'),
-('20240714214900');
+('20240714214900'),
+('20240801134328');
 
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/stem_vault_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/stem_vault_spec.rb
@@ -31,11 +31,9 @@ module Evidence
 
         it { should belong_to(:activity) }
 
-        it { have_many(:student_responses).dependent(:destroy) }
-        it { have_many(:quill_feedbacks).through(:student_responses) }
-        it { have_many(:llm_feedbacks).through(:student_responses) }
-        it { have_many(:trials).dependent(:destroy) }
         it { have_many(:guidelines).dependent(:destroy) }
+        it { have_many(:datasets).dependent(:destroy) }
+        it { have_many(:trials).through(:datasets) }
 
         describe '#relevant_text' do
           subject { stem_vault.relevant_text }

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
@@ -108,6 +108,18 @@ module Evidence
             it { is_expected.to eq suboptimal_examples.map(&:response_feedback_status).join("\n") }
           end
 
+          context 'optimal_student_responses' do
+            let(:contents) { delimit('optimal_student_responses') }
+
+            it { is_expected.to eq optimal_examples.map(&:student_response).join("\n- ") }
+          end
+
+          context 'suboptimal_student_responses' do
+            let(:contents) { delimit('suboptimal_student_responses') }
+
+            it { is_expected.to eq suboptimal_examples.map(&:student_response).join("\n- ") }
+          end
+
           context 'multiple substitutions' do
             let(:filler) { '...some filler here...' }
             let(:contents) { "#{delimit('stem')} #{filler} #{delimit('conjunction')}" }

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/llm_prompt_builder_spec.rb
@@ -111,13 +111,13 @@ module Evidence
           context 'optimal_student_responses' do
             let(:contents) { delimit('optimal_student_responses') }
 
-            it { is_expected.to eq optimal_examples.map(&:student_response).join("\n- ") }
+            it { is_expected.to eq optimal_examples.map { |eg| "- #{eg.student_response}" }.join("\n") }
           end
 
           context 'suboptimal_student_responses' do
             let(:contents) { delimit('suboptimal_student_responses') }
 
-            it { is_expected.to eq suboptimal_examples.map(&:student_response).join("\n- ") }
+            it { is_expected.to eq suboptimal_examples.map { |eg| "- #{eg.student_response}" }.join("\n") }
           end
 
           context 'multiple substitutions' do


### PR DESCRIPTION
## WHAT
* Add a student responses substitution into LLMPromptBuilder
* Fix some stale associations
* Fix a scope on prompt examples
* Remove quill_feedbacks table

## WHY
* The construction is used Dan's System Prompts
* The associations are no longer valid due to schema reorg
* The `unscoped` was wrong
* The table is no longer used and was missed in the last schema reorg

## HOW
* Add substitution and the associated replacement method
* Remove the relevant :has_many
* Remove `.unscoped` and use `sort_by`
* Add migration to remove table

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Tested on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
