### PR TITLE
guard-proofreader-from-missing-translation-error

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/session.ts
@@ -132,7 +132,16 @@ const activityUID = (): string => { return getParameterByName('uid', window.loca
 const handleGrammarSession = (session) => {
   return dispatch => {
     if (session && Object.keys(session).length > 1 && !session.error) {
-      QuestionApi.getAllForActivity(activityUID()).then((allQuestions) => {
+
+      // activityUID will not be set in cases where a user is resuming a
+      // Proofreader activity (that feeds into a Grammar activity).  We need
+      // to provide a fallback to load all questions in these cases so that
+      // the activity will fetch data properly
+      const fetchQuestions = activityUID()
+        ? QuestionApi.getAllForActivity(activityUID())
+        : QuestionApi.getAllForType(GRAMMAR_QUESTION_TYPE);
+
+      fetchQuestions.then((allQuestions) => {
         if (session.currentQuestion) {
           if (!session.currentQuestion.prompt || !session.currentQuestion.answers) {
             const currentQuestion = allQuestions[session.currentQuestion.uid]

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/intro.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/intro.tsx
@@ -45,6 +45,10 @@ export default class Intro extends React.Component<IntroProps, IntroState> {
 
   translatedText = () => {
     const { activity, language } = this.props;
+
+    // Proofreader does not actually set the activity on props, so bail
+    if (!activity) return false
+
     const { translations, } = activity;
     return translations && translations[language];
   }


### PR DESCRIPTION
## WHAT
Add a guard clause to protect against missing activity on props
## WHY
Because Proofreader doesn't actually set this value
## HOW
Check if `activity` exists before trying to destructure it, and bail early if it isn't there

### Screenshots
![image](https://github.com/user-attachments/assets/4f6cf569-7f22-461d-9727-38f37922e4ab)

### Notion Card Links
https://www.notion.so/quill/Student-sees-a-blank-page-when-they-click-the-Resume-button-for-the-activity-The-Supremes-106e439473f643a3bdafd3c010fe6304

### What have you done to QA this feature?
- Complete a Proofreader activity on staging
- Click "Save and exit"
- Confirm that when Resuming the activity, the page crashes when trying to load the follow-up Grammar activity
- Fix code and test
- Confirm by copying `data` blob from a known erroring production `ActiveActivitySession` to staging and confirm that Resuming does not crash the follow-up activity

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, there's no test coverage of the code with the edge case
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
