### PR TITLE
Standardize %literal delimiters

### DIFF
--- a/services/QuillLMS/.rubocop_todo.yml
+++ b/services/QuillLMS/.rubocop_todo.yml
@@ -878,11 +878,6 @@ Style/NumericLiterals:
 Style/NumericPredicate:
   Enabled: false
 
-# Offense count: 108
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: PreferredDelimiters.
-Style/PercentLiteralDelimiters:
-  Enabled: false
 
 # Offense count: 35
 # This cop supports safe autocorrection (--autocorrect).

--- a/services/QuillLMS/app/controllers/admins_controller.rb
+++ b/services/QuillLMS/app/controllers/admins_controller.rb
@@ -11,7 +11,7 @@ class AdminsController < ApplicationController
   before_action :admin!
 
   before_action :set_teacher, :admin_of_this_teacher!,
-    only: %w{
+    only: %w[
       resend_login_details
       remove_as_admin
       make_admin
@@ -19,14 +19,14 @@ class AdminsController < ApplicationController
       sign_in_classroom_manager
       sign_in_progress_reports
       sign_in_account_settings
-    }
+    ]
 
   before_action :sign_in,
-    only: %w{
+    only: %w[
       sign_in_classroom_manager
       sign_in_progress_reports
       sign_in_account_settings
-    }
+    ]
 
   def show
     serialized_admin_users_json = $redis.get("#{SchoolsAdmins::ADMIN_USERS_CACHE_KEY_STEM}#{current_user.id}")

--- a/services/QuillLMS/app/helpers/application_helper.rb
+++ b/services/QuillLMS/app/helpers/application_helper.rb
@@ -7,10 +7,10 @@ module ApplicationHelper
   end
 
   def pages
-    %w(home
+    %w[home
        the_peculiar_institution
        democracy_in_america
-       aggregation)
+       aggregation]
   end
 
   def question_section

--- a/services/QuillLMS/app/helpers/pages_helper.rb
+++ b/services/QuillLMS/app/helpers/pages_helper.rb
@@ -5,10 +5,10 @@ module PagesHelper
   def pages_tab_class(tabname)
     about_actions = ['mission', 'develop', 'faq']
     impact_actions = ['impact', 'map', 'stats']
-    team_actions = %w(team)
-    partners_actions = %w(partners)
-    news_actions = %w(news)
-    press_actions = %w(press)
+    team_actions = %w[team]
+    partners_actions = %w[partners]
+    news_actions = %w[news]
+    press_actions = %w[press]
     standards_actions = ['activities']
     topics_actions = ['index']
     faq_actions = ['faq']

--- a/services/QuillLMS/app/models/activity_health.rb
+++ b/services/QuillLMS/app/models/activity_health.rb
@@ -20,8 +20,8 @@
 #  url                     :string
 #
 class ActivityHealth < ApplicationRecord
-  ALLOWED_TOOLS = %w(connect grammar)
-  FLAGS = %w(production archived alpha beta gamma private)
+  ALLOWED_TOOLS = %w[connect grammar]
+  FLAGS = %w[production archived alpha beta gamma private]
 
   has_many :prompt_healths
 

--- a/services/QuillLMS/app/models/classroom.rb
+++ b/services/QuillLMS/app/models/classroom.rb
@@ -27,7 +27,7 @@
 class Classroom < ApplicationRecord
   include CheckboxCallback
 
-  GRADES = %w(1 2 3 4 5 6 7 8 9 10 11 12 University)
+  GRADES = %w[1 2 3 4 5 6 7 8 9 10 11 12 University]
   UNIVERSITY = 'University'
   GRADE_INTEGERS = { Kindergarten: 0, University: 13, PostGraduate: 14 }
 

--- a/services/QuillLMS/app/models/csv_export.rb
+++ b/services/QuillLMS/app/models/csv_export.rb
@@ -15,12 +15,12 @@
 #
 
 class CsvExport < ApplicationRecord
-  EXPORT_TYPE_OPTIONS = %w(activity_sessions
+  EXPORT_TYPE_OPTIONS = %w[activity_sessions
                            standards_classrooms
                            standards_classroom_students
                            standards_classroom_standards
                            standards_student_standards
-                           standards_standard_students)
+                           standards_standard_students]
 
   belongs_to :teacher, class_name: 'User'
 

--- a/services/QuillLMS/app/models/prompt_health.rb
+++ b/services/QuillLMS/app/models/prompt_health.rb
@@ -21,7 +21,7 @@
 #  fk_rails_...  (activity_health_id => activity_healths.id) ON DELETE => cascade
 #
 class PromptHealth < ApplicationRecord
-  FLAGS = %w(production archived alpha beta gamma private)
+  FLAGS = %w[production archived alpha beta gamma private]
 
   belongs_to :activity_health
 

--- a/services/QuillLMS/app/models/unit_template.rb
+++ b/services/QuillLMS/app/models/unit_template.rb
@@ -149,7 +149,7 @@ class UnitTemplate < ApplicationRecord
 
   def self.delete_all_caches
     UnitTemplate.all.each { |ut| $redis.del("unit_template_id:#{ut.id}_serialized") }
-    %w(private_ production_ gamma_ beta_ alpha_).each do |flag|
+    %w[private_ production_ gamma_ beta_ alpha_].each do |flag|
       $redis.del("#{flag}unit_templates")
     end
   end
@@ -196,12 +196,12 @@ class UnitTemplate < ApplicationRecord
     # from both the 'production' and 'gamma' caches while leaving it as-is in
     # 'beta'.  It's rare enough to make these changes that we should just flush
     # all the caches.
-    %w(private_ production_ gamma_ beta_ alpha_).each do |flag|
+    %w[private_ production_ gamma_ beta_ alpha_].each do |flag|
       $redis.del("#{flag}unit_templates")
     end
     yield
     $redis.del("unit_template_id:#{id}_serialized")
-    %w(private_ production_ gamma_ beta_ alpha_).each do |flag|
+    %w[private_ production_ gamma_ beta_ alpha_].each do |flag|
       $redis.del("#{flag}unit_templates")
     end
   end

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -107,7 +107,7 @@ class User < ApplicationRecord
   ARCHIVED = 'archived'
   COLLEGE_BOARD = 'college_board'
   TESTING_FLAGS = [ALPHA, BETA, GAMMA, PRIVATE, ARCHIVED, COLLEGE_BOARD]
-  PERMISSIONS_FLAGS = %w(auditor purchaser school_point_of_contact)
+  PERMISSIONS_FLAGS = %w[auditor purchaser school_point_of_contact]
   VALID_FLAGS = TESTING_FLAGS.dup.concat(PERMISSIONS_FLAGS)
 
   CANVAS_ACCOUNT = 'Canvas'
@@ -120,7 +120,7 @@ class User < ApplicationRecord
 
   SCHOOL_CHANGELOG_ATTRIBUTE = 'school_id'
 
-  LEADING_CAPITALIZE_NAMES = %w(van dit)
+  LEADING_CAPITALIZE_NAMES = %w[van dit]
 
   attr_accessor :newsletter,
     :require_password_confirmation_when_password_present,

--- a/services/QuillLMS/app/uploaders/staff_csv_uploader.rb
+++ b/services/QuillLMS/app/uploaders/staff_csv_uploader.rb
@@ -4,7 +4,7 @@ class StaffCSVUploader < ApplicationUploader
   fog_directory 'quill-staff-file-uploads'
 
   def extension_white_list
-    %w(csv)
+    %w[csv]
   end
 
   def store_dir

--- a/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
+++ b/services/QuillLMS/app/workers/generate_concepts_in_use_array_worker.rb
@@ -13,11 +13,11 @@ class GenerateConceptsInUseArrayWorker
     'D_SF_QUESTIONS' => 'diagnostic_sentence_fragments',
   }.freeze
 
-  CONCEPTS_IN_USE = [%w(
+  CONCEPTS_IN_USE = [%w[
     name uid grades_proofreader_activities grades_grammar_activities grades_connect_activities
     grades_diagnostic_activities categorized_connect_questions categorized_diagnostic_questions
     part_of_diagnostic_recommendations last_retrieved
-  )].to_json.freeze
+  ]].to_json.freeze
 
   def perform
     set_concepts_in_use

--- a/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
+++ b/services/QuillLMS/app/workers/get_concepts_in_use_individual_concept_worker.rb
@@ -162,7 +162,7 @@ class GetConceptsInUseIndividualConceptWorker
     begin
       $redis.watch('CONCEPTS_IN_USE')
       concepts_in_use = JSON.parse($redis.get('CONCEPTS_IN_USE'))
-      headers = %w(name uid grades_proofreader_activities grades_grammar_activities grades_connect_activities grades_diagnostic_activities categorized_connect_questions categorized_diagnostic_questions part_of_diagnostic_recommendations last_retrieved)
+      headers = %w[name uid grades_proofreader_activities grades_grammar_activities grades_connect_activities grades_diagnostic_activities categorized_connect_questions categorized_diagnostic_questions part_of_diagnostic_recommendations last_retrieved]
       @organized_concepts.each do |oc|
         concepts_in_use << headers.map do |attr|
           if oc[attr].is_a?(Array)

--- a/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
+++ b/services/QuillLMS/app/workers/internal_tool/email_feedback_history_session_data_worker.rb
@@ -4,7 +4,7 @@ class InternalTool::EmailFeedbackHistorySessionDataWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 
-  FEEDBACK_HISTORY_CSV_HEADERS = %w{Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule}
+  FEEDBACK_HISTORY_CSV_HEADERS = %w[Date/Time SessionID Conjunction Attempt Optimal? Completed? Response Feedback Rule]
   DEFAULT_MAX_ATTEMPTS = 5
 
   def perform(activity_id, start_date, end_date, filter_type, responses_for_scoring, email)

--- a/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
+++ b/services/QuillLMS/app/workers/quill_staff_accounts_changed_worker.rb
@@ -4,7 +4,7 @@ class QuillStaffAccountsChangedWorker
   include Sidekiq::Worker
   sidekiq_options queue: SidekiqQueue::LOW
 
-  PARAMS_TO_TRACK = %w(id name email username created_at google_id signed_up_with_google)
+  PARAMS_TO_TRACK = %w[id name email username created_at google_id signed_up_with_google]
   STAFF_ACCOUNTS_CACHE_KEY = 'check_staff_accounts'
   EXPIRES_IN = 25.hours.to_i
 

--- a/services/QuillLMS/config/application.rb
+++ b/services/QuillLMS/config/application.rb
@@ -50,7 +50,7 @@ module EmpiricalGrammar
     config.active_record.schema_format = :sql
     config.active_record.legacy_connection_handling = false
 
-    config.action_controller.always_permitted_parameters = %w(controller action format)
+    config.action_controller.always_permitted_parameters = %w[controller action format]
 
     # http://stackoverflow.com/questions/14647731/rails-converts-empty-arrays-into-nils-in-params-of-the-request
     config.action_dispatch.perform_deep_munge = false

--- a/services/QuillLMS/config/initializers/secure_headers.rb
+++ b/services/QuillLMS/config/initializers/secure_headers.rb
@@ -24,7 +24,7 @@ SecureHeaders::Configuration.default do |config|
       'https://td.doubleclick.net/'
     ],
 
-    object_src: %w('none'),                                       # addresses <embed>, <object>, and <applet>
+    object_src: %w['none'],                                       # addresses <embed>, <object>, and <applet>
 
     media_src: [
       '*',
@@ -87,7 +87,7 @@ SecureHeaders::Configuration.default do |config|
       'blob:'
     ],
 
-    base_uri: %w('self'),                                         # used for relative URLs
+    base_uri: %w['self'],                                         # used for relative URLs
 
     style_src: [
       "'self'",

--- a/services/QuillLMS/config/initializers/sentry.rb
+++ b/services/QuillLMS/config/initializers/sentry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Sentry.init do |config|
-  config.enabled_environments = %W(staging production)
+  config.enabled_environments = %W[staging production]
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
   config.dsn = ENV['SENTRY_DSN'] if ENV['SENTRY_DSN'].present?

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -411,7 +411,7 @@ EmpiricalGrammar::Application.routes.draw do
       end
 
       # TODO: abstract this list as well. Duplicated in nav in layout.
-      %w(accounts import).each do |page|
+      %w[accounts import].each do |page|
         get page => "classroom_manager##{page}"
       end
     end
@@ -788,7 +788,7 @@ EmpiricalGrammar::Application.routes.draw do
     end
   end
 
-  other_pages = %w(
+  other_pages = %w[
     beta
     board
     press
@@ -825,7 +825,7 @@ EmpiricalGrammar::Application.routes.draw do
     locker
     quill_academy
     teacher_premium
-  )
+  ]
 
   all_pages = other_pages
   all_pages.each do |page|
@@ -844,12 +844,12 @@ EmpiricalGrammar::Application.routes.draw do
   get 'partners', to: redirect('/about')
   # End legacy route redirects.
 
-  tools = %w(diagnostic_tool connect_tool grammar_tool proofreader_tool lessons_tool evidence_tool)
+  tools = %w[diagnostic_tool connect_tool grammar_tool proofreader_tool lessons_tool evidence_tool]
   tools.each do |tool|
     get "tools/#{tool.chomp('_tool')}" => "pages##{tool}"
   end
 
-  tutorials = %w(lessons)
+  tutorials = %w[lessons]
   tutorials.each do |tool|
     get "tutorials/#{tool}" => 'pages#tutorials'
     get "tutorials/#{tool}/:slide_number" => 'pages#tutorials'

--- a/services/QuillLMS/db/migrate/20180821200652_add_function_timespent_activity_session.rb
+++ b/services/QuillLMS/db/migrate/20180821200652_add_function_timespent_activity_session.rb
@@ -42,8 +42,8 @@ class AddFunctionTimespentActivitySession < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION timespent_activity_session;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180821201236_add_function_timespent_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180821201236_add_function_timespent_teacher.rb
@@ -15,8 +15,8 @@ class AddFunctionTimespentTeacher < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION timespent_teacher;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180821201559_add_function_timespent_student.rb
+++ b/services/QuillLMS/db/migrate/20180821201559_add_function_timespent_student.rb
@@ -14,8 +14,8 @@ class AddFunctionTimespentStudent < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION timespent_student;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180821202836_add_function_timespent_student_for_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180821202836_add_function_timespent_student_for_teacher.rb
@@ -16,8 +16,8 @@ class AddFunctionTimespentStudentForTeacher < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION timespent_student_for_teacher;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180821213520_add_function_old_timespent_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180821213520_add_function_old_timespent_teacher.rb
@@ -38,8 +38,8 @@ class AddFunctionOldTimespentTeacher < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION old_timespent_teacher;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180822144355_replace_function_old_timespent_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180822144355_replace_function_old_timespent_teacher.rb
@@ -39,8 +39,8 @@ class ReplaceFunctionOldTimespentTeacher < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION old_timespent_teacher;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180822155024_replace_function_timespent_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180822155024_replace_function_timespent_teacher.rb
@@ -15,8 +15,8 @@ class ReplaceFunctionTimespentTeacher < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION timespent_teacher;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180822155243_replace_function_timespent_student_for_teacher.rb
+++ b/services/QuillLMS/db/migrate/20180822155243_replace_function_timespent_student_for_teacher.rb
@@ -16,8 +16,8 @@ class ReplaceFunctionTimespentStudentForTeacher < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION timespent_student_for_teacher;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180824185130_replace_function_timepent_activity_session.rb
+++ b/services/QuillLMS/db/migrate/20180824185130_replace_function_timepent_activity_session.rb
@@ -42,8 +42,8 @@ class ReplaceFunctionTimepentActivitySession < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION timespent_activity_session;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180824195642_replace_function_timepent_activity_session_again.rb
+++ b/services/QuillLMS/db/migrate/20180824195642_replace_function_timepent_activity_session_again.rb
@@ -62,8 +62,8 @@ class ReplaceFunctionTimepentActivitySessionAgain < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION timespent_activity_session;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/db/migrate/20180831194810_add_function_timespent_question.rb
+++ b/services/QuillLMS/db/migrate/20180831194810_add_function_timespent_question.rb
@@ -71,8 +71,8 @@ class AddFunctionTimespentQuestion < ActiveRecord::Migration[4.2]
   end
 
   def down
-    connection.execute(%q{
+    connection.execute(%q(
       DROP FUNCTION timespent_question;
-    })
+    ))
   end
 end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt.rb
@@ -27,7 +27,7 @@ module Evidence
 
     MIN_TEXT_LENGTH = 10
     MAX_TEXT_LENGTH = 255
-    CONJUNCTIONS = %w(because but so)
+    CONJUNCTIONS = %w[because but so]
     DEFAULT_MAX_ATTEMPTS = 5
     MIN_MAX_ATTEMPTS = 3
     MAX_MAX_ATTEMPTS = 6

--- a/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/prompt_health.rb
@@ -60,7 +60,7 @@ module Evidence
 
       super(options.reverse_merge(
         only:
-          %i(
+          %i[
             id
             current_version
             version_responses
@@ -78,14 +78,14 @@ module Evidence
             avg_time_spent_per_prompt
             prompt_id
             activity_short_name
-          ),
+          ],
         methods:
-          %i(
+          %i[
             conjunction
             activity_id
             flag
             poor_health_flag
-          )
+          ]
       ))
     end
 

--- a/services/QuillLMS/lib/tasks/create_unit_template_categories.rake
+++ b/services/QuillLMS/lib/tasks/create_unit_template_categories.rake
@@ -24,12 +24,12 @@ namespace :unit_template_categories do
 
   def utc_data
     [
-      %w(ELL #348fdf #014f92),
-      %w(Elementary #9c2bde #560684),
-      %w(Middle #ea9a1a #875a12),
-      %w(High #ff4542 #c51916),
-      %w(University #82bf3c #457818),
-      %w(Themed #00c2a2 #027360)
+      %w[ELL #348fdf #014f92],
+      %w[Elementary #9c2bde #560684],
+      %w[Middle #ea9a1a #875a12],
+      %w[High #ff4542 #c51916],
+      %w[University #82bf3c #457818],
+      %w[Themed #00c2a2 #027360]
     ]
   end
 end

--- a/services/QuillLMS/lib/tasks/create_unit_templates.rake
+++ b/services/QuillLMS/lib/tasks/create_unit_templates.rake
@@ -22,9 +22,9 @@ namespace :unit_templates do
 
   def ut_data
     [
-      %w(John Landis Cool),
-      %w(Sarah Furth Great),
-      %w(Sarah Furth Nice)
+      %w[John Landis Cool],
+      %w[Sarah Furth Great],
+      %w[Sarah Furth Nice]
     ]
   end
 end

--- a/services/QuillLMS/lib/tasks/local_data.rake
+++ b/services/QuillLMS/lib/tasks/local_data.rake
@@ -91,7 +91,7 @@ namespace :local_data do
     # Tables that other tables have foreign keys to are loaded first
     # Or else they will raise FK errors
     # Then the rest alphabetically
-    NONUSER_TABLES = %w(
+    NONUSER_TABLES = %w[
       standard_categories
       standard_levels
       standards
@@ -156,6 +156,6 @@ namespace :local_data do
       unit_template_categories
       unit_templates
       zipcode_infos
-    )
+    ]
   end
 end

--- a/services/QuillLMS/lib/tasks/set_upgrade_notification.rake
+++ b/services/QuillLMS/lib/tasks/set_upgrade_notification.rake
@@ -4,14 +4,14 @@ namespace :upgrade do
   task :set_upgrade_vars, [:app_name, :start_time, :end_time] => [:environment] do |t, args|
     app_name = args[:app_name].downcase.gsub(/"/, '')
     if (['empirical-grammar-staging', 'empirical-grammar'].include?(app_name)) && args[:start_time] && args[:end_time] && Time.zone.parse(args[:start_time]) && Time.zone.parse(args[:end_time])
-      sh %{curl -n -X PATCH https://api.heroku.com/apps/#{app_name}/config-vars \
+      sh %(curl -n -X PATCH https://api.heroku.com/apps/#{app_name}/config-vars \
           -d '{
           "UPGRADE": "true",
           "UPGRADE_START_TIME": #{args[:start_time]},
           "UPGRADE_END_TIME": #{args[:end_time]}
         }' \
           -H "Content-Type: application/json" \
-          -H "Accept: application/vnd.heroku+json; version=3"}
+          -H "Accept: application/vnd.heroku+json; version=3")
     else
       puts 'You need to specify a start time and an end time for this task. Use the following command:'
       puts "rake 'upgrade:set_upgrade_vars[START_DATETIME_STRING, END_DATETIME_STRING]'"

--- a/services/QuillLMS/lib/tasks/staging_config.rake
+++ b/services/QuillLMS/lib/tasks/staging_config.rake
@@ -66,7 +66,7 @@ namespace :staging_config do
     end
 
     STAGING_APP = 'empirical-grammar-staging'
-    STAGING_PERSONAL_APPS = %w(
+    STAGING_PERSONAL_APPS = %w[
       quill-lms-brendan
       quill-lms-cissy
       quill-lms-dan
@@ -74,7 +74,7 @@ namespace :staging_config do
       quill-lms-eric
       quill-lms-pkong
       quill-lms-thomas
-    )
+    ]
     ALL_STAGING_APPS = STAGING_PERSONAL_APPS + [STAGING_APP]
   end
 end

--- a/services/QuillLMS/lib/tasks/temporary/translate.rake
+++ b/services/QuillLMS/lib/tasks/temporary/translate.rake
@@ -58,7 +58,7 @@ namespace :translate do
   end
 
   def activity_uids
-    %w(
+    %w[
       -LsTRP0gFdy-d5lIfifn
       22409f4f-c2d7-4b10-84c9-3fd046eb9a41
       -LuZ7PvG10DtLrdJDPvw
@@ -343,6 +343,6 @@ namespace :translate do
       72c938f8-ac9f-45dc-9eeb-8cab93f85dc7
       ae5fd428-0922-47f8-b9f8-c98679f1b4f1
       8f401c3f-4f75-4141-a41d-42d5643e7f72
-    )
+    ]
   end
 end

--- a/services/QuillLMS/script/map_concepts_to_activities_across_apps.rb
+++ b/services/QuillLMS/script/map_concepts_to_activities_across_apps.rb
@@ -158,7 +158,7 @@ concepts.each do |c|
 end
 
 CSV.open('organized_data.csv', 'wb') do |new_csv|
-  headers = %w(name uid rule_number grades_proofreader_activities grades_grammar_activities grades_connect_activities categorized_connect_questions part_of_diagnostic_recommendations)
+  headers = %w[name uid rule_number grades_proofreader_activities grades_grammar_activities grades_connect_activities categorized_connect_questions part_of_diagnostic_recommendations]
   new_csv << headers
   organized_concepts.each do |oc|
     new_csv << headers.map { |attr| oc[attr] }

--- a/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/app_settings_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
       get :admin_show, params: { name: 'lorem' }, as: :json
 
       expect(response).to be_successful
-      expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com c@d.com))
+      expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w[a@b.com c@d.com])
     end
 
     it 'should handle users with nil emails gracefully' do
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
       get :admin_show, params: { name: 'lorem' }, as: :json
 
       expect(response).to be_successful
-      expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com))
+      expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w[a@b.com])
     end
 
     it 'should return the names of users without emails' do
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::AppSettingsController, type: :controller do
       get :admin_show, params: { name: 'lorem' }, as: :json
 
       expect(response).to be_successful
-      expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w(a@b.com))
+      expect(JSON.parse(response.body)['user_emails_in_allow_list']).to eq(%w[a@b.com])
       expect(JSON.parse(response.body)['users_without_emails']).to eq([user2.name])
     end
   end

--- a/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/api/v1/concepts_controller_spec.rb
@@ -23,7 +23,7 @@ describe Api::V1::ConceptsController, type: :controller do
       before { subject }
 
       it { expect(response).to have_http_status(:ok) }
-      it { expect(parsed_body['concept'].keys).to match_array(%w(id uid name parent_id)) }
+      it { expect(parsed_body['concept'].keys).to match_array(%w[id uid name parent_id]) }
       it { expect(parsed_body['concept']['name']).to eq concept_name }
       it { expect(parsed_body['concept']['uid']).to_not be_nil }
     end

--- a/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/snapshots_controller_spec.rb
@@ -46,7 +46,7 @@ describe SnapshotsController, type: :controller do
       let(:grades) { ['Kindergarten', '1'] }
       let(:teacher_ids) { ['4', '5'] }
       let(:classroom_ids) { ['7', '8'] }
-      let(:headers_to_display) { %w(student_name student_email) }
+      let(:headers_to_display) { %w[student_name student_email] }
 
       before do
         allow(Snapshots::Timeframes).to receive(:calculate_timeframes).and_return(timeframes)

--- a/services/QuillLMS/spec/helpers/application_helper_spec.rb
+++ b/services/QuillLMS/spec/helpers/application_helper_spec.rb
@@ -20,7 +20,7 @@ describe ApplicationHelper do
 
   describe '#pages' do
     it 'should return the correct array' do
-      expect(pages).to eq %w{home the_peculiar_institution democracy_in_america aggregation}
+      expect(pages).to eq %w[home the_peculiar_institution democracy_in_america aggregation]
     end
   end
 

--- a/services/QuillLMS/spec/lib/core_extensions/array_spec.rb
+++ b/services/QuillLMS/spec/lib/core_extensions/array_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 describe CoreExtensions::Array do
   describe '#median' do
-    let(:odd_sized_letters) { %w{e a b c d} }
-    let(:even_sized_letters) { %w{f e a b c d} }
+    let(:odd_sized_letters) { %w[e a b c d] }
+    let(:even_sized_letters) { %w[f e a b c d] }
     let(:odd_sized_numbers) { [3, 2, 1] }
     let(:even_sized_numbers) { [4, 3, 2, 1] }
     let(:one_number) { [1] }

--- a/services/QuillLMS/spec/lib/extensions/array_spec.rb
+++ b/services/QuillLMS/spec/lib/extensions/array_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 describe Array do
   describe '#median' do
-    let(:odd_sized_letters) { %w{e a b c d} }
-    let(:even_sized_letters) { %w{f e a b c d} }
+    let(:odd_sized_letters) { %w[e a b c d] }
+    let(:even_sized_letters) { %w[f e a b c d] }
     let(:odd_sized_numbers) { [3, 2, 1] }
     let(:even_sized_numbers) { [4, 3, 2, 1] }
     let(:one_number) { [1] }

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -358,8 +358,8 @@ RSpec.describe User, type: :model do
 
   describe 'constants' do
     it 'should give the correct value for all the constants' do
-      expect(User::ROLES).to eq(%w(teacher student staff sales-contact admin))
-      expect(User::SAFE_ROLES).to eq(%w(student teacher sales-contact admin))
+      expect(User::ROLES).to eq(%w[teacher student staff sales-contact admin])
+      expect(User::SAFE_ROLES).to eq(%w[student teacher sales-contact admin])
     end
   end
 
@@ -685,7 +685,7 @@ RSpec.describe User, type: :model do
   describe 'User scope' do
     describe '::ROLES' do
       it 'must contain all roles' do
-        %w(student teacher staff).each do |role|
+        %w[student teacher staff].each do |role|
           expect(User::ROLES).to include role
         end
       end
@@ -693,7 +693,7 @@ RSpec.describe User, type: :model do
 
     describe '::SAFE_ROLES' do
       it 'must contain safe roles' do
-        %w(student teacher).each do |role|
+        %w[student teacher].each do |role|
           expect(User::SAFE_ROLES).to include role
         end
       end
@@ -718,11 +718,11 @@ RSpec.describe User, type: :model do
       user.authenticate(password)
     end
 
-    %i(email username).each do |cred_base|
+    %i[email username].each do |cred_base|
       context "with #{cred_base}" do
         let(:password_val) { send(:"#{cred_base}_password") }
 
-        %i(original swapped).each do |name_case|
+        %i[original swapped].each do |name_case|
           case_mod = if name_case == :swapped
                        :swapcase # e.g., "a B c" => "A b C"
                      else

--- a/services/QuillLMS/spec/queries/activity_search_spec.rb
+++ b/services/QuillLMS/spec/queries/activity_search_spec.rb
@@ -7,8 +7,8 @@ describe ActivitySearch do
     let!(:activity_classification) { create(:activity_classification) }
     let!(:standard) { create(:standard) }
     let!(:standard_level) { create(:standard_level) }
-    let!(:activity) { create(:activity, activity_categories: [], flags: %w{beta production}, activity_classification_id: activity_classification.id, standard: standard, standard_level: standard_level) }
-    let!(:beta_flagset_activity) { create(:activity, activity_categories: [], name: 'special activity', flags: %w{evidence_beta1}, activity_classification_id: activity_classification.id, standard: standard, standard_level: standard_level) }
+    let!(:activity) { create(:activity, activity_categories: [], flags: %w[beta production], activity_classification_id: activity_classification.id, standard: standard, standard_level: standard_level) }
+    let!(:beta_flagset_activity) { create(:activity, activity_categories: [], name: 'special activity', flags: %w[evidence_beta1], activity_classification_id: activity_classification.id, standard: standard, standard_level: standard_level) }
     let!(:activity_category) { create(:activity_category) }
     let!(:activity_category_activity) { create(:activity_category_activity, activity_category: activity_category, activity: activity) }
     let!(:content_partner) { create(:content_partner) }

--- a/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/data_export_query_spec.rb
@@ -94,7 +94,7 @@ module Snapshots
         it { expect(results.count).to eq 10 }
 
         it 'each row contains the expected fields' do
-          expected_fields = %i(
+          expected_fields = %i[
             student_name
             student_email
             completed_at
@@ -108,7 +108,7 @@ module Snapshots
             classroom_grade
             teacher_name
             classroom_name
-          )
+          ]
 
           results.each do |row|
             expect(row.keys.to_set > expected_fields.to_set).to be true

--- a/services/QuillLMS/spec/queries/snapshots/untruncated_data_export_query_spec.rb
+++ b/services/QuillLMS/spec/queries/snapshots/untruncated_data_export_query_spec.rb
@@ -70,7 +70,7 @@ module Snapshots
         end
 
         it 'each row contains the expected fields' do
-          expected_fields = %i(
+          expected_fields = %i[
             student_name
             student_email
             completed_at
@@ -84,7 +84,7 @@ module Snapshots
             classroom_grade
             teacher_name
             classroom_name
-          )
+          ]
 
           results.each do |row|
             expect(row.keys.to_set > expected_fields.to_set).to be true

--- a/services/QuillLMS/spec/serializers/activity_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/activity_serializer_spec.rb
@@ -42,7 +42,7 @@ describe ActivitySerializer, type: :serializer do
     let(:record_instance) { create(:activity) }
 
     let(:expected_serialized_keys) do
-      %w(anonymous_path
+      %w[anonymous_path
          classification
          created_at
          data
@@ -55,7 +55,7 @@ describe ActivitySerializer, type: :serializer do
          uid
          updated_at
          activity_category
-         supporting_info)
+         supporting_info]
     end
   end
 

--- a/services/QuillLMS/spec/serializers/activity_session_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/activity_session_serializer_spec.rb
@@ -41,14 +41,14 @@ describe ActivitySessionSerializer, type: :serializer do
     let(:concept)         { create(:concept) }
 
     let(:expected_serialized_keys) do
-      %w(activity_uid
+      %w[activity_uid
          anonymous
          completed_at
          data
          percentage
          state
          temporary
-         uid)
+         uid]
     end
   end
 end

--- a/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/admin/teacher_serializer_spec.rb
@@ -9,7 +9,7 @@ describe Admin::TeacherSerializer do
     let(:result_key) { 'teacher' }
 
     let(:expected_serialized_keys) do
-      %w{
+      %w[
         id
         name
         email
@@ -18,7 +18,7 @@ describe Admin::TeacherSerializer do
         number_of_students
         has_valid_subscription
         admin_info
-      }
+      ]
     end
   end
 

--- a/services/QuillLMS/spec/serializers/classification_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/classification_serializer_spec.rb
@@ -9,7 +9,7 @@ describe ClassificationSerializer, type: :serializer do
       let(:result_key) { 'classification' }
 
       let(:expected_serialized_keys) do
-        %w(uid
+        %w[uid
            id
            name
            key
@@ -19,7 +19,7 @@ describe ClassificationSerializer, type: :serializer do
            updated_at
            green_image_class
            alias
-           scorebook_icon_class)
+           scorebook_icon_class]
       end
     end
   end

--- a/services/QuillLMS/spec/serializers/cms/activity_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/cms/activity_serializer_spec.rb
@@ -8,7 +8,7 @@ describe Cms::ActivitySerializer do
     let(:result_key) { 'activity' }
 
     let(:expected_serialized_keys) do
-      %w{
+      %w[
         uid
         id
         name
@@ -22,7 +22,7 @@ describe Cms::ActivitySerializer do
         readability_grade_level
         unit_templates
         classification
-      }
+      ]
     end
   end
 end

--- a/services/QuillLMS/spec/serializers/cms/unit_template_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/cms/unit_template_serializer_spec.rb
@@ -8,7 +8,7 @@ describe Cms::UnitTemplateSerializer do
     let(:result_key) { 'unit_template' }
 
     let(:expected_serialized_keys) do
-      %w{
+      %w[
         activities
         id
         name
@@ -23,7 +23,7 @@ describe Cms::UnitTemplateSerializer do
         readability
         diagnostic_names
         unit_template_category
-      }
+      ]
     end
   end
 end

--- a/services/QuillLMS/spec/serializers/lesson_planner/unit_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/lesson_planner/unit_serializer_spec.rb
@@ -9,9 +9,9 @@ describe LessonPlanner::UnitSerializer, type: :serializer do
 
   it_behaves_like 'serializer' do
     let!(:record_instance) { create(:unit) }
-    let!(:expected_serialized_keys) { %w(id name selectedActivities classrooms dueDates) }
-    let!(:nested_hash_keys) { %w(dueDates) }
-    let!(:neseted_array_keys) { %w(selectedActivities classrooms) }
+    let!(:expected_serialized_keys) { %w[id name selectedActivities classrooms dueDates] }
+    let!(:nested_hash_keys) { %w[dueDates] }
+    let!(:neseted_array_keys) { %w[selectedActivities classrooms] }
   end
 
   context 'unit with nontrivial data' do

--- a/services/QuillLMS/spec/serializers/plan_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/plan_serializer_spec.rb
@@ -25,11 +25,11 @@ describe PlanSerializer, type: :serializer do
     let(:record_instance) { create(:plan) }
 
     let(:expected_serialized_keys) do
-      %w(
+      %w[
         display_name
         price_in_dollars
         stripe_price_id
-      )
+      ]
     end
   end
 end

--- a/services/QuillLMS/spec/serializers/profile/activity_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/profile/activity_serializer_spec.rb
@@ -7,14 +7,14 @@ describe Profile::ActivitySerializer, type: :serializer do
     let(:record_instance) { create(:activity) }
 
     let(:expected_serialized_keys) do
-      %w{
+      %w[
         name
         description
         repeatable
         classification
         standard_level
         standard
-      }
+      ]
     end
   end
 end

--- a/services/QuillLMS/spec/serializers/profile/activity_session_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/profile/activity_session_serializer_spec.rb
@@ -7,7 +7,7 @@ describe Profile::ActivitySessionSerializer do
     let(:record_instance) { create(:activity_session) }
 
     let(:expected_serialized_keys) do
-      %w{
+      %w[
         id
         percentage
         link
@@ -15,7 +15,7 @@ describe Profile::ActivitySessionSerializer do
         due_date
         state
         activity
-      }
+      ]
     end
   end
 end

--- a/services/QuillLMS/spec/serializers/profile/student_activity_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/profile/student_activity_serializer_spec.rb
@@ -8,12 +8,12 @@ describe Profile::StudentActivitySerializer, type: :serializer do
     let(:result_key) { 'student_activity' }
 
     let(:expected_serialized_keys) do
-      %w{
+      %w[
         name
         description
         repeatable
         activity_classification_id
-      }
+      ]
     end
   end
 end

--- a/services/QuillLMS/spec/serializers/progress_reports/concepts/concept_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/concepts/concept_serializer_spec.rb
@@ -40,13 +40,13 @@ describe ProgressReports::Concepts::ConceptSerializer, type: :serializer do
 
     it 'includes the right keys' do
       expect(parsed_concept.keys)
-        .to match_array %w(concept_id
+        .to match_array %w[concept_id
                            concept_name
                            total_result_count
                            correct_result_count
                            incorrect_result_count
                            level_2_concept_name
-                           percentage)
+                           percentage]
     end
 
     it 'includes the percentage' do

--- a/services/QuillLMS/spec/serializers/progress_reports/concepts/student_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/concepts/student_serializer_spec.rb
@@ -38,13 +38,13 @@ describe ProgressReports::Concepts::StudentSerializer, type: :serializer do
 
     it 'includes the right keys' do
       expect(parsed_student.keys)
-        .to match_array %w(name
+        .to match_array %w[name
                            concepts_href
                            total_result_count
                            correct_result_count
                            incorrect_result_count
                            percentage
-                           id)
+                           id]
     end
 
     it 'includes the percentage' do

--- a/services/QuillLMS/spec/serializers/progress_reports/standards/classroom_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/standards/classroom_serializer_spec.rb
@@ -34,13 +34,13 @@ describe ProgressReports::Standards::ClassroomSerializer, type: :serializer do
 
     it 'includes the right keys' do
       expect(parsed_classroom.keys)
-        .to match_array %w(name
+        .to match_array %w[name
                            total_student_count
                            proficient_student_count
                            not_proficient_student_count
                            total_standard_count
                            students_href
-                           standards_href)
+                           standards_href]
     end
   end
 end

--- a/services/QuillLMS/spec/serializers/progress_reports/standards/standard_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/progress_reports/standards/standard_serializer_spec.rb
@@ -39,7 +39,7 @@ describe ProgressReports::Standards::StandardSerializer, type: :serializer do
 
     it 'includes the right keys' do
       expect(parsed_standard.keys)
-        .to match_array %w(name
+        .to match_array %w[name
                            id
                            standard_level_name
                            total_student_count
@@ -50,7 +50,7 @@ describe ProgressReports::Standards::StandardSerializer, type: :serializer do
                            average_score
                            standard_students_href
                            mastery_status
-                           is_evidence)
+                           is_evidence]
     end
 
     it 'includes properly rounded scores' do

--- a/services/QuillLMS/spec/serializers/segment_analytics_user_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/segment_analytics_user_serializer_spec.rb
@@ -8,7 +8,7 @@ describe SegmentAnalyticsUserSerializer do
     let(:result_key) { 'segment_analytics_user' }
 
     let(:expected_serialized_keys) do
-      %w{
+      %w[
         email
         created_at
         id
@@ -21,7 +21,7 @@ describe SegmentAnalyticsUserSerializer do
         subscription
         school
         time_zone
-      }
+      ]
     end
   end
 end

--- a/services/QuillLMS/spec/serializers/standard_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/standard_serializer_spec.rb
@@ -40,7 +40,7 @@ describe StandardSerializer, type: :serializer do
       standard_level_key = 'standard_level'
 
       it 'has the correct keys' do
-        expect(parsed_standard.keys).to match_array %w(id created_at name) + [standard_level_key] + %w(standard_category updated_at)
+        expect(parsed_standard.keys).to match_array %w[id created_at name] + [standard_level_key] + %w[standard_category updated_at]
       end
 
       it "includes a '#{standard_level_key}' Hash" do

--- a/services/QuillLMS/spec/serializers/user_admin_serializer_spec.rb
+++ b/services/QuillLMS/spec/serializers/user_admin_serializer_spec.rb
@@ -12,7 +12,7 @@ describe UserAdminSerializer do
     let!(:schools_admins) { create(:schools_admins, school: school, user: record_instance) }
 
     let(:expected_serialized_keys) do
-      %w{
+      %w[
         associated_school
         id
         name
@@ -20,7 +20,7 @@ describe UserAdminSerializer do
         teachers
         schools
         admin_approval_requests
-      }
+      ]
     end
   end
 

--- a/services/QuillLMS/spec/services/analytics/analyzer_spec.rb
+++ b/services/QuillLMS/spec/services/analytics/analyzer_spec.rb
@@ -45,7 +45,7 @@ describe Analytics::Analyzer do
         event: 'another_event',
         context: { ip: user.ip_address }
       })
-      subject.track_chain(user, %w{event another_event})
+      subject.track_chain(user, %w[event another_event])
     end
   end
 end

--- a/services/QuillLMS/spec/support/pages/page.rb
+++ b/services/QuillLMS/spec/support/pages/page.rb
@@ -27,11 +27,11 @@ class Page
     #     end
     has_form_element element_method, locator
 
-    module_eval_str __LINE__, %{
+    module_eval_str __LINE__, %(
       public def #{value_method}
         #{element_method}.checked?
       end
-    }
+    )
   end
 
   def self.has_form_element(method_name, locator)
@@ -41,11 +41,11 @@ class Page
     #     private def accepted_tos_field
     #       find_field :user_terms_of_service
     #     end
-    module_eval_str __LINE__, %{
+    module_eval_str __LINE__, %(
       private def #{method_name}
         find_field :#{locator}
       end
-    }
+    )
   end
 
   def self.has_form_field_value(method_name, element_method)
@@ -55,11 +55,11 @@ class Page
     #     def zipcode
     #       zipcode_field.value
     #     end
-    module_eval_str __LINE__, %{
+    module_eval_str __LINE__, %(
       public def #{method_name}
         #{element_method}.value
       end
-    }
+    )
   end
 
   def self.has_input_field(value_method, element_method, locator)

--- a/services/QuillLMS/spec/support/pages/teachers/class_manager/class_manager_page.rb
+++ b/services/QuillLMS/spec/support/pages/teachers/class_manager/class_manager_page.rb
@@ -14,11 +14,11 @@ module Teachers
      ['Manage Classes',  :manage_classes]].each do |pair|
       text, sym = pair
 
-      module_eval_str __LINE__, %{
+      module_eval_str __LINE__, %(
         def has_#{sym}?
           has_link? '#{text}'
         end
-      }
+      )
     end
 
     [['Activity Planner', :activity_planner],

--- a/services/QuillLMS/spec/support/pages/teachers/class_manager/invite_students_page.rb
+++ b/services/QuillLMS/spec/support/pages/teachers/class_manager/invite_students_page.rb
@@ -70,7 +70,7 @@ module Teachers
       @element = element
     end
 
-    %i(first_name last_name username).each do |attrib|
+    %i[first_name last_name username].each do |attrib|
       line_no = __LINE__; str = %{
         def #{attrib}
           @element.find('td.#{attrib}').text

--- a/services/QuillLMS/spec/support/shared/api_request.rb
+++ b/services/QuillLMS/spec/support/shared/api_request.rb
@@ -31,7 +31,7 @@ shared_examples 'an api request' do
       context 'meta node' do
         let(:meta) { parsed_body['meta'] }
 
-        it { expect(meta.keys).to match_array(%w(status message errors)) }
+        it { expect(meta.keys).to match_array(%w[status message errors]) }
       end
     end
   end


### PR DESCRIPTION
## WHAT
Enforces the consistent usage of ‘%`-literal delimiters.
with [Style/PercentLiteralDelimiters](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/PercentLiteralDelimiters)

## WHY
Make our code more consistent and make the robots enforce it so we don't have to worry about it on PR reviews. 

## HOW
Remove the exception in rubocop_todo.


### What have you done to QA this feature?
Tests pass
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | NO--non-code change
Have you deployed to Staging? | NO - non-app change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
