### PR TITLE
Enforce more rubocop style rules. 

### DIFF
--- a/services/.rubocop_base.yml
+++ b/services/.rubocop_base.yml
@@ -494,6 +494,9 @@ Style/BarePercentLiterals:
 Style/BlockComments:
   Enabled: true
 
+Style/BlockDelimiters:
+  Enabled: false
+
 Style/ClassEqualityComparison:
   Enabled: true
 

--- a/services/.rubocop_base.yml
+++ b/services/.rubocop_base.yml
@@ -699,6 +699,10 @@ Style/RegexpLiteral:
 Style/SelectByRegexp:
   Enabled: true
 
+Style/Semicolon:
+  Enabled: true
+  AllowAsExpressionSeparator: true
+
 Style/SignalException:
   Enabled: true
 

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -771,7 +771,6 @@ Style/IdenticalConditionalBranches:
 Style/IfUnlessModifier:
   Enabled: false
 
-
 # Offense count: 5
 Style/MixinUsage:
   Exclude:
@@ -785,13 +784,6 @@ Style/MixinUsage:
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: literals, strict
 Style/MutableConstant:
-  Enabled: false
-
-# Offense count: 49
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: both, prefix, postfix
-Style/NegatedIf:
   Enabled: false
 
 # Offense count: 13

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -772,13 +772,6 @@ Style/IfUnlessModifier:
   Enabled: false
 
 
-# Offense count: 28
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: require_parentheses, require_no_parentheses, require_no_parentheses_except_multiline
-Style/MethodDefParentheses:
-  Enabled: false
-
 # Offense count: 5
 Style/MixinUsage:
   Exclude:

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -806,11 +806,7 @@ Style/NumericPredicate:
 Style/PercentLiteralDelimiters:
   Enabled: false
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantCapitalW:
-  Exclude:
-    - 'config/initializers/sentry.rb'
+
 
 # Offense count: 23
 # This cop supports safe autocorrection (--autocorrect).

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -662,15 +662,6 @@ Style/AndOr:
     - 'app/models/zipcode_info.rb'
     - 'lib/tasks/create_concepts.rake'
 
-# Offense count: 141
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, AllowedMethods, AllowedPatterns, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.
-# SupportedStyles: line_count_based, semantic, braces_for_chaining, always_braces
-# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-# FunctionalMethods: let, let!, subject, watch
-# AllowedMethods: lambda, proc, it
-Style/BlockDelimiters:
-  Enabled: false
 
 # Offense count: 9
 # This cop supports safe autocorrection (--autocorrect).

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -725,25 +725,7 @@ Style/DoubleNegation:
     - 'script/recommendations/01_import_group_lesson_recommendations.rb'
     - 'spec/models/classroom_spec.rb'
 
-# Offense count: 15
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: compact, expanded
-Style/EmptyMethod:
-  Exclude:
-    - 'app/controllers/cms/images_controller.rb'
-    - 'app/controllers/cms/rosters_controller.rb'
-    - 'app/controllers/cms/subscriptions_controller.rb'
-    - 'app/controllers/cms/unit_template_categories_controller.rb'
-    - 'app/controllers/cms/users_controller.rb'
-    - 'app/controllers/schools_controller.rb'
-    - 'app/controllers/teacher_fix_controller.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/models/ability.rb'
-    - 'db/migrate/20140423225449_add_search_indexes_to_users.rb'
-    - 'engines/evidence/spec/dummy/app/mailers/file_mailer.rb'
-    - 'engines/evidence/spec/dummy/app/models/concerns/sidekiq_module.rb'
-    - 'engines/evidence/spec/dummy/app/models/error_notifier.rb'
+
 
 # Offense count: 27
 # This cop supports safe autocorrection (--autocorrect).

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -844,14 +844,6 @@ Style/RescueStandardError:
 Style/SafeNavigation:
   Enabled: false
 
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowAsExpressionSeparator.
-Style/Semicolon:
-  Exclude:
-    - 'app/controllers/teachers/progress_reports/activity_sessions_controller.rb'
-    - 'spec/support/pages/teachers/class_manager/invite_students_page.rb'
-
 # Offense count: 6453
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -786,23 +786,6 @@ Style/MixinUsage:
 Style/MutableConstant:
   Enabled: false
 
-# Offense count: 13
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, MinBodyLength.
-# SupportedStyles: skip_modifier_ifs, always
-Style/Next:
-  Exclude:
-    - 'app/helpers/email_api_helper.rb'
-    - 'app/models/concerns/public_progress_reports.rb'
-    - 'app/models/concerns/student.rb'
-    - 'app/queries/progress_reports/activities_scores_by_classroom.rb'
-    - 'app/workers/concept_replacement_connect_worker.rb'
-    - 'app/workers/concept_replacement_grammar_worker.rb'
-    - 'db/migrate/20201023212528_populate_topics.rb'
-    - 'lib/tasks/add_user_id_to_units.rake'
-    - 'lib/tasks/convert_activity_session_timetracking_data.rake'
-    - 'lib/tasks/convert_to_markdown.rake'
-    - 'lib/tasks/reset_admin_caches.rake'
 
 # Offense count: 243
 # This cop supports safe autocorrection (--autocorrect).

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -806,11 +806,6 @@ Style/NumericPredicate:
 Style/PercentLiteralDelimiters:
   Enabled: false
 
-# Offense count: 35
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantBegin:
-  Enabled: false
-
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantCapitalW:

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -823,7 +823,6 @@ Style/RedundantPercentQ:
     - 'db/migrate/20180824185130_replace_function_timepent_activity_session.rb'
     - 'db/migrate/20180824195642_replace_function_timepent_activity_session_again.rb'
     - 'db/migrate/20180831194810_add_function_timespent_question.rb'
-    - 'spec/support/pages/teachers/class_manager/invite_students_page.rb'
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -844,12 +844,6 @@ Style/RescueStandardError:
 Style/SafeNavigation:
   Enabled: false
 
-# Offense count: 6453
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
 
 # Offense count: 284
 # This cop supports safe autocorrection (--autocorrect).

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -771,17 +771,6 @@ Style/IdenticalConditionalBranches:
 Style/IfUnlessModifier:
   Enabled: false
 
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowedMethods, AllowedPatterns.
-Style/MethodCallWithoutArgsParentheses:
-  Exclude:
-    - 'app/controllers/integrations_controller.rb'
-    - 'app/controllers/schools_controller.rb'
-    - 'app/models/concerns/public_progress_reports.rb'
-    - 'app/models/invitation.rb'
-    - 'spec/models/activity_spec.rb'
-    - 'spec/script/setup_concepts_spec.rb'
 
 # Offense count: 28
 # This cop supports safe autocorrection (--autocorrect).

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -812,11 +812,6 @@ Style/RedundantCapitalW:
   Exclude:
     - 'config/initializers/sentry.rb'
 
-# Offense count: 380
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantParentheses:
-  Enabled: false
-
 # Offense count: 23
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantPercentQ:

--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -732,14 +732,6 @@ Style/DoubleNegation:
 Style/ExpandPathArguments:
   Enabled: false
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: format, sprintf, percent
-Style/FormatString:
-  Exclude:
-    - 'engines/evidence/lib/generators/controller_tests/controller_tests_generator.rb'
-
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, MaxUnannotatedPlaceholdersAllowed, AllowedMethods, AllowedPatterns.

--- a/services/QuillLMS/app/controllers/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/activities_controller.rb
@@ -111,7 +111,7 @@ class ActivitiesController < ApplicationController
       selected_activities = selected_activities.or(Activity.evidence.evidence_beta2).or(Activity.evidence.evidence_beta1)
     end
 
-    selected_activities.map(&:serialize_with_topics_and_publication_date).sort_by { |a| Date.strptime(a[:publication_date], "%Y-%m-%dT%H:%M:%S") }.reverse!
+    selected_activities.map(&:serialize_with_topics_and_publication_date).sort_by { |a| Date.strptime(a[:publication_date], '%Y-%m-%dT%H:%M:%S') }.reverse!
   end
 
   private def authorized_activity_access?

--- a/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activities_controller.rb
@@ -85,10 +85,10 @@ class Api::V1::ActivitiesController < Api::ApiController
   def published_edition
     objective = Objective.find_by_name('Publish Customized Lesson')
     milestone = Milestone.find_by_name('Publish Customized Lesson')
-    if !Checkbox.find_by(objective_id: objective.id, user_id: current_user.id)
+    unless Checkbox.find_by(objective_id: objective.id, user_id: current_user.id)
       Checkbox.create(objective_id: objective.id, user_id: current_user.id)
     end
-    if !UserMilestone.find_by(milestone_id: milestone.id, user_id: current_user.id)
+    unless UserMilestone.find_by(milestone_id: milestone.id, user_id: current_user.id)
       UserMilestone.create(milestone_id: milestone.id, user_id: current_user.id)
     end
     render json: {}

--- a/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/activity_sessions_controller.rb
@@ -80,7 +80,7 @@ class Api::V1::ActivitySessionsController < Api::ApiController
   end
 
   private def handle_concept_results
-    return if !@concept_results
+    return unless @concept_results
 
     BatchSaveActivitySessionConceptResultsWorker.perform_async(@concept_results, @activity_session.id, @activity_session.uid)
   end

--- a/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
@@ -64,27 +64,23 @@ class Api::V1::ClassroomUnitsController < Api::ApiController
       end
     end
 
-    follow_up_unit_activity = begin
-      if params[:follow_up].present?
-        ActivitySession.assign_follow_up_lesson(
-          params[:classroom_unit_id],
-          params[:activity_id]
-        )
+    follow_up_unit_activity = if params[:follow_up].present?
+                                ActivitySession.assign_follow_up_lesson(
+                                  params[:classroom_unit_id],
+                                  params[:activity_id]
+                                )
       else
         false
       end
-    end
 
-    url = begin
-      if follow_up_unit_activity.present?
-        ActivitySession.generate_activity_url(
-          params[:classroom_unit_id],
-          follow_up_unit_activity.activity_id
-        )
+    url = if follow_up_unit_activity.present?
+            ActivitySession.generate_activity_url(
+              params[:classroom_unit_id],
+              follow_up_unit_activity.activity_id
+            )
       else
         (ENV['DEFAULT_URL']).to_s
       end
-    end
 
     render json: { follow_up_url: url }
   end

--- a/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/classroom_units_controller.rb
@@ -59,7 +59,7 @@ class Api::V1::ClassroomUnitsController < Api::ApiController
 
     if params[:edition_id]
       milestone = Milestone.find_by_name('Complete Customized Lesson')
-      if !UserMilestone.find_by(user_id: current_user.id, milestone_id: milestone.id)
+      unless UserMilestone.find_by(user_id: current_user.id, milestone_id: milestone.id)
         UserMilestone.create(user_id: current_user.id, milestone_id: milestone.id)
       end
     end

--- a/services/QuillLMS/app/controllers/api/v1/shared_cache_controller.rb
+++ b/services/QuillLMS/app/controllers/api/v1/shared_cache_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::SharedCacheController < Api::ApiController
 
   def show
     cached_data = $redis.get(cache_key)
-    if !cached_data
+    unless cached_data
       return not_found
     end
 

--- a/services/QuillLMS/app/controllers/application_controller.rb
+++ b/services/QuillLMS/app/controllers/application_controller.rb
@@ -90,12 +90,10 @@ class ApplicationController < ActionController::Base
   end
 
   def non_standard_route_redirect?(route)
-    (
-      route_redirects_to_my_account?(route) ||
+    route_redirects_to_my_account?(route) ||
       route_redirects_to_assign?(route) ||
       route_redirects_to_classrooms_index?(route) ||
       route_redirects_to_diagnostic?(route)
-    )
   end
 
   private def handle_invalid_authenticity_token

--- a/services/QuillLMS/app/controllers/cms/images_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/images_controller.rb
@@ -26,8 +26,7 @@ class Cms::ImagesController < Cms::CmsController
     redirect_to action: 'index'
   end
 
-  def update
-  end
+  def update; end
 
   private def directory
     credentials = {

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -3,8 +3,7 @@
 class Cms::RostersController < Cms::CmsController
   before_action :signed_in!
 
-  def index
-  end
+  def index; end
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def upload_teachers_and_students

--- a/services/QuillLMS/app/controllers/cms/rosters_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/rosters_controller.rb
@@ -39,7 +39,7 @@ class Cms::RostersController < Cms::CmsController
         teacher = User.find_by(email: teacher_email)
         classroom = Classroom.joins(:classrooms_teachers).where('classrooms_teachers.user_id = ?', teacher.id).where(name: s[:classroom]).first
 
-        if !classroom
+        unless classroom
           classroom = Classroom.create!(name: s[:classroom])
           ClassroomsTeacher.create!(user: teacher, classroom: classroom, role: 'owner')
         end

--- a/services/QuillLMS/app/controllers/cms/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/schools_controller.rb
@@ -112,52 +112,46 @@ class Cms::SchoolsController < Cms::CmsController
   end
 
   def add_admin_by_email
-    begin
-      user = User.find_by(email: params[:email_address])
-      school = School.find(params[:id])
-      SchoolsAdmins.create(user_id: user.id, school_id: school.id)
-      flash[:success] = 'Yay! It worked! 🎉'
-      redirect_to cms_school_path(params[:id])
-    rescue
-      flash[:error] = "It didn't work! 😭😭😭"
-      redirect_back(fallback_location: fallback_location)
-    end
+    user = User.find_by(email: params[:email_address])
+    school = School.find(params[:id])
+    SchoolsAdmins.create(user_id: user.id, school_id: school.id)
+    flash[:success] = 'Yay! It worked! 🎉'
+    redirect_to cms_school_path(params[:id])
+  rescue
+    flash[:error] = "It didn't work! 😭😭😭"
+    redirect_back(fallback_location: fallback_location)
   end
 
   def add_existing_user_by_email
-    begin
-      user = User.find_by!(email: params[:email_address])
-      raise ArgumentError unless user.teacher?
+    user = User.find_by!(email: params[:email_address])
+    raise ArgumentError unless user.teacher?
 
-      school = School.find_by!(id: params[:id])
-      SchoolsUsers.where(user: user).destroy_all
-      SchoolsUsers.create!(user_id: user.id, school_id: school.id)
-      flash[:success] = 'Yay! It worked! 🎉'
-      redirect_to cms_school_path(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      flash[:error] = "It didn't work! Make sure the email you typed is correct."
-      redirect_back(fallback_location: fallback_location)
-    rescue ArgumentError
-      flash[:error] = "It didn't work! Make sure the account you entered belogs to a teacher, not staff or student."
-      redirect_back(fallback_location: fallback_location)
-    rescue
-      flash[:error] = "It didn't work. See a developer about this issue."
-      redirect_back(fallback_location: fallback_location)
-    end
+    school = School.find_by!(id: params[:id])
+    SchoolsUsers.where(user: user).destroy_all
+    SchoolsUsers.create!(user_id: user.id, school_id: school.id)
+    flash[:success] = 'Yay! It worked! 🎉'
+    redirect_to cms_school_path(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    flash[:error] = "It didn't work! Make sure the email you typed is correct."
+    redirect_back(fallback_location: fallback_location)
+  rescue ArgumentError
+    flash[:error] = "It didn't work! Make sure the account you entered belogs to a teacher, not staff or student."
+    redirect_back(fallback_location: fallback_location)
+  rescue
+    flash[:error] = "It didn't work. See a developer about this issue."
+    redirect_back(fallback_location: fallback_location)
   end
 
   def unlink
-    begin
-      teacher = User.find(params[:teacher_id])
-      if teacher.unlink
-        flash[:success] = 'Yay! It worked! 🎉'
-      else
-        flash[:error] = "It didn't work. See a developer about this issue."
-      end
-      redirect_back(fallback_location: fallback_location)
-    rescue
-      flash[:error] = "It didn't work. Make sure the teacher still exists and belongs to this school."
+    teacher = User.find(params[:teacher_id])
+    if teacher.unlink
+      flash[:success] = 'Yay! It worked! 🎉'
+    else
+      flash[:error] = "It didn't work. See a developer about this issue."
     end
+    redirect_back(fallback_location: fallback_location)
+  rescue
+    flash[:error] = "It didn't work. Make sure the teacher still exists and belongs to this school."
   end
 
   private def set_school

--- a/services/QuillLMS/app/controllers/cms/subscriptions_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/subscriptions_controller.rb
@@ -4,8 +4,7 @@ class Cms::SubscriptionsController < Cms::CmsController
   before_action :set_subscription, only: %i[show edit update destroy]
   before_action :subscription_data, only: [:edit]
 
-  def show
-  end
+  def show; end
 
   def create
     if params[:subscriber_id] && params[:subscriber_type]
@@ -40,8 +39,7 @@ class Cms::SubscriptionsController < Cms::CmsController
     render json: @subscription.reload
   end
 
-  def destroy
-  end
+  def destroy; end
 
   private def set_subscription
     @subscription = Subscription.find(params[:id])

--- a/services/QuillLMS/app/controllers/cms/unit_template_categories_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/unit_template_categories_controller.rb
@@ -11,8 +11,7 @@ class Cms::UnitTemplateCategoriesController < Cms::CmsController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @unit_template_category = UnitTemplateCategory.new(unit_template_category_params)

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -233,21 +233,21 @@ class Cms::UsersController < Cms::CmsController
 
     case param
     when 'user_name'
-      "users.name ILIKE #{(sanitized_fuzzy_param_value)}"
+      "users.name ILIKE #{sanitized_fuzzy_param_value}"
     when 'user_role'
-      "users.role = #{(sanitized_param_value)}"
+      "users.role = #{sanitized_param_value}"
     when 'user_username'
-      "users.username ILIKE #{(sanitized_fuzzy_param_value)}"
+      "users.username ILIKE #{sanitized_fuzzy_param_value}"
     when 'user_email_exact'
-      "users.email = LOWER(TRIM(#{(sanitized_param_value)}))"
+      "users.email = LOWER(TRIM(#{sanitized_param_value}))"
     when 'user_email'
-      "users.email ILIKE #{(sanitized_fuzzy_param_value)}"
+      "users.email ILIKE #{sanitized_fuzzy_param_value}"
     when 'flagset'
-      "users.flagset = #{(sanitized_param_value)}"
+      "users.flagset = #{sanitized_param_value}"
     when 'user_ip'
-      "users.ip_address = #{(sanitized_param_value)}"
+      "users.ip_address = #{sanitized_param_value}"
     when 'school_name'
-      "schools.name ILIKE #{(sanitized_fuzzy_param_value)}"
+      "schools.name ILIKE #{sanitized_fuzzy_param_value}"
     when 'user_premium_status'
       "subscriptions.account_type IN (#{sanitized_param_value})"
     else

--- a/services/QuillLMS/app/controllers/cms/users_controller.rb
+++ b/services/QuillLMS/app/controllers/cms/users_controller.rb
@@ -90,8 +90,7 @@ class Cms::UsersController < Cms::CmsController
     redirect_back(fallback_location: cms_users_path)
   end
 
-  def edit
-  end
+  def edit; end
 
   def edit_subscription
     @subscription = @user.subscription

--- a/services/QuillLMS/app/controllers/concerns/slack_tasks.rb
+++ b/services/QuillLMS/app/controllers/concerns/slack_tasks.rb
@@ -4,7 +4,7 @@ module SlackTasks
   LIVE = Rails.env.production?
 
   def post_sales_form_submission(sales_form_submission)
-    return if !should_post_to_slack?
+    return unless should_post_to_slack?
 
     webhook_url = ENV.fetch('SLACK_API_WEBHOOK_SALES', '')
     return unless webhook_url.present?

--- a/services/QuillLMS/app/controllers/integrations_controller.rb
+++ b/services/QuillLMS/app/controllers/integrations_controller.rb
@@ -6,7 +6,7 @@ class IntegrationsController < ApplicationController
   before_action :set_root_url
 
   def amplify
-    store_partner_session()
+    store_partner_session
     @body_class = 'full-width-page white-page'
     @js_file = 'public'
     @active_tab = 'Featured Activities'

--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -178,12 +178,10 @@ class ProfilesController < ApplicationController
   protected def next_activity_session
     # We only need to check the first activity session record here because of
     # the order in which the the query returns these.
-    can_display_next_activity = begin
-      @act_sesh_records.any? &&
-      @act_sesh_records.first['locked'] == false &&
-      @act_sesh_records.first['marked_complete'] == false &&
-      !@act_sesh_records.first['max_percentage']
-    end
+    can_display_next_activity = @act_sesh_records.any? &&
+                                @act_sesh_records.first['locked'] == false &&
+                                @act_sesh_records.first['marked_complete'] == false &&
+                                !@act_sesh_records.first['max_percentage']
 
     return unless can_display_next_activity
 

--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -129,7 +129,7 @@ class SchoolsController < ApplicationController
     zipcode = nil
     if search.present?
       zipcode = search.match(/\d{5}/).to_s
-      prefix = search.gsub(/\d{5}/, '').strip()
+      prefix = search.gsub(/\d{5}/, '').strip
     end
     unless zipcode.present?
       zipcode = nil

--- a/services/QuillLMS/app/controllers/schools_controller.rb
+++ b/services/QuillLMS/app/controllers/schools_controller.rb
@@ -86,8 +86,7 @@ class SchoolsController < ApplicationController
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
-  def new
-  end
+  def new; end
 
   def select_school
     respond_to do |format|

--- a/services/QuillLMS/app/controllers/students_classrooms_controller.rb
+++ b/services/QuillLMS/app/controllers/students_classrooms_controller.rb
@@ -52,18 +52,16 @@ class StudentsClassroomsController < ApplicationController
   end
 
   def classroom_manager_data
-    begin
-      active = current_user.students_classrooms
-        .includes(classroom: :teacher)
-        .map(&:archived_classrooms_manager)
-      inactive = StudentsClassrooms.unscoped
-        .where(student_id: current_user.id, visible: false)
-        .includes(classroom: :teacher)
-        .map(&:archived_classrooms_manager)
-    rescue NoMethodError => e
-      render json: { error: 'No classrooms yet!' }, status: 400
-      else
-        render json: { active: active, inactive: inactive }
-    end
+    active = current_user.students_classrooms
+      .includes(classroom: :teacher)
+      .map(&:archived_classrooms_manager)
+    inactive = StudentsClassrooms.unscoped
+      .where(student_id: current_user.id, visible: false)
+      .includes(classroom: :teacher)
+      .map(&:archived_classrooms_manager)
+  rescue NoMethodError => e
+    render json: { error: 'No classrooms yet!' }, status: 400
+    else
+      render json: { active: active, inactive: inactive }
   end
 end

--- a/services/QuillLMS/app/controllers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/students_controller.rb
@@ -120,7 +120,7 @@ class StudentsController < ApplicationController
     unit = Unit.find(params['unit_id'])
     classroom_id = params['classroom']
 
-    if !unit.open
+    unless unit.open
       flash[:error] = t('activity_link.errors.activity_pack_closed')
       flash.keep(:error)
       redirect_to(classes_path) and return

--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -184,8 +184,8 @@ class TeacherFixController < ApplicationController
     begin
       classroom1 = Classroom.find_by(code: params['class_code1'])
       classroom2 = Classroom.find_by(code: params['class_code2'])
-      raise 'The first class code is invalid' if !classroom1
-      raise 'The second class code is invalid' if !classroom2
+      raise 'The first class code is invalid' unless classroom1
+      raise 'The second class code is invalid' unless classroom2
 
       TeacherFixes::merge_two_classrooms(classroom1.id, classroom2.id)
     rescue => e
@@ -201,8 +201,8 @@ class TeacherFixController < ApplicationController
 
       unit1 = Unit.find_by(id: params['from_activity_pack_id'])
       unit2 = Unit.find_by(id: params['to_activity_pack_id'])
-      raise 'The first activity pack ID is invalid.' if !unit1
-      raise 'The second activity pack ID is invalid.' if !unit2
+      raise 'The first activity pack ID is invalid.' unless unit1
+      raise 'The second activity pack ID is invalid.' unless unit2
       raise 'The two activity packs must belong to the same teacher.' if unit1.user != unit2.user
 
       raise 'The two activity packs must be assigned to the same classroom.' if (unit1.classrooms & unit2.classrooms).empty?
@@ -220,8 +220,8 @@ class TeacherFixController < ApplicationController
       account_identifier = params['student_identifier']
       user = User.find_by_username_or_email(account_identifier)
       activity = Activity.find_by(name: params['activity_name'])
-      raise 'No such student' if !user
-      raise 'No such activity' if !activity
+      raise 'No such student' unless user
+      raise 'No such activity' unless activity
 
       TeacherFixes::delete_last_activity_session(user.id, activity.id)
     rescue => e

--- a/services/QuillLMS/app/controllers/teacher_fix_controller.rb
+++ b/services/QuillLMS/app/controllers/teacher_fix_controller.rb
@@ -5,8 +5,7 @@ class TeacherFixController < ApplicationController
   before_action :staff!
   before_action :set_user, only: :archived_units
 
-  def index
-  end
+  def index; end
 
   def archived_units
     if !@user

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Teachers::ProgressReports::ActivitySessionsController < Teachers::ProgressReportsController
-  PAGE_SIZE = 25;
+  PAGE_SIZE = 25
 
   def index
     respond_to do |format|

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/activity_sessions_controller.rb
@@ -42,7 +42,7 @@ class Teachers::ProgressReports::ActivitySessionsController < Teachers::Progress
     student_filter = params[:student_id].blank? ? '' : " AND activity_sessions.user_id = #{params[:student_id].to_i}"
     unit_filter = params[:unit_id].blank? ? '' : " AND classroom_units.unit_id = #{params[:unit_id].to_i}"
 
-    case (params[:sort_param])
+    case params[:sort_param]
     when 'student_id'
       sort_field = 'sorting_name'
     when 'activity_name'

--- a/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/progress_reports/diagnostic_reports_controller.rb
@@ -85,7 +85,7 @@ class Teachers::ProgressReports::DiagnosticReportsController < Teachers::Progres
     ) do
       activity_session = find_activity_session_for_student_activity_and_classroom(student_id, activity_id, classroom_id, unit_id)
 
-      if !activity_session
+      unless activity_session
         return {}
       end
 

--- a/services/QuillLMS/app/controllers/teachers/students_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/students_controller.rb
@@ -114,7 +114,7 @@ class Teachers::StudentsController < ApplicationController
     # if teacher was the last user to reset the students password, we will show that password in the class manager to the teacher
     @teacher_created_student = @student.username.split('@').last == @classroom.code
     @teacher_can_edit_password = !(@student.clever_id || @student.signed_up_with_google)
-    @teacher_can_see_password =  (@student.password_digest && @student.authenticate(@student.last_name))
+    @teacher_can_see_password =  @student.password_digest && @student.authenticate(@student.last_name)
     @sign_up_method = {
       "Clever User": @student.clever_id,
       "Google Sign On User": @student.signed_up_with_google,

--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -76,11 +76,9 @@ class Teachers::UnitTemplatesController < ApplicationController
   end
 
   private def redirect_to_public_index_if_no_unit_template_found
-    begin
-      @unit_template = UnitTemplate.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      redirect_to :public_index
-    end
+    @unit_template = UnitTemplate.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to :public_index
   end
 
   private def format_unit_template(ut_id)

--- a/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/unit_templates_controller.rb
@@ -40,7 +40,7 @@ class Teachers::UnitTemplatesController < ApplicationController
     @title = "Activity Pack: #{unit_template&.name}"
     @image_link = @unit_template.image_link
     @unit_template_id = @unit_template.id
-    render 'public_show' if !@is_teacher
+    render 'public_show' unless @is_teacher
   end
 
   def count

--- a/services/QuillLMS/app/controllers/translated_texts_controller.rb
+++ b/services/QuillLMS/app/controllers/translated_texts_controller.rb
@@ -11,7 +11,7 @@ class TranslatedTextsController < ApplicationController
       .per(200)
 
     @translated_texts = @translated_texts.where(locale: params[:locale]) if params[:locale].present?
-    @js_file = "entrypoints/snippets/translated_text.ts"
+    @js_file = 'entrypoints/snippets/translated_text.ts'
     @locales = TranslatedText.select(:locale).distinct.pluck(:locale)
   end
 

--- a/services/QuillLMS/app/graphql/types/user_type.rb
+++ b/services/QuillLMS/app/graphql/types/user_type.rb
@@ -75,7 +75,7 @@ class Types::UserType < Types::BaseObject
     end
   end
 
-  private def concept_results_by_count activity_session
+  private def concept_results_by_count(activity_session)
     hash = Hash.new { |h, k| h[k] = Hash.new { |j, l| j[l] = 0 } }
     activity_session.concept_results.each do |concept_result|
       hash[concept_result.concept.uid]['correct'] += concept_result.correct ? 1 : 0

--- a/services/QuillLMS/app/helpers/application_helper.rb
+++ b/services/QuillLMS/app/helpers/application_helper.rb
@@ -13,8 +13,7 @@ module ApplicationHelper
        aggregation)
   end
 
-  def question_section
-  end
+  def question_section; end
 
   def combine(array1, array2)
     array1 + array2

--- a/services/QuillLMS/app/helpers/email_api_helper.rb
+++ b/services/QuillLMS/app/helpers/email_api_helper.rb
@@ -18,12 +18,12 @@ module EmailApiHelper
     if response['responses']
       response['responses'].each do |resp|
         # only collect feedback responses if there was a comment left
-        if resp['feedback']
-          result = {}
-          result['rating'] = resp['rating']
-          result['feedback'] = resp['feedback']
-          results << result
-        end
+        next unless resp['feedback']
+
+        result = {}
+        result['rating'] = resp['rating']
+        result['feedback'] = resp['feedback']
+        results << result
       end
     end
     results

--- a/services/QuillLMS/app/helpers/navigation_helper.rb
+++ b/services/QuillLMS/app/helpers/navigation_helper.rb
@@ -316,7 +316,7 @@ module NavigationHelper
   end
 
   def determine_mobile_navbar_tabs(current_user)
-    return UNAUTHED_USER_TABS if !current_user
+    return UNAUTHED_USER_TABS unless current_user
 
     return STUDENT_TABS if current_user.student?
 

--- a/services/QuillLMS/app/helpers/public_pages_helper.rb
+++ b/services/QuillLMS/app/helpers/public_pages_helper.rb
@@ -16,7 +16,6 @@ module PublicPagesHelper
   EVIDENCE_HANDBOOK_URL = 'https://docsend.com/view/29vcfdqa5aupkmfp'
 
   def render_react_component?(current_user)
-    (current_user)
     !!(current_user && current_user.email != Demo::ReportDemoCreator::EMAIL)
   end
 

--- a/services/QuillLMS/app/helpers/scorebook_helper.rb
+++ b/services/QuillLMS/app/helpers/scorebook_helper.rb
@@ -58,7 +58,7 @@ module ScorebookHelper
     end
   end
 
-  def alias_by_id id
+  def alias_by_id(id)
     case id
     when 1
       'Quill Proofreader'

--- a/services/QuillLMS/app/lib/core_extensions/array.rb
+++ b/services/QuillLMS/app/lib/core_extensions/array.rb
@@ -13,7 +13,7 @@ module CoreExtensions
       mid = (dup.size / 2).to_i
 
       return dup[mid] if dup.size.odd?
-      return dup[mid] if !dup[0].is_a?(Numeric)
+      return dup[mid] unless dup[0].is_a?(Numeric)
 
       (dup[mid] + dup[mid - 1]) / 2.0
     end

--- a/services/QuillLMS/app/lib/name_generator.rb
+++ b/services/QuillLMS/app/lib/name_generator.rb
@@ -7,7 +7,7 @@ module NameGenerator
 
   extend self
 
-  private def sample file
+  private def sample(file)
     File.readlines(Rails.root.join('db', file)).sample.strip
   end
 end

--- a/services/QuillLMS/app/lib/quill_authentication.rb
+++ b/services/QuillLMS/app/lib/quill_authentication.rb
@@ -177,7 +177,7 @@ module QuillAuthentication
     signed_in? && current_user.role.staff?
   end
 
-  def signed_in_path source
+  def signed_in_path(source)
     session[:attempted_path] || current_user.role.admin? ? cms_path : root_path
   end
 

--- a/services/QuillLMS/app/lib/school_selection_reminder_milestone.rb
+++ b/services/QuillLMS/app/lib/school_selection_reminder_milestone.rb
@@ -10,7 +10,7 @@ module SchoolSelectionReminderMilestone
   end
 
   def show_school_selection_reminders
-    return false if !current_user
+    return false unless current_user
 
     dismiss_school_selection_reminder_milestone = Milestone.find_by_name(Milestone::TYPES[:dismiss_school_selection_reminder])
     UserMilestone.find_by(milestone_id: dismiss_school_selection_reminder_milestone&.id, user_id: current_user.id).nil? && [nil, School::NO_SCHOOL_SELECTED_SCHOOL_NAME].include?(current_user.school&.name)

--- a/services/QuillLMS/app/lib/time_tracking_cleaner.rb
+++ b/services/QuillLMS/app/lib/time_tracking_cleaner.rb
@@ -44,19 +44,15 @@ class TimeTrackingCleaner < ApplicationService
   end
 
   private def max_outliers
-    @max_outliers ||= begin
-      time_tracking
-        .except(*median_outliers.keys)
-        .select { |_, v| v > MAX_TIME_SECTION }
-    end
+    @max_outliers ||= time_tracking
+      .except(*median_outliers.keys)
+      .select { |_, v| v > MAX_TIME_SECTION }
   end
 
   private def median_outliers
-    @median_outliers ||= begin
-      time_tracking
-        .except(*IGNORE_MEDIAN_KEYS)
-        .select { |_, v| v > median_outlier_threshold }
-    end
+    @median_outliers ||= time_tracking
+      .except(*IGNORE_MEDIAN_KEYS)
+      .select { |_, v| v > median_outlier_threshold }
   end
 
   private def median_value

--- a/services/QuillLMS/app/lib/utils/numeric.rb
+++ b/services/QuillLMS/app/lib/utils/numeric.rb
@@ -23,7 +23,7 @@ module Utils::Numeric
 
   # time must be in the format "MM:SS"
   def self.human_readable_time_to_seconds(time)
-    (time.split(':')[0].to_i * 60) + (time.split(':')[1].to_i)
+    (time.split(':')[0].to_i * 60) + time.split(':')[1].to_i
   end
 
   def self.safe_division(numerator, denominator, fallback = nil)

--- a/services/QuillLMS/app/mailers/user_mailer.rb
+++ b/services/QuillLMS/app/mailers/user_mailer.rb
@@ -25,18 +25,18 @@ class UserMailer < ActionMailer::Base
   FEEDBACK_SESSIONS_CSV_DOWNLOAD = 'Feedback Sessions CSV Download'
   FEEDBACK_SESSIONS_CSV_FILENAME = 'feedback_sessions.csv.zip'
 
-  def invitation_to_non_existing_user invitation_email_hash
+  def invitation_to_non_existing_user(invitation_email_hash)
     @email_hash = invitation_email_hash.merge(support_article_link: COTEACHER_SUPPORT_ARTICLE, join_link: new_account_url).stringify_keys
     mail from: 'The Quill Team <hello@quill.org>', 'reply-to': @email_hash['inviter_email'], to: @email_hash['invitee_email'], subject: "#{@email_hash['inviter_name']} has invited you to co-teach on Quill.org!"
   end
 
-  def invitation_to_existing_user invitation_email_hash
+  def invitation_to_existing_user(invitation_email_hash)
     invitation_email_hash.stringify_keys!
     @email_hash = invitation_email_hash.merge(support_article_link: COTEACHER_SUPPORT_ARTICLE, accept_link: teachers_classrooms_url).stringify_keys
     mail from: 'The Quill Team <hello@quill.org>', 'reply-to': @email_hash['inviter_email'], to: @email_hash['invitee_email'], subject: "#{@email_hash['inviter_name']} has invited you to co-teach on Quill.org!"
   end
 
-  def password_reset_email user
+  def password_reset_email(user)
     @user = user
     mail from: 'The Quill Team <hello@quill.org>', to: user.email, subject: 'Reset your Quill password'
   end

--- a/services/QuillLMS/app/models/ability.rb
+++ b/services/QuillLMS/app/models/ability.rb
@@ -27,6 +27,5 @@ class Ability
     temporary
   end
 
-  def temporary
-  end
+  def temporary; end
 end

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -211,7 +211,7 @@ class Activity < ApplicationRecord
     return nil unless is_evidence?
 
     created_time = child_activity.last_flags_change_log_record&.created_at || created_at
-    created_time.strftime("%Y-%m-%dT%H:%M:%S")
+    created_time.strftime('%Y-%m-%dT%H:%M:%S')
   end
 
   # TODO: cleanup
@@ -346,7 +346,7 @@ class Activity < ApplicationRecord
 
   def questions = Question.where(uid: question_uids)
 
-  private def question_uids = data["questions"]&.map { |q| q["key"] }
+  private def question_uids = data['questions']&.map { |q| q['key'] }
 
   private def update_evidence_title?
     is_evidence? && saved_change_to_name?

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -186,7 +186,7 @@ class Activity < ApplicationRecord
     url = Addressable::URI.parse(classification.form_url)
 
     if uid.present?
-      params = (url.query_values || {})
+      params = url.query_values || {}
       params[:uid] = uid
       url.query_values = params
     end
@@ -406,7 +406,7 @@ class Activity < ApplicationRecord
 
   private def construct_redirect_url(base_url, initial_params)
     @url = Addressable::URI.parse(base_url)
-    params = (@url.query_values || {})
+    params = @url.query_values || {}
     params.merge!(initial_params)
     @url.query_values = params
     fix_angular_fragment!
@@ -418,7 +418,7 @@ class Activity < ApplicationRecord
     return evidence_url_helper(initial_params) if classification.key == ActivityClassification::EVIDENCE_KEY
 
     @url = Addressable::URI.parse(classification.module_url)
-    params = (@url.query_values || {})
+    params = @url.query_values || {}
     params.merge!(initial_params)
     params[:uid] = uid if uid.present?
     @url.query_values = params

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -274,9 +274,9 @@ class Activity < ApplicationRecord
   end
 
   def add_question(question)
-    return if !validate_question(question)
+    return unless validate_question(question)
 
-    if !ACTIVITY_TYPES_WITH_QUESTIONS.include?(activity_classification_id)
+    unless ACTIVITY_TYPES_WITH_QUESTIONS.include?(activity_classification_id)
       errors.add(:activity, "You can't add questions to this type of activity.")
       return
     end

--- a/services/QuillLMS/app/models/activity.rb
+++ b/services/QuillLMS/app/models/activity.rb
@@ -153,11 +153,11 @@ class Activity < ApplicationRecord
     find_by(uid: arg) || find(arg)
   end
 
-  def standard_uid= uid
+  def standard_uid=(uid)
     self.standard_id = Standard.find_by_uid(uid).id
   end
 
-  def activity_classification_uid= uid
+  def activity_classification_uid=(uid)
     self.activity_classification_id = ActivityClassification.find_by(uid: uid).id
   end
 
@@ -174,7 +174,7 @@ class Activity < ApplicationRecord
     end
   end
 
-  def classification_key= key
+  def classification_key=(key)
     self.classification = ActivityClassification.find_by_key(key)
   end
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -267,9 +267,9 @@ class ActivitySession < ApplicationRecord
 
   def display_due_date_or_completed_at_date
     if completed_at.present?
-      (completed_at.strftime('%A, %B %d, %Y')).to_s
+      completed_at.strftime('%A, %B %d, %Y').to_s
     elsif unit_activity.present? and unit_activity.due_date.present?
-      (unit_activity.due_date.strftime('%A, %B %d, %Y')).to_s
+      unit_activity.due_date.strftime('%A, %B %d, %Y').to_s
     else
       ''
     end

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -467,12 +467,10 @@ class ActivitySession < ApplicationRecord
   # when using this method, you should eager load as
   # e.g. .includes(:concept_results, activity: {skills: :concepts})
   def correct_skills
-    @correct_skills ||= begin
-      skills.select do |skill|
-        results = concept_results.select { |cr| cr.concept_id.in?(skill.concept_ids) }
+    @correct_skills ||= skills.select do |skill|
+      results = concept_results.select { |cr| cr.concept_id.in?(skill.concept_ids) }
 
-        results.length && results.all?(&:correct)
-      end
+      results.length && results.all?(&:correct)
     end
   end
 

--- a/services/QuillLMS/app/models/activity_session.rb
+++ b/services/QuillLMS/app/models/activity_session.rb
@@ -307,7 +307,7 @@ class ActivitySession < ApplicationRecord
     self['data'] = data.to_h.update(input.except('activity_session'))
   end
 
-  def activity_uid= uid
+  def activity_uid=(uid)
     self.activity_id = Activity.find_by_uid!(uid).id
   end
 
@@ -326,7 +326,7 @@ class ActivitySession < ApplicationRecord
   alias owner user
 
   # TODO: legacy fix
-  def anonymous= anonymous
+  def anonymous=(anonymous)
     self.temporary = anonymous
   end
 

--- a/services/QuillLMS/app/models/change_log.rb
+++ b/services/QuillLMS/app/models/change_log.rb
@@ -157,7 +157,7 @@ class ChangeLog < ApplicationRecord
       'Evidence::Highlight',
       'Evidence::RegexRule',
       'Evidence::PlagiarismText'
-    ].include?(changed_record_type) || !(GENERIC_USER_ACTIONS.include?(action))
+    ].include?(changed_record_type) || !GENERIC_USER_ACTIONS.include?(action)
   end
 
   def record_is_not_being_created_from_cms?

--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -59,7 +59,7 @@ class ClassroomUnit < ApplicationRecord
   def validate_assigned_student(student_id)
     if assign_on_join
       if !assigned_student_ids || assigned_student_ids.exclude?(student_id)
-        if !assigned_student_ids.is_a?(Array)
+        unless assigned_student_ids.is_a?(Array)
           update(assigned_student_ids: [])
         end
         update(assigned_student_ids: StudentsClassrooms.where(classroom_id: classroom_id).pluck(:student_id))

--- a/services/QuillLMS/app/models/concept.rb
+++ b/services/QuillLMS/app/models/concept.rb
@@ -40,11 +40,11 @@ class Concept < ApplicationRecord
   end
 
   # need the below because those making POST requests to /api/v1/concepts know only uids, not ids
-  def parent_uid= uid
+  def parent_uid=(uid)
     self.parent_id = Concept.find_by(uid: uid).id
   end
 
-  def replacement_uid= uid
+  def replacement_uid=(uid)
     self.replacement_id = Concept.find_by(uid: uid).id
   end
 

--- a/services/QuillLMS/app/models/concerns/concepts.rb
+++ b/services/QuillLMS/app/models/concerns/concepts.rb
@@ -12,7 +12,7 @@ module Concepts
     organize_by_type
   end
 
-  private def human_readable_question_type question_type
+  private def human_readable_question_type(question_type)
     # return question_type with '-' changed to space, and each word capitalized, or just return 'Results'
     question_type ? question_type.gsub('-', ' ').split.map(&:capitalize).join(' ') : 'Results'
   end

--- a/services/QuillLMS/app/models/concerns/owner.rb
+++ b/services/QuillLMS/app/models/concerns/owner.rb
@@ -6,7 +6,7 @@ module Owner
   module ClassMethods
     attr_accessor :owner_name
 
-    def ownable owner_name = :owner
+    def ownable(owner_name = :owner)
       self.owner_name = owner_name
 
       if owner_name == :owner
@@ -33,7 +33,7 @@ module Owner
     self.class.owner_name.present?
   end
 
-  def owned_by? user
+  def owned_by?(user)
     return false if owner.blank?
     return false if user.blank?
 

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -135,7 +135,7 @@ module PublicProgressReports
       unit_id: unit_id
     )
 
-    return [] if !classroom_unit
+    return [] unless classroom_unit
 
     activity_sessions = ActivitySession
       .includes(concept_results: :concept)
@@ -194,7 +194,7 @@ module PublicProgressReports
     average_scores = ActivitySession.average_scores_by_student(students.map(&:id))
 
     students.each do |student|
-      next if !student.students_classrooms.map(&:classroom_id).include?(classroom.id)
+      next unless student.students_classrooms.map(&:classroom_id).include?(classroom.id)
 
       finished_session = final_sessions_by_user[student.id]&.first
       if finished_session.present?
@@ -280,7 +280,7 @@ module PublicProgressReports
   end
 
   def get_time_in_minutes(activity_session)
-    return 'Untracked' if !(activity_session.started_at && activity_session.completed_at)
+    return 'Untracked' unless activity_session.started_at && activity_session.completed_at
 
     time = ((activity_session.completed_at - activity_session.started_at) / 60).round
     time > 60 ? '> 60' : time
@@ -423,7 +423,7 @@ module PublicProgressReports
       unit_template_id = recommendation[:activityPackId]
       # teachers may rename and reassign activity packs so we check all
       units = Unit.where(user_id: teacher_id, unit_template_id: unit_template_id, visible: true)
-      if !units
+      unless units
         name = UnitTemplate.find_by(id: unit_template_id).name
         units = Unit.where(user_id: teacher_id, name: name, visible: true)
       end
@@ -497,7 +497,7 @@ module PublicProgressReports
     questions = activity.data['questions'].map { |q| Question.find_by_uid(q['key']) }
 
     questions.compact.each do |q|
-      next if !q.prompt
+      next unless q.prompt
 
       question_array.push({
         question_id: question_array.length + 1,

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -282,7 +282,7 @@ module PublicProgressReports
   def get_time_in_minutes(activity_session)
     return 'Untracked' if !(activity_session.started_at && activity_session.completed_at)
 
-    time = ((activity_session.completed_at - activity_session.started_at) / 60).round()
+    time = ((activity_session.completed_at - activity_session.started_at) / 60).round
     time > 60 ? '> 60' : time
   end
 
@@ -366,7 +366,7 @@ module PublicProgressReports
     if formatted_results.empty?
       100
     else
-      (formatted_results.inject(0) { |sum, crs| sum + crs[:score] } / formatted_results.length).round()
+      (formatted_results.inject(0) { |sum, crs| sum + crs[:score] } / formatted_results.length).round
     end
   end
 
@@ -380,7 +380,7 @@ module PublicProgressReports
       { id: s&.id, name: s&.name || 'Unknown Student', completed: completed }
     end
 
-    sorted_students = students.compact.sort_by { |stud| stud[:name].split().second || '' }
+    sorted_students = students.compact.sort_by { |stud| stud[:name].split.second || '' }
 
     recommendations = RecommendationsQuery.new(diagnostic.id).activity_recommendations.map do |recommendation|
       student_ids = []

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -107,15 +107,15 @@ module PublicProgressReports
         cuas = ClassroomUnitActivityState.find_by(unit_activity: unit_activity, classroom_unit: cu)
         classroom = cu.classroom.attributes
         activity_sessions = cu.completed_activity_sessions
-        if activity_sessions.present? || cuas&.completed || Activity.diagnostic_activity_ids.include?(activity_id.to_i)
-          class_id = classroom['id']
-          h[class_id] ||= classroom
-          h[class_id][:classroom_unit_id] = cu.id
-          activity_sessions.each do |activity_session|
-            h[class_id][:students] ||= []
-            if h[class_id][:students].exclude? activity_session.user
-              h[class_id][:students] << activity_session.user
-            end
+        next unless activity_sessions.present? || cuas&.completed || Activity.diagnostic_activity_ids.include?(activity_id.to_i)
+
+        class_id = classroom['id']
+        h[class_id] ||= classroom
+        h[class_id][:classroom_unit_id] = cu.id
+        activity_sessions.each do |activity_session|
+          h[class_id][:students] ||= []
+          if h[class_id][:students].exclude? activity_session.user
+            h[class_id][:students] << activity_session.user
           end
         end
       end

--- a/services/QuillLMS/app/models/concerns/student.rb
+++ b/services/QuillLMS/app/models/concerns/student.rb
@@ -177,14 +177,14 @@ module Student
     secondary_account_grouped_activity_sessions = secondary_account_activity_sessions.group_by { |as| as.classroom_unit_id }
 
     secondary_account_grouped_activity_sessions.each do |classroom_unit_id, activity_sessions|
-      if classroom_unit_id
-        activity_sessions.each { |as| as.update_columns(user_id: id, updated_at: DateTime.current) }
-        if primary_account_grouped_activity_sessions[classroom_unit_id]
-          hide_extra_activity_sessions(classroom_unit_id)
-        else
-          cu = ClassroomUnit.find_by(id: classroom_unit_id)
-          cu.update(assigned_student_ids: cu.assigned_student_ids.push(id))
-        end
+      next unless classroom_unit_id
+
+      activity_sessions.each { |as| as.update_columns(user_id: id, updated_at: DateTime.current) }
+      if primary_account_grouped_activity_sessions[classroom_unit_id]
+        hide_extra_activity_sessions(classroom_unit_id)
+      else
+        cu = ClassroomUnit.find_by(id: classroom_unit_id)
+        cu.update(assigned_student_ids: cu.assigned_student_ids.push(id))
       end
     end
   end

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -367,7 +367,7 @@ module Teacher
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def update_teacher(params)
-    return if !teacher?
+    return unless teacher?
 
     params.permit(
       :id,
@@ -399,7 +399,7 @@ module Teacher
         find_or_create_checkbox('Add School', self)
       end
     end
-    if !are_there_school_related_errors
+    unless are_there_school_related_errors
       if update(
         username: params.key?(:username) ? params[:username] : username,
         email: params.key?(:email) ? params[:email] : email,
@@ -542,9 +542,7 @@ module Teacher
   end
 
   def set_lessons_cache(lessons_data = nil)
-    if !lessons_data
-      lessons_data = data_for_lessons_cache
-    end
+    lessons_data ||= data_for_lessons_cache
     $redis.set("user_id:#{id}_lessons_array", lessons_data.to_json)
   end
 

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -366,7 +366,7 @@ module Teacher
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  def update_teacher params
+  def update_teacher(params)
     return if !teacher?
 
     params.permit(

--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -321,7 +321,7 @@ module Teacher
       classy
     end
     # TODO: move setter to background worker
-    classroom_minis_cache = (info)
+    classroom_minis_cache = info
     info
   end
 

--- a/services/QuillLMS/app/models/concerns/translatable_question.rb
+++ b/services/QuillLMS/app/models/concerns/translatable_question.rb
@@ -26,7 +26,7 @@ module TranslatableQuestion
     translated_texts
       .joins(english_text: :translation_mappings)
       .where(translation_mappings: { source: self })
-      .where("translation_mappings.field_name LIKE ?", "#{prefix}%")
+      .where('translation_mappings.field_name LIKE ?', "#{prefix}%")
       .where(locale: locale)
       .pluck('translation_mappings.field_name', :translation)
       .to_h

--- a/services/QuillLMS/app/models/feedback_session.rb
+++ b/services/QuillLMS/app/models/feedback_session.rb
@@ -32,7 +32,7 @@ class FeedbackSession < ApplicationRecord
 
   def self.get_uid_for_activity_session(activity_session_uid)
     find_or_create_by!(activity_session_uid: activity_session_uid) do |item|
-      item.uid = SecureRandom.uuid if !item.uid
+      item.uid = SecureRandom.uuid unless item.uid
     end.uid
   end
 end

--- a/services/QuillLMS/app/models/invitation.rb
+++ b/services/QuillLMS/app/models/invitation.rb
@@ -37,7 +37,7 @@ class Invitation < ApplicationRecord
     # In order to avoid letting people use our platform to spam folks,
     # we want to put some limits on the number of invitations a user can issue.
     # One of those limits is a cap on invitations per user per time period
-    recent_invitation_count = Invitation.unscoped.where(inviter_id: inviter_id, invitation_type: TYPES[:coteacher], created_at: MAX_COTEACHER_INVITATIONS_PER_TIME_LIMIT_RESET_HOURS.hours.ago..Time.current).count()
+    recent_invitation_count = Invitation.unscoped.where(inviter_id: inviter_id, invitation_type: TYPES[:coteacher], created_at: MAX_COTEACHER_INVITATIONS_PER_TIME_LIMIT_RESET_HOURS.hours.ago..Time.current).count
     return if recent_invitation_count <= MAX_COTEACHER_INVITATIONS_PER_TIME
 
     errors.add(:base, "User #{inviter_id} has reached the maximum of #{MAX_COTEACHER_INVITATIONS_PER_TIME} coteacher invitations that they can issue in a #{MAX_COTEACHER_INVITATIONS_PER_TIME_LIMIT_RESET_HOURS} hour period")

--- a/services/QuillLMS/app/models/question.rb
+++ b/services/QuillLMS/app/models/question.rb
@@ -120,7 +120,7 @@ class Question < ApplicationRecord
   end
 
   def get_incorrect_sequence(incorrect_sequence_id)
-    return nil if !incorrectSequences
+    return nil unless incorrectSequences
 
     incorrect_sequence_id = incorrect_sequence_id.to_i if stored_as_array?(INCORRECT_SEQUENCES)
     return incorrectSequences[incorrect_sequence_id]

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -72,7 +72,7 @@ module SegmentIntegration
     end
 
     def integration_rules
-      { all: true, Intercom: (teacher?) }
+      { all: true, Intercom: teacher? }
     end
   end
 end

--- a/services/QuillLMS/app/models/subscription.rb
+++ b/services/QuillLMS/app/models/subscription.rb
@@ -147,7 +147,7 @@ class Subscription < ApplicationRecord
   scope :expiring, ->(date) { where(expiration: date) }
 
   def self.create_and_attach_subscriber(subscription_attrs, subscriber)
-    if !subscription_attrs[:expiration]
+    unless subscription_attrs[:expiration]
       case subscription_attrs[:account_type]
       when TEACHER_TRIAL
         subscription_attrs = subscription_attrs.merge(set_trial_expiration_and_start_date(subscriber))

--- a/services/QuillLMS/app/models/unit_activity.rb
+++ b/services/QuillLMS/app/models/unit_activity.rb
@@ -58,7 +58,7 @@ class UnitActivity < ApplicationRecord
     end
   end
 
-  def due_date_string= val
+  def due_date_string=(val)
     self.due_date = Date.strptime(val, Time::DATE_FORMATS[:quill_default])
   end
 

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -117,7 +117,7 @@ class UnitTemplate < ApplicationRecord
     diagnostics_recommended_by.pluck(:name)
   end
 
-  def activity_ids= activity_ids
+  def activity_ids=(activity_ids)
     # getting around rails defaulting to activities being set in order of the activity id rather than the selected order
     new_activities = activity_ids.map { |id| Activity.find(id) }
     self.activities = new_activities

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -447,7 +447,7 @@ class User < ApplicationRecord
     false
   end
 
-  def safe_role_assignment role
+  def safe_role_assignment(role)
     sanitized_role = SAFE_ROLES.find { |r| r == role.strip }
     self.role = sanitized_role || 'user'
   end
@@ -505,7 +505,7 @@ class User < ApplicationRecord
     @role_inquirer ||= ActiveSupport::StringInquirer.new(self[:role])
   end
 
-  def role= role
+  def role=(role)
     remove_instance_variable :@role_inquirer if defined?(@role_inquirer)
     super
   end
@@ -570,7 +570,7 @@ class User < ApplicationRecord
     "#{role.capitalize}Serializer".constantize.new(self)
   end
 
-  def first_name= first_name
+  def first_name=(first_name)
     last_name
     @first_name = first_name
     set_name
@@ -580,7 +580,7 @@ class User < ApplicationRecord
     ClearUserDataWorker.perform_async(id)
   end
 
-  def last_name= last_name
+  def last_name=(last_name)
     first_name
     @last_name = last_name
     set_name

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -664,7 +664,7 @@ class User < ApplicationRecord
   end
 
   def generate_student_username_if_absent
-    return if !student?
+    return unless student?
     return if username.present?
 
     classroom_id = classrooms.any? ? classrooms.first.id : nil
@@ -952,7 +952,7 @@ class User < ApplicationRecord
   end
 
   private def clever_id_present_and_has_changed?
-    return false if !clever_id
+    return false unless clever_id
     return true if new_record?
 
     existing_user = User.find_by_id(id)

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -997,7 +997,7 @@ class User < ApplicationRecord
   end
 
   private def school_type_account_info
-    return (School::ALTERNATIVE_SCHOOLS_DISPLAY_NAME_MAP[school.name] || School::US_K12_SCHOOL_DISPLAY_NAME) if school&.name
+    return School::ALTERNATIVE_SCHOOLS_DISPLAY_NAME_MAP[school.name] || School::US_K12_SCHOOL_DISPLAY_NAME if school&.name
 
     School::US_K12_SCHOOL_DISPLAY_NAME
   end

--- a/services/QuillLMS/app/models/user_activity_classification.rb
+++ b/services/QuillLMS/app/models/user_activity_classification.rb
@@ -49,14 +49,12 @@ class UserActivityClassification < ApplicationRecord
   end
 
   def self.count_for(user, activity_classification)
-    begin
-      transaction(requires_new: true) do
-        instance = find_or_create_by(user: user, activity_classification: activity_classification)
-        instance.increment_count
-      end
-    rescue ActiveRecord::RecordNotUnique
-      retry
+    transaction(requires_new: true) do
+      instance = find_or_create_by(user: user, activity_classification: activity_classification)
+      instance.increment_count
     end
+  rescue ActiveRecord::RecordNotUnique
+    retry
   end
 
   def increment_count

--- a/services/QuillLMS/app/pdfs/login_pdf.rb
+++ b/services/QuillLMS/app/pdfs/login_pdf.rb
@@ -169,7 +169,7 @@ class LoginPdf < Prawn::Document
     elsif student.signed_up_with_google?
       'N/A (Log in with Google)'
     elsif student.authenticate(student.last_name)
-      (student.last_name.capitalize).to_s
+      student.last_name.capitalize.to_s
     else
       'N/A (Custom Password)'
     end

--- a/services/QuillLMS/app/presenters/api_presenter.rb
+++ b/services/QuillLMS/app/presenters/api_presenter.rb
@@ -7,7 +7,7 @@ class ApiPresenter
 
   def simple_index
     @model.all.map do |s|
-      (Api::SimpleSerializer.new(s)).as_json(root: false)
+      Api::SimpleSerializer.new(s).as_json(root: false)
     end
   end
 end

--- a/services/QuillLMS/app/queries/activity_feedback_history.rb
+++ b/services/QuillLMS/app/queries/activity_feedback_history.rb
@@ -26,7 +26,7 @@ class ActivityFeedbackHistory
     average_completion_rate = activity_sessions_agg[0]['average_completion_rate']
 
     {
-      average_time_spent: average_time_spent ? Utils::Numeric.seconds_to_human_readable_time((activity_sessions_agg[0]['average_time_spent'].to_f)) : nil,
+      average_time_spent: average_time_spent ? Utils::Numeric.seconds_to_human_readable_time(activity_sessions_agg[0]['average_time_spent'].to_f) : nil,
       average_completion_rate: average_completion_rate ? (average_completion_rate.to_f * 100).round(2) : nil
     }
   end

--- a/services/QuillLMS/app/queries/progress_reports/activities_scores_by_classroom.rb
+++ b/services/QuillLMS/app/queries/progress_reports/activities_scores_by_classroom.rb
@@ -17,14 +17,14 @@ class ProgressReports::ActivitiesScoresByClassroom
   #       Examples: "America/Chicago", 'Eastern Time (US & Canada)', nil
   def self.transform_timestamps!(data, timezone)
     data.each_index do |i|
-      if timezone
-        begin
-          data[i]['last_active'] = DateTime.strptime(
-            data[i]['last_active'], '%Y-%m-%d %H:%M:%S'
-          ).in_time_zone(timezone).strftime('%Y-%m-%d %H:%M:%S')
-        rescue ArgumentError, TypeError, NoMethodError => e
-          # no-op error handling, fails silently
-        end
+      next unless timezone
+
+      begin
+        data[i]['last_active'] = DateTime.strptime(
+          data[i]['last_active'], '%Y-%m-%d %H:%M:%S'
+        ).in_time_zone(timezone).strftime('%Y-%m-%d %H:%M:%S')
+      rescue ArgumentError, TypeError, NoMethodError => e
+        # no-op error handling, fails silently
       end
     end
   end

--- a/services/QuillLMS/app/queries/student_dashboard_metrics.rb
+++ b/services/QuillLMS/app/queries/student_dashboard_metrics.rb
@@ -28,13 +28,11 @@ class StudentDashboardMetrics
   end
 
   def completed_sessions
-    @completed_sessions ||= begin
-      ActivitySession
-        .unscoped
-        .joins(:classroom_unit)
-        .where(user:, classroom_unit: { classroom_id: })
-        .where.not(completed_at: nil)
-        .where(visible: true)
-    end
+    @completed_sessions ||= ActivitySession
+      .unscoped
+      .joins(:classroom_unit)
+      .where(user:, classroom_unit: { classroom_id: })
+      .where.not(completed_at: nil)
+      .where(visible: true)
   end
 end

--- a/services/QuillLMS/app/services/diagnostics_organized_by_classroom_fetcher.rb
+++ b/services/QuillLMS/app/services/diagnostics_organized_by_classroom_fetcher.rb
@@ -99,7 +99,7 @@ class DiagnosticsOrganizedByClassroomFetcher < ApplicationService
       .uniq { |activity_session| activity_session.user_id }
 
     record = records[0]
-    return if !record
+    return unless record
 
     record['eligible_for_question_scoring'] = activity_sessions.empty? || activity_sessions.last.completed_at > QUESTION_SCORING_ELIGIBILITY_CUTOFF_DATE
     record['completed_count'] = activity_sessions.size

--- a/services/QuillLMS/app/services/gengo/request_translations.rb
+++ b/services/QuillLMS/app/services/gengo/request_translations.rb
@@ -27,22 +27,20 @@ module Gengo
     end
 
     def gengo_payload
-      @gengo_payload ||= begin
-        english_texts
-          .reject { |e| e.gengo_translation?(locale:) }
-          .each_with_object({}) do |english_text, hash|
-            hash[english_text.id.to_s] = {
-              type: 'text',
-              body_src: english_text.text,
-              lc_src: 'en',
-              lc_tgt: Translatable::DEFAULT_LOCALE,
-              tier: 'standard',
-              slug: english_text.id,
-              group: true,
-              auto_approve: true,
-              comment: STANDARD_COMMENT
-            }
-          end
+      @gengo_payload ||= english_texts
+        .reject { |e| e.gengo_translation?(locale:) }
+        .each_with_object({}) do |english_text, hash|
+        hash[english_text.id.to_s] = {
+          type: 'text',
+          body_src: english_text.text,
+          lc_src: 'en',
+          lc_tgt: Translatable::DEFAULT_LOCALE,
+          tier: 'standard',
+          slug: english_text.id,
+          group: true,
+          auto_approve: true,
+          comment: STANDARD_COMMENT
+        }
       end
     end
   end

--- a/services/QuillLMS/app/services/google_integration/user.rb
+++ b/services/QuillLMS/app/services/google_integration/user.rb
@@ -12,11 +12,9 @@ class GoogleIntegration::User
   end
 
   private def set_user
-    @user ||= begin
-      find_user_by_google_id_or_email.tap do |user|
-        new_attributes = user_params(user)
-        user.new_record? ? user.assign_attributes(new_attributes) : user.update!(new_attributes)
-      end
+    @user ||= find_user_by_google_id_or_email.tap do |user|
+      new_attributes = user_params(user)
+      user.new_record? ? user.assign_attributes(new_attributes) : user.update!(new_attributes)
     end
   end
 

--- a/services/QuillLMS/app/services/independent_practice_packs_assigner.rb
+++ b/services/QuillLMS/app/services/independent_practice_packs_assigner.rb
@@ -73,11 +73,9 @@ class IndependentPracticePacksAssigner < ApplicationService
   end
 
   private def selections_with_students
-    @selections_with_students ||= begin
-      selections
-        .select { |selection| selection[:classrooms][0][:student_ids]&.compact&.any? }
-        .map { |selection| selection.permit(:id, classrooms: [:id, :order, student_ids: []]).to_h }
-    end
+    @selections_with_students ||= selections
+      .select { |selection| selection[:classrooms][0][:student_ids]&.compact&.any? }
+      .map { |selection| selection.permit(:id, classrooms: [:id, :order, student_ids: []]).to_h }
   end
 
   private def set_diagnostic_recommendations_start_time

--- a/services/QuillLMS/app/services/order_recommendations.rb
+++ b/services/QuillLMS/app/services/order_recommendations.rb
@@ -7,15 +7,13 @@ class OrderRecommendations
 
   def update_order
     ActiveRecord::Base.transaction do
-      begin
-        @recommendation_ids.each_with_index do |id, i|
-          Recommendation.find(id).update!(order: i)
-        end
-
-        true
-      rescue
-        false
+      @recommendation_ids.each_with_index do |id, i|
+        Recommendation.find(id).update!(order: i)
       end
+
+      true
+    rescue
+      false
     end
   end
 end

--- a/services/QuillLMS/app/services/sales_stage_types_factory.rb
+++ b/services/QuillLMS/app/services/sales_stage_types_factory.rb
@@ -84,15 +84,13 @@ class SalesStageTypesFactory
 
   def build
     STAGE_TYPE_SEEDS.map do |seed|
-      begin
-        SalesStageType.find_or_create_by!(name: seed[:name]) do |type|
-          type.order       = seed[:order]
-          type.description = seed[:description]
-          type.trigger     = seed[:trigger]
-        end
-      rescue ActiveRecord::RecordInvalid
-        retry
+      SalesStageType.find_or_create_by!(name: seed[:name]) do |type|
+        type.order       = seed[:order]
+        type.description = seed[:description]
+        type.trigger     = seed[:trigger]
       end
+    rescue ActiveRecord::RecordInvalid
+      retry
     end
   end
 end

--- a/services/QuillLMS/app/services/serialize_activity_health.rb
+++ b/services/QuillLMS/app/services/serialize_activity_health.rb
@@ -32,7 +32,7 @@ class SerializeActivityHealth
 
   def prompt_data
     questions = @activity.data['questions']
-    return [] if !questions.present?
+    return [] unless questions.present?
 
     @questions_arr ||= questions.each.with_index(1).map { |q, question_number|
       question = Question.find_by(uid: q['key'])

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_organization.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_organization.rb
@@ -122,7 +122,7 @@ module VitallyIntegration
     end
 
     def diagnostics_assigned_between_count(start, stop)
-      district.schools.select("array_length(classroom_units.assigned_student_ids, 1) AS assigned_students")
+      district.schools.select('array_length(classroom_units.assigned_student_ids, 1) AS assigned_students')
         .joins(users: {
           unscoped_classrooms_i_teach: {
             classroom_units: {
@@ -193,7 +193,7 @@ module VitallyIntegration
       @activities_completed ||= ClassroomsTeacher.select('students.id')
         .joins([user: [schools_users: [school: :district]]])
         .joins([classroom_unscoped: [classroom_units: :activity_sessions]])
-        .joins("JOIN users students on students.id = activity_sessions.user_id")
+        .joins('JOIN users students on students.id = activity_sessions.user_id')
         .where('districts.id = ?', district.id)
         .where('activity_sessions.state = ?', 'finished')
     end

--- a/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_organization.rb
+++ b/services/QuillLMS/app/services/vitally_integration/serialize_vitally_sales_organization.rb
@@ -56,9 +56,9 @@ module VitallyIntegration
         activities_completed_this_year: activities_completed_this_year,
         activities_completed_last_year: activities_completed_last_year,
         activities_completed_all_time: activities_completed_all_time,
-        activities_completed_per_student_this_year: active_students_this_year > 0 ? ((activities_completed_this_year.to_f / active_students_this_year).round(2)) : 0,
-        activities_completed_per_student_last_year: active_students_last_year > 0 ? ((activities_completed_last_year.to_f / active_students_last_year).round(2)) : 0,
-        activities_completed_per_student_all_time: active_students_all_time > 0 ? ((activities_completed_all_time.to_f / active_students_all_time).round(2)) : 0,
+        activities_completed_per_student_this_year: active_students_this_year > 0 ? (activities_completed_this_year.to_f / active_students_this_year).round(2) : 0,
+        activities_completed_per_student_last_year: active_students_last_year > 0 ? (activities_completed_last_year.to_f / active_students_last_year).round(2) : 0,
+        activities_completed_per_student_all_time: active_students_all_time > 0 ? (activities_completed_all_time.to_f / active_students_all_time).round(2) : 0,
         last_active_time: last_active_time,
       }
     end

--- a/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
@@ -41,7 +41,7 @@ class ConceptReplacementConnectWorker
         end
       end
 
-      if !data.empty?
+      unless data.empty?
         HTTParty.put("#{ENV['FIREBASE_DATABASE_URL']}/v2/#{endpoint}/#{key}.json", body: data.to_json)
       end
     end

--- a/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_connect_worker.rb
@@ -56,16 +56,16 @@ class ConceptReplacementConnectWorker
     begin
       fp_obj.each do |k, v|
         v['conceptResults'].each do |crk, crv|
-          if crv['conceptUID'] == original_concept_uid
-            concept = Concept.unscoped.find_by(uid: new_concept_uid)
-            parent_concept = concept.try(:parent)
-            grandparent_concept = parent_concept.try(:parent)
-            if concept && parent_concept && grandparent_concept
-              name = "#{grandparent_concept.name} | #{parent_concept.name} | #{concept.name}"
-              new_fp_obj[k]['conceptResults'][crk]['name'] = name
-            end
-            new_fp_obj[k]['conceptResults'][crk]['conceptUID'] = new_concept_uid
+          next unless crv['conceptUID'] == original_concept_uid
+
+          concept = Concept.unscoped.find_by(uid: new_concept_uid)
+          parent_concept = concept.try(:parent)
+          grandparent_concept = parent_concept.try(:parent)
+          if concept && parent_concept && grandparent_concept
+            name = "#{grandparent_concept.name} | #{parent_concept.name} | #{concept.name}"
+            new_fp_obj[k]['conceptResults'][crk]['name'] = name
           end
+          new_fp_obj[k]['conceptResults'][crk]['conceptUID'] = new_concept_uid
         end
       end
     rescue => e
@@ -84,16 +84,16 @@ class ConceptReplacementConnectWorker
     begin
       is_array.each_with_index do |is, i|
         is['conceptResults'].each do |crk, crv|
-          if crv['conceptUID'] == original_concept_uid
-            concept = Concept.unscoped.find_by(uid: new_concept_uid)
-            parent_concept = concept.try(:parent)
-            grandparent_concept = parent_concept.try(:parent)
-            if concept && parent_concept && grandparent_concept
-              name = "#{grandparent_concept.name} | #{parent_concept.name} | #{concept.name}"
-              new_is_array[i]['conceptResults'][crk]['name'] = name
-            end
-            new_is_array[i]['conceptResults'][crk]['conceptUID'] = new_concept_uid
+          next unless crv['conceptUID'] == original_concept_uid
+
+          concept = Concept.unscoped.find_by(uid: new_concept_uid)
+          parent_concept = concept.try(:parent)
+          grandparent_concept = parent_concept.try(:parent)
+          if concept && parent_concept && grandparent_concept
+            name = "#{grandparent_concept.name} | #{parent_concept.name} | #{concept.name}"
+            new_is_array[i]['conceptResults'][crk]['name'] = name
           end
+          new_is_array[i]['conceptResults'][crk]['conceptUID'] = new_concept_uid
         end
       end
     rescue => e

--- a/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
+++ b/services/QuillLMS/app/workers/concept_replacement_grammar_worker.rb
@@ -41,7 +41,7 @@ class ConceptReplacementGrammarWorker
         end
       end
 
-      if !data.empty?
+      unless data.empty?
         HTTParty.put("#{ENV['FIREBASE_DATABASE_URL']}/v3/questions/#{key}.json", body: data.to_json)
       end
     end

--- a/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
+++ b/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
@@ -74,9 +74,8 @@ class GetConceptsInUseIndividualConceptWorker
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def get_activity_rows(id)
-    begin
-      RawSqlRunner.execute(
-        <<-SQL
+    RawSqlRunner.execute(
+      <<-SQL
           SELECT
             concepts.name AS concept_name,
             concepts.uid AS concept_uid,
@@ -117,11 +116,10 @@ class GetConceptsInUseIndividualConceptWorker
             parent_concepts.name,
             concept_name,
             classification_name
-        SQL
-      ).to_a
-    rescue => e
-      get_activity_rows(id)
-    end
+      SQL
+    ).to_a
+  rescue => e
+    get_activity_rows(id)
   end
 
   def find_categorized_connect_questions(uid)
@@ -159,23 +157,21 @@ class GetConceptsInUseIndividualConceptWorker
   end
 
   def set_concepts_in_use_cache
-    begin
-      $redis.watch('CONCEPTS_IN_USE')
-      concepts_in_use = JSON.parse($redis.get('CONCEPTS_IN_USE'))
-      headers = %w(name uid grades_proofreader_activities grades_grammar_activities grades_connect_activities grades_diagnostic_activities categorized_connect_questions categorized_diagnostic_questions part_of_diagnostic_recommendations last_retrieved)
-      @organized_concepts.each do |oc|
-        concepts_in_use << headers.map do |attr|
-          if oc[attr].is_a?(Array)
-            oc[attr].flatten.uniq.join(', ')
-          else
-            oc[attr]
-          end
+    $redis.watch('CONCEPTS_IN_USE')
+    concepts_in_use = JSON.parse($redis.get('CONCEPTS_IN_USE'))
+    headers = %w(name uid grades_proofreader_activities grades_grammar_activities grades_connect_activities grades_diagnostic_activities categorized_connect_questions categorized_diagnostic_questions part_of_diagnostic_recommendations last_retrieved)
+    @organized_concepts.each do |oc|
+      concepts_in_use << headers.map do |attr|
+        if oc[attr].is_a?(Array)
+          oc[attr].flatten.uniq.join(', ')
+        else
+          oc[attr]
         end
       end
-      $redis.set('CONCEPTS_IN_USE', concepts_in_use.to_json)
-      $redis.unwatch
-    rescue => e
-      set_concepts_in_use_cache
     end
+    $redis.set('CONCEPTS_IN_USE', concepts_in_use.to_json)
+    $redis.unwatch
+  rescue => e
+    set_concepts_in_use_cache
   end
 end

--- a/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -18,7 +18,7 @@ class InternalTool::EmailFeedbackHistorySessionDataWorker
     results = []
     feedback_histories.find_each(batch_size: 10_000) { |feedback_history| results << feedback_history.serialize_csv_data }
     results.sort! { |a, b| b['datetime'] <=> a['datetime'] }
-    return if !results
+    return unless results
 
     csv_file_path = Rails.root.join('public', "feedback_history_#{activity_id}_#{Time.current.to_i}.csv")
 

--- a/services/QuillLMS/app/workers/ip_location_worker.rb
+++ b/services/QuillLMS/app/workers/ip_location_worker.rb
@@ -13,7 +13,7 @@ class IpLocationWorker
     user = User.find(id)
     response = HTTParty.get(pinpoint_url(ip_address))
 
-    if !response.success?
+    unless response.success?
       raise PinpointAPIError, "#{response.code}: #{response}"
     end
 

--- a/services/QuillLMS/config/initializers/responder.rb
+++ b/services/QuillLMS/config/initializers/responder.rb
@@ -7,7 +7,7 @@ class ActionController::Responder
     navigation_behavior(e)
   end
 
-  def api_behavior error
+  def api_behavior(error)
     raise error unless resourceful?
 
     if get?

--- a/services/QuillLMS/db/migrate/20140423225449_add_search_indexes_to_users.rb
+++ b/services/QuillLMS/db/migrate/20140423225449_add_search_indexes_to_users.rb
@@ -11,6 +11,5 @@ class AddSearchIndexesToUsers < ActiveRecord::Migration[4.2]
       create index on users using gin(to_tsvector('english', split_part((ip_address)::text, '/', 1)));"
   end
 
-  def down
-  end
+  def down; end
 end

--- a/services/QuillLMS/db/migrate/20200604165331_migrate_lessons_to_activity.rb
+++ b/services/QuillLMS/db/migrate/20200604165331_migrate_lessons_to_activity.rb
@@ -57,7 +57,7 @@ class MigrateLessonsToActivity < ActiveRecord::Migration[4.2]
         end
 
         activity.data = lesson.data
-        activity.save! if !lesson[:data]['flag'].blank?
+        activity.save! unless lesson[:data]['flag'].blank?
       end
     end
 

--- a/services/QuillLMS/db/migrate/20201016142046_populate_content_partners.rb
+++ b/services/QuillLMS/db/migrate/20201016142046_populate_content_partners.rb
@@ -12,13 +12,11 @@ class PopulateContentPartners < ActiveRecord::Migration[4.2]
 
     table = CSV.parse(File.read('lib/data/content_partners_by_activity.csv'), headers: true)
     table.each do |row|
-      begin
-        activity = Activity.find(row['Activity ID'])
-        content_partner = ContentPartner.find_by(name: row['Content Partner'])
-        content_partner.activities << activity
-      rescue => e
-        puts e
-      end
+      activity = Activity.find(row['Activity ID'])
+      content_partner = ContentPartner.find_by(name: row['Content Partner'])
+      content_partner.activities << activity
+    rescue => e
+      puts e
     end
   end
 end

--- a/services/QuillLMS/db/migrate/20201019183425_populate_raw_scores_by_activity.rb
+++ b/services/QuillLMS/db/migrate/20201019183425_populate_raw_scores_by_activity.rb
@@ -10,14 +10,12 @@ class PopulateRawScoresByActivity < ActiveRecord::Migration[4.2]
 
     table = CSV.parse(File.read('lib/data/readability_levels_by_activity.csv'), headers: true)
     table.each do |row|
-      begin
-        activity = Activity.find(row['Activity ID'])
-        raw_score = RawScore.find_by(name: row['Lexile Raw'])
-        activity.raw_score_id = raw_score.id
-        activity.save!
-      rescue => e
-        puts e
-      end
+      activity = Activity.find(row['Activity ID'])
+      raw_score = RawScore.find_by(name: row['Lexile Raw'])
+      activity.raw_score_id = raw_score.id
+      activity.save!
+    rescue => e
+      puts e
     end
   end
 end

--- a/services/QuillLMS/db/migrate/20201020204615_archive_standard_levels.rb
+++ b/services/QuillLMS/db/migrate/20201020204615_archive_standard_levels.rb
@@ -5,18 +5,16 @@ class ArchiveStandardLevels < ActiveRecord::Migration[4.2]
 
   def change
     TO_ARCHIVE.each do |sl|
-      begin
-        standard_level = StandardLevel.find_by(:name => sl)
-        standard_level.visible = false
-        standard_level.save!
-        standard_level.standards.each do |s|
-          s.activities.each do |a|
-            a.update(standard: nil)
-          end
+      standard_level = StandardLevel.find_by(:name => sl)
+      standard_level.visible = false
+      standard_level.save!
+      standard_level.standards.each do |s|
+        s.activities.each do |a|
+          a.update(standard: nil)
         end
-      rescue => e
-        puts e
       end
+    rescue => e
+      puts e
     end
   end
 end

--- a/services/QuillLMS/db/migrate/20201023212528_populate_topics.rb
+++ b/services/QuillLMS/db/migrate/20201023212528_populate_topics.rb
@@ -4,24 +4,22 @@ class PopulateTopics < ActiveRecord::Migration[4.2]
   def change
     table = CSV.parse(File.read('lib/data/topics_by_activity.csv'), headers: true)
     table.each do |row|
-      begin
-        activity = Activity.find(row['Activity ID'])
-        topic_columns = ['Level 0 Theme', 'Level 1 Theme', 'Level 2 Theme']
-        topic_columns.each_with_index do |tc, i|
-          next unless tc.present? && row[tc] != 'None'
+      activity = Activity.find(row['Activity ID'])
+      topic_columns = ['Level 0 Theme', 'Level 1 Theme', 'Level 2 Theme']
+      topic_columns.each_with_index do |tc, i|
+        next unless tc.present? && row[tc] != 'None'
 
-          if i == 2
-            parent_topic = Topic.find_or_create_by(name: row['Level 3 Theme'], level: 3)
-            activity.topics << parent_topic
-            topic = Topic.find_or_create_by(name: row[tc], level: i, parent_id: parent_topic.id)
-          else
-            topic = Topic.find_or_create_by(name: row[tc], level: i)
-          end
-          activity.topics << topic
+        if i == 2
+          parent_topic = Topic.find_or_create_by(name: row['Level 3 Theme'], level: 3)
+          activity.topics << parent_topic
+          topic = Topic.find_or_create_by(name: row[tc], level: i, parent_id: parent_topic.id)
+        else
+          topic = Topic.find_or_create_by(name: row[tc], level: i)
         end
-      rescue => e
-        puts e
+        activity.topics << topic
       end
+    rescue => e
+      puts e
     end
   end
 end

--- a/services/QuillLMS/db/migrate/20201023212528_populate_topics.rb
+++ b/services/QuillLMS/db/migrate/20201023212528_populate_topics.rb
@@ -8,16 +8,16 @@ class PopulateTopics < ActiveRecord::Migration[4.2]
         activity = Activity.find(row['Activity ID'])
         topic_columns = ['Level 0 Theme', 'Level 1 Theme', 'Level 2 Theme']
         topic_columns.each_with_index do |tc, i|
-          if tc.present? && row[tc] != 'None'
-            if i == 2
-              parent_topic = Topic.find_or_create_by(name: row['Level 3 Theme'], level: 3)
-              activity.topics << parent_topic
-              topic = Topic.find_or_create_by(name: row[tc], level: i, parent_id: parent_topic.id)
-            else
-              topic = Topic.find_or_create_by(name: row[tc], level: i)
-            end
-            activity.topics << topic
+          next unless tc.present? && row[tc] != 'None'
+
+          if i == 2
+            parent_topic = Topic.find_or_create_by(name: row['Level 3 Theme'], level: 3)
+            activity.topics << parent_topic
+            topic = Topic.find_or_create_by(name: row[tc], level: i, parent_id: parent_topic.id)
+          else
+            topic = Topic.find_or_create_by(name: row[tc], level: i)
           end
+          activity.topics << topic
         end
       rescue => e
         puts e

--- a/services/QuillLMS/db/migrate/20240626193615_create_email_subscriptions.rb
+++ b/services/QuillLMS/db/migrate/20240626193615_create_email_subscriptions.rb
@@ -6,7 +6,7 @@ class CreateEmailSubscriptions < ActiveRecord::Migration[7.0]
       t.integer :user_id, null: false
       t.string :frequency, null: false
       t.string :subscription_type, null: false
-      t.string :cancel_token, null: false, default: -> { "md5(random()::text)" }
+      t.string :cancel_token, null: false, default: -> { 'md5(random()::text)' }
       t.jsonb :params
 
       t.timestamps

--- a/services/QuillLMS/engines/evidence/app/helpers/evidence/research/gen_ai/application_helper.rb
+++ b/services/QuillLMS/engines/evidence/app/helpers/evidence/research/gen_ai/application_helper.rb
@@ -10,11 +10,11 @@ module Evidence
         LIGHT_RED = 'light-red'
 
         def date_helper(datetime, time_zone = EASTERN_TIME_ZONE)
-          datetime.in_time_zone(time_zone).strftime("%m/%d/%y")
+          datetime.in_time_zone(time_zone).strftime('%m/%d/%y')
         end
 
         def datetime_helper(datetime, time_zone = EASTERN_TIME_ZONE)
-          datetime.in_time_zone(time_zone).strftime("%m/%d/%y, %I:%M %p")
+          datetime.in_time_zone(time_zone).strftime('%m/%d/%y, %I:%M %p')
         end
 
         def llm_example_match_color(llm_example)

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -120,7 +120,7 @@ module Evidence
       parent_activity&.flag
     end
 
-    def flag=flag
+    def flag=(flag)
       set_parent_activity
       parent_activity.lms_user_id = @lms_user_id
       parent_activity.update(flag: flag)

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
@@ -90,12 +90,10 @@ module Evidence
     end
 
     def poor_health_flag
-      (
-        failed_cutoff(first_attempt_optimal, FIRST_ATTEMPT_OPTIMAL_CUTOFF) ||
+      failed_cutoff(first_attempt_optimal, FIRST_ATTEMPT_OPTIMAL_CUTOFF) ||
         failed_cutoff(final_attempt_optimal, FINAL_ATTEMPT_OPTIMAL_CUTFF) ||
         failed_cutoff(confidence, CONFIDENCE_CUTOFF) ||
         (percent_automl_consecutive_repeated && percent_automl_consecutive_repeated > PERCENT_AUTOML_CONSECUTIVE_REPEATED_CUTOFF)
-      )
     end
 
     def conjunction

--- a/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/regex_rule.rb
@@ -97,12 +97,10 @@ module Evidence
     end
 
     private def validate_regex
-      begin
-        Regexp.new(regex_text)
-      rescue RegexpError => e
-        rule.errors.add(:invalid_regex, e.to_s)
-        throw(:abort)
-      end
+      Regexp.new(regex_text)
+    rescue RegexpError => e
+      rule.errors.add(:invalid_regex, e.to_s)
+      throw(:abort)
     end
 
     private def log_creation

--- a/services/QuillLMS/engines/evidence/lib/evidence/check/base.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/check/base.rb
@@ -19,14 +19,12 @@ module Evidence
 
     def self.run(entry, prompt, previous_feedback, session_uid = nil)
       new(entry, prompt, previous_feedback, session_uid).tap do |check|
-        begin
-          check.run
-        rescue => e
-          context = { entry: entry, prompt_id: prompt&.id, prompt_text: prompt&.text }
-          Evidence.error_notifier.report(e, context)
+        check.run
+      rescue => e
+        context = { entry: entry, prompt_id: prompt&.id, prompt_text: prompt&.text }
+        Evidence.error_notifier.report(e, context)
 
-          @error = e
-        end
+        @error = e
       end
     end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/grammar/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/grammar/client.rb
@@ -21,7 +21,7 @@ module Evidence
       def post
         response = api_request
 
-        if !response.success?
+        unless response.success?
           raise APIError, "Encountered upstream error: #{response}"
         end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/opinion/client.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/opinion/client.rb
@@ -18,7 +18,7 @@ module Evidence
 
       def post
         response = api_request_with_retry
-        if !response.success?
+        unless response.success?
           raise APIError, "Encountered upstream error: #{response}"
         end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
@@ -81,13 +81,13 @@ module Evidence
     end
 
     private def matched_slice
-      return '' if !minimum_overlap?
+      return '' unless minimum_overlap?
 
       @matched_slice ||= match_entry_on_passage
     end
 
     private def matched_slice_passage
-      return '' if !minimum_overlap?
+      return '' unless minimum_overlap?
 
       @matched_slice_passage ||= match_passage_on_entry
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
@@ -152,8 +152,8 @@ module Evidence
       # we know that there's a minimum number of words that have to be identical.  This function
       # confirms that minimum amount of overlap to justify doing a set of Levenshtein calculations.
       source_arrays.any? do |source_array|
-        ((target_array - source_array).length <= FUZZY_CHARACTER_THRESHOLD ||
-         (source_array - target_array).length <= FUZZY_CHARACTER_THRESHOLD)
+        (target_array - source_array).length <= FUZZY_CHARACTER_THRESHOLD ||
+          (source_array - target_array).length <= FUZZY_CHARACTER_THRESHOLD
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -81,7 +81,7 @@ module Evidence
       end
 
       it 'should create a valid record and return it as json' do
-        post(:create, :params => ({ :activity => ({ :parent_activity_id => activity.parent_activity_id, :scored_level => activity.scored_level, :target_level => activity.target_level, :title => activity.title, :notes => activity.notes }) }))
+        post(:create, :params => { :activity => { :parent_activity_id => activity.parent_activity_id, :scored_level => activity.scored_level, :target_level => activity.target_level, :title => activity.title, :notes => activity.notes } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(201))
         expect(parsed_response['title']).to(eq('First Activity'))
@@ -103,7 +103,7 @@ module Evidence
       end
 
       it 'should not create an invalid record and return errors as json' do
-        post(:create, :params => ({ :activity => ({ :parent_activity_id => activity.parent_activity_id }) }))
+        post(:create, :params => { :activity => { :parent_activity_id => activity.parent_activity_id } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(422))
         expect(parsed_response['title'].include?("can't be blank")).to(eq(true))
@@ -111,7 +111,7 @@ module Evidence
       end
 
       it 'should create a valid record with passage attributes' do
-        post(:create, :params => ({ :activity => ({ :parent_activity_id => activity.parent_activity_id, :scored_level => activity.scored_level, :target_level => activity.target_level, :title => activity.title, :notes => activity.notes, :passages_attributes => ([{ :text => ('Hello ' * 20) }]) }) }))
+        post(:create, :params => { :activity => { :parent_activity_id => activity.parent_activity_id, :scored_level => activity.scored_level, :target_level => activity.target_level, :title => activity.title, :notes => activity.notes, :passages_attributes => [{ :text => ('Hello ' * 20) }] } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(201))
         expect(parsed_response['title']).to(eq('First Activity'))
@@ -122,7 +122,7 @@ module Evidence
       end
 
       it 'should create a valid record with prompt attributes' do
-        post(:create, :params => ({ :activity => ({ :parent_activity_id => activity.parent_activity_id, :scored_level => activity.scored_level, :target_level => activity.target_level, :title => activity.title, :notes => activity.notes, :prompts_attributes => ([{ :text => 'meat is bad for you.', :conjunction => 'because' }]) }) }))
+        post(:create, :params => { :activity => { :parent_activity_id => activity.parent_activity_id, :scored_level => activity.scored_level, :target_level => activity.target_level, :title => activity.title, :notes => activity.notes, :prompts_attributes => [{ :text => 'meat is bad for you.', :conjunction => 'because' }] } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(201))
         expect(parsed_response['title']).to(eq('First Activity'))
@@ -133,7 +133,7 @@ module Evidence
       end
 
       it 'should create a new parent activity and activity if no parent_activity_id is passed' do
-        post(:create, :params => ({ :activity => ({ :parent_activity_id => nil, :scored_level => activity.scored_level, :target_level => activity.target_level, :title => activity.title, :notes => activity.notes, :prompts_attributes => ([{ :text => 'meat is bad for you.', :conjunction => 'because' }]) }) }))
+        post(:create, :params => { :activity => { :parent_activity_id => nil, :scored_level => activity.scored_level, :target_level => activity.target_level, :title => activity.title, :notes => activity.notes, :prompts_attributes => [{ :text => 'meat is bad for you.', :conjunction => 'because' }] } })
         parent_activity = Evidence.parent_activity_class.find_by_name(activity.title)
         new_activity = Activity.find_by_title(activity.title)
         expect(parent_activity.present?).to(eq(true))
@@ -216,11 +216,11 @@ module Evidence
 
     context 'should show' do
       let!(:activity) { create(:evidence_activity, :parent_activity_id => 1, :title => 'First Activity', :target_level => 8, :scored_level => '4th grade') }
-      let!(:passage) { create(:evidence_passage, :activity => (activity), :text => ('Hello' * 20)) }
-      let!(:prompt) { create(:evidence_prompt, :activity => (activity), :text => 'it is good.') }
+      let!(:passage) { create(:evidence_passage, :activity => activity, :text => ('Hello' * 20)) }
+      let!(:prompt) { create(:evidence_prompt, :activity => activity, :text => 'it is good.') }
 
       it 'should return json if found' do
-        get(:show, :params => ({ :id => activity.id }))
+        get(:show, :params => { :id => activity.id })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(200))
         expect(parsed_response['title']).to(eq('First Activity'))
@@ -229,22 +229,22 @@ module Evidence
       end
 
       it 'should raise if not found (to be handled by parent app)' do
-        expect { get(:show, :params => ({ :id => 99999 })) }.to(raise_error(ActiveRecord::RecordNotFound))
+        expect { get(:show, :params => { :id => 99999 }) }.to(raise_error(ActiveRecord::RecordNotFound))
       end
     end
 
     context 'should update' do
       let!(:staff_user_id) { 1 }
       let!(:activity) { create(:evidence_activity, :parent_activity_id => 1, :title => 'First Activity', :target_level => 8, :scored_level => '4th grade') }
-      let!(:passage) { create(:evidence_passage, :activity => (activity)) }
-      let!(:prompt) { create(:evidence_prompt, :activity => (activity)) }
+      let!(:passage) { create(:evidence_passage, :activity => activity) }
+      let!(:prompt) { create(:evidence_prompt, :activity => activity) }
 
       before do
         session[:user_id] = staff_user_id
       end
 
       it 'should update record if valid, return nothing' do
-        put(:update, :params => ({ :id => activity.id, :activity => ({ :parent_activity_id => 2, :scored_level => '5th grade', :target_level => 9, :title => 'New title' }) }))
+        put(:update, :params => { :id => activity.id, :activity => { :parent_activity_id => 2, :scored_level => '5th grade', :target_level => 9, :title => 'New title' } })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         activity.reload
@@ -296,7 +296,7 @@ module Evidence
       end
 
       it 'should update passage if valid, return nothing' do
-        put(:update, :params => ({ :id => activity.id, :activity => ({ :passages_attributes => ([{ :id => passage.id, :text => ('Goodbye' * 20) }]) }) }))
+        put(:update, :params => { :id => activity.id, :activity => { :passages_attributes => [{ :id => passage.id, :text => ('Goodbye' * 20) }] } })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         passage.reload
@@ -304,7 +304,7 @@ module Evidence
       end
 
       it 'should update prompt if valid, return nothing' do
-        put(:update, :params => ({ :id => activity.id, :activity => ({ :prompts_attributes => ([{ :id => prompt.id, :text => 'this is a good thing.' }]) }) }))
+        put(:update, :params => { :id => activity.id, :activity => { :prompts_attributes => [{ :id => prompt.id, :text => 'this is a good thing.' }] } })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         prompt.reload
@@ -338,7 +338,7 @@ module Evidence
       end
 
       it 'should not update record and return errors as json' do
-        put(:update, :params => ({ :id => activity.id, :activity => ({ :parent_activity_id => 2, :scored_level => '5th grade', :target_level => 99999999, :title => 'New title' }) }))
+        put(:update, :params => { :id => activity.id, :activity => { :parent_activity_id => 2, :scored_level => '5th grade', :target_level => 99999999, :title => 'New title' } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(422))
         expect(parsed_response['target_level'].include?('must be less than or equal to 12')).to(eq(true))
@@ -347,10 +347,10 @@ module Evidence
 
     context 'should destroy' do
       let!(:activity) { create(:evidence_activity) }
-      let!(:passage) { create(:evidence_passage, :activity => (activity)) }
+      let!(:passage) { create(:evidence_passage, :activity => activity) }
 
       it 'should destroy record at id' do
-        delete(:destroy, :params => ({ :id => activity.id }))
+        delete(:destroy, :params => { :id => activity.id })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         expect(activity.id).to(be_truthy)
@@ -415,23 +415,23 @@ module Evidence
 
     context 'should rules' do
       let!(:activity) { create(:evidence_activity) }
-      let!(:prompt) { create(:evidence_prompt, :activity => (activity)) }
-      let!(:rule) { create(:evidence_rule, :prompts => ([prompt])) }
-      let!(:passage) { create(:evidence_passage, :activity => (activity)) }
+      let!(:prompt) { create(:evidence_prompt, :activity => activity) }
+      let!(:rule) { create(:evidence_rule, :prompts => [prompt]) }
+      let!(:passage) { create(:evidence_passage, :activity => activity) }
       let!(:feedback1) { create(:evidence_feedback, rule: rule) }
       let!(:highlight1) { create(:evidence_highlight, feedback: feedback1, text: 'lorem') }
 
       it 'should return rules' do
-        get(:rules, :params => ({ :id => activity.id }))
+        get(:rules, :params => { :id => activity.id })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(200))
         expect(rule.id).to(eq(parsed_response[0]['id']))
       end
 
       it 'should filter rule by rule_type' do
-        grammar_rule = create(:evidence_rule, :rule_type => (Rule::TYPE_GRAMMAR), :prompts => ([prompt]))
-        automl_rule = create(:evidence_rule, :rule_type => (Rule::TYPE_AUTOML), :prompts => ([prompt]))
-        get(:rules, :params => ({ :id => activity.id, :rule_type => (Rule::TYPE_GRAMMAR) }))
+        grammar_rule = create(:evidence_rule, :rule_type => Rule::TYPE_GRAMMAR, :prompts => [prompt])
+        automl_rule = create(:evidence_rule, :rule_type => Rule::TYPE_AUTOML, :prompts => [prompt])
+        get(:rules, :params => { :id => activity.id, :rule_type => Rule::TYPE_GRAMMAR })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(200))
         expect(parsed_response.size).to eq(1)
@@ -439,7 +439,7 @@ module Evidence
       end
 
       it 'should return feedbacks and highlights associated with the rules' do
-        get(:rules, :params => ({ :id => activity.id }))
+        get(:rules, :params => { :id => activity.id })
         parsed_response = JSON.parse(response.body)
 
         expect(parsed_response.first['feedbacks'].count).to eq 1
@@ -447,7 +447,7 @@ module Evidence
       end
 
       it 'should 404 if activity is invalid' do
-        expect { get(:rules, :params => ({ :id => 99999 })) }.to(raise_error(ActiveRecord::RecordNotFound))
+        expect { get(:rules, :params => { :id => 99999 }) }.to(raise_error(ActiveRecord::RecordNotFound))
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/hints_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/hints_controller_spec.rb
@@ -35,7 +35,7 @@ module Evidence
 
       it 'should create a valid record and return it as json' do
         expect do
-          post(:create, :params => ({ :hint => ({ :name => hint.name, :image_link => hint.image_link, :image_alt_text => hint.image_alt_text, :explanation => hint.explanation }) }))
+          post(:create, :params => { :hint => { :name => hint.name, :image_link => hint.image_link, :image_alt_text => hint.image_alt_text, :explanation => hint.explanation } })
           parsed_response = JSON.parse(response.body)
           expect(response.code.to_i).to(eq(201))
           expect(parsed_response['name']).to(eq(hint.name))
@@ -47,7 +47,7 @@ module Evidence
 
       it 'should not create an invalid record and return errors as json' do
         expect do
-          post(:create, :params => ({ :hint => { :name => 'New Hint' } }))
+          post(:create, :params => { :hint => { :name => 'New Hint' } })
           parsed_response = JSON.parse(response.body)
           expect(response.code.to_i).to(eq(422))
           expect(parsed_response['image_link']).to(include("can't be blank"))
@@ -61,7 +61,7 @@ module Evidence
       let!(:hint) { create(:evidence_hint) }
 
       it 'should return json if found' do
-        get(:show, :params => ({ :id => hint.id }))
+        get(:show, :params => { :id => hint.id })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(200))
         expect(parsed_response['name']).to(eq(hint.name))
@@ -71,7 +71,7 @@ module Evidence
       end
 
       it 'should raise if not found (to be handled by parent app)' do
-        expect { get(:show, :params => ({ :id => 99999 })) }.to(raise_error(ActiveRecord::RecordNotFound))
+        expect { get(:show, :params => { :id => 99999 }) }.to(raise_error(ActiveRecord::RecordNotFound))
       end
     end
 
@@ -81,7 +81,7 @@ module Evidence
       it 'should update record if valid, return nothing' do
         new_name = 'This is a new name'
         new_explanation = 'This is a new explanation'
-        patch(:update, :params => ({ :id => hint.id, :hint => ({ :name => new_name, :explanation => new_explanation }) }))
+        patch(:update, :params => { :id => hint.id, :hint => { :name => new_name, :explanation => new_explanation } })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         hint.reload
@@ -90,7 +90,7 @@ module Evidence
       end
 
       it 'should not update record and return errors as json' do
-        patch(:update, :params => ({ :id => hint.id, :hint => ({ :name => nil, :explanation => nil }) }))
+        patch(:update, :params => { :id => hint.id, :hint => { :name => nil, :explanation => nil } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(422))
         expect(parsed_response['name']).to(include("can't be blank"))
@@ -102,7 +102,7 @@ module Evidence
       let!(:hint) { create(:evidence_hint) }
 
       it 'should destroy record at id' do
-        delete(:destroy, :params => ({ :id => hint.id }))
+        delete(:destroy, :params => { :id => hint.id })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         expect(hint.id).to(be_truthy)

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/turking_round_activity_sessions_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/turking_round_activity_sessions_controller_spec.rb
@@ -33,14 +33,14 @@ module Evidence
 
       it 'should create a valid record and return it as json' do
         turking_round = create(:evidence_turking_round)
-        post(:create, :params => ({ :turking_round_activity_session => ({ :turking_round_id => turking_round.id, :activity_session_uid => SecureRandom.uuid }) }))
+        post(:create, :params => { :turking_round_activity_session => { :turking_round_id => turking_round.id, :activity_session_uid => SecureRandom.uuid } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(201))
         expect(TurkingRoundActivitySession.count).to(eq(1))
       end
 
       it 'should not create an invalid record and return errors as json' do
-        post(:create, :params => ({ :turking_round_activity_session => ({ :activity_session_uid => nil }) }))
+        post(:create, :params => { :turking_round_activity_session => { :activity_session_uid => nil } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(422))
         expect(parsed_response['activity_session_uid'].include?("can't be blank")).to(eq(true))
@@ -52,13 +52,13 @@ module Evidence
       let!(:turking_round_activity_session) { create(:evidence_turking_round_activity_session) }
 
       it 'should return json if found' do
-        get(:show, :params => ({ :id => turking_round_activity_session.id }))
+        get(:show, :params => { :id => turking_round_activity_session.id })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(200))
       end
 
       it 'should raise if not found (to be handled by parent app)' do
-        expect { get(:show, :params => ({ :id => 99999 })) }.to(raise_error(ActiveRecord::RecordNotFound))
+        expect { get(:show, :params => { :id => 99999 }) }.to(raise_error(ActiveRecord::RecordNotFound))
       end
     end
 
@@ -67,7 +67,7 @@ module Evidence
 
       it 'should update record if valid, return nothing' do
         new_session_uid = SecureRandom.uuid
-        patch(:update, :params => ({ :id => turking_round_activity_session.id, :turking_round_activity_session => ({ :activity_session_uid => new_session_uid }) }))
+        patch(:update, :params => { :id => turking_round_activity_session.id, :turking_round_activity_session => { :activity_session_uid => new_session_uid } })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         turking_round_activity_session.reload
@@ -75,7 +75,7 @@ module Evidence
       end
 
       it 'should not update record and return errors as json' do
-        patch(:update, :params => ({ :id => turking_round_activity_session.id, :turking_round_activity_session => ({ :activity_session_uid => nil }) }))
+        patch(:update, :params => { :id => turking_round_activity_session.id, :turking_round_activity_session => { :activity_session_uid => nil } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(422))
         expect(parsed_response['activity_session_uid'].include?("can't be blank")).to(eq(true))
@@ -86,7 +86,7 @@ module Evidence
       let!(:turking_round_activity_session) { create(:evidence_turking_round_activity_session) }
 
       it 'should destroy record at id' do
-        delete(:destroy, :params => ({ :id => turking_round_activity_session.id }))
+        delete(:destroy, :params => { :id => turking_round_activity_session.id })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         expect(turking_round_activity_session.id).to(be_truthy)
@@ -95,14 +95,14 @@ module Evidence
     end
 
     context 'should validate' do
-      let!(:archived_activity) { Evidence.parent_activity_class.create(:name => 'Archived Activity', :flags => (['archived'])) }
+      let!(:archived_activity) { Evidence.parent_activity_class.create(:name => 'Archived Activity', :flags => ['archived']) }
       let!(:unarchived_activity) { Evidence.parent_activity_class.create(:name => 'Unarchived Activity') }
       let!(:turking_round) { create(:evidence_turking_round, expires_at: 1.second.from_now) }
       let!(:activity) { create(:evidence_activity, parent_activity_id: unarchived_activity.id) }
 
       it 'should return false if turking round is expired' do
         sleep(2.seconds)
-        get(:validate, :params => ({ :turking_round_id => turking_round.id, :activity_id => activity.id }))
+        get(:validate, :params => { :turking_round_id => turking_round.id, :activity_id => activity.id })
         expect(JSON.parse(response.body)).to(eq(false))
         expect(response.code.to_i).to(eq(200))
       end
@@ -110,14 +110,14 @@ module Evidence
       it 'should return false if the parent activity is archived' do
         turking_round.update(expires_at: 1.day.from_now)
         activity.update(parent_activity_id: archived_activity.id)
-        get(:validate, :params => ({ :turking_round_id => turking_round.id, :activity_id => activity.id }))
+        get(:validate, :params => { :turking_round_id => turking_round.id, :activity_id => activity.id })
         expect(JSON.parse(response.body)).to(eq(false))
         expect(response.code.to_i).to(eq(200))
       end
 
       it 'should return true if turking round is not expired and parent activity is not archived' do
         turking_round.update(expires_at: 1.day.from_now)
-        get(:validate, :params => ({ :turking_round_id => turking_round.id, :activity_id => activity.id }))
+        get(:validate, :params => { :turking_round_id => turking_round.id, :activity_id => activity.id })
         expect(JSON.parse(response.body)).to(eq(true))
         expect(response.code.to_i).to(eq(200))
       end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/turking_rounds_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/turking_rounds_controller_spec.rb
@@ -33,10 +33,10 @@ module Evidence
 
     context 'should create' do
       let!(:activity) { create(:evidence_activity) }
-      let!(:turking_round) { build(:evidence_turking_round, :activity => (activity)) }
+      let!(:turking_round) { build(:evidence_turking_round, :activity => activity) }
 
       it 'should create a valid record and return it as json' do
-        post(:create, :params => ({ :turking_round => ({ :activity_id => activity.id, :uuid => turking_round.uuid, :expires_at => turking_round.expires_at.iso8601(3) }) }))
+        post(:create, :params => { :turking_round => { :activity_id => activity.id, :uuid => turking_round.uuid, :expires_at => turking_round.expires_at.iso8601(3) } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(201))
         expect(parsed_response['activity_id']).to(eq(turking_round.activity_id))
@@ -46,7 +46,7 @@ module Evidence
       end
 
       it 'should not create an invalid record and return errors as json' do
-        post(:create, :params => ({ :turking_round => ({ :activity_id => nil, :expires_at => nil }) }))
+        post(:create, :params => { :turking_round => { :activity_id => nil, :expires_at => nil } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(422))
         expect(parsed_response['activity_id'].include?("can't be blank")).to(eq(true))
@@ -59,7 +59,7 @@ module Evidence
       let!(:turking_round) { create(:evidence_turking_round) }
 
       it 'should return json if found' do
-        get(:show, :params => ({ :id => turking_round.id }))
+        get(:show, :params => { :id => turking_round.id })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(200))
         expect(parsed_response['activity_id']).to(eq(turking_round.activity.id))
@@ -68,7 +68,7 @@ module Evidence
       end
 
       it 'should raise if not found (to be handled by parent app)' do
-        expect { get(:show, :params => ({ :id => 99999 })) }.to(raise_error(ActiveRecord::RecordNotFound))
+        expect { get(:show, :params => { :id => 99999 }) }.to(raise_error(ActiveRecord::RecordNotFound))
       end
     end
 
@@ -78,7 +78,7 @@ module Evidence
       it 'should update record if valid, return nothing' do
         new_activity = create(:evidence_activity)
         new_datetime = DateTime.current.utc
-        patch(:update, :params => ({ :id => turking_round.id, :turking_round => ({ :activity_id => new_activity.id, :expires_at => new_datetime }) }))
+        patch(:update, :params => { :id => turking_round.id, :turking_round => { :activity_id => new_activity.id, :expires_at => new_datetime } })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         turking_round.reload
@@ -87,7 +87,7 @@ module Evidence
       end
 
       it 'should not update record and return errors as json' do
-        patch(:update, :params => ({ :id => turking_round.id, :turking_round => ({ :activity_id => nil, :uuid => nil, :expires_at => nil }) }))
+        patch(:update, :params => { :id => turking_round.id, :turking_round => { :activity_id => nil, :uuid => nil, :expires_at => nil } })
         parsed_response = JSON.parse(response.body)
         expect(response.code.to_i).to(eq(422))
         expect(parsed_response['activity_id'].include?("can't be blank")).to(eq(true))
@@ -100,7 +100,7 @@ module Evidence
       let!(:turking_round) { create(:evidence_turking_round) }
 
       it 'should destroy record at id' do
-        delete(:destroy, :params => ({ :id => turking_round.id }))
+        delete(:destroy, :params => { :id => turking_round.id })
         expect(response.body).to(eq(''))
         expect(response.code.to_i).to(eq(204))
         expect(turking_round.id).to(be_truthy)

--- a/services/QuillLMS/engines/evidence/spec/lib/regex_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/regex_check_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 module Evidence
   RSpec.describe(RegexCheck, :type => :model) do
     let!(:prompt) { create(:evidence_prompt) }
-    let!(:rule) { create(:evidence_rule, :rule_type => 'rules-based-1', :prompts => ([prompt]), :suborder => 0) }
-    let!(:regex_rule) { create(:evidence_regex_rule, :rule => (rule), :regex_text => '^Test') }
-    let!(:feedback) { create(:evidence_feedback, :rule => (rule), :text => 'This string begins with the word Test!') }
+    let!(:rule) { create(:evidence_rule, :rule_type => 'rules-based-1', :prompts => [prompt], :suborder => 0) }
+    let!(:regex_rule) { create(:evidence_regex_rule, :rule => rule, :regex_text => '^Test') }
+    let!(:feedback) { create(:evidence_feedback, :rule => rule, :text => 'This string begins with the word Test!') }
 
     context 'should #initialize' do
       it 'should should have working accessor methods for all initialized fields' do
@@ -45,7 +45,7 @@ module Evidence
       end
 
       it 'should return the highest priority feedback when two feedbacks exist' do
-        new_rule = create(:evidence_rule, :rule_type => 'rules-based-1', :prompts => ([prompt]), :suborder => 1)
+        new_rule = create(:evidence_rule, :rule_type => 'rules-based-1', :prompts => [prompt], :suborder => 1)
         new_regex_rule = create(:evidence_regex_rule, :rule => new_rule, :regex_text => '^Testing')
         entry = 'Test this is a good regex match'
         regex_check = Evidence::RegexCheck.new(entry, prompt, rule.rule_type)

--- a/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/spelling_check_spec.rb
@@ -7,7 +7,7 @@ module Evidence
   RSpec.describe(SpellingCheck, :type => :model) do
     context 'should #feedback_object' do
       it 'should return appropriate feedback attributes if there is a spelling error' do
-        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => 'spelin' }]) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => [{ :token => 'spelin' }] }.to_json, :headers => {})
         entry = 'there is a spelin error here'
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -22,7 +22,7 @@ module Evidence
 
       it 'should not flag error if the spelling error downcased is in exception list' do
         spelling_error = 'SpeliN'
-        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ([{ :token => spelling_error }]) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20a%20spelin%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => [{ :token => spelling_error }] }.to_json, :headers => {})
         stub_const('Evidence::SpellingCheck::EXCEPTIONS', [spelling_error.downcase])
         entry = 'there is a spelin error here'
         spelling_check = Evidence::SpellingCheck.new(entry)
@@ -38,7 +38,7 @@ module Evidence
       end
 
       it 'should return appropriate feedback attributes if there is no spelling error' do
-        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => ({}) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :flaggedTokens => {} }.to_json, :headers => {})
         entry = 'there is no spelling error here'
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -51,7 +51,7 @@ module Evidence
       end
 
       it 'should return appropriate feedback attributes if there is no spelling error even if Bing does not return a "flaggedTokens" value' do
-        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => {}.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => {}.to_json, :headers => {})
         entry = 'there is no spelling error here'
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -80,7 +80,7 @@ module Evidence
       end
 
       it 'should return appropriate error if the endpoint returns an error' do
-        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 200, :body => { :error => { :message => "There's a problem here" } }.to_json, :headers => {})
         entry = 'there is no spelling error here'
         spelling_check = Evidence::SpellingCheck.new(entry)
         feedback = spelling_check.feedback_object
@@ -95,14 +95,14 @@ module Evidence
       end
 
       it 'should use the feedback from the spelling rule if it is available' do
-        rule = create(:evidence_rule, :rule_type => (Evidence::Rule::TYPE_SPELLING))
+        rule = create(:evidence_rule, :rule_type => Evidence::Rule::TYPE_SPELLING)
         feedback = create(:evidence_feedback, :rule => rule)
         spelling_check = Evidence::SpellingCheck.new('')
         expect(feedback.text).to(eq(spelling_check.non_optimal_feedback_string))
       end
 
       it 'should use the higher ordered feedback if lower ordered feedback is in feedback_history' do
-        rule = create(:evidence_rule, :rule_type => (Evidence::Rule::TYPE_SPELLING))
+        rule = create(:evidence_rule, :rule_type => Evidence::Rule::TYPE_SPELLING)
         feedback = create(:evidence_feedback, :text => 'First feedback', :rule => rule, :order => 1)
         feedback2 = create(:evidence_feedback, :text => 'Second feedback', :rule => rule, :order => 2)
         feedback_history = [{
@@ -114,7 +114,7 @@ module Evidence
       end
 
       it 'should use the highest ordered feedback if all feedback options are in feedback_history' do
-        rule = create(:evidence_rule, :rule_type => (Evidence::Rule::TYPE_SPELLING))
+        rule = create(:evidence_rule, :rule_type => Evidence::Rule::TYPE_SPELLING)
         feedback = create(:evidence_feedback, :text => 'First feedback', :rule => rule, :order => 1)
         feedback2 = create(:evidence_feedback, :text => 'Second feedback', :rule => rule, :order => 2)
         feedback_history = [{
@@ -131,7 +131,7 @@ module Evidence
 
     context 'should handle appropriate Bing API errors' do
       it 'should raise exception if the endpoint returns a rate-limit error' do
-        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 429, :body => { :error => ({ :message => "There's a problem here" }) }.to_json, :headers => ({}))
+        stub_request(:get, "#{::Evidence::SpellingCheck::BING_API_URL}?mode=proof&text=there%20is%20no%20spelling%20error%20here").to_return(:status => 429, :body => { :error => { :message => "There's a problem here" } }.to_json, :headers => {})
         entry = 'there is no spelling error here'
         spelling_check = Evidence::SpellingCheck.new(entry)
         expect { spelling_check.feedback_object }.to raise_error(Evidence::SpellingCheck::BingRateLimitException)

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -75,8 +75,8 @@ module Evidence
 
     context 'should serializable_hash' do
       let!(:activity) { create(:evidence_activity, :title => 'First Activity', :notes => 'First Activity - Notes', :target_level => 8, :scored_level => '4th grade') }
-      let!(:passage) { create(:evidence_passage, :activity => (activity), :text => ('Hello' * 20)) }
-      let!(:prompt) { create(:evidence_prompt, :activity => (activity), :text => 'it is good.', :conjunction => 'because', :max_attempts_feedback => 'good work!.') }
+      let!(:passage) { create(:evidence_passage, :activity => activity, :text => ('Hello' * 20)) }
+      let!(:prompt) { create(:evidence_prompt, :activity => activity, :text => 'it is good.', :conjunction => 'because', :max_attempts_feedback => 'good work!.') }
 
       it 'should fill out hash with all fields' do
         json_hash = activity.as_json
@@ -175,14 +175,14 @@ module Evidence
     context 'should dependent destroy' do
       it 'should destroy dependent passages' do
         activity = create(:evidence_activity)
-        passage = create(:evidence_passage, :activity => (activity))
+        passage = create(:evidence_passage, :activity => activity)
         activity.destroy
         expect(Passage.exists?(passage.id)).to(eq(false))
       end
 
       it 'should destroy dependent prompts' do
         activity = create(:evidence_activity)
-        prompt = create(:evidence_prompt, :activity => (activity))
+        prompt = create(:evidence_prompt, :activity => activity)
         activity.destroy
         expect(Prompt.exists?(prompt.id)).to(eq(false))
       end
@@ -191,7 +191,7 @@ module Evidence
     context 'should before_destroy' do
       it 'should expire all associated Turking Rounds before destroy' do
         activity = create(:evidence_activity)
-        turking_round = create(:evidence_turking_round, :activity => (activity))
+        turking_round = create(:evidence_turking_round, :activity => activity)
         expect(turking_round.expires_at > Time.current).to be true
         activity.destroy
         turking_round.reload

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/label_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/label_spec.rb
@@ -36,10 +36,10 @@ module Evidence
 
         it 'should not allow a label to be created if its name collides with another on the prompt' do
           prompt = create(:evidence_prompt)
-          label.rule.update(:prompts => ([prompt]))
-          rule = create(:evidence_rule, :prompts => ([prompt]))
+          label.rule.update(:prompts => [prompt])
+          rule = create(:evidence_rule, :prompts => [prompt])
           new_label = build(:evidence_label, :rule => rule, :name => label.name)
-          expect((!new_label.valid?)).to(be_truthy)
+          expect(!new_label.valid?).to(be_truthy)
           expect(new_label.errors[:name].include?("can't be the same as any other labels related to the same prompt")).to(eq(true))
         end
       end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/prompt_spec.rb
@@ -44,7 +44,7 @@ module Evidence
         it 'should not allow a prompt to be created that is too short' do
           activity = create(:evidence_activity)
           prompt = build(:evidence_prompt, :conjunction => 'but', :text => 'too short', :max_attempts => 5, :activity_id => activity.id)
-          expect((!prompt.valid?)).to(be_truthy)
+          expect(!prompt.valid?).to(be_truthy)
           expect(prompt.errors[:text].include?("#{prompt.conjunction} prompt too short (minimum is #{Prompt::MIN_TEXT_LENGTH} characters)")).to(eq(true))
         end
 
@@ -52,7 +52,7 @@ module Evidence
           activity = create(:evidence_activity)
           prompt_text = "And both that morning equally lay In leaves no step had trodden black. Oh, I kept the first for another day! Yet knowing how way leads on to way, I doubted if I should ever come back. I shall be telling this with a sigh Somewhere ages and ages hence: Two roads diverged in a wood, and I\u2014 I took the one less traveled by, And that has made all the difference."
           prompt = build(:evidence_prompt, :conjunction => 'because', :text => prompt_text, :max_attempts => 5, :activity_id => activity.id)
-          expect((!prompt.valid?)).to(be_truthy)
+          expect(!prompt.valid?).to(be_truthy)
           expect(prompt.errors[:text].include?("#{prompt.conjunction} prompt too long (maximum is #{Prompt::MAX_TEXT_LENGTH} characters)")).to(eq(true))
         end
       end
@@ -72,7 +72,7 @@ module Evidence
         it 'should not duplicate rule assignments if some exist already' do
           rule1 = create(:evidence_rule, :universal => true)
           rule2 = create(:evidence_rule, :universal => true)
-          prompt = create(:evidence_prompt, :rules => ([rule1]))
+          prompt = create(:evidence_prompt, :rules => [rule1])
           expect(prompt.rules.length).to(eq(2))
           expect(prompt.rules.include?(rule1)).to(eq(true))
           expect(prompt.rules.include?(rule2)).to(eq(true))
@@ -90,7 +90,7 @@ module Evidence
         it 'should not remove existing non-universal assignments' do
           universal_rule = create(:evidence_rule, :universal => true)
           non_universal_rule = create(:evidence_rule, :universal => false)
-          prompt = create(:evidence_prompt, :rules => ([non_universal_rule]))
+          prompt = create(:evidence_prompt, :rules => [non_universal_rule])
           expect(prompt.rules.length).to(eq(2))
           expect(prompt.rules.include?(universal_rule)).to(eq(true))
           expect(prompt.rules.include?(non_universal_rule)).to(eq(true))

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/regex_rule_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/regex_rule_spec.rb
@@ -32,14 +32,14 @@ module Evidence
 
     context 'should custom validations' do
       let!(:rule) { create(:evidence_rule) }
-      let(:regex_rule) { RegexRule.create(:rule => (rule), :regex_text => 'test regex') }
+      let(:regex_rule) { RegexRule.create(:rule => rule, :regex_text => 'test regex') }
 
       it 'provide a default value for "case_sensitive"' do
         expect(regex_rule.case_sensitive).to(be_truthy)
       end
 
       it 'not override a "case_sensitive" with the default if one is provided' do
-        a_rule = RegexRule.create(:rule => (rule), :regex_text => 'test regex', :case_sensitive => false)
+        a_rule = RegexRule.create(:rule => rule, :regex_text => 'test regex', :case_sensitive => false)
         expect(a_rule.valid?).to(eq(true))
         expect(a_rule.case_sensitive).to(be_falsey)
       end
@@ -52,7 +52,7 @@ module Evidence
 
     context 'should entry_failing?' do
       let!(:rule) { create(:evidence_rule) }
-      let!(:regex_rule) { RegexRule.create(:rule => (rule), :regex_text => '^test', :sequence_type => 'required', :case_sensitive => false) }
+      let!(:regex_rule) { RegexRule.create(:rule => rule, :regex_text => '^test', :sequence_type => 'required', :case_sensitive => false) }
 
       it 'should flag entry as failing if regex does not match and sequence type is required' do
         expect(regex_rule.entry_failing?('not test passing')).to(eq(true))

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/rule_spec.rb
@@ -94,9 +94,9 @@ module Evidence
 
     context 'should #determine_feedback_from_history' do
       let!(:rule) { create(:evidence_rule) }
-      let!(:feedback1) { create(:evidence_feedback, :rule => (rule), :order => 0, :text => 'Example feedback 1') }
-      let!(:feedback2) { create(:evidence_feedback, :rule => (rule), :order => 1, :text => 'Example feedback 2') }
-      let!(:feedback3) { create(:evidence_feedback, :rule => (rule), :order => 2, :text => 'Example feedback 3') }
+      let!(:feedback1) { create(:evidence_feedback, :rule => rule, :order => 0, :text => 'Example feedback 1') }
+      let!(:feedback2) { create(:evidence_feedback, :rule => rule, :order => 1, :text => 'Example feedback 2') }
+      let!(:feedback3) { create(:evidence_feedback, :rule => rule, :order => 2, :text => 'Example feedback 3') }
 
       it 'should fetch lowest order feedback if feedback history is empty' do
         feedback_history = []
@@ -134,8 +134,8 @@ module Evidence
     context 'should regex_is_passing?' do
       context 'when the regex rules are not conditional' do
         let!(:rule) { create(:evidence_rule) }
-        let!(:regex_rule) { create(:evidence_regex_rule, :rule => (rule), :regex_text => '^Hello', :sequence_type => 'incorrect', :conditional => false) }
-        let!(:regex_rule_two) { create(:evidence_regex_rule, :rule => (rule), :regex_text => '^Something', :sequence_type => 'incorrect', :conditional => false) }
+        let!(:regex_rule) { create(:evidence_regex_rule, :rule => rule, :regex_text => '^Hello', :sequence_type => 'incorrect', :conditional => false) }
+        let!(:regex_rule_two) { create(:evidence_regex_rule, :rule => rule, :regex_text => '^Something', :sequence_type => 'incorrect', :conditional => false) }
 
         it 'should be true if sequence_type is incorrect and entry does not match the regex text' do
           expect(rule.regex_is_passing?('Nope, I dont start with hello.')).to(eq(true))
@@ -184,16 +184,16 @@ module Evidence
           dual_rule = create(:evidence_rule)
           regex_rule_three = create(:evidence_regex_rule, :rule => dual_rule, :regex_text => 'you need this sequence', :sequence_type => 'required', :case_sensitive => false)
           regex_rule_four = create(:evidence_regex_rule, :rule => dual_rule, :regex_text => 'but not this one', :sequence_type => 'incorrect', :case_sensitive => false)
-          expect((dual_rule.regex_is_passing?('you need this sequence but not this one'))).to(eq(false))
-          expect((dual_rule.regex_is_passing?('you need this sequence and this should pass'))).to(eq(true))
-          expect((dual_rule.regex_is_passing?("this fails because you don't have the needed sequence"))).to(eq(false))
+          expect(dual_rule.regex_is_passing?('you need this sequence but not this one')).to(eq(false))
+          expect(dual_rule.regex_is_passing?('you need this sequence and this should pass')).to(eq(true))
+          expect(dual_rule.regex_is_passing?("this fails because you don't have the needed sequence")).to(eq(false))
         end
       end
 
       context 'when the regex rules are conditional' do
         let!(:rule) { create(:evidence_rule) }
-        let!(:regex_rule) { create(:evidence_regex_rule, :rule => (rule), :regex_text => '^Conditional-start', :sequence_type => 'incorrect', :conditional => true) }
-        let!(:regex_rule_two) { create(:evidence_regex_rule, :rule => (rule), :regex_text => 'required-end.$', :sequence_type => 'required', :conditional => true) }
+        let!(:regex_rule) { create(:evidence_regex_rule, :rule => rule, :regex_text => '^Conditional-start', :sequence_type => 'incorrect', :conditional => true) }
+        let!(:regex_rule_two) { create(:evidence_regex_rule, :rule => rule, :regex_text => 'required-end.$', :sequence_type => 'required', :conditional => true) }
 
         it 'should require the required sequence if the incorrect sequence is present' do
           expect(rule.regex_is_passing?('Conditional-start that does not contain the right end.')).to(eq(false))
@@ -210,24 +210,24 @@ module Evidence
     context 'should one_plagiarism_per_prompt' do
       let!(:prompt1) { create(:evidence_prompt) }
       let!(:prompt2) { create(:evidence_prompt) }
-      let!(:plagiarism_rule) { create(:evidence_rule, :rule_type => (Rule::TYPE_PLAGIARISM), :prompt_ids => ([prompt1.id])) }
+      let!(:plagiarism_rule) { create(:evidence_rule, :rule_type => Rule::TYPE_PLAGIARISM, :prompt_ids => [prompt1.id]) }
 
       it 'should creates plagiarism rule if first rule for prompt' do
         expect(plagiarism_rule.valid?).to(eq(true))
       end
 
       it 'should does not create plagiarism rule if plagiarism rule already exists for prompt' do
-        invalid_plagiarism_rule = build(:evidence_rule, :rule_type => (Rule::TYPE_PLAGIARISM), :prompt_ids => ([prompt1.id]))
-        expect((invalid_plagiarism_rule.valid?)).to(eq(false))
+        invalid_plagiarism_rule = build(:evidence_rule, :rule_type => Rule::TYPE_PLAGIARISM, :prompt_ids => [prompt1.id])
+        expect(invalid_plagiarism_rule.valid?).to(eq(false))
       end
 
       it 'should creates subsequent plagiarism rule for different prompt' do
-        second_plagiarism_rule = build(:evidence_rule, :rule_type => (Rule::TYPE_PLAGIARISM), :prompt_ids => ([prompt2.id]))
+        second_plagiarism_rule = build(:evidence_rule, :rule_type => Rule::TYPE_PLAGIARISM, :prompt_ids => [prompt2.id])
         expect(second_plagiarism_rule.valid?).to(eq(true))
       end
 
       it 'should create a different type of rule if it is not plagiarism' do
-        valid_automl_rule = build(:evidence_rule, :rule_type => (Rule::TYPE_AUTOML), :prompt_ids => ([prompt1.id]))
+        valid_automl_rule = build(:evidence_rule, :rule_type => Rule::TYPE_AUTOML, :prompt_ids => [prompt1.id])
         expect(valid_automl_rule.valid?).to(eq(true))
       end
     end
@@ -235,24 +235,24 @@ module Evidence
     context 'should one_low_confidence_per_prompt' do
       let!(:prompt1) { create(:evidence_prompt) }
       let!(:prompt2) { create(:evidence_prompt) }
-      let!(:low_confidence_rule) { create(:evidence_rule, :rule_type => (Rule::TYPE_LOW_CONFIDENCE), :prompt_ids => ([prompt1.id])) }
+      let!(:low_confidence_rule) { create(:evidence_rule, :rule_type => Rule::TYPE_LOW_CONFIDENCE, :prompt_ids => [prompt1.id]) }
 
       it 'should creates low_confidence rule if first rule for prompt' do
         expect(low_confidence_rule.valid?).to(eq(true))
       end
 
       it 'should does not create low_confidence rule if low_confidence rule already exists for prompt' do
-        invalid_low_confidence_rule = build(:evidence_rule, :rule_type => (Rule::TYPE_LOW_CONFIDENCE), :prompt_ids => ([prompt1.id]))
+        invalid_low_confidence_rule = build(:evidence_rule, :rule_type => Rule::TYPE_LOW_CONFIDENCE, :prompt_ids => [prompt1.id])
         expect(invalid_low_confidence_rule.valid?).to(eq(false))
       end
 
       it 'should creates subsequent low_confidence rule for different prompt' do
-        second_low_confidence_rule = build(:evidence_rule, :rule_type => (Rule::TYPE_LOW_CONFIDENCE), :prompt_ids => ([prompt2.id]))
+        second_low_confidence_rule = build(:evidence_rule, :rule_type => Rule::TYPE_LOW_CONFIDENCE, :prompt_ids => [prompt2.id])
         expect(second_low_confidence_rule.valid?).to(eq(true))
       end
 
       it 'should create a different type of rule if it is not low_confidence' do
-        valid_automl_rule = build(:evidence_rule, :rule_type => (Rule::TYPE_AUTOML), :prompt_ids => ([prompt1.id]))
+        valid_automl_rule = build(:evidence_rule, :rule_type => Rule::TYPE_AUTOML, :prompt_ids => [prompt1.id])
         expect(valid_automl_rule.valid?).to(eq(true))
       end
     end
@@ -275,7 +275,7 @@ module Evidence
 
         it 'should not assign newly created rules to prompts that somehow already have them assigned' do
           prompt = create(:evidence_prompt)
-          rule = create(:evidence_rule, :universal => true, :prompts => ([prompt]))
+          rule = create(:evidence_rule, :universal => true, :prompts => [prompt])
           expect(prompt.reload.rules.length).to eq 1
           expect(rule.reload.prompts).to include prompt
         end

--- a/services/QuillLMS/lib/tasks/add_user_id_to_units.rake
+++ b/services/QuillLMS/lib/tasks/add_user_id_to_units.rake
@@ -8,19 +8,19 @@ namespace :add_user_id_to_units do
 
     Unit.where(user_id: nil).each do |unit|
       classroom_activities = ClassroomActivity.unscoped.where(unit_id: unit.id)
-      if classroom_activities.any?
-        teacher = nil
-        ca_with_teacher = classroom_activities.find do |ca|
-          classy = Classroom.unscoped.find_by_id(ca.classroom_id)
-          teacher = User.find_by_id(classy.teacher_id) if classy
-          classy && teacher
-        end
-        if ca_with_teacher
-          unit.update_attribute('user_id', teacher.id)
-          puts 'unit_id'
-          puts unit.id
-        end
+      next unless classroom_activities.any?
+
+      teacher = nil
+      ca_with_teacher = classroom_activities.find do |ca|
+        classy = Classroom.unscoped.find_by_id(ca.classroom_id)
+        teacher = User.find_by_id(classy.teacher_id) if classy
+        classy && teacher
       end
+      next unless ca_with_teacher
+
+      unit.update_attribute('user_id', teacher.id)
+      puts 'unit_id'
+      puts unit.id
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/app_settings.rake
+++ b/services/QuillLMS/lib/tasks/app_settings.rake
@@ -28,7 +28,7 @@ namespace :app_settings do
     emails = CSV.parse(iostream, headers: true).map { |row| row['email'] }
     user_ids = emails.map do |email|
       user = User.find_by_email(email)
-      if !user
+      unless user
         puts "User with email #{email} not found"
         next
       end

--- a/services/QuillLMS/lib/tasks/assets.rake
+++ b/services/QuillLMS/lib/tasks/assets.rake
@@ -18,7 +18,7 @@ if defined?(Sprockets)
           puts "stderr:\n#{stderr}" if stderr.present?
         end
 
-        if !status.success?
+        unless status.success?
           # print everything in the case of an error
           puts stdout
           abort 'error: could not execute command.'

--- a/services/QuillLMS/lib/tasks/convert_activity_session_timetracking_data.rake
+++ b/services/QuillLMS/lib/tasks/convert_activity_session_timetracking_data.rake
@@ -4,11 +4,11 @@ namespace :activity_session_timetracking_data do
   desc 'updates data that had formerly been saved as json in hstore to be parsable in jsonb'
   task :convert => :environment do
     ActivitySession.where("activity_sessions.data->'time_tracking' IS NOT NULL").each do |as|
-      if as.data['time_tracking'].instance_of? String
-        time_tracking = JSON.parse(as.data['time_tracking'])
-        as.data = { time_tracking: time_tracking }
-        as.save
-      end
+      next unless as.data['time_tracking'].instance_of? String
+
+      time_tracking = JSON.parse(as.data['time_tracking'])
+      as.data = { time_tracking: time_tracking }
+      as.save
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/convert_to_markdown.rake
+++ b/services/QuillLMS/lib/tasks/convert_to_markdown.rake
@@ -16,11 +16,11 @@ namespace :unit_templates do
       unless ut.teacher_review.blank?
         markdown.concat "### Activity Info\n\n#{ut.teacher_review}\n\n"
       end
-      unless markdown.blank?
-        ut.activity_info = markdown
-        ut.save
-        puts "💪   Unit Template updated: #{ut.name}"
-      end
+      next if markdown.blank?
+
+      ut.activity_info = markdown
+      ut.save
+      puts "💪   Unit Template updated: #{ut.name}"
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/create_lesson_recommendations.rake
+++ b/services/QuillLMS/lib/tasks/create_lesson_recommendations.rake
@@ -441,13 +441,11 @@ namespace :recommendations do
           puts "Created recommendation - #{recommendation.name}"
 
           recommendation_data[:requirements].each do |criterion_data|
-            concept_uid = begin
-              if criterion_data[:concept_id] === 'mandatory'
-                manditory_concept.uid
+            concept_uid = if criterion_data[:concept_id] === 'mandatory'
+                            manditory_concept.uid
               else
                 criterion_data[:concept_id]
               end
-            end
 
             concept   = Concept.find_by(uid: concept_uid)
             criterion = Criterion.create!(
@@ -664,13 +662,11 @@ namespace :recommendations do
           puts "Created recommendation - #{recommendation.name}"
 
           recommendation_data[:requirements].each do |criterion_data|
-            concept_uid = begin
-              if criterion_data[:concept_id] === 'mandatory'
-                manditory_concept.uid
+            concept_uid = if criterion_data[:concept_id] === 'mandatory'
+                            manditory_concept.uid
               else
                 criterion_data[:concept_id]
               end
-            end
 
             concept   = Concept.find_by(uid: concept_uid)
             criterion = Criterion.create!(

--- a/services/QuillLMS/lib/tasks/create_unit_templates.rake
+++ b/services/QuillLMS/lib/tasks/create_unit_templates.rake
@@ -11,7 +11,7 @@ namespace :unit_templates do
     end
   end
 
-  def create_unit_template arr
+  def create_unit_template(arr)
     author = Author.find_or_create_by name: "#{arr[0]} #{arr[1]}"
     UnitTemplate.create(author_id: author.id, name: arr[2], activity_ids: activity_ids, time: 40, unit_template_category_id: UnitTemplateCategory.first.id)
   end

--- a/services/QuillLMS/lib/tasks/gen_ai_tasks.thor
+++ b/services/QuillLMS/lib/tasks/gen_ai_tasks.thor
@@ -17,21 +17,19 @@ class GenAITasks < Thor
       system_prompt = Evidence::GenAI::SystemPromptBuilder.run(prompt:, template_file:)
 
       prompt.example_sets(optimal:).each do |entry|
-        begin
-          response = Evidence::OpenAI::Chat.run(system_prompt:, entry:)
-          total += 1
+        response = Evidence::OpenAI::Chat.run(system_prompt:, entry:)
+        total += 1
 
-          if response[KEY_OPTIMAL] == optimal
-            print '.'
-            correct_count += 1
-          else
-            print 'F'
-            incorrect_examples.append([prompt, entry, response[KEY_FEEDBACK]])
-          end
-        rescue => e
-          error_count += 1
-          error_examples.append([prompt, entry])
+        if response[KEY_OPTIMAL] == optimal
+          print '.'
+          correct_count += 1
+        else
+          print 'F'
+          incorrect_examples.append([prompt, entry, response[KEY_FEEDBACK]])
         end
+      rescue => e
+        error_count += 1
+        error_examples.append([prompt, entry])
       end
     end
     puts '' # new line after prints
@@ -57,21 +55,19 @@ class GenAITasks < Thor
 
       test_data = optimal ? dataset.optimals : dataset.suboptimals
       test_data.each do |entry|
-        begin
-          response = Evidence::OpenAI::Chat.run(system_prompt:, entry:)
-          total += 1
+        response = Evidence::OpenAI::Chat.run(system_prompt:, entry:)
+        total += 1
 
-          if response[KEY_OPTIMAL] == optimal
-            print '.'
-            correct_count += 1
-          else
-            print 'F'
-            incorrect_examples.append([prompt, entry, response[KEY_FEEDBACK]])
-          end
-        rescue => e
-          error_count += 1
-          error_examples.append([prompt, entry])
+        if response[KEY_OPTIMAL] == optimal
+          print '.'
+          correct_count += 1
+        else
+          print 'F'
+          incorrect_examples.append([prompt, entry, response[KEY_FEEDBACK]])
         end
+      rescue => e
+        error_count += 1
+        error_examples.append([prompt, entry])
       end
     end
     puts '' # new line after prints

--- a/services/QuillLMS/lib/tasks/gen_ai_tasks.thor
+++ b/services/QuillLMS/lib/tasks/gen_ai_tasks.thor
@@ -38,7 +38,7 @@ class GenAITasks < Thor
   end
 
   # bundle exec thor gen_a_i_tasks:static_sample_test 2
-  desc "static_sample_test 2", 'Run to see if examplar optimals are labeled optimal by the prompt'
+  desc 'static_sample_test 2', 'Run to see if examplar optimals are labeled optimal by the prompt'
   def static_sample_test(limit = 10, optimal = true, template_file = nil)
     correct_count = 0
     total = 0
@@ -76,20 +76,20 @@ class GenAITasks < Thor
   end
 
   # bundle exec thor gen_a_i_tasks:static_full_test 2
-  desc "static_full_test  2", 'Run to see if examplar optimals are labeled optimal by the prompt'
+  desc 'static_full_test  2', 'Run to see if examplar optimals are labeled optimal by the prompt'
   def static_full_test(limit = 50, template_file = nil)
     static_sample_test(limit, true, template_file)
     static_sample_test(limit, false, template_file)
   end
 
   # bundle exec thor gen_a_i_tasks:static_optimal_test 2
-  desc "static_optimal_test  2", 'Run to see if examplar optimals are labeled optimal by the prompt'
+  desc 'static_optimal_test  2', 'Run to see if examplar optimals are labeled optimal by the prompt'
   def static_optimal_test(limit = 50, template_file = nil)
     static_sample_test(limit, true, template_file)
   end
 
   # bundle exec thor gen_a_i_tasks:static_suboptimal_test 'because' 2
-  desc "static_suboptimal_test 2", 'Run to see if examplar suboptimals are labeled suboptimal by the prompt'
+  desc 'static_suboptimal_test 2', 'Run to see if examplar suboptimals are labeled suboptimal by the prompt'
   def static_suboptimal_test(limit = 50, template_file = nil)
     static_sample_test(limit, false, template_file)
   end
@@ -175,7 +175,7 @@ class GenAITasks < Thor
   end
 
   # bundle exec thor gen_a_i_tasks:generate_secondary_data_files
-  desc "generate_secondary_data_files", 'Create a csv for training and test.'
+  desc 'generate_secondary_data_files', 'Create a csv for training and test.'
   def generate_secondary_data_files
     file_all = Evidence::GenAI::SecondaryFeedbackDataFetcher::FILE_ALL
     file_train = Evidence::GenAI::SecondaryFeedbackDataFetcher::FILE_TRAIN

--- a/services/QuillLMS/lib/tasks/ip_location.rake
+++ b/services/QuillLMS/lib/tasks/ip_location.rake
@@ -4,7 +4,7 @@ namespace :ip_location do
   desc 'give every teacher with an ip address but no school a location'
   task :location_of_schoolless_teachers => :environment do
     # Selects from teachers that have no school, but do have an ip address and no ip_location
-    target = User.where(role: 'teacher').select { |t| (t.school.nil?) && (!!t.ip_address) && !t.ip_location }
+    target = User.where(role: 'teacher').select { |t| t.school.nil? && !!t.ip_address && !t.ip_location }
     generate_location(target)
   end
 

--- a/services/QuillLMS/lib/tasks/populate_diagnostic_question_skills.rake
+++ b/services/QuillLMS/lib/tasks/populate_diagnostic_question_skills.rake
@@ -7,12 +7,10 @@ namespace :diagnostic_question_skills do
 
     ActiveRecord::Base.transaction do
       skill_to_question_mapping.each do |row|
-        begin
-          question = Question.find_by_uid(row['Question ID'])
-          DiagnosticQuestionSkill.create(question: question, skill_group_id: row['Skill Group ID'], name: row['Skill Name'])
-        rescue => e
-          puts "ID:#{row['Question ID']}: #{e}"
-        end
+        question = Question.find_by_uid(row['Question ID'])
+        DiagnosticQuestionSkill.create(question: question, skill_group_id: row['Skill Group ID'], name: row['Skill Name'])
+      rescue => e
+        puts "ID:#{row['Question ID']}: #{e}"
       end
     end
   end

--- a/services/QuillLMS/lib/tasks/renaming_and_reflagging_for_diagnostic_activities_and_packs.rake
+++ b/services/QuillLMS/lib/tasks/renaming_and_reflagging_for_diagnostic_activities_and_packs.rake
@@ -6,23 +6,19 @@ namespace :diagnostic_activities_and_packs do
     activity_pack_table = CSV.parse(File.read('lib/data/activity_pack_renaming_and_reflagging.csv'), headers: true)
     ActiveRecord::Base.transaction do
       activity_pack_table.each do |row|
-        begin
-          activity_pack = UnitTemplate.find_or_initialize_by(id: row['ID'])
-          activity_pack.update!(name: row['Name'], flag: row['Flag'].downcase)
-        rescue => e
-          puts "ID:#{row['ID']}: #{e}"
-        end
+        activity_pack = UnitTemplate.find_or_initialize_by(id: row['ID'])
+        activity_pack.update!(name: row['Name'], flag: row['Flag'].downcase)
+      rescue => e
+        puts "ID:#{row['ID']}: #{e}"
       end
     end
     activity_table = CSV.parse(File.read('lib/data/activity_renaming_and_reflagging.csv'), headers: true)
     ActiveRecord::Base.transaction do
       activity_table.each do |row|
-        begin
-          activity = Activity.find_or_initialize_by(id: row['ID'])
-          activity.update!(name: row['Name'], flag: row['Flag'].downcase)
-        rescue => e
-          puts "ID:#{row['ID']}: #{e}"
-        end
+        activity = Activity.find_or_initialize_by(id: row['ID'])
+        activity.update!(name: row['Name'], flag: row['Flag'].downcase)
+      rescue => e
+        puts "ID:#{row['ID']}: #{e}"
       end
     end
   end

--- a/services/QuillLMS/lib/tasks/reset_admin_caches.rake
+++ b/services/QuillLMS/lib/tasks/reset_admin_caches.rake
@@ -4,12 +4,12 @@ namespace :admin_caches do
   desc 'reset caches for district admin reports'
   task :reset => :environment do
     SchoolsAdmins.all.select { |sa| sa.user && sa.user.last_sign_in && sa.user.last_sign_in > 1.month.ago }.pluck(:user_id).uniq.each do |user_id|
-      if User.find_by_id(user_id)
-        FindAdminUsersWorker.perform_async(user_id)
-        FindDistrictConceptReportsWorker.perform_async(user_id)
-        FindDistrictStandardsReportsWorker.perform_async(user_id)
-        FindDistrictActivityScoresWorker.perform_async(user_id)
-      end
+      next unless User.find_by_id(user_id)
+
+      FindAdminUsersWorker.perform_async(user_id)
+      FindDistrictConceptReportsWorker.perform_async(user_id)
+      FindDistrictStandardsReportsWorker.perform_async(user_id)
+      FindDistrictActivityScoresWorker.perform_async(user_id)
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/set_upgrade_notification.rake
+++ b/services/QuillLMS/lib/tasks/set_upgrade_notification.rake
@@ -3,7 +3,7 @@
 namespace :upgrade do
   task :set_upgrade_vars, [:app_name, :start_time, :end_time] => [:environment] do |t, args|
     app_name = args[:app_name].downcase.gsub(/"/, '')
-    if (['empirical-grammar-staging', 'empirical-grammar'].include?(app_name)) && args[:start_time] && args[:end_time] && Time.zone.parse(args[:start_time]) && Time.zone.parse(args[:end_time])
+    if ['empirical-grammar-staging', 'empirical-grammar'].include?(app_name) && args[:start_time] && args[:end_time] && Time.zone.parse(args[:start_time]) && Time.zone.parse(args[:end_time])
       sh %{curl -n -X PATCH https://api.heroku.com/apps/#{app_name}/config-vars \
           -d '{
           "UPGRADE": "true",

--- a/services/QuillLMS/lib/tasks/temporary/translate.rake
+++ b/services/QuillLMS/lib/tasks/temporary/translate.rake
@@ -17,7 +17,7 @@ namespace :translate do
   desc 'on zsh use `noglob rake translate:activities[es-la, 2]`'
   desc 'first param is locale, second is (optional) number of activities to translate'
   task :activities, [:locale, :limit] => :environment do |t, args|
-    puts "translating activities"
+    puts 'translating activities'
     limit = args[:limit] ? args[:limit].to_i : nil
     locale = args[:locale] || Translatable::DEFAULT_LOCALE
 

--- a/services/QuillLMS/lib/tasks/topics_to_standards.rake
+++ b/services/QuillLMS/lib/tasks/topics_to_standards.rake
@@ -25,11 +25,9 @@ namespace :topics_to_standards do
     ActiveRecord::Base.connection.reset_pk_sequence!('standards')
 
     Activity.all.each do |a|
-      begin
-        a.update(standard_id: a.topic_id)
-      rescue
-        puts 'a.name', a.name
-      end
+      a.update(standard_id: a.topic_id)
+    rescue
+      puts 'a.name', a.name
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/update_activities.rake
+++ b/services/QuillLMS/lib/tasks/update_activities.rake
@@ -5,25 +5,21 @@ namespace :activities do
   task :update => :environment do
     descriptions_table = CSV.parse(File.read('lib/data/activity_descriptions.csv'), headers: true)
     descriptions_table.each do |row|
-      begin
-        activity = Activity.find(row['ID'])
-        description = row['Revised Activity Description']
-        activity.update!(description: description)
-      rescue => e
-        puts "ID:#{row['ID']}: #{e}"
-      end
+      activity = Activity.find(row['ID'])
+      description = row['Revised Activity Description']
+      activity.update!(description: description)
+    rescue => e
+      puts "ID:#{row['ID']}: #{e}"
     end
     instructions_table = CSV.parse(File.read('lib/data/activity_instructions.csv'), headers: true)
     instructions_table.each do |row|
-      begin
-        activity = Activity.find(row['ID'])
-        instructions = row['Instructions']
-        data = activity.data
-        data['instructions'] = instructions
-        activity.update!(data: data)
-      rescue => e
-        puts "ID:#{row['ID']}: #{e}"
-      end
+      activity = Activity.find(row['ID'])
+      instructions = row['Instructions']
+      data = activity.data
+      data['instructions'] = instructions
+      activity.update!(data: data)
+    rescue => e
+      puts "ID:#{row['ID']}: #{e}"
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/update_optimal_value_for_student_problem_reports.rake
+++ b/services/QuillLMS/lib/tasks/update_optimal_value_for_student_problem_reports.rake
@@ -5,7 +5,7 @@ namespace :update_optimal_value_for_student_problem_reports do
   task :run => :environment do
     StudentProblemReport.all.each do |report|
       is_optimal = FeedbackHistory.find(report.feedback_history_id)&.optimal
-      report.optimal = is_optimal if !is_optimal.nil?
+      report.optimal = is_optimal unless is_optimal.nil?
       report.save!
     end
   end

--- a/services/QuillLMS/script/recommendations/00_import_independent_practice_recommendations.rb
+++ b/services/QuillLMS/script/recommendations/00_import_independent_practice_recommendations.rb
@@ -438,13 +438,11 @@ activities.each do |activity_id, recommendations|
       puts "Created recommendation - #{recommendation.name}"
 
       recommendation_data[:requirements].each do |criterion_data|
-        concept_uid = begin
-          if criterion_data[:concept_id] === 'mandatory'
-            manditory_concept.uid
+        concept_uid = if criterion_data[:concept_id] === 'mandatory'
+                        manditory_concept.uid
           else
             criterion_data[:concept_id]
           end
-        end
 
         concept   = Concept.find_by(uid: concept_uid)
         criterion = Criterion.create!(

--- a/services/QuillLMS/script/recommendations/01_import_group_lesson_recommendations.rb
+++ b/services/QuillLMS/script/recommendations/01_import_group_lesson_recommendations.rb
@@ -199,13 +199,11 @@ activities.each do |activity_id, recommendations|
       puts "Created recommendation - #{recommendation.name}"
 
       recommendation_data[:requirements].each do |criterion_data|
-        concept_uid = begin
-          if criterion_data[:concept_id] === 'mandatory'
-            manditory_concept.uid
+        concept_uid = if criterion_data[:concept_id] === 'mandatory'
+                        manditory_concept.uid
           else
             criterion_data[:concept_id]
           end
-        end
 
         concept   = Concept.find_by(uid: concept_uid)
         criterion = Criterion.create!(

--- a/services/QuillLMS/spec/controllers/api/v1/activity_questions_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/activity_questions_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V1::ActivityQuestionsController, type: :controller do
     allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::RedisCacheStore.new(redis: redis))
   end
 
-  describe "GET #index" do
+  describe 'GET #index' do
     let(:activity) { create(:activity) }
     let(:questions) { create_list(:question, 3) }
     let(:locale) { 'en' }
@@ -19,34 +19,34 @@ RSpec.describe Api::V1::ActivityQuestionsController, type: :controller do
       allow(Activity).to receive(:find_by).with(uid: activity.uid).and_return(activity)
       allow(activity).to receive(:questions).and_return(questions)
       questions.each do |question|
-        allow(question).to receive(:as_json).with(locale:).and_return({ "id" => question.id, "content" => "Question content" })
+        allow(question).to receive(:as_json).with(locale:).and_return({ 'id' => question.id, 'content' => 'Question content' })
       end
     end
 
-    it "returns http success" do
+    it 'returns http success' do
       get :index, params: { activity_id: activity.uid, locale: }
       expect(response).to have_http_status(:success)
     end
 
-    it "returns questions as a hash with UIDs as keys" do
+    it 'returns questions as a hash with UIDs as keys' do
       get :index, params: { activity_id: activity.uid, locale: }
 
       json_response = JSON.parse(response.body)
       expect(json_response.keys).to match_array(questions.map(&:uid))
     end
 
-    it "calls as_json with the correct locale for each question" do
+    it 'calls as_json with the correct locale for each question' do
       expect(questions).to all(receive(:as_json).with(locale:))
       get :index, params: { activity_id: activity.uid, locale: }
     end
 
-    it "caches the result" do
+    it 'caches the result' do
       expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 1.hour).and_call_original
 
       get :index, params: { activity_id: activity.uid, locale: }
     end
 
-    it "returns cached result on subsequent requests" do
+    it 'returns cached result on subsequent requests' do
       get :index, params: { activity_id: activity.uid, locale: }
 
       # Clear any existing stub to ensure we're testing the actual caching
@@ -57,32 +57,32 @@ RSpec.describe Api::V1::ActivityQuestionsController, type: :controller do
       expect(response).to have_http_status(:success)
     end
 
-    context "when activity is not found" do
+    context 'when activity is not found' do
       before do
         allow(Activity).to receive(:find_by).and_return(nil)
       end
 
-      it "returns http not_found" do
+      it 'returns http not_found' do
         get :index, params: { activity_id: 'non_existent_uid', locale: }
         expect(response).to have_http_status(:not_found)
       end
 
-      it "does not attempt to cache" do
+      it 'does not attempt to cache' do
         expect(Rails.cache).not_to receive(:fetch)
 
         get :index, params: { activity_id: 'non_existent_uid', locale: }
       end
     end
 
-    context "with different locales" do
+    context 'with different locales' do
       let(:locale) { 'es' }
 
-      it "passes the correct locale to as_json" do
+      it 'passes the correct locale to as_json' do
         expect(questions).to all(receive(:as_json).with(locale: 'es'))
         get :index, params: { activity_id: activity.uid, locale: }
       end
 
-      it "uses a different cache key for different locales" do
+      it 'uses a different cache key for different locales' do
         expect(Rails.cache).to receive(:fetch).with("activity_questions/#{activity.uid}/es", expires_in: 1.hour).and_call_original
         get :index, params: { activity_id: activity.uid, locale: }
       end

--- a/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concept_feedback_controller_spec.rb
@@ -28,7 +28,7 @@ describe Api::V1::ConceptFeedbackController, type: :controller do
     end
   end
 
-  describe "#translations" do
+  describe '#translations' do
     let(:locale) { Translatable::DEFAULT_LOCALE }
     let!(:concept_feedback_untranslated) { create(:concept_feedback) }
     let(:cache_key) {

--- a/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/progress_reports/diagnostic_reports_controller_spec.rb
@@ -20,7 +20,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
       let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
       it 'redirects to the correct page' do
-        get :report_from_classroom_unit_and_activity_and_user, params: ({ classroom_unit_id: classroom_unit.id, user_id: student.id, activity_id: activity.id })
+        get :report_from_classroom_unit_and_activity_and_user, params: { classroom_unit_id: classroom_unit.id, user_id: student.id, activity_id: activity.id }
         expect(response).to redirect_to("/teachers/progress_reports/diagnostic_reports#/u/#{unit.id}/a/#{activity.id}/c/#{classroom.id}/student_report/#{student.id}")
       end
     end
@@ -36,7 +36,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
         it 'responds with a responses link' do
-          get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({ unit_id: unit.id, activity_id: activity.id })
+          get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: { unit_id: unit.id, activity_id: activity.id }
           expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}" }.to_json)
         end
       end
@@ -50,7 +50,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
         it 'responds with a responses link' do
-          get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({ unit_id: unit.id, activity_id: activity.id })
+          get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: { unit_id: unit.id, activity_id: activity.id }
           expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}" }.to_json)
         end
       end
@@ -64,7 +64,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
         it 'responds with a growth responses link' do
-          get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({ unit_id: unit.id, activity_id: activity.id })
+          get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: { unit_id: unit.id, activity_id: activity.id }
           expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}" }.to_json)
         end
       end
@@ -77,7 +77,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         let!(:activity_session) { create(:activity_session, classroom_unit: classroom_unit, activity: activity, user: student) }
 
         it 'responds with a responses link that has a unit query param' do
-          get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: ({ unit_id: unit.id, activity_id: activity.id })
+          get :redirect_to_report_for_most_recent_activity_session_associated_with_activity_and_unit, params: { unit_id: unit.id, activity_id: activity.id }
           expect(response.body).to eq({ url: "/teachers/progress_reports/diagnostic_reports#/diagnostics/#{activity.id}/classroom/#{classroom.id}/responses?unit=#{unit.id}" }.to_json)
         end
       end
@@ -95,14 +95,14 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
       expect_any_instance_of(Teachers::ProgressReports::DiagnosticReportsController).to receive(:results_for_classroom).with(unit.id.to_s, activity.id.to_s, classroom.id.to_s).once.and_call_original
 
       2.times do
-        get :students_by_classroom, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+        get :students_by_classroom, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
         expect(response).to be_successful
       end
     end
 
     it 'should return empty arrays when there are no activity_sessions' do
-      get :students_by_classroom, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+      get :students_by_classroom, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
       expect(response).to be_successful
 
@@ -123,7 +123,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
       end
 
       it 'should return report data for students and not_completed_name' do
-        get :students_by_classroom, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+        get :students_by_classroom, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
         expect(response).to be_successful
 
@@ -148,7 +148,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         end
 
         it 'should return report data for students and missing_name' do
-          get :students_by_classroom, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+          get :students_by_classroom, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
           expect(response).to be_successful
 
@@ -177,7 +177,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         end
 
         it 'should return all 3 records and average score' do
-          get :students_by_classroom, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+          get :students_by_classroom, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
           expect(response).to be_successful
 
@@ -198,7 +198,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     let!(:ua) { create(:unit_activity, unit: unit, activity: activity) }
 
     it 'should return empty arrays when there are no activity_sessions' do
-      get :classrooms_with_students, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+      get :classrooms_with_students, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
       json = JSON.parse(response.body)
 
@@ -220,7 +220,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
 
       it 'should return report data for completed student sessions' do
         Rails.logger.info "\n\n\nStart"
-        get :classrooms_with_students, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+        get :classrooms_with_students, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
         expect(response).to be_successful
 
@@ -234,7 +234,7 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
         expect(controller).to receive(:classrooms_with_students_for_report).with(any_args).once.and_call_original
 
         2.times do
-          get :classrooms_with_students, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+          get :classrooms_with_students, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
           expect(response).to be_successful
 
@@ -294,14 +294,14 @@ describe Teachers::ProgressReports::DiagnosticReportsController, type: :controll
     end
 
     it 'should not error with no activity_sessions' do
-      get :lesson_recommendations_for_classroom, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+      get :lesson_recommendations_for_classroom, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
       expect(response).to be_successful
     end
 
     it 'should not error with activity_sessions' do
       create(:activity_session, classroom_unit: @classroom_unit, activity: activity)
-      get :lesson_recommendations_for_classroom, params: ({ activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id })
+      get :lesson_recommendations_for_classroom, params: { activity_id: activity.id, unit_id: unit.id, classroom_id: classroom.id }
 
       expect(response).to be_successful
     end

--- a/services/QuillLMS/spec/controllers/teachers/unit_templates_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/teachers/unit_templates_controller_spec.rb
@@ -26,7 +26,7 @@ describe Teachers::UnitTemplatesController, type: :controller do
       it 'can create new units and classroom activities' do
         data = { "id": unit_template1.id }
         current_jobs = FastAssignWorker.jobs.size
-        post 'fast_assign', params: (data)
+        post 'fast_assign', params: data
         expect(FastAssignWorker.jobs.size).to eq(current_jobs + 1)
       end
     end

--- a/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/translated_texts_controller_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe TranslatedTextsController, type: :controller do
       end
 
       it 'assigns @js_file' do
-        expect(assigns(:js_file)).to eq("entrypoints/snippets/translated_text.ts")
+        expect(assigns(:js_file)).to eq('entrypoints/snippets/translated_text.ts')
       end
 
       it 'assigns @locales' do
-        locales = ["es-la", "zh-cn"]
+        locales = ['es-la', 'zh-cn']
         locales.each { |locale| create(:translated_text, locale:) }
         get :index
         expect(assigns(:locales)).to match_array(locales)
@@ -45,7 +45,7 @@ RSpec.describe TranslatedTextsController, type: :controller do
       context 'a locale parameter is passed in' do
         let(:locale) { 'es-la' }
         let!(:es_text) { create(:translated_text, locale:) }
-        let!(:zh_text) { create(:translated_text, locale: "zh-cn") }
+        let!(:zh_text) { create(:translated_text, locale: 'zh-cn') }
 
         before do
           get :index, params: { locale: }

--- a/services/QuillLMS/spec/helpers/email_api_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/email_api_helper_spec.rb
@@ -27,10 +27,10 @@ describe EmailApiHelper do
 
   describe '#parse_nps_response' do
     it 'should return the parsed response for the Satismeter response statistics API' do
-      mock_result = ({
+      mock_result = {
         'nps': 73.33,
         'respondents': [11, 4, 0]
-      }).as_json
+      }.as_json
 
       result = parse_nps_response(mock_nps_response.as_json)
       expect(result).to eq(mock_result)
@@ -39,10 +39,10 @@ describe EmailApiHelper do
 
   describe '#parse_comment_response' do
     it 'should return the parsed response for the Satismeter responses API' do
-      mock_result = ([
+      mock_result = [
         { 'feedback': 'this is great!', 'rating': 10 },
         { 'feedback': 'meh', 'rating': 5 }
-      ]).as_json
+      ].as_json
 
       result = parse_comment_response(mock_comment_response.as_json)
       expect(result).to eq(mock_result)

--- a/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
+++ b/services/QuillLMS/spec/lib/time_tracking_cleaner_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 describe TimeTrackingCleaner do
-  let(:empty_data) { ({}) }
-  let(:data_without_time_tracking) { ({ 'other_key' => 'other_value' }) }
+  let(:empty_data) { {} }
+  let(:data_without_time_tracking) { { 'other_key' => 'other_value' } }
 
   let(:data_without_outliers) do
     {

--- a/services/QuillLMS/spec/mailers/user_mailer_spec.rb
+++ b/services/QuillLMS/spec/mailers/user_mailer_spec.rb
@@ -157,10 +157,10 @@ describe UserMailer, type: :mailer do
     let(:user) { build(:user) }
 
     before do
-      mock_nps_data = ({
+      mock_nps_data = {
         'nps': 100,
         'respondents': [9, 0, 0]
-      }).as_json
+      }.as_json
       allow_any_instance_of(UserMailer).to receive(:get_satismeter_nps_data).and_return(mock_nps_data)
       allow_any_instance_of(UserMailer).to receive(:get_satismeter_comment_data).and_return([])
       allow_any_instance_of(UserMailer).to receive(:get_intercom_data).and_return({})

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -199,12 +199,12 @@ describe Activity, type: :model, redis: true do
 
     it "must add uid param of it's a valid student session" do
       activity.valid?
-      expect(activity.module_url(student.activity_sessions.build()).to_s).to include 'uid='
+      expect(activity.module_url(student.activity_sessions.build).to_s).to include 'uid='
     end
 
     it "must add student param of it's a valid student session" do
       activity.valid?
-      expect(activity.module_url(student.activity_sessions.build()).to_s).to include 'student'
+      expect(activity.module_url(student.activity_sessions.build).to_s).to include 'student'
     end
 
     it "must add 'activities' param if the student has completed previous sessions of this activity classification" do

--- a/services/QuillLMS/spec/models/activity_spec.rb
+++ b/services/QuillLMS/spec/models/activity_spec.rb
@@ -731,7 +731,7 @@ describe Activity, type: :model, redis: true do
         activity = create(:evidence_lms_activity, created_at: Time.zone.today - 10.days)
         create(:evidence_activity, parent_activity: activity, title: 'title', notes: 'notes')
 
-        expect(activity.publication_date).to eq(activity.created_at.strftime("%Y-%m-%dT%H:%M:%S"))
+        expect(activity.publication_date).to eq(activity.created_at.strftime('%Y-%m-%dT%H:%M:%S'))
       end
     end
 
@@ -741,7 +741,7 @@ describe Activity, type: :model, redis: true do
         evidence_activity = create(:evidence_activity, parent_activity: activity, title: 'title', notes: 'notes')
         change_log = create(:change_log, created_at: Time.zone.today - 20.days, changed_attribute: Activity::FLAGS_ATTRIBUTE, changed_record: evidence_activity)
 
-        expect(activity.publication_date).to eq(change_log.created_at.strftime("%Y-%m-%dT%H:%M:%S"))
+        expect(activity.publication_date).to eq(change_log.created_at.strftime('%Y-%m-%dT%H:%M:%S'))
       end
     end
   end
@@ -756,7 +756,7 @@ describe Activity, type: :model, redis: true do
       serialized_hash = activity.serialize_with_topics_and_publication_date
       expect(serialized_hash['id']).to eq(activity.id)
       expect(serialized_hash[:topics]).to eq([topic.genealogy])
-      expect(serialized_hash[:publication_date]).to eq(change_log.created_at.strftime("%Y-%m-%dT%H:%M:%S"))
+      expect(serialized_hash[:publication_date]).to eq(change_log.created_at.strftime('%Y-%m-%dT%H:%M:%S'))
     end
   end
 
@@ -799,7 +799,7 @@ describe Activity, type: :model, redis: true do
       let(:questions) { create_list(:question, 2) }
 
       before do
-        activity.data["questions"] = questions.map { |q| { "key" => q.uid } }
+        activity.data['questions'] = questions.map { |q| { 'key' => q.uid } }
         activity.save
       end
 
@@ -809,7 +809,7 @@ describe Activity, type: :model, redis: true do
 
       context 'has an extra question key that does not exist' do
         before do
-          activity.data["questions"] << { "key" => "124" }
+          activity.data['questions'] << { 'key' => '124' }
           activity.save
         end
 
@@ -819,7 +819,7 @@ describe Activity, type: :model, redis: true do
 
     context 'there are no questions in the data field' do
       before do
-        activity.data.delete("questions")
+        activity.data.delete('questions')
         activity.save
       end
 
@@ -835,9 +835,9 @@ describe Activity, type: :model, redis: true do
 
     context 'there are translations' do
       it 'is data + all available languages' do
-        activity.data.merge!({ 'landingPageHtml' => "html" })
+        activity.data.merge!({ 'landingPageHtml' => 'html' })
         activity.create_translation_mappings
-        chinese_locale = "zh-cn"
+        chinese_locale = 'zh-cn'
         english_text = activity.english_texts.first
         chinese = create(:translated_text, english_text:, locale: chinese_locale)
         spanish = create(:translated_text, english_text:, locale: Translatable::SPANISH_LOCALE)

--- a/services/QuillLMS/spec/models/concerns/translatable_question_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/translatable_question_spec.rb
@@ -21,7 +21,7 @@ shared_context 'array and hash data fields' do |data_field|
       ]
     }
 
-    it "creates translation mappings for focusPoints" do
+    it 'creates translation mappings for focusPoints' do
       subject
       expect(translation_map1.text).to eq(feedback1)
       expect(translation_map2.text).to eq(feedback2)
@@ -36,7 +36,7 @@ shared_context 'array and hash data fields' do |data_field|
       }
     }
 
-    it "creates translation mappings for focusPoints" do
+    it 'creates translation mappings for focusPoints' do
       subject
       expect(translation_map1.text).to eq(feedback1)
       expect(translation_map2.text).to eq(feedback2)
@@ -59,7 +59,7 @@ RSpec.describe TranslatableQuestion do
     context 'instructions' do
       let(:field_name) { 'instructions' }
       let(:data) { { field_name => instructions } }
-      let(:instructions) { "do this question" }
+      let(:instructions) { 'do this question' }
 
       it 'creates translation_mappings for instructions' do
         subject
@@ -99,14 +99,14 @@ RSpec.describe TranslatableQuestion do
           [
             {
               "id": id1,
-              "question_uid": "-Jzw0qjNNnNInNWZT9tJ",
-              "text": "Last year, my teacher knew my name.",
+              "question_uid": '-Jzw0qjNNnNInNWZT9tJ',
+              "text": 'Last year, my teacher knew my name.',
               "feedback": feedback1
             },
             {
               "id": id2,
-              "question_uid": "-Jzw0qjNNnNInNWZT9tJ",
-              "text": "Last year, my teacher knew my name.",
+              "question_uid": '-Jzw0qjNNnNInNWZT9tJ',
+              "text": 'Last year, my teacher knew my name.',
               "feedback": feedback2
             }
           ]
@@ -130,7 +130,7 @@ RSpec.describe TranslatableQuestion do
     end
   end
 
-  describe "#translated_data(locale:)" do
+  describe '#translated_data(locale:)' do
     subject { question.translated_data(locale:) }
 
     let(:question) { create(:question, :with_all_translations) }
@@ -138,7 +138,7 @@ RSpec.describe TranslatableQuestion do
 
     shared_examples 'translatable field' do |field_key|
       let(:translated_field) { subject[field_key] }
-      let(:field_mappings) { question.translation_mappings.where("field_name LIKE ?", "#{field_key}%") }
+      let(:field_mappings) { question.translation_mappings.where('field_name LIKE ?', "#{field_key}%") }
 
       it "includes translations for all #{field_key}" do
         field_mappings.each do |mapping|

--- a/services/QuillLMS/spec/models/question_spec.rb
+++ b/services/QuillLMS/spec/models/question_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe Question, type: :model do
     end
 
     context 'a locale is passed in' do
-      let(:locale) { "ch-zn" }
+      let(:locale) { 'ch-zn' }
       let(:options) { { locale: } }
 
       it 'should return translated_data(locale:)' do

--- a/services/QuillLMS/spec/models/subscription_spec.rb
+++ b/services/QuillLMS/spec/models/subscription_spec.rb
@@ -205,7 +205,7 @@ describe Subscription, type: :model do
   describe '#length_in_months' do
     it 'returns the length of the subscription in months' do
       length_in_months = 45
-      subscription = create(:subscription, start_date: Time.zone.today, expiration: Time.zone.today + (length_in_months).months)
+      subscription = create(:subscription, start_date: Time.zone.today, expiration: Time.zone.today + length_in_months.months)
 
       expect(subscription.length_in_months).to eq(length_in_months)
     end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe User, type: :model do
         end
 
         it 'returns false if the user has a subscription that does not have a trial account type' do
-          (Subscription::OFFICIAL_PAID_TYPES).each do |type|
+          Subscription::OFFICIAL_PAID_TYPES.each do |type|
             subscription.update(account_type: type)
             expect(user.reload.eligible_for_new_subscription?).to be false
           end

--- a/services/QuillLMS/spec/queries/cms/teacher_search_query_spec.rb
+++ b/services/QuillLMS/spec/queries/cms/teacher_search_query_spec.rb
@@ -31,7 +31,7 @@ describe Cms::TeacherSearchQuery do
         email: user.email,
         number_classrooms: 1,
         number_students: 1,
-        last_active: (todays_date).strftime("%b %d,\u00A0%Y"),
+        last_active: todays_date.strftime("%b %d,\u00A0%Y"),
         subscription: subscription.account_type,
         user_id: user.id,
         admin_id: schools_admins.id

--- a/services/QuillLMS/spec/queries/scorebook/query_spec.rb
+++ b/services/QuillLMS/spec/queries/scorebook/query_spec.rb
@@ -128,7 +128,7 @@ describe 'ScorebookQuery' do
         new_act_sesh_2_completed_at = activity_session_completed_at_to_time_midnight_minus_offset(activity_session2, offset + 1)
         activity_session1.update(completed_at: new_act_sesh_1_completed_at)
         activity_session2.update(completed_at: new_act_sesh_2_completed_at)
-        begin_date = (activity_session1.reload.completed_at).to_date.to_s
+        begin_date = activity_session1.reload.completed_at.to_date.to_s
         end_date = begin_date
         results = Scorebook::Query.run(classroom.id, 1, nil, begin_date, end_date, offset)
         expect(results.find { |res| res['id'] == activity_session2.id }).to be

--- a/services/QuillLMS/spec/queries/teachers_data_spec.rb
+++ b/services/QuillLMS/spec/queries/teachers_data_spec.rb
@@ -16,7 +16,7 @@ describe 'TeachersData' do
   let!(:student2) { classroom.students.second }
 
   let!(:time2) { Time.current }
-  let!(:time1) { time2 - (10.minutes) }
+  let!(:time1) { time2 - 10.minutes }
 
   let!(:classroom_unit) {
     create(:classroom_unit, classroom_id: classroom.id,

--- a/services/QuillLMS/spec/script/setup_concepts_spec.rb
+++ b/services/QuillLMS/spec/script/setup_concepts_spec.rb
@@ -14,7 +14,7 @@ describe 'Downloading the concepts' do
 
   before do
     VCR.use_cassette('fetching concepts') do
-      @response = @setup.fetch_concepts()
+      @response = @setup.fetch_concepts
     end
   end
 

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -36,7 +36,7 @@ describe Admin::TeacherSerializer do
     let!(:schools_admins2) { create(:schools_admins, user: teacher, school: school2) }
     let!(:unit) { create(:unit, user_id: teacher.id) }
     let!(:time2) { Time.current }
-    let!(:time1) { time2 - (10.minutes) }
+    let!(:time1) { time2 - 10.minutes }
     let!(:classroom_unit) { create(:classroom_unit, classroom_id: classroom.id, unit: unit, assigned_student_ids: classroom.students.ids) }
     let!(:activity_session1) { create(:activity_session_without_concept_results, user: student1, state: 'finished', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }
     let!(:activity_session2) { create(:activity_session_without_concept_results, user: student1, state: 'finished', started_at: time1, completed_at: time2, classroom_unit: classroom_unit) }

--- a/services/QuillLMS/spec/support/helpers/session_helper.rb
+++ b/services/QuillLMS/spec/support/helpers/session_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SessionHelper
-  def user_params hash = {}
+  def user_params(hash = {})
     {
       name: 'John Smith',
       email: 'user@example.com',

--- a/services/QuillLMS/spec/support/pages/teachers/class_manager/invite_students_page.rb
+++ b/services/QuillLMS/spec/support/pages/teachers/class_manager/invite_students_page.rb
@@ -18,7 +18,7 @@ module Teachers
     end
 
     def class_code
-      find(:xpath, %q(//*[@class='class-code']/following-sibling::input)).value
+      find(:xpath, "//*[@class='class-code']/following-sibling::input").value
     end
 
     def class_menu

--- a/services/QuillLMS/spec/workers/open_ai/translate_activity_and_questions_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/open_ai/translate_activity_and_questions_worker_spec.rb
@@ -21,7 +21,7 @@ describe OpenAI::TranslateActivityAndQuestionsWorker, type: :worker do
 
     it 'calls translate on each of the questions' do
       question = create(:question)
-      activity.data["questions"] = [{ "key" => question.uid }]
+      activity.data['questions'] = [{ 'key' => question.uid }]
       allow(activity).to receive(:questions).and_return([question])
       expect(question).to receive(:translate!)
       subject
@@ -29,7 +29,7 @@ describe OpenAI::TranslateActivityAndQuestionsWorker, type: :worker do
   end
 
   context 'the activity is not present' do
-    subject { worker.perform("223980") }
+    subject { worker.perform('223980') }
 
     it do
       expect(OpenAI::Translate).not_to receive(:run)

--- a/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/set_impact_metrics_worker_spec.rb
@@ -37,12 +37,12 @@ describe SetImpactMetricsWorker do
 
     it 'should set the NUMBER_OF_SENTENCES redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_SENTENCES)).to eq((SetImpactMetricsWorker.round_to_hundred_millions(activity_sessions_payload.size * SetImpactMetricsWorker::SENTENCES_PER_ACTIVITY_SESSION)).to_s)
+      expect($redis.get(PagesController::NUMBER_OF_SENTENCES)).to eq(SetImpactMetricsWorker.round_to_hundred_millions(activity_sessions_payload.size * SetImpactMetricsWorker::SENTENCES_PER_ACTIVITY_SESSION).to_s)
     end
 
     it 'should set the NUMBER_OF_STUDENTS redis value' do
       subject.perform
-      expect($redis.get(PagesController::NUMBER_OF_STUDENTS)).to eq((SetImpactMetricsWorker.round_to_hundred_thousands(activity_sessions_payload.count('DISTINCT(user_id)'))).to_s)
+      expect($redis.get(PagesController::NUMBER_OF_STUDENTS)).to eq(SetImpactMetricsWorker.round_to_hundred_thousands(activity_sessions_payload.count('DISTINCT(user_id)')).to_s)
     end
 
     it 'should set the NUMBER_OF_TEACHERS redis value' do


### PR DESCRIPTION
## WHAT
- disabled [Style/BlockDelimiters](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BlockDelimiters) in `.rubocop_base.yml` rather than in the todo. 
> Check for uses of braces or do/end around single line or multi-line blocks.

- enabled [Style/Semicolon](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Semicolon)
> Checks for multiple expressions placed on the same line. It also checks for lines terminated with a semicolon.
Used the ‘AllowAsExpressionSeparator` configuration option to allow `;` to separate several expressions on the same line.

- enabled [Style/EmptyMethod](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyMethod)
> enforces empty method definitions to go on a single line

- enabled [Style/FormatString](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FormatString) (it came up with zero exceptions) 

- enabled [Style/MethodCallWithoutArgsParentheses](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MethodCallWithoutArgsParentheses)
> Checks for unwanted parentheses in parameterless method calls.

- enabled [Style/MethodDefParentheses](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MethodDefParentheses)
> Checks for parentheses around the arguments in method definitions. Both instance and class/singleton methods are checked.

- enabled [Style/NegatedIf](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NegatedIf)
> Checks for uses of if with a negated condition. Only ifs without else are considered. There are three different styles:


- enabled [Style/Next](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Next)
> Use ‘next` to skip iteration instead of a condition at the end.

- enabled [Style/RedundantBegin](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantBegin)
> Checks for redundant ‘begin` blocks.

- enabled [Style/RedundantParentheses](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantParentheses)
> Checks for redundant parentheses.

- enabled [Style/RedundantPercentQ](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantPercentQ) for a spec where it was used. 
> Checks for usage of the %q/%Q syntax when ” or “” would do.

- enabled [Style/StringLiterals](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringLiterals)
> Checks if uses of quotes match the configured preference.

## WHY
To make our code more consistent, and let rubocop format your code into quill style for you rather than having to think about it or correct it on PR reviews. 

## HOW
Removed exclusions from `rubocop_todo` and added a few configurations to `rubocop_base`


### What have you done to QA this feature?
Ran tests. Smoke test on staging. 
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO, non-code change.
Have you deployed to Staging? |  YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
