### PR TITLE
Add Number to Trial schema

### DIFF
--- a/services/QuillLMS/db/migrate/20240805190219_add_number_to_evidence_research_gen_ai_trials.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240805190219_add_number_to_evidence_research_gen_ai_trials.evidence.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240805185650)
+class AddNumberToEvidenceResearchGenAITrials < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_trials, :number, :integer
+
+    Evidence::Research::GenAI::Trial.reset_column_information
+
+    Evidence::Research::GenAI::Trial.order(:dataset_id, :created_at).group_by(&:dataset_id).each do |dataset_id, trials|
+      trials.each_with_index do |trial, index|
+        trial.update_column(:number, index + 1)
+      end
+    end
+
+    # Now that the column is filled, make it non-nullable
+    change_column_null :evidence_research_gen_ai_trials, :number, false
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3601,7 +3601,8 @@ CREATE TABLE public.evidence_research_gen_ai_trials (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     trial_duration double precision,
-    evaluation_duration double precision
+    evaluation_duration double precision,
+    number integer NOT NULL
 );
 
 
@@ -12091,6 +12092,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240710195857'),
 ('20240713144717'),
 ('20240714215711'),
-('20240801134426');
+('20240801134426'),
+('20240805190219');
 
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/activities_controller.rb
@@ -4,7 +4,7 @@ module Evidence
   module Research
     module GenAI
       class ActivitiesController < ApplicationController
-        def index = @activities = Activity.all
+        def index = @activities = Activity.all.order(created_at: :desc)
 
         def new = @activity = Activity.new
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/trial.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/trial.rb
@@ -6,6 +6,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  evaluation_duration :float
+#  number              :integer          not null
 #  results             :jsonb
 #  status              :string           default("pending"), not null
 #  trial_duration      :float
@@ -56,6 +57,8 @@ module Evidence
 
         attr_accessor :guideline_ids, :llm_prompt_template_id, :prompt_example_ids, :g_eval_id
 
+        before_create :set_trial_number
+
         def pending? = status == PENDING
         def failed? = status == FAILED
         def running? = status == RUNNING
@@ -95,6 +98,11 @@ module Evidence
         end
 
         def retry_params = { llm_id:, llm_prompt_id:, dataset_id: }
+
+        private def set_trial_number
+          last_trial_number = self.class.where(dataset_id:).maximum(:number) || 0
+          self.number = last_trial_number + 1
+        end
 
         private def query_llm
           [].tap do |api_call_times|

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_importer.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_importer.rb
@@ -6,8 +6,23 @@ module Evidence
       class DatasetImporter < ApplicationService
         attr_reader :dataset, :file
 
+        HEADERS = [
+          CURRICULUM_ASSIGNED_OPTIMAL_STATUS = 'Curriculum Assigned Optimal Status',
+          DATA_PARTITION = 'Data Partition',
+          OPTIONAL_AUTOML_LABEL = 'Optional - AutoML Label',
+          OPTIONAL_AUTOML_PRIMARY_FEEDBACK = 'Optional - AutoML Primary Feedback',
+          OPTIONAL_AUTOML_SECONDARY_FEEDBACK = 'Optional - AutoML Secondary Feedback',
+          OPTIONAL_CURRICULUM_LABEL = 'Optional - Curriculum Label',
+          CURRICULUM_PROPOSED_FEEDBACK = 'Curriculum Proposed Feedback',
+          OPTIONAL_HIGHLIGHT = 'Optional - Highlight',
+          STUDENT_RESPONSE = 'Student Response'
+        ]
+
         OPTIMAL = HasAssignedStatus::OPTIMAL
         SUBOPTIMAL = HasAssignedStatus::SUBOPTIMAL
+
+        TEST_DATA = 'test'
+        PROMPT_DATA = 'prompt'
 
         def initialize(dataset:, file:)
           @dataset = dataset
@@ -19,25 +34,25 @@ module Evidence
           suboptimal_count = 0
 
           CSV.parse(file.read, headers: true) do |row|
-            curriculum_assigned_optimal_status = row['Curriculum Assigned Optimal Status'] == 'TRUE'
+            curriculum_assigned_optimal_status = row[CURRICULUM_ASSIGNED_OPTIMAL_STATUS] == 'TRUE'
             curriculum_assigned_status = curriculum_assigned_optimal_status ? OPTIMAL : SUBOPTIMAL
-            data_partition = row['Data Partition']
+            data_partition = row[DATA_PARTITION]
 
             example_attrs = {
-              automl_label: row['Optional - AutoML Label'],
-              automl_primary_feedback: row['Optional - AutoML Primary Feedback'],
-              automl_secondary_feedback: row['Optional - AutoML Secondary Feedback'],
+              automl_label: row[OPTIONAL_AUTOML_LABEL],
+              automl_primary_feedback: row[OPTIONAL_AUTOML_PRIMARY_FEEDBACK],
+              automl_secondary_feedback: row[OPTIONAL_AUTOML_SECONDARY_FEEDBACK],
               curriculum_assigned_status:,
-              curriculum_label: row['Optional - Curriculum Label'],
-              curriculum_proposed_feedback: row['Curriculum Proposed Feedback'],
-              highlight: row['Optional - Highlight'],
-              student_response: row['Student Response'],
+              curriculum_label: row[OPTIONAL_CURRICULUM_LABEL],
+              curriculum_proposed_feedback: row[CURRICULUM_PROPOSED_FEEDBACK],
+              highlight: row[OPTIONAL_HIGHLIGHT],
+              student_response: row[STUDENT_RESPONSE]
             }
 
-            if data_partition == 'test'
-              curriculum_assigned_status == HasAssignedStatus::OPTIMAL ? optimal_count += 1 : suboptimal_count += 1
+            if data_partition == TEST_DATA
+              curriculum_assigned_status == OPTIMAL ? optimal_count += 1 : suboptimal_count += 1
               dataset.test_examples.create!(example_attrs)
-            elsif data_partition == 'prompt'
+            elsif data_partition == PROMPT_DATA
               dataset.prompt_examples.create!(example_attrs)
             end
           end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_validator.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_validator.rb
@@ -7,9 +7,16 @@ module Evidence
         attr_reader :file
 
         HEADERS = DatasetImporter::HEADERS
+        STUDENT_RESPONSE = DatasetImporter::STUDENT_RESPONSE
+        CURRICULUM_ASSIGNED_OPTIMAL_STATUS = DatasetImporter::CURRICULUM_ASSIGNED_OPTIMAL_STATUS
+        DATA_PARTITION = DatasetImporter::DATA_PARTITION
+        CURRICULUM_PROPOSED_FEEDBACK = DatasetImporter::CURRICULUM_PROPOSED_FEEDBACK
+        OPTIONAL_AUTOML_PRIMARY_FEEDBACK = DatasetImporter::OPTIONAL_AUTOML_PRIMARY_FEEDBACK
+        TEST_DATA = DatasetImporter::TEST_DATA
 
         OPTIMAL = HasAssignedStatus::OPTIMAL
         SUBOPTIMAL = HasAssignedStatus::SUBOPTIMAL
+
         MISSING_FEEDBACK_ERROR = 'CSV is missing feedback. Please add Curriculum Proposed Feedback or AutoML Primary Feedback.'
         MISSING_STUDENT_RESPONSE_ERROR = 'is missing a Student Response.'
         MISSING_HEADERS_ERROR = 'CSV is missing required headers: %s.'
@@ -39,13 +46,13 @@ module Evidence
 
         private def missing_headers = HEADERS - csv.headers
 
-        private def missing_student_response?(row) = row['Student Response'].blank?
+        private def missing_student_response?(row) = row[STUDENT_RESPONSE].blank?
 
         private def missing_feedback?(row)
-          row['Curriculum Assigned Optimal Status'] == 'FALSE' &&
-          row['Data Partition'] == 'test' &&
-          row['Curriculum Proposed Feedback'].blank? &&
-          row['Optional - AutoML Primary Feedback'].blank?
+          row[CURRICULUM_ASSIGNED_OPTIMAL_STATUS] == 'FALSE' &&
+          row[DATA_PARTITION] == TEST_DATA &&
+          row[CURRICULUM_PROPOSED_FEEDBACK].blank? &&
+          row[OPTIONAL_AUTOML_PRIMARY_FEEDBACK].blank?
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_validator.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_validator.rb
@@ -17,8 +17,8 @@ module Evidence
         def run
           [].tap do |errors|
             CSV.parse(file.read, headers: true).each.with_index(2) do |row, index|
-              next if row['Data Partition'] == 'test'
               next if row['Curriculum Assigned Optimal Status'] == 'TRUE'
+              next if row['Data Partition'] == 'prompt'
               next if row['Curriculum Proposed Feedback'].present? || row['Optional - AutoML Primary Feedback'].present?
 
               errors << "Row #{index}: #{MISSING_FEEDBACK_ERROR}"

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_validator.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_validator.rb
@@ -6,28 +6,46 @@ module Evidence
       class DatasetValidator < ApplicationService
         attr_reader :file
 
+        HEADERS = DatasetImporter::HEADERS
+
         OPTIMAL = HasAssignedStatus::OPTIMAL
         SUBOPTIMAL = HasAssignedStatus::SUBOPTIMAL
-        MISSING_FEEDBACK_ERROR = 'is missing feedback. Please add Curriculum Proposed Feedback or AutoML Primary Feedback.'
+        MISSING_FEEDBACK_ERROR = 'CSV is missing feedback. Please add Curriculum Proposed Feedback or AutoML Primary Feedback.'
+        MISSING_STUDENT_RESPONSE_ERROR = 'is missing a Student Response.'
+        MISSING_HEADERS_ERROR = 'CSV is missing required headers: %s.'
 
         def initialize(file:)
           @file = file
         end
 
         def run
-          [].tap do |errors|
-            CSV.parse(file.read, headers: true).each.with_index(2) do |row, index|
-              next if row['Curriculum Assigned Optimal Status'] == 'TRUE'
-              next if row['Data Partition'] == 'prompt'
-              next if row['Curriculum Proposed Feedback'].present? || row['Optional - AutoML Primary Feedback'].present?
+          return headers_error if missing_headers.any?
 
-              errors << "Row #{index}: #{MISSING_FEEDBACK_ERROR}"
+          [].tap do |errors|
+            csv.each.with_index(2) do |row, index|
+              errors << "Row #{index}: #{MISSING_STUDENT_RESPONSE_ERROR}" if missing_student_response?(row)
+              errors << "Row #{index}: #{MISSING_FEEDBACK_ERROR}" if missing_feedback?(row)
             end
 
             file.rewind
 
             errors.empty? ? nil : errors.join(",\n")
           end
+        end
+
+        private def csv = @csv ||= CSV.parse(file.read, headers: true)
+
+        private def headers_error = format(MISSING_HEADERS_ERROR, missing_headers.join(', '))
+
+        private def missing_headers = HEADERS - csv.headers
+
+        private def missing_student_response?(row) = row['Student Response'].blank?
+
+        private def missing_feedback?(row)
+          row['Curriculum Assigned Optimal Status'] == 'FALSE' &&
+          row['Data Partition'] == 'test' &&
+          row['Curriculum Proposed Feedback'].blank? &&
+          row['Optional - AutoML Primary Feedback'].blank?
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
@@ -44,6 +44,10 @@
                   <%= llm_prompt.optimal_examples_count %> Optimal,
                   <%= llm_prompt.suboptimal_examples_count %> Sub-Optimal
                 </li>
+                <li>
+                  Prompt Template:
+                  <%= link_to llm_prompt.llm_prompt_template, llm_prompt.llm_prompt_template %>
+                </li>
               </ul>
             </div>
             <%= render 'confusion_matrix', matrix: trial.confusion_matrix %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
@@ -31,7 +31,7 @@
           <th class='dark-border-top-bottom'></th>
           <th class="dark-border-top-bottom-right trial-column">
             <div style='font-size: 0.7em'>
-              Trial <%= trial.id %>
+              Trial <%= trial.number %>
               <ul style='list-style-type: none; padding: 0;'>
                 <li>Model: <%= trial.llm.version %></li>
                 <li>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
@@ -31,7 +31,7 @@
           <th class='dark-border-top-bottom'></th>
           <th class="dark-border-top-bottom-right trial-column">
             <div style='font-size: 0.7em'>
-              Trial <%= trial.number %>
+              <%= link_to "Trial #{trial.number}", research_gen_ai_dataset_trial_path(@dataset, trial) %></td>
               <ul style='list-style-type: none; padding: 0;'>
                 <li>Model: <%= trial.llm.version %></li>
                 <li>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
@@ -46,11 +46,10 @@
           </tr>
         </thead>
         <tbody>
-          <% num_trials = @trials.count %>
           <% @trials.each.with_index(0) do |trial, index| %>
             <% llm_prompt = trial.llm_prompt %>
             <tr>
-              <td><%= "Trial #{num_trials - index}" %></td>
+              <td><%= "Trial #{trial.number}" %></td>
               <td><%= date_helper(trial.created_at) %></td>
               <td><%= llm_prompt.name %></td>
               <td><%= llm_prompt.optimal_examples_count %></td>

--- a/services/QuillLMS/engines/evidence/db/migrate/20240805185650_add_number_to_evidence_research_gen_ai_trials.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240805185650_add_number_to_evidence_research_gen_ai_trials.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddNumberToEvidenceResearchGenAITrials < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_trials, :number, :integer
+
+    Evidence::Research::GenAI::Trial.reset_column_information
+
+    Evidence::Research::GenAI::Trial.order(:dataset_id, :created_at).group_by(&:dataset_id).each do |dataset_id, trials|
+      trials.each_with_index do |trial, index|
+        trial.update_column(:number, index + 1)
+      end
+    end
+
+    # Now that the column is filled, make it non-nullable
+    change_column_null :evidence_research_gen_ai_trials, :number, false
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1525,7 +1525,8 @@ CREATE TABLE public.evidence_research_gen_ai_trials (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     trial_duration double precision,
-    evaluation_duration double precision
+    evaluation_duration double precision,
+    number integer NOT NULL
 );
 
 
@@ -2600,6 +2601,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240701180438'),
 ('20240713141016'),
 ('20240714214900'),
-('20240801134328');
+('20240801134328'),
+('20240805185650');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/trials.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/trials.rb
@@ -6,6 +6,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  evaluation_duration :float
+#  number              :integer          not null
 #  results             :jsonb
 #  status              :string           default("pending"), not null
 #  trial_duration      :float

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  evaluation_duration :float
+#  number              :integer          not null
 #  results             :jsonb
 #  status              :string           default("pending"), not null
 #  trial_duration      :float
@@ -43,6 +44,28 @@ module Evidence
 
         it { have_many(:llm_examples) }
         it { have_many(:test_examples).through(:dataset) }
+
+        describe 'callbacks' do
+          describe 'before_create :set_trial_number' do
+            let(:dataset) { create(:evidence_research_gen_ai_dataset) }
+
+            let!(:trial1) { create(:evidence_research_gen_ai_trial, dataset:) }
+            let!(:trial2) { create(:evidence_research_gen_ai_trial, dataset:) }
+
+            it { expect(trial1.number).to eq(1) }
+            it { expect(trial2.number).to eq(2) }
+
+            it 'assigns the correct number to a new trial' do
+              new_trial = create(:evidence_research_gen_ai_trial, dataset:)
+              expect(new_trial.number).to eq(3)
+            end
+
+            it 'assigns the correct number to a new trial with a different dataset' do
+              new_trial = create(:evidence_research_gen_ai_trial)
+              expect(new_trial.number).to eq(1)
+            end
+          end
+        end
 
         describe '#run' do
           subject { trial.run }

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/dataset_validator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/dataset_validator_spec.rb
@@ -9,24 +9,11 @@ module Evidence
         subject { described_class.run(file:) }
 
         let(:file) { StringIO.new(content) }
-
-        let(:headers) do
-          [
-            'Curriculum Assigned Optimal Status',
-            'Data Partition',
-            'Optional - AutoML Label',
-            'Optional - AutoML Primary Feedback',
-            'Optional - AutoML Secondary Feedback',
-            'Optional - Curriculum Label',
-            'Curriculum Proposed Feedback',
-            'Optional - Highlight',
-            'Student Response'
-          ]
-        end
+        let(:headers) { DatasetImporter::HEADERS }
 
         context 'when the CSV content is valid' do
           let(:content) do
-            <<-CSV
+            <<~CSV
               #{headers.join(',')}
               TRUE,test,label1,primary_feedback1,secondary_feedback1,curriculum_label1,proposed_feedback1,highlight1,response1
               FALSE,test,label2,,secondary_feedback2,curriculum_label2,proposed_feedback2,highlight2,response2
@@ -38,9 +25,34 @@ module Evidence
           it { is_expected.to eq [] }
         end
 
+        context 'when the CSV content is missing required headers' do
+          let(:content) do
+            <<~CSV
+              Curriculum Assigned Optimal Status,Data Partition,Optional - AutoML Label,Optional - AutoML Primary Feedback
+              TRUE,test,label1,primary_feedback1
+            CSV
+          end
+
+          it { is_expected.to eq("CSV is missing required headers: Optional - AutoML Secondary Feedback, Optional - Curriculum Label, Curriculum Proposed Feedback, Optional - Highlight, Student Response.") }
+        end
+
+        context 'when the CSV content is missing a Student Response' do
+          let(:content) do
+            <<~CSV
+              #{headers.join(',')}
+              TRUE,test,label1,primary_feedback1,secondary_feedback1,curriculum_label1,proposed_feedback1,highlight1,
+              FALSE,test,label2,,secondary_feedback2,curriculum_label2,,highlight2,response2
+              TRUE,prompt,label3,primary_feedback3,secondary_feedback3,curriculum_label3,proposed_feedback3,highlight3,response3
+              FALSE,prompt,label4,primary_feedback4,secondary_feedback4,curriculum_label4,proposed_feedback4,highlight4,response4
+            CSV
+          end
+
+          it { is_expected.to eq(["Row 2: #{described_class::MISSING_STUDENT_RESPONSE_ERROR}", "Row 3: #{described_class::MISSING_FEEDBACK_ERROR}"]) }
+        end
+
         context 'when the CSV content is invalid' do
           let(:content) do
-            <<-CSV
+            <<~CSV
               #{headers.join(',')}
               TRUE,test,label1,primary_feedback1,secondary_feedback1,curriculum_label1,proposed_feedback1,highlight1,response1
               FALSE,test,label2,,secondary_feedback2,curriculum_label2,,highlight2,response2

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/dataset_validator_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/dataset_validator_spec.rb
@@ -28,10 +28,10 @@ module Evidence
           let(:content) do
             <<-CSV
               #{headers.join(',')}
-              TRUE,prompt,label1,primary_feedback1,secondary_feedback1,curriculum_label1,proposed_feedback1,highlight1,response1
-              FALSE,prompt,label2,,secondary_feedback2,curriculum_label2,proposed_feedback2,highlight2,response2
-              TRUE,test,label3,primary_feedback3,secondary_feedback3,curriculum_label3,proposed_feedback3,highlight3,response3
-              FALSE,test,label4,primary_feedback4,secondary_feedback4,curriculum_label4,proposed_feedback4,highlight4,response4
+              TRUE,test,label1,primary_feedback1,secondary_feedback1,curriculum_label1,proposed_feedback1,highlight1,response1
+              FALSE,test,label2,,secondary_feedback2,curriculum_label2,proposed_feedback2,highlight2,response2
+              TRUE,prompt,label3,primary_feedback3,secondary_feedback3,curriculum_label3,proposed_feedback3,highlight3,response3
+              FALSE,prompt,label4,primary_feedback4,secondary_feedback4,curriculum_label4,proposed_feedback4,highlight4,response4
             CSV
           end
 
@@ -42,10 +42,10 @@ module Evidence
           let(:content) do
             <<-CSV
               #{headers.join(',')}
-              TRUE,prompt,label1,primary_feedback1,secondary_feedback1,curriculum_label1,proposed_feedback1,highlight1,response1
-              FALSE,prompt,label2,,secondary_feedback2,curriculum_label2,,highlight2,response2
-              TRUE,test,label3,primary_feedback3,secondary_feedback3,curriculum_label3,proposed_feedback3,highlight3,response3
-              FALSE,test,label4,primary_feedback4,secondary_feedback4,curriculum_label4,proposed_feedback4,highlight4,response4
+              TRUE,test,label1,primary_feedback1,secondary_feedback1,curriculum_label1,proposed_feedback1,highlight1,response1
+              FALSE,test,label2,,secondary_feedback2,curriculum_label2,,highlight2,response2
+              TRUE,prompt,label3,primary_feedback3,secondary_feedback3,curriculum_label3,proposed_feedback3,highlight3,response3
+              FALSE,prompt,label4,primary_feedback4,secondary_feedback4,curriculum_label4,proposed_feedback4,highlight4,response4
             CSV
           end
 


### PR DESCRIPTION
## WHAT
* Add number to Trial schema
* Fix dataset validation
* Fix ordering of Activities
* Add dataset validation for headers
* Add dataset validation for blank student response

## WHY
* We need a identifier specific to trial rather than the trial_id to label in trials in the Datasets#show as well as Comparison#show header
* The DatasetValidator needs to check for suboptimal test examples that lack feedback.  It's currently checking this for prompt examples.
* The Evidence::Research::GenAI::Activities#index is ordering items randomly
* If any headers are missing, parsing the CSV is impractical
* Student response is required

## HOW
* Write a migration and backfill existing trials
* Change the guard clause for datasets to check for 'test' rather than 'prompt'
* Add order by :created_at
* Iterate through the headers provided and make sure they match all the expected ones.
* Add a check for student responses and report errors for specific rows

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I've checked on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
