### PR TITLE
add-banner-to-diagnostic-assignment-page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/__tests__/__snapshots__/assign_a_diagnostic.test.tsx.snap
@@ -71,6 +71,25 @@ exports[`AssignADiagnostic component should render AssignADiagnostic 1`] = `
       <h1>
         Which diagnostic covers the skills you want to assess?
       </h1>
+      <DisabledDiagnosticsBanner
+        className="assignment-flow"
+      >
+        <div
+          className="disabled-diagnostic-banner assignment-flow"
+        >
+          <p>
+            We've made improvements to the diagnostics for the 2024-2025 school year.
+          </p>
+          <a
+            className="focus-on-dark"
+            href="https://www.quill.org/teacher-center/important-update-to-diagnostics"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Learn more
+          </a>
+        </div>
+      </DisabledDiagnosticsBanner>
       <section
         className="filter-tabs"
       >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/assign_a_diagnostic.tsx
@@ -5,6 +5,7 @@ import AssignmentCard from './assignment_card';
 import ScrollToTop from '../../shared/scroll_to_top';
 import * as constants from '../assignmentFlowConstants';
 import AssignmentFlowNavigation from '../assignment_flow_navigation';
+import { DisabledDiagnosticsBanner } from '../../../helpers/unitTemplates';
 
 const ALL = 'All'
 const GENERAL = 'General'
@@ -130,6 +131,7 @@ const AssignADiagnostic = ({ history, assignedPreTests, }) => {
       <ScrollToTop />
       <div className="diagnostic-page container">
         <h1>Which diagnostic covers the skills you want to assess?</h1>
+        <DisabledDiagnosticsBanner className="assignment-flow" />
         <section className="filter-tabs">
           <FilterTab activeFilter={filter} filter={ALL} number={16} setFilter={setFilter} />
           <FilterTab activeFilter={filter} filter={GENERAL} number={6} setFilter={setFilter} />

--- a/services/QuillLMS/client/app/bundles/Teacher/helpers/unitTemplates.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/helpers/unitTemplates.tsx
@@ -202,3 +202,10 @@ export const renderPreviouslyAssignedActivitiesTooltipElement = (data) => {
   )
   return renderToString(table)
 }
+
+export const DisabledDiagnosticsBanner = ({ className }) => (
+  <div className={`disabled-diagnostic-banner ${className}`}>
+    <p>We've made improvements to the diagnostics for the 2024-2025 school year.</p>
+    <a className="focus-on-dark" href="https://www.quill.org/teacher-center/important-update-to-diagnostics" rel='noopener noreferrer' target="_blank">Learn more</a>
+  </div>
+)


### PR DESCRIPTION
## WHAT
Add the new Diagnostic banner back to the Assign Diagnostics page

With updated copy so that it talks about there being new diagnostics rather than new diagnostics "coming soon".
## WHY
We want to make it easy for teachers to understand what's changed from the old diagnostics
## HOW
Add back the old code that displayed the banner in the past, and update the copy the banner shows

### Screenshots
![image](https://github.com/user-attachments/assets/ce99fcb3-de22-4df5-9c37-c82d96338a5d)

### What have you done to QA this feature?
- As a teacher, go to the Assign Diagnostics page and confirm that the banner is visible
- Confirm that the "Learn more" link goes to Teacher Center post about new diagnostics

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes, snapshot updated
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes