### PR TITLE
Don’t allow trailing commas

### DIFF
--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -966,39 +966,6 @@ Style/SymbolArray:
 Style/SymbolProc:
   Enabled: false
 
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInArguments:
-  Exclude:
-    - 'app/models/activity_session.rb'
-    - 'app/services/demo/create_admin_report.rb'
-    - 'spec/models/activity_session_spec.rb'
-    - 'spec/serializers/lesson_planner/unit_serializer_spec.rb'
-    - 'spec/serializers/progress_reports/activity_session_serializer_spec.rb'
-    - 'spec/serializers/progress_reports/concepts/student_serializer_spec.rb'
-
-# Offense count: 19
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInArrayLiteral:
-  Exclude:
-    - 'app/helpers/pages_helper.rb'
-    - 'app/models/csv_exporter/standards/classroom.rb'
-    - 'lib/tasks/create_lesson_recommendations.rake'
-    - 'script/recommendations/00_import_independent_practice_recommendations.rb'
-    - 'spec/controllers/profiles_controller_spec.rb'
-    - 'spec/queries/lesson_recommendations_query.rb'
-
-# Offense count: 111
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Enabled: false
-
 # Offense count: 89
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, MinSize, WordRegex.

--- a/services/QuillLMS/app/controllers/concerns/slack_tasks.rb
+++ b/services/QuillLMS/app/controllers/concerns/slack_tasks.rb
@@ -17,7 +17,7 @@ module SlackTasks
     response = HTTParty.post(
       webhook_url,
       body: {
-        text: message,
+        text: message
       }.to_json
     )
   end

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -139,7 +139,7 @@ class ProfilesController < ApplicationController
         teacher: {
           name: @current_classroom&.owner&.name
         }
-      },
+      }
     }
   end
 

--- a/services/QuillLMS/app/controllers/stripe_integration/subscription_payment_methods_controller.rb
+++ b/services/QuillLMS/app/controllers/stripe_integration/subscription_payment_methods_controller.rb
@@ -17,8 +17,8 @@ module StripeIntegration
         customer: customer,
         setup_intent_data: {
           metadata: {
-            subscription_id: subscription_id,
-          },
+            subscription_id: subscription_id
+          }
         },
         success_url: success_url,
         cancel_url: subscriptions_url

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -146,7 +146,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
         students: current_user.ids_and_names_of_affiliated_students(params[:classroom_id]),
         units: current_user.ids_and_names_of_affiliated_units,
         activity_sessions: activity_sessions,
-        page_count: page_count,
+        page_count: page_count
       }
     else
       csv_string(activity_sessions)

--- a/services/QuillLMS/app/graphql/mutations/concepts/create.rb
+++ b/services/QuillLMS/app/graphql/mutations/concepts/create.rb
@@ -35,7 +35,7 @@ class Mutations::Concepts::Create < Mutations::BaseMutation
 
       {
         concept: concept,
-        errors: [],
+        errors: []
       }
     else
       # Failed save, return the errors to the client

--- a/services/QuillLMS/app/graphql/mutations/concepts/edit.rb
+++ b/services/QuillLMS/app/graphql/mutations/concepts/edit.rb
@@ -41,7 +41,7 @@ class Mutations::Concepts::Edit < Mutations::BaseMutation
 
       {
         concept: concept,
-        errors: [],
+        errors: []
       }
     else
       # Failed save, return the errors to the client

--- a/services/QuillLMS/app/graphql/mutations/concepts/replace.rb
+++ b/services/QuillLMS/app/graphql/mutations/concepts/replace.rb
@@ -40,7 +40,7 @@ class Mutations::Concepts::Replace < Mutations::BaseMutation
       # Successful update, return the updated object with no errors
       {
         concept: replacement,
-        errors: [],
+        errors: []
       }
     else
       # Failed save, return the errors to the client

--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -416,7 +416,7 @@ module PagesHelper
                 description: 'Explore narrative revelations with sudden character shifts',
                 unit_template_id: '220',
                 cb_anchor_tag: 'lamb-to-the-slaughter'
-              },
+              }
             ]
           },
           {
@@ -447,7 +447,7 @@ module PagesHelper
                 description: 'Explore poetic contrast and human truths',
                 unit_template_id: '223',
                 cb_anchor_tag: 'the-fight'
-              },
+              }
             ]
           },
           {
@@ -463,7 +463,7 @@ module PagesHelper
                 description: 'Explore the application of hip-hop storytelling to a historical figure',
                 unit_template_id: '225',
                 cb_anchor_tag: 'the-hamilton-mixtape'
-              },
+              }
             ]
           },
           {
@@ -473,7 +473,7 @@ module PagesHelper
                 description: 'Explore dramatic characterization and Shakepearean turns of phrase',
                 unit_template_id: '226',
                 cb_anchor_tag: 'romeo-and-juliet'
-              },
+              }
             ]
           }
         ]
@@ -494,7 +494,7 @@ module PagesHelper
                 description: 'Explore how seemingly menial work may lead to meaningful life lessons',
                 unit_template_id: '228',
                 cb_anchor_tag: 'drowning-in-dishes-but-finding-a-home'
-              },
+              }
             ]
           },
           {
@@ -510,7 +510,7 @@ module PagesHelper
                 description: 'Explore evolving perspectives of the summer job and its value to teens’ lives',
                 unit_template_id: '230',
                 cb_anchor_tag: 'the-decline-of-the-american-teenagers-summer-job'
-              },
+              }
             ]
           },
           {
@@ -520,7 +520,7 @@ module PagesHelper
                 description: 'Explore multiple views of a controversial issue using data to inform perspectives',
                 unit_template_id: '231',
                 cb_anchor_tag: 'teenagers-have-stopped-getting-summer-jobs-why'
-              },
+              }
             ]
           }
         ]
@@ -541,7 +541,7 @@ module PagesHelper
                 description: 'Explore how second-person point of view sets up a fantastical world',
                 unit_template_id: '233',
                 cb_anchor_tag: 'the-night-circus'
-              },
+              }
             ]
           },
           {
@@ -557,7 +557,7 @@ module PagesHelper
                 description: 'Explore how omniscient point of view shines a light on multiple characters’ experiences of a threatening world',
                 unit_template_id: '235',
                 cb_anchor_tag: 'all-the-light-we-cannot-see'
-              },
+              }
             ]
           },
           {
@@ -567,7 +567,7 @@ module PagesHelper
                 description: 'Explore how a present-tense narrative moment establishes a child’s perspective',
                 unit_template_id: '236',
                 cb_anchor_tag: 'the-girl-who-fell-from-the-sky'
-              },
+              }
             ]
           }
         ]

--- a/services/QuillLMS/app/helpers/segmentio_helper.rb
+++ b/services/QuillLMS/app/helpers/segmentio_helper.rb
@@ -22,13 +22,13 @@ module SegmentioHelper
     {
       first_name: user.first_name,
       last_name: user.last_name,
-      email: user.email,
+      email: user.email
     }
   end
 
   def format_analytics_properties(request, properties)
     common_properties = { path: request.fullpath,
-                          referrer: request.referrer, }
+                          referrer: request.referrer }
     custom_properties = properties.to_h { |k, v| ["custom_#{k}", v] }
     custom_properties.merge(common_properties)
   end

--- a/services/QuillLMS/app/helpers/tools_helper.rb
+++ b/services/QuillLMS/app/helpers/tools_helper.rb
@@ -61,7 +61,7 @@ def evidence_text_helper
     },
     third_attempt: {
       large: '<p>The student strengthened their evidence by adding a precise statistic from the text that explains how significantly seaweed impacts methane. Since the key ideas are in place, Quill now provides a mini-lesson on the grammar errors in their response. Quill only provides grammar and spelling feedback once the student has written a strong response with the key ideas from the text.</p>'.html_safe,
-      small: '<p>The student strengthened their evidence by adding a precise statistic from the text that explains how significantly seaweed impacts methane.</p>'.html_safe,
+      small: '<p>The student strengthened their evidence by adding a precise statistic from the text that explains how significantly seaweed impacts methane.</p>'.html_safe
     },
     fourth_attempt: {
       large: '<p>At this point the student has now written a precise, textually-supported sentence. Students often come into the tool writing vague or inaccurate statements, and through multiple rounds of practice, feedback, and revision, students gain the ability to utilize precise evidence in their responses.</p>'.html_safe,

--- a/services/QuillLMS/app/lib/rule_feedback_history.rb
+++ b/services/QuillLMS/app/lib/rule_feedback_history.rb
@@ -88,7 +88,7 @@ class RuleFeedbackHistory
         strong_responses: r.total_strong,
         weak_responses: r.total_weak,
         repeated_consecutive_responses: r.repeated_consecutive,
-        repeated_non_consecutive_responses: r.repeated_non_consecutive,
+        repeated_non_consecutive_responses: r.repeated_non_consecutive
       }
     end
   end

--- a/services/QuillLMS/app/lib/snapshots/timeframes.rb
+++ b/services/QuillLMS/app/lib/snapshots/timeframes.rb
@@ -18,35 +18,35 @@ module Snapshots
         previous_start: proc { |reference_time| (reference_time - 178.days).beginning_of_day },
         previous_end: proc { |reference_time| (reference_time - 89.days).end_of_day },
         current_start: proc { |reference_time| (reference_time - 89.days).beginning_of_day },
-        current_end: proc { |reference_time| reference_time.end_of_day },
+        current_end: proc { |reference_time| reference_time.end_of_day }
       }, {
         value: 'this-month',
         name: 'This month',
         previous_start: proc { |reference_time| reference_time.beginning_of_month - 1.month },
         previous_end: proc { |reference_time| reference_time - 1.month },
         current_start: proc { |reference_time| reference_time.beginning_of_month },
-        current_end: proc { |reference_time| reference_time },
+        current_end: proc { |reference_time| reference_time }
       }, {
         value: 'last-month',
         name: 'Last month',
         previous_start: proc { |reference_time| (reference_time.beginning_of_month - 2.months) },
         previous_end: proc { |reference_time| (reference_time - 2.months).end_of_month },
         current_start: proc { |reference_time| reference_time.beginning_of_month - 1.month },
-        current_end: proc { |reference_time| (reference_time - 1.month).end_of_month },
+        current_end: proc { |reference_time| (reference_time - 1.month).end_of_month }
       }, {
         value: 'this-school-year',
         name: 'This school year',
         previous_start: proc { |reference_time| (School.school_year_start(reference_time) - 1.year).beginning_of_day },
         previous_end: proc { |reference_time| (reference_time - 1.year).end_of_day },
         current_start: proc { |reference_time| School.school_year_start(reference_time).beginning_of_day },
-        current_end: proc { |reference_time| reference_time.end_of_day },
+        current_end: proc { |reference_time| reference_time.end_of_day }
       }, {
         value: 'last-school-year',
         name: 'Last school year',
         previous_start: proc { |reference_time| (School.school_year_start(reference_time) - 2.years).beginning_of_day },
         previous_end: proc { |reference_time| (School.school_year_start(reference_time) - 1.year).end_of_day },
         current_start: proc { |reference_time| (School.school_year_start(reference_time) - 1.year).beginning_of_day },
-        current_end: proc { |reference_time| (School.school_year_start(reference_time) - 1.day).end_of_day },
+        current_end: proc { |reference_time| (School.school_year_start(reference_time) - 1.day).end_of_day }
       }, {
         value: 'all-time',
         name: 'All time',
@@ -54,7 +54,7 @@ module Snapshots
         previous_start: proc {},
         previous_end: proc {},
         current_start: proc { DateTime.new(2010, 1, 1) }, # This is well before any data exists in our system, so works for "all time"
-        current_end: proc { |reference_time| reference_time },
+        current_end: proc { |reference_time| reference_time }
       }, {
         value: 'custom',
         name: 'Custom',

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -357,7 +357,7 @@ class ActivitySession < ApplicationRecord
         concept_id: concept_result[:concept_id],
         question_type: concept_result[:question_type],
         activity_session_id: concept_result[:activity_session_id],
-        metadata: concept_result[:metadata],
+        metadata: concept_result[:metadata]
       })
     end
     report_invalid_concept_results(concept_results)
@@ -413,7 +413,7 @@ class ActivitySession < ApplicationRecord
 
     state = ClassroomUnitActivityState.find_or_create_by(
       unit_activity: unit_activity,
-      classroom_unit: classroom_unit,
+      classroom_unit: classroom_unit
     )
 
     state.update(locked: false)
@@ -493,7 +493,7 @@ class ActivitySession < ApplicationRecord
   def self.search_sort_sql(sort)
     if sort.blank? or sort[:field].blank?
       sort = {
-        field: 'student_name',
+        field: 'student_name'
       }
     end
 

--- a/services/QuillLMS/app/models/concerns/lessons_recommendations.rb
+++ b/services/QuillLMS/app/models/concerns/lessons_recommendations.rb
@@ -52,7 +52,7 @@ module LessonsRecommendations
       name: lessons_rec[:recommendation],
       students_needing_instruction: students_needing_instruction,
       percentage_needing_instruction: percentage_needing_instruction(fail_count),
-      activities: lessons_rec[:activities],
+      activities: lessons_rec[:activities]
     }
   end
 

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -274,7 +274,7 @@ module PublicProgressReports
         {
           name: key_target_skill_group.first[:name],
           correct: key_target_skill_group.filter { |ktsc| ktsc[:correct] }.length,
-          incorrect: key_target_skill_group.filter { |ktsc| ktsc[:correct] == false }.length,
+          incorrect: key_target_skill_group.filter { |ktsc| ktsc[:correct] == false }.length
         }
       end
   end

--- a/services/QuillLMS/app/models/concerns/translatable_question.rb
+++ b/services/QuillLMS/app/models/concerns/translatable_question.rb
@@ -42,7 +42,7 @@ module TranslatableQuestion
     {
       CMS_RESPONSES => cms_responses,
       INCORRECT_SEQUENCES => translatable_data(type: INCORRECT_SEQUENCES),
-      FOCUS_POINTS => translatable_data(type: FOCUS_POINTS),
+      FOCUS_POINTS => translatable_data(type: FOCUS_POINTS)
     }
   end
 

--- a/services/QuillLMS/app/models/concerns/user_flagset.rb
+++ b/services/QuillLMS/app/models/concerns/user_flagset.rb
@@ -84,9 +84,9 @@ module UserFlagset
           Flags::COLLEGE_BOARD =>     { display_name: 'College Board' },
           Flags::PRODUCTION =>        { display_name: 'Production' },
           Flags::PRIVATE =>           { display_name: 'Private' },
-          Flags::GAMMA =>             { display_name: 'Gamma' },
+          Flags::GAMMA =>             { display_name: 'Gamma' }
         }
-      },
+      }
 
     }
 

--- a/services/QuillLMS/app/models/csv_exporter/standards/classroom.rb
+++ b/services/QuillLMS/app/models/csv_exporter/standards/classroom.rb
@@ -23,7 +23,7 @@ module CsvExporter::Standards
         json_hash[:total_student_count],
         json_hash[:proficient_student_count],
         json_hash[:not_proficient_student_count],
-        json_hash[:total_standard_count],
+        json_hash[:total_standard_count]
       ]
     end
 

--- a/services/QuillLMS/app/models/one_off_banner.rb
+++ b/services/QuillLMS/app/models/one_off_banner.rb
@@ -41,7 +41,7 @@ class OneOffBanner < WebinarBanner
     '8-09-16' => WEBINAR_EVIDENCE,
     '8-23-11' => WEBINAR_EVIDENCE,
     '9-06-16' => WEBINAR_EVIDENCE,
-    '9-20-11' => WEBINAR_EVIDENCE,
+    '9-20-11' => WEBINAR_EVIDENCE
   }
 
   private def values

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -49,7 +49,7 @@ class Question < ApplicationRecord
     TYPE_DIAGNOSTIC_SENTENCE_COMBINING => 'diagnostic_questions',
     TYPE_DIAGNOSTIC_SENTENCE_FRAGMENTS => 'diagnostic_sentenceFragments',
     TYPE_DIAGNOSTIC_FILL_IN_BLANKS => 'diagnostic_fillInBlankQuestions',
-    TYPE_GRAMMAR_QUESTION => 'grammar_questions',
+    TYPE_GRAMMAR_QUESTION => 'grammar_questions'
   }
 
   INCORRECT_SEQUENCES = TranslatableQuestion::INCORRECT_SEQUENCES

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -128,7 +128,7 @@ class School < ApplicationRecord
     9 => HIGH,
     10 => HIGH,
     11 => HIGH,
-    12 => HIGH,
+    12 => HIGH
   }
 
   LEAP_CSV_HEADERS = %w[

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -51,7 +51,7 @@ module SegmentIntegration
       {
         email: email,
         premium_state: premium_state,
-        premium_type: subscription&.account_type,
+        premium_type: subscription&.account_type
       }.reject { |_, v| v.nil? }
     end
 

--- a/services/QuillLMS/app/pdfs/login_pdf.rb
+++ b/services/QuillLMS/app/pdfs/login_pdf.rb
@@ -12,7 +12,7 @@ class LoginPdf < Prawn::Document
         :normal => "#{File.dirname(__FILE__)}/../assets/fonts/dejavu-sans/DejaVuSans.ttf",
         :bold => "#{File.dirname(__FILE__)}/../assets/fonts/dejavu-sans/DejaVuSans-Bold.ttf",
         :italic => "#{File.dirname(__FILE__)}/../assets/fonts/dejavu-sans/DejaVuSans-Oblique.ttf",
-        :bold_italic => "#{File.dirname(__FILE__)}/../assets/fonts/dejavu-sans/DejaVuSans-BoldOblique.ttf",
+        :bold_italic => "#{File.dirname(__FILE__)}/../assets/fonts/dejavu-sans/DejaVuSans-BoldOblique.ttf"
       }
     )
     render_login_pdf

--- a/services/QuillLMS/app/services/activity_search_wrapper.rb
+++ b/services/QuillLMS/app/services/activity_search_wrapper.rb
@@ -26,7 +26,7 @@ class ActivitySearchWrapper
       activities: @activities,
       activity_classifications: @activity_classifications,
       activity_categories: @activity_categories,
-      standard_levels: @standard_levels,
+      standard_levels: @standard_levels
     }
   end
 

--- a/services/QuillLMS/app/services/analytics/segment_analytics.rb
+++ b/services/QuillLMS/app/services/analytics/segment_analytics.rb
@@ -290,7 +290,7 @@ module Analytics
         track({
           user_id: admin.id,
           event: Analytics::SegmentIo::BackgroundEvents::ADMIN_INVITED_BY_TEACHER,
-          properties: properties,
+          properties: properties
         })
       else
         identify_anonymous_user({ anonymous_id: admin_email, traits: { email: admin_email, name: admin_name } })

--- a/services/QuillLMS/app/services/canvas_integration/classroom_data_adapter.rb
+++ b/services/QuillLMS/app/services/canvas_integration/classroom_data_adapter.rb
@@ -18,7 +18,7 @@ module CanvasIntegration
         alreadyImported: already_imported?,
         classroom_external_id: CanvasClassroom.build_classroom_external_id(canvas_instance_id, section_id),
         name: classroom_name,
-        studentCount: students.count,
+        studentCount: students.count
       }
     end
 

--- a/services/QuillLMS/app/services/canvas_integration/role_extractor.rb
+++ b/services/QuillLMS/app/services/canvas_integration/role_extractor.rb
@@ -23,7 +23,7 @@ module CanvasIntegration
       INSTRUCTOR_INST_ROLE => USER_TEACHER_ROLE,
       INSTRUCTOR_ROLE => USER_TEACHER_ROLE,
       LEARNER_ROLE => USER_STUDENT_ROLE,
-      STUDENT_INST_ROLE => USER_STUDENT_ROLE,
+      STUDENT_INST_ROLE => USER_STUDENT_ROLE
     }
 
     def initialize(canvas_roles)

--- a/services/QuillLMS/app/services/clever_integration/library_classroom_data_adapter.rb
+++ b/services/QuillLMS/app/services/clever_integration/library_classroom_data_adapter.rb
@@ -14,7 +14,7 @@ module CleverIntegration
         classroom_external_id: classroom_external_id,
         grade: data[:grade],
         name: data[:name],
-        studentCount: data[:students]&.count || 0,
+        studentCount: data[:students]&.count || 0
       }
     end
 

--- a/services/QuillLMS/app/services/demo/create_admin_report.rb
+++ b/services/QuillLMS/app/services/demo/create_admin_report.rb
@@ -42,7 +42,7 @@ class Demo::CreateAdminReport
     email_safe_last_name = teacher_name.split.last.downcase.gsub(/[^a-zA-Z\d]/, '').gsub(/\s/, '')
     user = User.find_or_initialize_by(
       name: teacher_name,
-      email: "hello+admindemo-#{email_safe_last_name}.#{school.id}@quill.org",
+      email: "hello+admindemo-#{email_safe_last_name}.#{school.id}@quill.org"
     )
     user.update(password: SecureRandom.urlsafe_base64, role: User::TEACHER)
 

--- a/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
+++ b/services/QuillLMS/app/services/demo/report_demo_ap_creator.rb
@@ -21,7 +21,7 @@ module Demo::ReportDemoAPCreator
       email: email,
       role: User::TEACHER,
       password: 'password',
-      password_confirmation: 'password',
+      password_confirmation: 'password'
     }
 
     teacher = User.create(values)
@@ -131,28 +131,28 @@ module Demo::ReportDemoAPCreator
         username: "william.shakespeare.#{classroom.id}@demo-teacher",
         role: 'student',
         password: 'password',
-        password_confirmation: 'password',
+        password_confirmation: 'password'
       },
       {
         name: 'Harper Lee',
         username: "harper.lee.#{classroom.id}@demo-teacher",
         role: 'student',
         password: 'password',
-        password_confirmation: 'password',
+        password_confirmation: 'password'
       },
       {
         name: 'Charles Dickens',
         username: "charles.dickens.#{classroom.id}@demo-teacher",
         role: 'student',
         password: 'password',
-        password_confirmation: 'password',
+        password_confirmation: 'password'
       },
       {
         name: 'James Joyce',
         username: "james.joyce.#{classroom.id}@demo-teacher",
         role: 'student',
         password: 'password',
-        password_confirmation: 'password',
+        password_confirmation: 'password'
       },
       {
         name: 'Bell Hooks',
@@ -178,7 +178,7 @@ module Demo::ReportDemoAPCreator
   def self.create_unit(teacher, unit_name)
     values = {
       name: unit_name,
-      user: teacher,
+      user: teacher
     }
     unit = Unit.create(values)
   end
@@ -195,7 +195,7 @@ module Demo::ReportDemoAPCreator
     activities.each do |act_id|
       values = {
         activity_id: act_id,
-        unit: unit,
+        unit: unit
       }
       ua = UnitActivity.create(values)
     end

--- a/services/QuillLMS/app/services/google_integration/user.rb
+++ b/services/QuillLMS/app/services/google_integration/user.rb
@@ -24,7 +24,7 @@ class GoogleIntegration::User
     @user_params ||= begin
       params = {
         signed_up_with_google: true,
-        auth_credential_attributes: auth_credential_attributes(user),
+        auth_credential_attributes: auth_credential_attributes(user)
       }
 
       params[:name]      = profile.name      if profile.name.present?

--- a/services/QuillLMS/app/services/pdfs/admin_usage_snapshot_reports/snapshot_sections_builder.rb
+++ b/services/QuillLMS/app/services/pdfs/admin_usage_snapshot_reports/snapshot_sections_builder.rb
@@ -24,7 +24,7 @@ module Pdfs
                 queryKey: 'active-classrooms',
                 singularLabel: 'Active classroom',
                 size: SMALL,
-                type: COUNT,
+                type: COUNT
               },
               {
                 label: 'Average active classrooms per teacher',
@@ -37,7 +37,7 @@ module Pdfs
                 queryKey: 'classrooms-created',
                 singularLabel: 'Classroom created',
                 size: SMALL,
-                type: COUNT,
+                type: COUNT
               },
               {
                 label: 'Average active students per classroom',
@@ -54,7 +54,7 @@ module Pdfs
                 headers: ['Grade', 'Activities completed'],
                 label: 'Most active grades',
                 queryKey: 'most-active-grades',
-                type: RANKING,
+                type: RANKING
               }
             ]
           }
@@ -118,7 +118,7 @@ module Pdfs
                 queryKey: 'activity-packs-completed',
                 singularLabel: 'Activity pack completed',
                 size: SMALL,
-                type: COUNT,
+                type: COUNT
               }
             ]
           },
@@ -234,9 +234,9 @@ module Pdfs
                 queryKey: 'student-accounts-created',
                 singularLabel: 'Student account created',
                 size: SMALL,
-                type: COUNT,
+                type: COUNT
               }
-            ],
+            ]
           },
           {
             className: RANKING,

--- a/services/QuillLMS/app/services/serialize_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_activity_health.rb
@@ -26,7 +26,7 @@ class SerializeActivityHealth
       avg_mins_to_complete: avg_mins_to_complete,
       avg_difficulty: average(prompt_data, :difficulty),
       avg_common_unmatched: average(prompt_data, :percent_common_unmatched),
-      standard_dev_difficulty: standard_deviation(prompt_data, :difficulty),
+      standard_dev_difficulty: standard_deviation(prompt_data, :difficulty)
     }
   end
 

--- a/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_evidence_activity_health.rb
@@ -20,7 +20,7 @@ class SerializeEvidenceActivityHealth
       because_final_optimal: percent_final_optimal_for_conjunction(FeedbackHistory::BECAUSE),
       but_final_optimal: percent_final_optimal_for_conjunction(FeedbackHistory::BUT),
       so_final_optimal: percent_final_optimal_for_conjunction(FeedbackHistory::SO),
-      avg_completion_time: activity_feedback_history[:average_time_spent] ? Utils::Numeric.human_readable_time_to_seconds(activity_feedback_history[:average_time_spent]) : nil,
+      avg_completion_time: activity_feedback_history[:average_time_spent] ? Utils::Numeric.human_readable_time_to_seconds(activity_feedback_history[:average_time_spent]) : nil
     }
   end
 

--- a/services/QuillLMS/app/services/snapshots/premium_data_csv_generator.rb
+++ b/services/QuillLMS/app/services/snapshots/premium_data_csv_generator.rb
@@ -19,7 +19,7 @@ module Snapshots
       school_name:      { csv_header: 'School', formatter: Formatter::DEFAULT },
       classroom_grade:  { csv_header: 'Grade', formatter: Formatter::DEFAULT },
       teacher_name:     { csv_header: 'Teacher', formatter: Formatter::DEFAULT },
-      classroom_name:   { csv_header: 'Class', formatter: Formatter::DEFAULT },
+      classroom_name:   { csv_header: 'Class', formatter: Formatter::DEFAULT }
     }.freeze
 
     def ordered_columns = ORDERED_COLUMNS

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_account.rb
@@ -97,7 +97,7 @@ module VitallyIntegration
         evidence_activities_completed_this_year:,
         evidence_activities_completed_last_year: get_from_cache('evidence_activities_completed'),
         evidence_activities_completed_per_student_this_year:,
-        evidence_activities_completed_per_student_last_year: get_from_cache('completed_evidence_activities_per_student'),
+        evidence_activities_completed_per_student_last_year: get_from_cache('completed_evidence_activities_per_student')
       }
     end
 

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_organization.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_organization.rb
@@ -59,7 +59,7 @@ module VitallyIntegration
         activities_completed_per_student_this_year: active_students_this_year > 0 ? ((activities_completed_this_year.to_f / active_students_this_year).round(2)) : 0,
         activities_completed_per_student_last_year: active_students_last_year > 0 ? ((activities_completed_last_year.to_f / active_students_last_year).round(2)) : 0,
         activities_completed_per_student_all_time: active_students_all_time > 0 ? ((activities_completed_all_time.to_f / active_students_all_time).round(2)) : 0,
-        last_active_time: last_active_time,
+        last_active_time: last_active_time
       }
     end
 
@@ -104,7 +104,7 @@ module VitallyIntegration
         evidence_activities_completed_this_year:,
         evidence_activities_completed_last_year:,
         evidence_activities_completed_per_student_this_year:,
-        evidence_activities_completed_per_student_last_year:,
+        evidence_activities_completed_per_student_last_year:
       }
     end
 
@@ -117,7 +117,7 @@ module VitallyIntegration
         annual_revenue_current_contract:,
         stripe_invoice_id_current_contract:,
         purchase_order_number_current_contract:,
-        total_premium_months:,
+        total_premium_months:
       }
     end
 

--- a/services/QuillLMS/app/validators/stripe_uid_validator.rb
+++ b/services/QuillLMS/app/validators/stripe_uid_validator.rb
@@ -32,7 +32,7 @@ class StripeUidValidator < ActiveModel::EachValidator
     PROD => 'Product',
     SETI => 'Setup Intent',
     SI => 'Subscription Item',
-    SUB => 'Subscription',
+    SUB => 'Subscription'
   }.freeze
 
   def check_validity!

--- a/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
+++ b/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
@@ -10,7 +10,7 @@ class GenerateConceptsInUseArrayWorker
     'SF_QUESTIONS' => 'connect_sentence_fragments',
     'D_QUESTIONS' => 'diagnostic_sentence_combining',
     'D_FIB_QUESTIONS' => 'diagnostic_fill_in_blanks',
-    'D_SF_QUESTIONS' => 'diagnostic_sentence_fragments',
+    'D_SF_QUESTIONS' => 'diagnostic_sentence_fragments'
   }.freeze
 
   CONCEPTS_IN_USE = [%w(

--- a/services/QuillLMS/app/workers/sync_school_data_from_url_worker.rb
+++ b/services/QuillLMS/app/workers/sync_school_data_from_url_worker.rb
@@ -50,7 +50,7 @@ class SyncSchoolDataFromUrlWorker
       fte_classroom_teacher: school_data['teachers_fte'].to_i,
       free_lunches: school_data['enrollment'].to_i > 0 ? (school_data['free_or_reduced_price_lunch'].to_i / school_data['enrollment'].to_f * 100).to_i : nil, # we receive free_or_reduced_price_lunch as an integer but want to store it as a percentage,
       direct_certification: school_data['enrollment'].to_i > 0 ? (school_data['direct_certification'].to_i / school_data['enrollment'].to_f * 100).to_i : nil, # we receive direct_certification as an integer but want to store it as a percentage
-      total_students: school_data['enrollment'],
+      total_students: school_data['enrollment']
     }
   end
 end

--- a/services/QuillLMS/bin/dev/airbyte
+++ b/services/QuillLMS/bin/dev/airbyte
@@ -5,7 +5,7 @@ INSTANCES = {
   1 => {
     name: 'airbyte2',
     port: 8001,
-    tables: 'concept_results (prefix: special)',
+    tables: 'concept_results (prefix: special)'
   },
   2 => {
     name: 'airbyte-indigo',

--- a/services/QuillLMS/config/initializers/carrierwave.rb
+++ b/services/QuillLMS/config/initializers/carrierwave.rb
@@ -14,7 +14,7 @@ CarrierWave.configure do |config|
   config.fog_credentials = {
     provider: 'AWS',
     aws_access_key_id: ENV.fetch('AWS_UPLOADS_ACCESS_KEY_ID', ''),
-    aws_secret_access_key: ENV.fetch('AWS_UPLOADS_SECRET_ACCESS_KEY', ''),
+    aws_secret_access_key: ENV.fetch('AWS_UPLOADS_SECRET_ACCESS_KEY', '')
   }
 
   config.fog_directory = ENV.fetch('FOG_UPLOADS_DIRECTORY', 'quill-image-uploads')

--- a/services/QuillLMS/config/initializers/grover.rb
+++ b/services/QuillLMS/config/initializers/grover.rb
@@ -7,6 +7,6 @@ Grover.configure do |config|
     margin: {
       top: '54px',
       bottom: '54px'
-    },
+    }
   }
 end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai/response_builder.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai/response_builder.rb
@@ -39,7 +39,7 @@ module Evidence
           concept_uid: rule&.concept_uid,
           rule_uid:,
           hint: nil,
-          highlight:,
+          highlight:
         }
       end
 

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_importer.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_importer.rb
@@ -31,7 +31,7 @@ module Evidence
               curriculum_label: row['Optional - Curriculum Label'],
               curriculum_proposed_feedback: row['Curriculum Proposed Feedback'],
               highlight: row['Optional - Highlight'],
-              student_response: row['Student Response'],
+              student_response: row['Student Response']
             }
 
             if data_partition == 'test'

--- a/services/QuillLMS/engines/evidence/lib/evidence/change_log.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/change_log.rb
@@ -67,7 +67,7 @@ module Evidence
           note: row.explanation,
           start_date: row.created_at,
           end_date: next_version ? next_version.created_at : Time.current,
-          new_value: row.new_value,
+          new_value: row.new_value
         }
 
         include_count ? version_data.merge(session_count: session_count(row, id)) : version_data

--- a/services/QuillLMS/engines/evidence/lib/evidence/check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/check.rb
@@ -19,7 +19,7 @@ module Evidence
     FALLBACK_RESPONSE = {
       feedback: '<p>Thank you for your response! Something went wrong on our end and our feedback system doesn’t understand your response. Move on to the next prompt!</p>',
       feedback_type: Rule::TYPE_ERROR,
-      optimal: true,
+      optimal: true
     }
 
     def self.get_feedback(entry, prompt, previous_feedback, session_uid = nil, feedback_types = nil)
@@ -56,7 +56,7 @@ module Evidence
       feedback = {
         feedback: @error_rule.feedbacks.first&.text || FALLBACK_RESPONSE[:feedback],
         feedback_type: @error_rule.rule_type,
-        optimal: @error_rule.optimal,
+        optimal: @error_rule.optimal
       }
 
       return feedback.merge({ debug: debug }) if debug

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
@@ -28,7 +28,7 @@ module Evidence
           model: llm.version,
           messages: [
             { role: 'user', content: prompt }
-          ],
+          ]
         }.merge(llm.request_body_customizations)
       end
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/edit.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/edit.rb
@@ -34,7 +34,7 @@ module Evidence
           temperature: temperature,
           input: input,
           instruction: instruction,
-          n: [count.to_i, Evidence::OpenAI::MAX_COUNT].min,
+          n: [count.to_i, Evidence::OpenAI::MAX_COUNT].min
         }
       end
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/synthetic/seed_data_generator.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/synthetic/seed_data_generator.rb
@@ -42,7 +42,7 @@ module Evidence
       CONJUNCTION_EXCLUSIONS = {
         SO => [/^that/],
         BUT => [],
-        BECAUSE => [/^of/],
+        BECAUSE => [/^of/]
       }
 
       attr_reader :passage, :stem, :conjunction, :nouns, :results, :label_configs, :use_passage, :batch

--- a/services/QuillLMS/engines/evidence/lib/tasks/add_grammar_api_rules_and_feedback.rake
+++ b/services/QuillLMS/engines/evidence/lib/tasks/add_grammar_api_rules_and_feedback.rake
@@ -20,7 +20,7 @@ namespace :grammar_api_rules_and_feedback do
           rule_type: r['Module'] == 'Grammar API' ? 'grammar' : 'opinion',
           optimal: false,
           suborder: r['Rule Suborder'],
-          state: 'active',
+          state: 'active'
         }
         created_rule.save!
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -387,7 +387,7 @@ module Evidence
               conjunction: prompt.conjunction,
               max_attempts: prompt.max_attempts,
               max_attempts_feedback: prompt.max_attempts_feedback
-            }],
+            }]
           }
         }
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/trials_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/trials_controller_spec.rb
@@ -36,7 +36,7 @@ module Evidence
                 guideline_ids:,
                 llm_id:,
                 llm_prompt_template_id:,
-                prompt_example_ids:,
+                prompt_example_ids:
               }
             }
           end

--- a/services/QuillLMS/lib/tasks/create_lesson_recommendations.rake
+++ b/services/QuillLMS/lib/tasks/create_lesson_recommendations.rake
@@ -307,7 +307,7 @@ namespace :recommendations do
               noIncorrect: true
             }
           ]
-        },
+        }
       ],
       '602' => [
         {
@@ -409,7 +409,7 @@ namespace :recommendations do
             {
               concept_id: 'mandatory',
               count: 1
-            },
+            }
           ]
         },
         {
@@ -419,7 +419,7 @@ namespace :recommendations do
             {
               concept_id: 'mandatory',
               count: 1
-            },
+            }
           ]
         }
       ]

--- a/services/QuillLMS/script/recommendations/00_import_independent_practice_recommendations.rb
+++ b/services/QuillLMS/script/recommendations/00_import_independent_practice_recommendations.rb
@@ -304,7 +304,7 @@ activities = {
           noIncorrect: true
         }
       ]
-    },
+    }
   ],
   '602' => [
     {
@@ -406,7 +406,7 @@ activities = {
         {
           concept_id: 'mandatory',
           count: 1
-        },
+        }
       ]
     },
     {
@@ -416,7 +416,7 @@ activities = {
         {
           concept_id: 'mandatory',
           count: 1
-        },
+        }
       ]
     }
   ]

--- a/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_sessions_controller_spec.rb
@@ -49,7 +49,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
           'metadata' => {
             'foo' => 'bar',
             'correct' => true
-          },
+          }
         }
       end
 
@@ -61,7 +61,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
           'metadata' => {
             'baz' => 'foo',
             'correct' => true
-          },
+          }
         }
       end
 
@@ -72,7 +72,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
           'concept_uid' => another_concept.uid,
           'metadata' => {
             'correct' => true
-          },
+          }
         }
       end
 
@@ -116,7 +116,7 @@ describe Api::V1::ActivitySessionsController, type: :controller do
           {
             concept_uid: 'Non-existent UID',
             metadata: {
-              foo: 'bar',
+              foo: 'bar'
             }
           }
         ]

--- a/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/feedback_histories_controller_spec.rb
@@ -110,7 +110,7 @@ describe Api::V1::FeedbackHistoriesController, type: :controller do
             metadata: {
               foo: 'bar'
             }
-          },
+          }
         },
         as: :json
 

--- a/services/QuillLMS/spec/controllers/cms/student_feedback_responses_controller.rb
+++ b/services/QuillLMS/spec/controllers/cms/student_feedback_responses_controller.rb
@@ -8,7 +8,7 @@ describe StudentFeedbackResponsesController do
       post :create, params: { student_feedback_response: {
         question: 'What’s a part of your culture, upbringing, or background you’d like your classmates to learn more about in a Quill activity?',
         response: 'I would like for them to learn about how Philadelphia is the greatest city on earth.',
-        grade_levels: ['University', '9'],
+        grade_levels: ['University', '9']
       } }
       parsed_response = JSON.parse(response.body)
       id = parsed_response['student_feedback_response']['id']

--- a/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/growth_results_summary_spec.rb
@@ -47,7 +47,7 @@ describe GrowthResultsSummary do
                 post: 1.0
               }
             },
-            question_uids: pre_test_skill_group_activity.skill_group.questions.pluck(:uid),
+            question_uids: pre_test_skill_group_activity.skill_group.questions.pluck(:uid)
           }
         ],
         student_results: [
@@ -138,7 +138,7 @@ describe GrowthResultsSummary do
             total_maintained_skill_group_proficiency_count: 0,
             total_possible_questions_count: 2,
             correct_question_text: '2 of 2 Questions Correct',
-            correct_skill_groups_text: '1 of 1 Skills',
+            correct_skill_groups_text: '1 of 1 Skills'
           },
           {
             name: student2.name
@@ -253,7 +253,7 @@ describe GrowthResultsSummary do
             total_pre_possible_questions_count: 2,
             total_possible_questions_count: 2,
             correct_question_text: '2 of 2 Questions Correct',
-            correct_skill_groups_text: '1 of 1 Skills',
+            correct_skill_groups_text: '1 of 1 Skills'
           },
           {
             name: student2.name

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -39,7 +39,7 @@ describe ResultsSummary do
               student1.name => 0.5,
               student3.name => 1.0
             },
-            question_uids: skill_group_activity.skill_group.questions.pluck(:uid),
+            question_uids: skill_group_activity.skill_group.questions.pluck(:uid)
           }
         ],
         student_results: [
@@ -78,14 +78,14 @@ describe ResultsSummary do
                 id: skill_group_activity.skill_group.id,
                 number_correct: 1,
                 number_incorrect: 1,
-                summary: ResultsSummary::PARTIALLY_CORRECT,
+                summary: ResultsSummary::PARTIALLY_CORRECT
               }
             ],
             total_correct_questions_count: 1,
             total_correct_skill_groups_count: 0,
             total_possible_questions_count: 2,
             correct_question_text: '1 of 2 Questions Correct',
-            correct_skill_groups_text: '0 of 1 Skills',
+            correct_skill_groups_text: '0 of 1 Skills'
           },
           {
             name: student2.name
@@ -116,14 +116,14 @@ describe ResultsSummary do
                 id: skill_group_activity.skill_group.id,
                 number_correct: 1,
                 number_incorrect: 0,
-                summary: ResultsSummary::FULLY_CORRECT,
+                summary: ResultsSummary::FULLY_CORRECT
               }
             ],
             total_correct_questions_count: 1,
             total_correct_skill_groups_count: 1,
             total_possible_questions_count: 1,
             correct_question_text: '1 of 1 Questions Correct',
-            correct_skill_groups_text: '1 of 1 Skills',
+            correct_skill_groups_text: '1 of 1 Skills'
           }
         ]
       })
@@ -161,7 +161,7 @@ describe ResultsSummary do
                     number_incorrect: 0,
                     proficiency_score: 1,
                     summary: ResultsSummary::FULLY_CORRECT,
-                    question_uid: diagnostic_question_skill1.question.uid,
+                    question_uid: diagnostic_question_skill1.question.uid
                   },
                   {
                     id: diagnostic_question_skill2.id,
@@ -170,7 +170,7 @@ describe ResultsSummary do
                     number_incorrect: 1,
                     proficiency_score: 0,
                     summary: ResultsSummary::NOT_CORRECT,
-                    question_uid: diagnostic_question_skill2.question.uid,
+                    question_uid: diagnostic_question_skill2.question.uid
                   }
                 ],
                 skill_ids: [diagnostic_question_skill1.id, diagnostic_question_skill2.id],
@@ -181,14 +181,14 @@ describe ResultsSummary do
                 proficiency_text: ResultsSummary::PARTIAL_PROFICIENCY,
                 question_uids: skill_group_activity.skill_group.questions.pluck(:uid),
                 id: skill_group_activity.skill_group.id,
-                summary: ResultsSummary::PARTIALLY_CORRECT,
+                summary: ResultsSummary::PARTIALLY_CORRECT
               }
             ],
             total_correct_questions_count: 1,
             total_correct_skill_groups_count: 0,
             total_possible_questions_count: 2,
             correct_question_text: '1 of 2 Questions Correct',
-            correct_skill_groups_text: '0 of 1 Skills',
+            correct_skill_groups_text: '0 of 1 Skills'
           },
           {
             name: student2.name
@@ -220,7 +220,7 @@ describe ResultsSummary do
               number_incorrect: 0,
               proficiency_score: 1,
               summary: ResultsSummary::FULLY_CORRECT,
-              question_uid: diagnostic_question_skill1.question.uid,
+              question_uid: diagnostic_question_skill1.question.uid
             },
             {
               id: diagnostic_question_skill2.id,
@@ -229,7 +229,7 @@ describe ResultsSummary do
               number_incorrect: 1,
               proficiency_score: 0,
               summary: ResultsSummary::NOT_CORRECT,
-              question_uid: diagnostic_question_skill2.question.uid,
+              question_uid: diagnostic_question_skill2.question.uid
             }
           ],
           skill_ids: [diagnostic_question_skill1.id, diagnostic_question_skill2.id],

--- a/services/QuillLMS/spec/controllers/concerns/slack_tasks_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/slack_tasks_spec.rb
@@ -20,7 +20,7 @@ describe SlackTasks do
     it 'should post a sales form submission to slack' do
       expect(HTTParty).to receive(:post).with('slack-test.com',
         body: {
-          text: "Sales Form submitted\n #{sales_form_submission.attributes.map { |key, value| "#{key}: #{value}\n" }.join}",
+          text: "Sales Form submitted\n #{sales_form_submission.attributes.map { |key, value| "#{key}: #{value}\n" }.join}"
         }.to_json)
       post_sales_form_submission(sales_form_submission)
     end

--- a/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/profiles_controller_spec.rb
@@ -50,7 +50,7 @@ describe ProfilesController, type: :controller do
         create(:unit_activity, unit: units[0], activity: activities[1], order_number: 2),
         create(:unit_activity, unit: units[0], activity: activities[2], order_number: 1),
         create(:unit_activity, unit: units[1], activity: activities[3], order_number: 2),
-        create(:unit_activity, unit: units[1], activity: activities[4], order_number: 1),
+        create(:unit_activity, unit: units[1], activity: activities[4], order_number: 1)
       ]
     end
 

--- a/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/sessions_controller_spec.rb
@@ -80,7 +80,7 @@ describe SessionsController, type: :controller do
                 email: user.email,
                 password: 'test123'
               },
-              redirect: root_path,
+              redirect: root_path
             },
             as: :json
 

--- a/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -38,7 +38,7 @@ describe Teachers::ClassroomsController, type: :controller do
       post :remove_students,
         params: {
           classroom_id: classroom.id,
-          student_ids: [students_classroom.student_id],
+          student_ids: [students_classroom.student_id]
         },
         as: :json
       students_classroom.reload

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/csv_exports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/csv_exports_controller_spec.rb
@@ -12,7 +12,7 @@ describe Teachers::ProgressReports::CsvExportsController, type: :controller do
     subject do
       post :create, params: { report_url: "/teachers/progress_reports/standards/classrooms/#{classroom_one.id}/students", csv_export: {
         export_type: export_type,
-        filters: filters,
+        filters: filters
       } }
     end
 

--- a/services/QuillLMS/spec/helpers/segment_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/segment_helper_spec.rb
@@ -75,7 +75,7 @@ describe SegmentioHelper do
       request = RequestStruct.new(nil, nil)
       properties = {
         'test1': 1,
-        'test2': 2,
+        'test2': 2
       }
       formatted_properties = format_analytics_properties(request, properties)
       properties.keys.each do |property|

--- a/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
+++ b/services/QuillLMS/spec/lib/rule_feedback_history_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RuleFeedbackHistory, type: :model do
         total_responses: 2,
         weak_responses: 1,
         repeated_consecutive_responses: 1,
-        repeated_non_consecutive_responses: 1,
+        repeated_non_consecutive_responses: 1
       }
 
       expect(report.first).to eq(expected)

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -66,7 +66,7 @@ describe TimeTrackingCleaner do
       },
       'time_tracking_edits' => {
         'since' => 99999,
-        'so' => 9999999,
+        'so' => 9999999
       }
     }
   end
@@ -93,7 +93,7 @@ describe TimeTrackingCleaner do
       },
       'time_tracking_edits' => {
         'so' => 9999999,
-        'but' => 999999,
+        'but' => 999999
       }
     }
   end

--- a/services/QuillLMS/spec/models/activity_session_spec.rb
+++ b/services/QuillLMS/spec/models/activity_session_spec.rb
@@ -79,7 +79,7 @@ describe ActivitySession, type: :model, redis: true do
       it 'should return false' do
         result = ActivitySession.assign_follow_up_lesson(
           classroom_unit.id,
-          activity.uid,
+          activity.uid
         )
 
         expect(result).to eq(false)
@@ -100,7 +100,7 @@ describe ActivitySession, type: :model, redis: true do
       it 'should create the unit_activity and the classroom unit activity state' do
         unit_activity = ActivitySession.assign_follow_up_lesson(
           classroom_unit.id,
-          activity.id,
+          activity.id
         )
         expect(unit_activity.activity_id).to eq(follow_up_activity.id)
         expect(unit_activity.unit_id).to eq(unit.id)
@@ -124,7 +124,7 @@ describe ActivitySession, type: :model, redis: true do
       it 'should return the unit_activity and create a classroom activity unit state' do
         follow_up_unit_activity = ActivitySession.assign_follow_up_lesson(
           classroom_unit.id,
-          activity.id,
+          activity.id
         )
         expect(follow_up_unit_activity.id).to eq(unit_activity.id)
         expect(unit_activity.classroom_unit_activity_states.first).to be
@@ -146,7 +146,7 @@ describe ActivitySession, type: :model, redis: true do
       it 'should return the unit_activity, make it visible, and create a classroom activity unit state' do
         follow_up_unit_activity = ActivitySession.assign_follow_up_lesson(
           classroom_unit.id,
-          activity.id,
+          activity.id
         )
         expect(follow_up_unit_activity.id).to eq(unit_activity.id)
         expect(follow_up_unit_activity.visible).to eq(true)

--- a/services/QuillLMS/spec/models/concept_result_spec.rb
+++ b/services/QuillLMS/spec/models/concept_result_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe ConceptResult, type: :model do
           "prompt": 'Deserts are very dry. Years go by without rain.',
           "attemptNumber": 2,
           "answer": 'Deserts are very dry, and years go by without rain.',
-          "questionNumber": 1,
+          "questionNumber": 1
         }
       end
       let(:metadata3) do
@@ -258,7 +258,7 @@ RSpec.describe ConceptResult, type: :model do
           "prompt": 'Deserts are very dry. Years go by without rain.',
           "attemptNumber": 2,
           "answer": 'Deserts are very dry, and years go by without rain.',
-          "questionNumber": 1,
+          "questionNumber": 1
         }
       end
       let(:concept_result1) { ConceptResult.create_from_json({ concept_id: concept.id, activity_session_id: activity_session.id, metadata: metadata1, activity_classification_id: activity.activity_classification_id, question_type: 'sentence-combining' }) }

--- a/services/QuillLMS/spec/models/feedback_history_spec.rb
+++ b/services/QuillLMS/spec/models/feedback_history_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe FeedbackHistory, type: :model do
         feedback: 'write better',
         feedback_type: 'grammar',
         optimal: false,
-        highlight: [],
+        highlight: []
       }
     }
 

--- a/services/QuillLMS/spec/models/segment_integration/user_spec.rb
+++ b/services/QuillLMS/spec/models/segment_integration/user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SegmentIntegration::User do
           last_name: admin.last_name,
           email: admin.email,
           flags: admin.flags&.join(', '),
-          flagset: admin.flagset,
+          flagset: admin.flagset
         }.reject { |_, v| v.nil? },
         integrations: admin.segment_user.integration_rules
       }

--- a/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_aggregate_query_spec.rb
+++ b/services/QuillLMS/spec/queries/admin_diagnostic_reports/diagnostic_aggregate_query_spec.rb
@@ -70,7 +70,7 @@ module AdminDiagnosticReports
       {
         timeframe_start: timeframe_start,
         timeframe_end: timeframe_end,
-        school_ids: school_ids,
+        school_ids: school_ids
       }
     end
     let(:results) { test_admin_diagnostic_query.run(**query_args, aggregation: aggregation_arg, runner: runner) }

--- a/services/QuillLMS/spec/queries/lesson_recommendations_query.rb
+++ b/services/QuillLMS/spec/queries/lesson_recommendations_query.rb
@@ -17,7 +17,7 @@ describe LessonRecommendationsQuery do
       expect(subject.rec_activities(unit_template.id).first).to eq(
         {
           name: activity.name,
-          url: "#{activity_classification.form_url}customize/#{activity.uid}?&preview=true",
+          url: "#{activity_classification.form_url}customize/#{activity.uid}?&preview=true"
         }
       )
     end
@@ -74,7 +74,7 @@ describe LessonRecommendationsQuery do
                     },
                     {
                       concept_id: 'QNkNRs8zbCXU7nLBeo4mgA',
-                      count: 1,
+                      count: 1
                     }
                   ],
                 previously_assigned: true
@@ -87,7 +87,7 @@ describe LessonRecommendationsQuery do
                   [
                     {
                       concept_id: 'oCQCO1_eVXQ2zqw_7QOuBw',
-                      count: 1,
+                      count: 1
                     }
                   ],
                 previously_assigned: true
@@ -210,7 +210,7 @@ describe LessonRecommendationsQuery do
                     },
                     {
                       concept_id: 'QNkNRs8zbCXU7nLBeo4mgA',
-                      count: 1,
+                      count: 1
                     }
                   ]
               },
@@ -222,7 +222,7 @@ describe LessonRecommendationsQuery do
                   [
                     {
                       concept_id: 'oCQCO1_eVXQ2zqw_7QOuBw',
-                      count: 1,
+                      count: 1
                     }
                   ]
               },
@@ -346,7 +346,7 @@ describe LessonRecommendationsQuery do
                   concept_id: 'KvF_BYehx-U2Mk5oGbcjBw',
                   count: 1,
                   noIncorrect: true
-                },
+                }
 
               ],
               previously_assigned: true

--- a/services/QuillLMS/spec/queries/staff/rules_analysis_query_spec.rb
+++ b/services/QuillLMS/spec/queries/staff/rules_analysis_query_spec.rb
@@ -15,13 +15,13 @@ module Staff
 
         example_bigquery_result = [
           {
-            :id => rule.id,
+            :id => rule.id
           }
         ]
 
         expected = {
           first_feedback: 'a' * 10,
-          second_feedback: 'b' * 10,
+          second_feedback: 'b' * 10
         }
 
         expect(

--- a/services/QuillLMS/spec/requests/canvas_instances_controller_spec.rb
+++ b/services/QuillLMS/spec/requests/canvas_instances_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe CanvasInstancesController do
 
       let(:valid_params) do
         {
-          id: canvas_instance.id,
+          id: canvas_instance.id
         }
       end
 

--- a/services/QuillLMS/spec/serializers/lesson_planner/unit_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/lesson_planner/unit_serializer_spec.rb
@@ -26,7 +26,7 @@ describe LessonPlanner::UnitSerializer, type: :serializer do
       create(:classroom_unit,
         classroom: classroom,
         assigned_student_ids: [],
-        unit: unit,)
+        unit: unit)
     end
 
     let!(:unit_activity) do

--- a/services/QuillLMS/spec/serializers/progress_reports/activity_session_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/activity_session_serializer_spec.rb
@@ -7,7 +7,7 @@ describe ProgressReports::ActivitySessionSerializer, type: :serializer do
     create(:activity_session,
       started_at: started_at,
       completed_at: completed_at,
-      percentage: 0.25,)
+      percentage: 0.25)
   end
   let(:classroom) { create(:classroom) }
   let(:standard) { create(:standard) }

--- a/services/QuillLMS/spec/serializers/progress_reports/concepts/student_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/concepts/student_serializer_spec.rb
@@ -25,7 +25,7 @@ describe ProgressReports::Concepts::StudentSerializer, type: :serializer do
       classroom_unit: classroom_unit,
       percentage: 0.7547,
       state: 'finished',
-      completed_at: 5.minutes.ago,
+      completed_at: 5.minutes.ago
     )
     activity_session.concept_results.create!(concept: concept, correct: true)
     activity_session.concept_results.create!(concept: concept, correct: false)

--- a/services/QuillLMS/spec/services/admin_diagnostic_reports/overview_csv_generator_spec.rb
+++ b/services/QuillLMS/spec/services/admin_diagnostic_reports/overview_csv_generator_spec.rb
@@ -35,7 +35,7 @@ module AdminDiagnosticReports
         {
           name: aggregate_row_name1,
           pre_students_assigned: assigned1,
-          pre_students_completed: completed1,
+          pre_students_completed: completed1
         }
       ]
     end

--- a/services/QuillLMS/spec/services/admin_diagnostic_reports/skills_csv_generator_spec.rb
+++ b/services/QuillLMS/spec/services/admin_diagnostic_reports/skills_csv_generator_spec.rb
@@ -26,7 +26,7 @@ module AdminDiagnosticReports
         {
           skill_group_name: skill_group_name2,
           pre_score: pre_score2,
-          post_score: post_score2,
+          post_score: post_score2
         }
       ]
     end
@@ -35,7 +35,7 @@ module AdminDiagnosticReports
         {
           name: aggregate_row_name1,
           pre_score: pre_score1,
-          post_score: post_score1,
+          post_score: post_score1
         }
       ]
     end

--- a/services/QuillLMS/spec/services/canvas_integration/classroom_data_adapter_spec.rb
+++ b/services/QuillLMS/spec/services/canvas_integration/classroom_data_adapter_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CanvasIntegration::ClassroomDataAdapter do
       alreadyImported: already_imported,
       classroom_external_id: classroom_external_id,
       name: classroom_name,
-      studentCount: students.count,
+      studentCount: students.count
     }
   end
 

--- a/services/QuillLMS/spec/services/google_integration/student_creator_spec.rb
+++ b/services/QuillLMS/spec/services/google_integration/student_creator_spec.rb
@@ -20,7 +20,7 @@ module GoogleIntegration
         first_name: first_name,
         last_name: last_name,
         name: name,
-        user_external_id: user_external_id,
+        user_external_id: user_external_id
       }
     end
 

--- a/services/QuillLMS/spec/services/learn_worlds_integration/sso_request_spec.rb
+++ b/services/QuillLMS/spec/services/learn_worlds_integration/sso_request_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe LearnWorldsIntegration::SSORequest do
         user_id: user_id,
         url: url,
         errors: [],
-        success: true,
+        success: true
       }.stringify_keys
     end
 

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_organization_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_organization_spec.rb
@@ -63,7 +63,7 @@ describe VitallyIntegration::SerializeVitallySalesOrganization do
           activities_completed_per_student_this_year: 0,
           activities_completed_per_student_last_year: 0,
           activities_completed_per_student_all_time: 0,
-          last_active_time: nil,
+          last_active_time: nil
         }
       })
     end

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_user_spec.rb
@@ -38,7 +38,7 @@ describe VitallyIntegration::SerializeVitallySalesUser do
       percent_completed_diagnostics: 1.0,
       evidence_activities_assigned: 2,
       evidence_activities_completed: 1,
-      completed_evidence_activities_per_student: 0.5,
+      completed_evidence_activities_per_student: 0.5
     }
     year = School.school_year_start(1.year.ago).year
     VitallyIntegration::CacheVitallyTeacherData.set(teacher.id, year, previous_year_data.to_json)

--- a/services/QuillLMS/spec/support/carrierwave.rb
+++ b/services/QuillLMS/spec/support/carrierwave.rb
@@ -4,7 +4,7 @@ Fog.mock!
 Fog.credentials = {
   provider: 'AWS',
   aws_access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID', ''),
-  aws_secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY', ''),
+  aws_secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY', '')
 }
 
 # Ridiculous hack to get Fog.mock! to cache this fake connection

--- a/services/QuillLMS/spec/workers/ip_location_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/ip_location_worker_spec.rb
@@ -25,7 +25,7 @@ describe IpLocationWorker do
           'country_name' => 'country',
           'region_name' => 'region',
           'city_name' => 'city',
-          'postcode' => '110011',
+          'postcode' => '110011'
         }.to_json
       }
 


### PR DESCRIPTION
## WHAT
Don't allow trailing commas in arrays or argument lists. 
- [Style/TrailingCommaInArguments](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInArguments)
- [Style/TrailingCommaInArrayLiteral](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInArrayLiteral) 
- [Style/TrailingCommaInBlockArgs](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInBlockArgs) 
- [Style/TrailingCommaInHashLiteral](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInHashLiteral) 


## WHY
It's a little strange looking, and it's good to have consistency so you don't have to think about this. 
## HOW
Remove exceptions from Rubocop. 


### What have you done to QA this feature?
Ran tests
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO--non-code change
Have you deployed to Staging? | NO -- non-code change 
Self-Review: Have you done an initial self-review of the code below on Github? | YES

### Note: 
This may be controversial as I know we use a lot of trailing commas in the javascript, so feel free to take it or leave it. 
