### PR TITLE
Add underscores before unused parameters.

### DIFF
--- a/services/.rubocop_base.yml
+++ b/services/.rubocop_base.yml
@@ -274,6 +274,11 @@ Lint/UnexpectedBlockArity:
 Lint/UnmodifiedReduceAccumulator:
   Enabled: true
 
+# Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods, IgnoreNotImplementedMethods.
+Lint/UnusedMethodArgument:
+  Enabled: true
+  AllowUnusedKeywordArguments: true
+
 Lint/UriEscapeUnescape:
   Enabled: true
 

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -34,18 +34,6 @@ Lint/RedundantSafeNavigation:
     - 'app/controllers/admins_controller.rb'
     - 'engines/evidence/lib/evidence/change_log.rb'
 
-# Offense count: 70
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
-Lint/UnusedBlockArgument:
-  Enabled: false
-
-# Offense count: 42
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods, IgnoreNotImplementedMethods.
-Lint/UnusedMethodArgument:
-  Enabled: false
-
 # Offense count: 218
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Lint/UselessAssignment:

--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -33,7 +33,7 @@ class ActivitySessionsController < ApplicationController
     @classroom_id = @activity_session&.classroom_unit&.classroom_id
 
     questions = @activity_session.concept_results.group_by { |cr| cr.question_number }
-    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, @activity_session) }
+    key_target_skill_concepts = questions.map { |_key, question| get_key_target_skill_concept_for_question(question, @activity_session) }
     correct_key_target_skill_concepts = key_target_skill_concepts.filter { |ktsc| ktsc[:correct] }
 
     @number_of_questions = questions.length

--- a/services/QuillLMS/app/controllers/api/api_controller.rb
+++ b/services/QuillLMS/app/controllers/api/api_controller.rb
@@ -9,7 +9,7 @@ class Api::ApiController < ActionController::Base
 
   include NewRelicAttributable
 
-  rescue_from ActiveRecord::RecordNotFound do |e|
+  rescue_from ActiveRecord::RecordNotFound do |_e|
     not_found
   end
 

--- a/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
@@ -125,6 +125,6 @@ class Api::V1::ActivitiesController < Api::ApiController
       :uid,
       flags: [])
       .merge(data: @data)
-      .reject { |k, v| v.nil? }
+      .reject { |_k, v| v.nil? }
   end
 end

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -42,7 +42,7 @@ class ApplicationController < ActionController::Base
     render_error(status)
   end
 
-  def routing_error(error = 'Routing error', status = :not_found, exception = nil)
+  def routing_error(_error = 'Routing error', _status = :not_found, _exception = nil)
     render_error(404)
   end
 

--- a/services/QuillLMS/app/controllers/auth/clever_controller.rb
+++ b/services/QuillLMS/app/controllers/auth/clever_controller.rb
@@ -47,7 +47,7 @@ module Auth
     end
     # rubocop:enable Metrics/CyclomaticComplexity
 
-    private def user_success(user, redirect = nil)
+    private def user_success(user, _redirect = nil)
       CompleteAccountCreation.new(user, request.remote_ip).call if user.previous_changes['id']
       user.update(ip_address: request.remote_ip)
 

--- a/services/QuillLMS/app/controllers/cms/districts_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/districts_controller.rb
@@ -109,7 +109,7 @@ class Cms::DistrictsController < Cms::CmsController
     params.permit(default_params + all_search_inputs)
   end
 
-  private def district_query(params)
+  private def district_query(_params)
     page = [district_query_params[:page].to_i - 1, 0].max
     result = District.distinct.offset(DISTRICTS_PER_PAGE * page)
 

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -178,7 +178,7 @@ class Cms::SchoolsController < Cms::CmsController
     params.permit(default_params + all_search_inputs)
   end
 
-  private def school_query(params)
+  private def school_query(_params)
     # This should return an array of hashes that look like this:
     # [
     #   {

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -154,7 +154,7 @@ class Cms::UsersController < Cms::CmsController
     params.permit(@text_search_inputs.map(&:to_sym) + default_params + [:flagset, :page, :user_role, :user_flag, :sort, :sort_direction, :user_premium_status, :class_code])
   end
 
-  protected def user_query(params)
+  protected def user_query(_params)
     # This should return an array of hashes that look like this:
     # [
     #   {

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -93,7 +93,7 @@ class ProfilesController < ApplicationController
 
   private def student_score_cache_key = User.student_scores_cache_key(current_user.id, params[:classroom_id])
 
-  private def exact_scores_data_all(user, data, classroom_id)
+  private def exact_scores_data_all(user, data, _classroom_id)
     activity_sessions_grouped = student_activity_sessions_grouped(user.id, data)
 
     data.map do |user_activity|

--- a/services/QuillLMS/app/graphql/mutations/concepts/create.rb
+++ b/services/QuillLMS/app/graphql/mutations/concepts/create.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Mutations::Concepts::Create < Mutations::BaseMutation
-  def self.authorized?(value, context)
+  def self.authorized?(_value, context)
     return true if context[:current_user].staff?
 
     raise GraphQL::ExecutionError, 'Only staff can run this mutation'

--- a/services/QuillLMS/app/graphql/mutations/concepts/edit.rb
+++ b/services/QuillLMS/app/graphql/mutations/concepts/edit.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Mutations::Concepts::Edit < Mutations::BaseMutation
-  def self.authorized?(value, context)
+  def self.authorized?(_value, context)
     return true if context[:current_user].staff?
 
     raise GraphQL::ExecutionError, 'Only staff can run this mutation'
@@ -22,7 +22,7 @@ class Mutations::Concepts::Edit < Mutations::BaseMutation
 
   def resolve(inputs)
     concept = Concept.find(inputs[:id])
-    values = inputs.reject { |k, v| k == :id || k === :change_logs }
+    values = inputs.reject { |k, _v| k == :id || k === :change_logs }
     if concept.update(values)
       # Successful update, return the updated object with no errors
       change_logs = inputs[:change_logs].map do |cl|

--- a/services/QuillLMS/app/graphql/mutations/concepts/replace.rb
+++ b/services/QuillLMS/app/graphql/mutations/concepts/replace.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Mutations::Concepts::Replace < Mutations::BaseMutation
-  def self.authorized?(value, context)
+  def self.authorized?(_value, context)
     return true if context[:current_user].staff?
 
     raise GraphQL::ExecutionError, 'Only staff can run this mutation'

--- a/services/QuillLMS/app/graphql/types/query_type.rb
+++ b/services/QuillLMS/app/graphql/types/query_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Types::QueryType < Types::BaseObject
-  field :current_user, Types::UserType, null: true, resolve: ->(obj, args, ctx) { ctx[:current_user] }
+  field :current_user, Types::UserType, null: true, resolve: ->(_obj, _args, ctx) { ctx[:current_user] }
 
   field :concept, Types::ConceptType, null: true do
     argument :id, Int, 'Restrict items to this status', required: false

--- a/services/QuillLMS/app/helpers/email_api_helper.rb
+++ b/services/QuillLMS/app/helpers/email_api_helper.rb
@@ -47,7 +47,7 @@ module EmailApiHelper
     parse_comment_response(JSON.parse(response.body)) if response.is_a?(Net::HTTPSuccess)
   end
 
-  def get_intercom_data(start_time, end_time)
+  def get_intercom_data(start_time, _end_time)
     # The Intercom API has a before key to fetch all conversations before a certain time, but it does not yet
     # have support for fetching conversations closed after a certain time, so this is the most efficient way to handle this case
     # https://github.com/intercom/intercom-ruby/issues/377

--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -177,7 +177,7 @@ module QuillAuthentication
     signed_in? && current_user.role.staff?
   end
 
-  def signed_in_path source
+  def signed_in_path _source
     session[:attempted_path] || current_user.role.admin? ? cms_path : root_path
   end
 

--- a/services/QuillLMS/app/models/active_activity_session.rb
+++ b/services/QuillLMS/app/models/active_activity_session.rb
@@ -30,7 +30,7 @@ class ActiveActivitySession < ApplicationRecord
       .where('classroom_units.visible = false OR activity_sessions.completed_at IS NOT NULL')
   }
 
-  def as_json(options = nil)
+  def as_json(_options = nil)
     data
   end
 

--- a/services/QuillLMS/app/models/concept_feedback.rb
+++ b/services/QuillLMS/app/models/concept_feedback.rb
@@ -37,7 +37,7 @@ class ConceptFeedback < ApplicationRecord
 
   def cache_key = "#{ALL_CONCEPT_FEEDBACKS_KEY}_#{activity_type}"
 
-  def as_json(options = nil)
+  def as_json(_options = nil)
     data
   end
 

--- a/services/QuillLMS/app/models/concerns/lessons_recommendations.rb
+++ b/services/QuillLMS/app/models/concerns/lessons_recommendations.rb
@@ -6,7 +6,7 @@ include DiagnosticReports
 module LessonsRecommendations
   extend ActiveSupport::Concern
 
-  def get_recommended_lessons(current_user, unit_id, classroom_id, activity_id)
+  def get_recommended_lessons(_current_user, unit_id, classroom_id, activity_id)
     set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id)
     @activity_id = activity_id
     @classroom_id = classroom_id

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -122,7 +122,7 @@ module PublicProgressReports
 
       # TODO: change the diagnostic reports so they take in a hash of classrooms -- this is just
       # being converted to an array because that is what the diagnostic reports expect
-      h.map { |k, v| v }
+      h.map { |_k, v| v }
     else
       []
     end
@@ -249,7 +249,7 @@ module PublicProgressReports
   def format_activity_session_for_tooltip(activity_session, user)
     questions = activity_session.concept_results.group_by { |cr| cr.question_number }
 
-    key_target_skill_concepts = questions.map { |key, question| get_key_target_skill_concept_for_question(question, activity_session) }
+    key_target_skill_concepts = questions.map { |_key, question| get_key_target_skill_concept_for_question(question, activity_session) }
 
     correct_key_target_skill_concepts = key_target_skill_concepts.filter { |ktsc| ktsc[:correct] }
 
@@ -270,7 +270,7 @@ module PublicProgressReports
   def format_grouped_key_target_skill_concepts(key_target_skill_concepts)
     key_target_skill_concepts
       .group_by { |ktsc| ktsc[:name] }
-      .map do |key, key_target_skill_group|
+      .map do |_key, key_target_skill_group|
         {
           name: key_target_skill_group.first[:name],
           correct: key_target_skill_group.filter { |ktsc| ktsc[:correct] }.length,
@@ -288,7 +288,7 @@ module PublicProgressReports
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def format_concept_results(activity_session, concept_results)
-    concept_results.group_by { |cr| cr.question_number }.map { |key, cr|
+    concept_results.group_by { |cr| cr.question_number }.map { |_key, cr|
       # if we don't sort them, we can't rely on the first result being the first attemptNum
       # however, it would be more efficient to make them a hash with attempt numbers as keys
       cr.sort! { |x, y| (x.attempt_number || 0) <=> (y.attempt_number || 0) }
@@ -371,7 +371,7 @@ module PublicProgressReports
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  def generate_recommendations_for_classroom(current_user, unit_id, classroom_id, activity_id)
+  def generate_recommendations_for_classroom(_current_user, unit_id, classroom_id, activity_id)
     set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id)
     diagnostic = Activity.find(activity_id)
     activity_sessions_counted = activity_sessions_with_counted_concepts(@activity_sessions)

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -674,7 +674,7 @@ module Teacher
     credit_transactions.sum(:amount)
   end
 
-  def teaches_student?(student_id)
+  def teaches_student?(_student_id)
     RawSqlRunner.execute(
       <<-SQL
         SELECT 1

--- a/services/QuillLMS/app/models/csv_exporter/activity_session.rb
+++ b/services/QuillLMS/app/models/csv_exporter/activity_session.rb
@@ -18,7 +18,7 @@ module CsvExporter
       ]
     end
 
-    def data_row(record, filters)
+    def data_row(record, _filters)
       json_hash = ProgressReports::ActivitySessionSerializer.new(record).as_json(root: false)
       # Student, Date, Activity, Score, Standard, App
       [

--- a/services/QuillLMS/app/models/csv_exporter/standards/classroom.rb
+++ b/services/QuillLMS/app/models/csv_exporter/standards/classroom.rb
@@ -15,7 +15,7 @@ module CsvExporter::Standards
       ]
     end
 
-    def data_row(record, filters)
+    def data_row(record, _filters)
       json_hash = ProgressReports::Standards::ClassroomSerializer.new(record).as_json(root: false)
       [
         PAGE_TITLE,

--- a/services/QuillLMS/app/models/plan.rb
+++ b/services/QuillLMS/app/models/plan.rb
@@ -49,7 +49,7 @@ class Plan < ApplicationRecord
   validates :interval, presence: true, inclusion: { in: INTERVAL_TYPES }
   validates :interval_count, numericality: { greater_than_or_equal_to: 0 }
 
-  before_destroy { |record| raise ActiveRecord::ReadOnlyRecord }
+  before_destroy { |_record| raise ActiveRecord::ReadOnlyRecord }
 
   def self.find_stripe_plan!(stripe_price_id)
     find_by!(name: STRIPE_PRICE_ID_TO_NAME[stripe_price_id])

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -240,7 +240,7 @@ class Question < ApplicationRecord
 
     case sequences
     when Hash
-      sequences.each { |key, value| validate_text_and_feedback(value) }
+      sequences.each { |_key, value| validate_text_and_feedback(value) }
     when Array
       sequences.each { |value| validate_text_feedback_and_uid(value) }
     end

--- a/services/QuillLMS/app/pusher_modules/pusher_recommendation_completed.rb
+++ b/services/QuillLMS/app/pusher_modules/pusher_recommendation_completed.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PusherRecommendationCompleted
-  def self.run(classroom, unit_template_id, lesson)
+  def self.run(classroom, _unit_template_id, lesson)
     pusher_client = Pusher::Client.new(
       app_id: ENV['PUSHER_APP_ID'],
       key: ENV['PUSHER_KEY'],

--- a/services/QuillLMS/app/queries/profile/query.rb
+++ b/services/QuillLMS/app/queries/profile/query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Profile::Query
-  def query(student, batch_size, offset, classroom_id)
+  def query(student, _batch_size, _offset, classroom_id)
     student.activity_sessions
       .joins(:activityactivity)
       .joins(:classroom_unit)

--- a/services/QuillLMS/app/queries/scorebook/query.rb
+++ b/services/QuillLMS/app/queries/scorebook/query.rb
@@ -2,7 +2,7 @@
 
 # SUM(CASE WHEN acts.is_final_score = true THEN acts.id ELSE 0 END) AS act_id
 class Scorebook::Query
-  def self.run(classroom_id, current_page = 1, unit_id = nil, begin_date = nil, end_date = nil, utc_offset = 0)
+  def self.run(classroom_id, _current_page = 1, unit_id = nil, begin_date = nil, end_date = nil, utc_offset = 0)
     first_unit = units(unit_id) ? units(unit_id).first : nil
     last_unit = units(unit_id) ? units(unit_id).last : nil
     user_timezone_offset = "+ INTERVAL '#{utc_offset}' SECOND"

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -15,7 +15,7 @@ module Analytics
 
       self.backend ||= Segment::Analytics.new(
         write_key: Analytics::SegmentIo.configuration.write_key,
-        on_error: proc { |status, msg| print msg }
+        on_error: proc { |_status, msg| print msg }
       )
     end
 

--- a/services/QuillLMS/app/services/learn_worlds_integration/sync_orchestrator.rb
+++ b/services/QuillLMS/app/services/learn_worlds_integration/sync_orchestrator.rb
@@ -32,7 +32,7 @@ module LearnWorldsIntegration
       end
     end
 
-    def enqueue_jobs(users, worker, &block)
+    def enqueue_jobs(users, worker)
       users.each_with_index do |user, idx|
         worker.perform_in((counter + (idx * SMEAR_RATE_IN_SECONDS)).seconds, *yield(user))
       end

--- a/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
+++ b/services/QuillLMS/app/services/unit_template_pseudo_serializer.rb
@@ -3,7 +3,7 @@
 class UnitTemplatePseudoSerializer
   # attributes :id, :name, :time, :grades, :order_number, :number_of_standards, :activity_info, :unit_template_category, :activities, :standards, :readability, :activities_recommended_by
 
-  def initialize(unit_template, flag = nil)
+  def initialize(unit_template, _flag = nil)
     @unit_template = unit_template
   end
 

--- a/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
@@ -50,7 +50,7 @@ class ConceptReplacementConnectWorker
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def replace_focus_points_for_question(fp_obj, original_concept_uid, new_concept_uid)
-    return if fp_obj.none? { |k, v| v['conceptResults'] && v['conceptResults'].any? { |crk, crv| crv['conceptUID'] == original_concept_uid } }
+    return if fp_obj.none? { |_k, v| v['conceptResults'] && v['conceptResults'].any? { |_crk, crv| crv['conceptUID'] == original_concept_uid } }
 
     new_fp_obj = fp_obj.deep_dup
     begin
@@ -77,7 +77,7 @@ class ConceptReplacementConnectWorker
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def replace_incorrect_sequences_for_question(is_array, original_concept_uid, new_concept_uid)
-    return if is_array.none? { |is| is['conceptResults'] && is['conceptResults'].any? { |crk, crv| crv['conceptUID'] == original_concept_uid } }
+    return if is_array.none? { |is| is['conceptResults'] && is['conceptResults'].any? { |_crk, crv| crv['conceptUID'] == original_concept_uid } }
 
     new_is_array = is_array.deep_dup
 

--- a/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
@@ -50,7 +50,7 @@ class ConceptReplacementGrammarWorker
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def replace_focus_points_or_incorrect_sequences_for_question(fp_or_is, original_concept_uid, new_concept_uid)
-    return unless fp_or_is.any? { |k, v| v['conceptResults'] && v['conceptResults'].any? { |crk, crv| crv['conceptUID'] == original_concept_uid } }
+    return unless fp_or_is.any? { |_k, v| v['conceptResults'] && v['conceptResults'].any? { |_crk, crv| crv['conceptUID'] == original_concept_uid } }
 
     new_fp_or_is = fp_or_is.deep_dup
     begin

--- a/services/QuillLMS/app/workers/premium_analytics_worker.rb
+++ b/services/QuillLMS/app/workers/premium_analytics_worker.rb
@@ -4,7 +4,7 @@ class PremiumAnalyticsWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 
-  def perform(id, account_type)
+  def perform(id, _account_type)
     @user = User.find_by_id(id)
     return unless @user
 

--- a/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_premium_reports_worker.rb
@@ -8,7 +8,7 @@ module Snapshots
 
     QUERIES = ::Snapshots::PREMIUM_REPORTS_QUERY_MAPPING
 
-    def perform(cache_key, query, user_id, timeframe, school_ids, filters, previous_timeframe)
+    def perform(cache_key, query, user_id, timeframe, school_ids, filters, _previous_timeframe)
       user = User.find(user_id)
       payload = generate_payload(query, timeframe, school_ids, user, filters)
       Rails.cache.write(cache_key, payload.to_a, expires_in: cache_expiry)

--- a/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
+++ b/services/QuillLMS/app/workers/snapshots/cache_snapshot_top_x_worker.rb
@@ -18,7 +18,7 @@ module Snapshots
     QUERIES = ::Snapshots::TOPX_QUERY_MAPPING
 
     # previous_timeframe param here is not used, but is included to enforce parity with the CacheSnapshotCountWorker signature
-    def perform(cache_key, query, user_id, timeframe, school_ids, filters, previous_timeframe)
+    def perform(cache_key, query, user_id, timeframe, school_ids, filters, _previous_timeframe)
       payload = generate_payload(query, timeframe, school_ids, filters)
 
       Rails.cache.write(cache_key, payload.to_a, expires_in: cache_expiry)

--- a/services/QuillLMS/app/workers/student_joined_classroom_worker.rb
+++ b/services/QuillLMS/app/workers/student_joined_classroom_worker.rb
@@ -3,7 +3,7 @@
 class StudentJoinedClassroomWorker
   include Sidekiq::Worker
 
-  def perform(teacher_id, student_id)
+  def perform(teacher_id, _student_id)
     teacher = User.find_by(id: teacher_id)
 
     # do in following order so we identify the teacher last

--- a/services/QuillLMS/config/initializers/rack_attack.rb
+++ b/services/QuillLMS/config/initializers/rack_attack.rb
@@ -30,7 +30,7 @@ class Rack::Attack
       req.path.match?(BLOCKLIST_REGEX)
   end
 
-  Rack::Attack.throttled_response = lambda do |request|
+  Rack::Attack.throttled_response = lambda do |_request|
     # NB: you have access to the name and other data about the matched throttle
     #  request.env['rack.attack.matched'],
     #  request.env['rack.attack.match_type'],
@@ -39,7 +39,7 @@ class Rack::Attack
     THROTTLE_RESPONSE
   end
 
-  Rack::Attack.blocklisted_response = lambda do |request|
+  Rack::Attack.blocklisted_response = lambda do |_request|
     BLOCKLIST_RESPONSE
   end
 end

--- a/services/QuillLMS/config/initializers/rails_admin.rb
+++ b/services/QuillLMS/config/initializers/rails_admin.rb
@@ -5,7 +5,7 @@ RailsAdmin.config do |config|
 
   config.asset_source = :sprockets
 
-  config.authorize_with do |controller|
+  config.authorize_with do |_controller|
     current_user = User.find_by(id: session[:user_id])
     redirect_to main_app.root_path unless current_user&.staff?
   end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -374,7 +374,7 @@ EmpiricalGrammar::Application.routes.draw do
         get :archived_classroom_manager_data, controller: 'classroom_manager', action: 'archived_classroom_manager_data'
         get :manage_archived_classrooms, controller: 'classroom_manager', action: 'manage_archived_classrooms'
         get :lesson_planner, controller: 'classroom_manager', action: 'lesson_planner', path: 'activity_planner'
-        get 'lesson_planner', to: redirect { |params, request|
+        get 'lesson_planner', to: redirect { |_params, request|
           "#{Rails.application.routes.url_helpers.lesson_planner_teachers_classrooms_path}?#{request.params.to_query}"
         }
         post :lesson_planner, controller: 'classroom_manager', action: 'lesson_planner'

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/llm_prompt_builder.rb
@@ -34,7 +34,7 @@ module Evidence
           'suboptimal_guidelines' => ->(builder, _) { builder.suboptimal_guidelines }
         }.freeze
 
-        GENERAL_SUBSTITUTIONS = PromptTemplateVariable::NAMES.index_with do |name|
+        GENERAL_SUBSTITUTIONS = PromptTemplateVariable::NAMES.index_with do |_name|
           ->(builder, id) { builder.prompt_template_variable(id) }
         end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/grammar/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/grammar/client.rb
@@ -25,7 +25,7 @@ module Evidence
           raise APIError, "Encountered upstream error: #{response}"
         end
 
-        response.filter { |k, v| ALLOWED_PAYLOAD_KEYS.include?(k) }
+        response.filter { |k, _v| ALLOWED_PAYLOAD_KEYS.include?(k) }
       end
 
       private def api_request

--- a/services/QuillLMS/engines/evidence/lib/evidence/opinion/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/opinion/client.rb
@@ -22,7 +22,7 @@ module Evidence
           raise APIError, "Encountered upstream error: #{response}"
         end
 
-        response.filter { |k, v| ALLOWED_PAYLOAD_KEYS.include?(k) }
+        response.filter { |k, _v| ALLOWED_PAYLOAD_KEYS.include?(k) }
       end
 
       private def api_request_with_retry

--- a/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
@@ -174,7 +174,7 @@ module Evidence
       end_index = start_index + matched_slice.size - 1
       extra_space_indexes.each { |i| end_index += 1 if i > start_index && i <= end_index }
 
-      char_positions = text.enum_for(:scan, /[A-Za-z0-9\s]/).map { |c| Regexp.last_match.begin(0) }
+      char_positions = text.enum_for(:scan, /[A-Za-z0-9\s]/).map { |_c| Regexp.last_match.begin(0) }
       text[char_positions[start_index]..char_positions[end_index]]
     end
     # rubocop:enable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/engines/evidence/lib/evidence/prefilter_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/prefilter_check.rb
@@ -19,7 +19,7 @@ module Evidence
       @prefilters = {
         QUESTION_MARK_RULE_UID => ->(the_entry) { the_entry.match?(/\?$/) },
         MULTIPLE_SENTENCE_RULE_UID => ->(the_entry) { PrefilterCheck.sentence_count(the_entry) > 1 },
-        PROFANITY_RULE_UID => ->(the_entry) { profanity? },
+        PROFANITY_RULE_UID => ->(_the_entry) { profanity? },
         MINIMUM_WORD_RULE_UID => ->(the_entry) { PrefilterCheck.word_count(the_entry) < MINIMUM_WORD_COUNT }
       }
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/synthetic/generators/base.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/synthetic/generators/base.rb
@@ -9,7 +9,7 @@ module Evidence
         attr_reader :results_hash
 
         # takes an array of unique strings, e.g. ['original string', 'sample 2']
-        def initialize(string_array, options = {})
+        def initialize(string_array, _options = {})
           @results_hash = string_array.to_h { |string| [string, []] }
         end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/synthetic/labeled_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/synthetic/labeled_data_generator.rb
@@ -100,7 +100,7 @@ module Evidence
       # generated
       # {'their originial response' => [Generated(spelling)]}
       def run_generators(generator_hash, results_set)
-        generator_hash.each do |type, generator|
+        generator_hash.each do |_type, generator|
           results_hash = generator.run(results_set.map(&:text), passage: passage)
 
           results_set.each do |result|

--- a/services/QuillLMS/engines/evidence/lib/tasks/migrate_plagiarism.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/migrate_plagiarism.rake
@@ -3,7 +3,7 @@
 namespace :plagiarism do
   desc 'Migrates old plagiarism from fields on Prompt to new models PlagiarismText and Feedback'
 
-  task :migrate => :environment do |t, args|
+  task :migrate => :environment do |_t, _args|
     CONCEPT_ID = 863
     concept = Concept.find(CONCEPT_ID)
     ActiveRecord::Base.transaction do

--- a/services/QuillLMS/engines/evidence/lib/tasks/plagiarized_responses.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/plagiarized_responses.rake
@@ -5,7 +5,7 @@ require 'csv'
 namespace :plagiarized_responses do
   desc 'Reads a csv of responses and returns a csv with plagiarized responses filtered out'
 
-  task :filter, [:passage, :responses] => :environment do |t, args|
+  task :filter, [:passage, :responses] => :environment do |_t, args|
     passage_file_path = args[:passage]
     response_csv = args[:responses]
 
@@ -42,7 +42,7 @@ namespace :plagiarized_responses do
   # JOIN comprehension_plagiarism_texts
   #     ON comprehension_prompts_rules.rule_id = comprehension_plagiarism_texts.rule_id
 
-  task :test, [:input_csv_path] => :environment do |t, args|
+  task :test, [:input_csv_path] => :environment do |_t, args|
     # Derived from lib/evidence/evidence/plagiarism_check.rb 'match_entry_on_passage'
     def minimum_edit_distance_per_slice(entry, plagiarism_text)
       match_minimum = 10

--- a/services/QuillLMS/engines/evidence/lib/tasks/quill_scaffold.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/quill_scaffold.rake
@@ -3,7 +3,7 @@
 namespace :quill_scaffold do
   desc "Generate a scaffold resource, uses syntax following rails scaffold generator passed in as the arg, e.g.o: bundle exec rake quill_scaffold:generate['FakeModel name:string level:integer activity:references']"
 
-  task :generate, [:options] do |t, args|
+  task :generate, [:options] do |_t, args|
     system("rails g quill_scaffold #{args[:options]} --force")
     system("rails g factory_bot:model #{args[:options]} --force")
     system("rails g quill_scaffold_controller #{args[:options]} --force")

--- a/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/synthetic.rake
@@ -10,7 +10,7 @@ namespace :synthetic do
   # Some conjunctions (NB: don't leave spaces after commas)
   # Run: bundle exec rake synthetic:generate_seed_data\[262,1,'but','so'\]
   desc 'generate seed data to local files'
-  task :generate_seed_data, [:activity_id, :run_number] => :environment do |t, args|
+  task :generate_seed_data, [:activity_id, :run_number] => :environment do |_t, args|
     activity_id = args[:activity_id]
     run_number = args[:run_number]
     conjunctions = args.extras.presence || Evidence::Synthetic::SeedDataGenerator::CONJUNCTIONS
@@ -33,7 +33,7 @@ namespace :synthetic do
 
   # Run: bundle exec rake synthetic:generate_labeled_data\['/Users/danieldrabik/Dropbox/quill/synthetic_surge_sample.csv',133, 1\]
   desc 'generate labeled data from a local file'
-  task :generate_labeled_data, [:filepath, :prompt_id, :run_number] => :environment do |t, args|
+  task :generate_labeled_data, [:filepath, :prompt_id, :run_number] => :environment do |_t, args|
     filepath = args[:filepath]
     prompt_id = args[:prompt_id]
     run_number = args[:run_number]

--- a/services/QuillLMS/lib/eg_form_builder.rb
+++ b/services/QuillLMS/lib/eg_form_builder.rb
@@ -63,23 +63,23 @@ class EgFormBuilder < CMS::FormBuilder
     text(name, options.merge(label: options[:label], append: counter))
   end
 
-  def boolean(*args, **options)
+  def boolean(*args, **_options)
     field :boolean, *_apply_default_options(args, label_first: false)
   end
 
-  def string(*args, **options)
+  def string(*args, **_options)
     field :string, *args
   end
 
-  def search(*args, **options)
+  def search(*args, **_options)
     field :search, *args
   end
 
-  def text(*args, **options)
+  def text(*args, **_options)
     field :text, *args
   end
 
-  def email(*args, **options)
+  def email(*args, **_options)
     field :email, *args
   end
 
@@ -87,7 +87,7 @@ class EgFormBuilder < CMS::FormBuilder
     field :password, *args, **options
   end
 
-  def hidden(*args, **options)
+  def hidden(*args, **_options)
     field :hidden, *_apply_default_options(args, label: false, wrap_field: false)
   end
 
@@ -158,7 +158,7 @@ class EgFormBuilder < CMS::FormBuilder
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  def field(*args, **kwargs, &block)
+  def field(*args, **_kwargs)
     type, name, options = _extract_field_args(args)
     out = ''.html_safe
 

--- a/services/QuillLMS/lib/tasks/app_settings.rake
+++ b/services/QuillLMS/lib/tasks/app_settings.rake
@@ -5,7 +5,7 @@ namespace :app_settings do
   # Example usage: rake 'app_settings:create[theName,true,true,50,[]]'
   # To pass user_ids to the allow list, separate ids with spaces instead of commas
   # Example usage: rake 'app_settings:create[theName,true,true,50,[1 5]]'
-  task :create, [:name, :enabled, :enabled_for_staff, :percent_active, :user_ids_allow_list] => :environment do |t, args|
+  task :create, [:name, :enabled, :enabled_for_staff, :percent_active, :user_ids_allow_list] => :environment do |_t, args|
     app_setting = AppSetting.create!(
       name: args[:name],
       enabled: args[:enabled],
@@ -18,7 +18,7 @@ namespace :app_settings do
 
   desc 'Updates user allow list for existing AppSetting from a CSV file.'
   # Example usage: rake 'app_settings:update_user_ids_allow_list_from_csv[theName, filename]'
-  task :update_user_ids_allow_list_from_csv, [:name, :filename] => :environment do |t, args|
+  task :update_user_ids_allow_list_from_csv, [:name, :filename] => :environment do |_t, args|
     iostream = File.read(args[:filename])
     if (CSV.parse(iostream, headers: true).headers & ['email', 'flag']).count != 2
       puts 'Invalid headers. Exiting.'
@@ -43,7 +43,7 @@ namespace :app_settings do
 
   # Example usage: rake 'remove_user_ids_from_allow_list[theName, filename]'
   # This task uses ids instead of emails, since some users do not have emails
-  task :remove_user_ids_from_allow_list, [:name, :filename] => :environment do |t, args|
+  task :remove_user_ids_from_allow_list, [:name, :filename] => :environment do |_t, args|
     iostream = File.read(args[:filename])
     if (CSV.parse(iostream, headers: true).headers & ['id']).count != 1
       puts 'Invalid headers. Exiting.'

--- a/services/QuillLMS/lib/tasks/backfill.rake
+++ b/services/QuillLMS/lib/tasks/backfill.rake
@@ -3,7 +3,7 @@
 namespace :backfill do
   # rake 'backfill:updated_at[ClassroomUnit "2020-01-01"]'
   desc 'backfills updated_at so null values do not exist'
-  task :updated_at, [:klass, :fill_datetime] => :environment do |t, args|
+  task :updated_at, [:klass, :fill_datetime] => :environment do |_t, args|
     klass = args[:klass].constantize
     fallback_fill_datetime = DateTime.new(2018, 4, 1)
 

--- a/services/QuillLMS/lib/tasks/classrooms.rake
+++ b/services/QuillLMS/lib/tasks/classrooms.rake
@@ -4,7 +4,7 @@ require_relative './progress_bar'
 
 namespace :classrooms do
   desc 'Purge activity history for a specified list of classroom ids'
-  task :purge_histories, [:classroom_ids] => :environment do |t, args|
+  task :purge_histories, [:classroom_ids] => :environment do |_t, args|
     classroom_ids = args[:classroom_ids].split
 
     classroom_units = ClassroomUnit.where(classroom_id: classroom_ids)

--- a/services/QuillLMS/lib/tasks/flags.rake
+++ b/services/QuillLMS/lib/tasks/flags.rake
@@ -39,7 +39,7 @@ namespace :flags do
     end
 
     desc 'Update User.flags from a CSV file'
-    task :update_from_csv, [:filepath] => :environment do |t, args|
+    task :update_from_csv, [:filepath] => :environment do |_t, args|
       iostream = File.read(args[:filepath])
       if (CSV.parse(iostream, headers: true).headers & ['email', 'flag']).count != 2
         puts 'Invalid headers. Exiting.'
@@ -61,7 +61,7 @@ namespace :flags do
     end
 
     desc 'remove specified flag for users from a CSV file'
-    task :remove_from_csv, [:filepath, :flag_name] => :environment do |t, args|
+    task :remove_from_csv, [:filepath, :flag_name] => :environment do |_t, args|
       iostream = File.read(args[:filepath])
       if (CSV.parse(iostream, headers: true).headers & ['id']).count != 1
         puts 'Invalid headers. Exiting.'

--- a/services/QuillLMS/lib/tasks/flagsets.rake
+++ b/services/QuillLMS/lib/tasks/flagsets.rake
@@ -6,7 +6,7 @@ namespace :flagsets do
   namespace :users do
     # Example usage: rake 'flagsets:users:update_flagsets_from_csv[filepath, flagset]'
     desc 'Add flagsets to users from csv'
-    task :update_flagsets_from_csv, [:filepath, :flagset] => :environment do |t, args|
+    task :update_flagsets_from_csv, [:filepath, :flagset] => :environment do |_t, args|
       iostream = File.read(args[:filepath])
       if (CSV.parse(iostream, headers: true).headers & ['email', 'flagset']).count != 2
         puts 'Invalid headers. Exiting.'

--- a/services/QuillLMS/lib/tasks/import_comprehension.rake
+++ b/services/QuillLMS/lib/tasks/import_comprehension.rake
@@ -6,7 +6,7 @@ require 'evidence'
 namespace :import_comprehension do
   desc 'Import records from existing Comprehension API with the base URL of the Comprehension API you want to import from as the arg: `rake import_comprehension:activities[https://comprehension-247816.appspot.com]`'
 
-  task :activities, [:options] => :environment do |t, args|
+  task :activities, [:options] => :environment do |_t, args|
     base_url = args[:options]
     activities_list_url = "#{base_url}/api/activities.json"
     response = HTTParty.get(activities_list_url)

--- a/services/QuillLMS/lib/tasks/is_final_score.rake
+++ b/services/QuillLMS/lib/tasks/is_final_score.rake
@@ -6,7 +6,7 @@ namespace :activity_sessions do
     User.find_each do |user|
       a = user.activity_sessions.where('completed_at IS NOT NULL and percentage IS NOT NULL').group_by(&:activity_id)
 
-      a.each do |aid, ass|
+      a.each do |_aid, ass|
         x1 = ass.max_by { |x| x.percentage }
         x1.update_columns is_final_score: true
 

--- a/services/QuillLMS/lib/tasks/nces_sync.rake
+++ b/services/QuillLMS/lib/tasks/nces_sync.rake
@@ -6,7 +6,7 @@ namespace :nces_sync do
   # Every year we need to run a fresh update of our data with NCES data.
 
   desc 'update the Districts table with data from Urban Institute database and a year, e.g. bundle exec rake nces_sync:import_districts_from_urban_institute[2022]'
-  task :import_districts_from_urban_institute, [:year] => :environment do |t, args|
+  task :import_districts_from_urban_institute, [:year] => :environment do |_t, args|
     SyncDistrictDataFromUrlWorker.perform_async("https://educationdata.urban.org/api/v1/school-districts/ccd/directory/#{args[:year]}/")
   end
 
@@ -14,7 +14,7 @@ namespace :nces_sync do
   # that don't exist in our DB yet.
 
   desc 'update the Schools table with data from Urban Institute database and a year, e.g. bundle exec rake nces_sync:import_schools_from_urban_institute[2022]'
-  task :import_schools_from_urban_institute, [:year] => [:environment] do |t, args|
+  task :import_schools_from_urban_institute, [:year] => [:environment] do |_t, args|
     SyncSchoolDataFromUrlWorker.perform_async("https://educationdata.urban.org/api/v1/schools/ccd/directory/#{args[:year]}/")
   end
 end

--- a/services/QuillLMS/lib/tasks/prefilter_data.rake
+++ b/services/QuillLMS/lib/tasks/prefilter_data.rake
@@ -2,7 +2,7 @@
 
 namespace :data do
   desc 'Add prefilter rules and feedbacks'
-  task :prefilter => :environment do |t, args|
+  task :prefilter => :environment do |_t, _args|
     TOO_SHORT_FEEDBACK = 'Whoops, it looks like you submitted your response before it was ready! Re-read what you wrote and finish the sentence provided.'
     PROFANITY_FEEDBACK = 'Revise your work. When writing your response, make sure to use appropriate language.'
     MULTIPLE_SENTENCES_FEEDBACK = 'Revise your work. Your response should be only one sentence long.'

--- a/services/QuillLMS/lib/tasks/report_demo.rake
+++ b/services/QuillLMS/lib/tasks/report_demo.rake
@@ -2,7 +2,7 @@
 
 namespace :report_demo do
   desc 'make report demo accounts'
-  task :create, [:name] => :environment do |t, args|
+  task :create, [:name] => :environment do |_t, args|
     # call this with no arguments if you want quill.org/demo to be created. otherwise
     # to use this call rake report_demo:create["firstname lastname"]
     name = args[:name] ? args[:name].to_s : nil

--- a/services/QuillLMS/lib/tasks/reports.rake
+++ b/services/QuillLMS/lib/tasks/reports.rake
@@ -6,7 +6,7 @@ namespace :reports do
   # Example invocation:
   #   rake 'reports:diagnostic_scores_by_school_and_class[1 2]'
   desc 'Diagnostic scores by school and class'
-  task :diagnostic_scores_by_school_and_class, [:space_separated_school_ids, :space_separated_unit_template_ids] => :environment do |t, args|
+  task :diagnostic_scores_by_school_and_class, [:space_separated_school_ids, :space_separated_unit_template_ids] => :environment do |_t, args|
     default_unit_template_ids = '99,100,126,154,193,194,195,299,300,217,237,409,411,444,445'
     unit_template_ids = args[:space_separated_unit_template_ids] ? args[:unit_template_ids].split.join(',') : default_unit_template_ids
     school_ids = args[:space_separated_school_ids].split.join(',')

--- a/services/QuillLMS/lib/tasks/set_upgrade_notification.rake
+++ b/services/QuillLMS/lib/tasks/set_upgrade_notification.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :upgrade do
-  task :set_upgrade_vars, [:app_name, :start_time, :end_time] => [:environment] do |t, args|
+  task :set_upgrade_vars, [:app_name, :start_time, :end_time] => [:environment] do |_t, args|
     app_name = args[:app_name].downcase.gsub(/"/, '')
     if (['empirical-grammar-staging', 'empirical-grammar'].include?(app_name)) && args[:start_time] && args[:end_time] && Time.zone.parse(args[:start_time]) && Time.zone.parse(args[:end_time])
       sh %{curl -n -X PATCH https://api.heroku.com/apps/#{app_name}/config-vars \

--- a/services/QuillLMS/lib/tasks/staging_config.rake
+++ b/services/QuillLMS/lib/tasks/staging_config.rake
@@ -5,7 +5,7 @@ require 'open3'
 namespace :staging_config do
   # bundle exec rake staging_config:copy_from_staging_to_personals\[SOME_KEY\]
   desc 'copy a config from main staging to all other staging envs'
-  task :copy_from_staging_to_personals, [:config] => :environment do |t, args|
+  task :copy_from_staging_to_personals, [:config] => :environment do |_t, args|
     include StagingConfigCommands
 
     config = args[:config]
@@ -20,7 +20,7 @@ namespace :staging_config do
 
   # bundle exec rake staging_config:set_all\[TEST_KEY='some_value'\]
   desc 'set a config key/value on all staging envs'
-  task :set_all, [:config_setting] => :environment do |t, args|
+  task :set_all, [:config_setting] => :environment do |_t, args|
     include StagingConfigCommands
     config_setting = args[:config_setting]
 
@@ -31,7 +31,7 @@ namespace :staging_config do
 
   # bundle exec rake staging_config:remove_all\[TEST_KEY\]
   desc 'delete a config from all staging envs'
-  task :remove_all, [:config] => :environment do |t, args|
+  task :remove_all, [:config] => :environment do |_t, args|
     include StagingConfigCommands
     config = args[:config]
 

--- a/services/QuillLMS/lib/tasks/subscriptions.rake
+++ b/services/QuillLMS/lib/tasks/subscriptions.rake
@@ -4,7 +4,7 @@ require 'csv'
 
 namespace :subscriptions do
   desc 'Add credit to users from a CSV file'
-  task :add_credit_to_users, [:filepath, :amount_in_days] => :environment do |t, args|
+  task :add_credit_to_users, [:filepath, :amount_in_days] => :environment do |_t, args|
     iostream = File.read(args[:filepath])
     if (CSV.parse(iostream, headers: true).headers & ['email']).count != 1
       puts 'Invalid headers. Exiting.'

--- a/services/QuillLMS/lib/tasks/temporary/concept_results.rake
+++ b/services/QuillLMS/lib/tasks/temporary/concept_results.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :concept_results do
-  task :update_metadata_strings_to_json, [:id] => [:environment] do |task, args|
+  task :update_metadata_strings_to_json, [:id] => [:environment] do |_task, args|
     concept_results = ConceptResult.where("id >= ? AND question_type = 'lessons-slide'", args[:id])
 
     puts "Going to check #{concept_results.count} concept results"

--- a/services/QuillLMS/lib/tasks/temporary/translate.rake
+++ b/services/QuillLMS/lib/tasks/temporary/translate.rake
@@ -3,7 +3,7 @@
 namespace :translate do
   desc 'translate hints (concept feedback)'
   desc 'on zsh use `noglob rake translate:hints[es-la]` or whatever language code you choose'
-  task :hints, [:locale] => :environment do |t, args|
+  task :hints, [:locale] => :environment do |_t, args|
     locale = args[:locale] || Translatable::DEFAULT_LOCALE
     hints = ConceptFeedback.all
     count = hints.count
@@ -16,7 +16,7 @@ namespace :translate do
   desc 'translate activities and their questions'
   desc 'on zsh use `noglob rake translate:activities[es-la, 2]`'
   desc 'first param is locale, second is (optional) number of activities to translate'
-  task :activities, [:locale, :limit] => :environment do |t, args|
+  task :activities, [:locale, :limit] => :environment do |_t, args|
     puts "translating activities"
     limit = args[:limit] ? args[:limit].to_i : nil
     locale = args[:locale] || Translatable::DEFAULT_LOCALE
@@ -38,7 +38,7 @@ namespace :translate do
   end
 
   desc 'translate hard-coded feedback_strings'
-  task :feedback_strings, [:locale] => :environment do |t, args|
+  task :feedback_strings, [:locale] => :environment do |_t, args|
     locale = args[:locale] || Translatable::DEFAULT_LOCALE
     prompt = TranslationPrompts.feedback_strings_prompt(locale:)
     english_text = feedback_data

--- a/services/QuillLMS/lib/tasks/temporary/users.rake
+++ b/services/QuillLMS/lib/tasks/temporary/users.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :users do
-  task :update_email_domain, [:old_domain, :new_domain] => [:environment] do |task, args|
+  task :update_email_domain, [:old_domain, :new_domain] => [:environment] do |_task, args|
     old_domain = "@#{args[:old_domain].downcase}"
     new_domain = "@#{args[:new_domain].downcase}"
 

--- a/services/QuillLMS/lib/tasks/universal_rules.rake
+++ b/services/QuillLMS/lib/tasks/universal_rules.rake
@@ -3,13 +3,13 @@
 namespace :universal_rules do
   desc 'Add or update universal rules from CSV file'
   # Example usage: rake 'universal_rules:update_from_csv[grammar, rules.csv]'
-  task :update_from_csv, [:type, :filename] => :environment do |t, args|
+  task :update_from_csv, [:type, :filename] => :environment do |_t, args|
     iostream = File.read(args[:filename])
     UniversalRuleLoader.update_from_csv(type: args[:type], iostream: iostream)
   end
 
   desc 'Data migration to add or update the ERROR type universal rule'
-  task :set_error_feedback, [:feedback_text] => :environment do |t, args|
+  task :set_error_feedback, [:feedback_text] => :environment do |_t, args|
     error_rule = Evidence::Rule.find_by(rule_type: Evidence::Rule::TYPE_ERROR)
     if error_rule
       error_rule.feedbacks.first.update!(text: args[:feedback_text])

--- a/services/QuillLMS/spec/controllers/api/v1/active_activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/active_activity_sessions_controller_spec.rb
@@ -331,7 +331,7 @@ describe Api::V1::ActiveActivitySessionsController, type: :controller do
       Benchmark.bm do |x|
         x.report do
           uids = ActiveActivitySession.all.pluck(:uid)
-          uids.each do |uid|
+          uids.each do |_uid|
             put :update, params: { id: active_activity_session.uid, active_activity_session: update_payload }, as: :json
           end
         end

--- a/services/QuillLMS/spec/factories/questions.rb
+++ b/services/QuillLMS/spec/factories/questions.rb
@@ -149,7 +149,7 @@ FactoryBot.define do
 
     trait :with_translated_focus_points do
       after(:create) do |question|
-        focus_points.each do |key, value|
+        focus_points.each do |key, _value|
           create(:translation_mapping_with_translation,
             source: question,
             field_name: "#{Question::FOCUS_POINTS}.#{key}")
@@ -159,7 +159,7 @@ FactoryBot.define do
 
     trait :with_translated_incorrect_sequences do
       after(:create) do |question|
-        incorrect_sequences.each do |key, value|
+        incorrect_sequences.each do |key, _value|
           create(:translation_mapping_with_translation,
             source: question,
             field_name: "#{Question::INCORRECT_SEQUENCES}.#{key}")

--- a/services/QuillLMS/spec/middleware/auth/canvas/setup_spec.rb
+++ b/services/QuillLMS/spec/middleware/auth/canvas/setup_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Auth::Canvas::Setup do
   subject { described_class.new(env, strategy: strategy).run }
 
-  let(:rack_app) { ->(env) { [200, {}, ''] } }
+  let(:rack_app) { ->(_env) { [200, {}, ''] } }
   let(:strategy) { OmniAuth::Strategies::Canvas.new(rack_app, {}) }
 
   let(:request_path_env) do

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -689,7 +689,7 @@ describe Activity, type: :model, redis: true do
       Rails.cache.clear
       expect(Recommendation).to receive(:all).with(any_args).once.and_call_original
 
-      2.times do |i|
+      2.times do |_i|
         expect(Activity.activity_with_recommendations_ids).to eq([recommendation1.activity_id, recommendation2.activity_id])
       end
     end

--- a/services/QuillLMS/spec/models/user_activity_classification_spec.rb
+++ b/services/QuillLMS/spec/models/user_activity_classification_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe UserActivityClassification, type: :model do
         wait_to_start = true
         failure_in_thread = false
 
-        threads = call_count.times.map do |i|
+        threads = call_count.times.map do |_i|
           Thread.new do
             true while wait_to_start
             begin

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_aggregate_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_aggregate_query_spec.rb
@@ -45,7 +45,7 @@ module AdminDiagnosticReports
     let(:classrooms) { grades.map { |grade| create(:classroom, grade: grade) } }
 
     let(:activities) { [pre_diagnostic] }
-    let(:units) { activities.map { |a| create(:unit, activities: activities) } }
+    let(:units) { activities.map { |_a| create(:unit, activities: activities) } }
     let(:unit_activities) { units.map(&:unit_activities) }
     let(:classroom_units) do
       classrooms.map do |classroom|

--- a/services/QuillLMS/spec/queries/lesson_recommendations_query.rb
+++ b/services/QuillLMS/spec/queries/lesson_recommendations_query.rb
@@ -52,7 +52,7 @@ describe LessonRecommendationsQuery do
         let!(:classroom_activity) { create(:classroom_activity, classroom: classroom, unit: unit) }
 
         before do
-          allow(subject).to receive(:mark_previously_assigned) do |recs, activity|
+          allow(subject).to receive(:mark_previously_assigned) do |recs, _activity|
             recs.each { |r| r[:previously_assigned] = true }
             recs
           end
@@ -327,7 +327,7 @@ describe LessonRecommendationsQuery do
         let!(:classroom_activity) { create(:classroom_activity, classroom: classroom, unit: unit) }
 
         before do
-          allow(subject).to receive(:mark_previously_assigned) do |recs, activity|
+          allow(subject).to receive(:mark_previously_assigned) do |recs, _activity|
             recs.each { |r| r[:previously_assigned] = true }
             recs
           end

--- a/services/QuillLMS/spec/services/student_classroom_associator_spec.rb
+++ b/services/QuillLMS/spec/services/student_classroom_associator_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe StudentClassroomAssociator do
     def makes_concurrent_calls_and_not_raise_errors
       wait_to_start = true
 
-      threads = call_count.times.map do |i|
-        Thread.new do |t|
+      threads = call_count.times.map do |_i|
+        Thread.new do |_t|
           true while wait_to_start
           subject
         end

--- a/services/QuillLMS/spec/support/pages/sign_up_page.rb
+++ b/services/QuillLMS/spec/support/pages/sign_up_page.rb
@@ -45,7 +45,7 @@ class SignUpPage < Page
     submit_form
   end
 
-  def select_school(choose_unlisted_school)
+  def select_school(_choose_unlisted_school)
     # choose_unlisted_school is deprecated, and this method now
     # simply selects the the user is not a member of any school.
     # page.has_content?('not listed')

--- a/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
+++ b/services/QuillLMS/spec/support/shared/quill_big_query/test_runner.rb
@@ -37,7 +37,7 @@ module QuillBigQuery
       cte_records
         .flatten
         .group_by { |record| record.class.table_name }
-        .reject { |table_name, records| records.empty? }
+        .reject { |_table_name, records| records.empty? }
         .map { |table_name, records| "#{table_name} AS ( #{cte_query(records)} )" }
         .join(",\n\t")
     end

--- a/services/QuillLMS/spec/support/shared/section_progress_report.rb
+++ b/services/QuillLMS/spec/support/shared/section_progress_report.rb
@@ -23,7 +23,7 @@ shared_context 'StandardLevel Progress Report' do
       classroom_unit = create(:classroom_unit,
         classroom: classroom,
         unit: unit)
-      3.times do |j|
+      3.times do |_j|
         activity_session = create(:activity_session,
           classroom_unit: classroom_unit,
           user: student,


### PR DESCRIPTION
## WHAT
Turn on the rubocop rule that will add underscores before unused parameters

## WHY
So that it's obvious what is used and what is not used. 

## HOW
Delete exceptions from the rubocop_todo file

### What have you done to QA this feature?
Ran tests
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO
Have you deployed to Staging? | NO
Self-Review: Have you done an initial self-review of the code below on Github? | YES
