### PR TITLE
vite config cleanup

### DIFF
--- a/services/QuillLMS/.env.development
+++ b/services/QuillLMS/.env.development
@@ -1,6 +1,0 @@
-VITE_PROCESS_ENV_CDN_URL=https://assets.quill.org
-VITE_PROCESS_ENV_PUSHER_KEY=
-VITE_PROCESS_ENV_RAILS_ENV=default
-VITE_DEFAULT_URL=http://localhost:5000
-VITE_CMS_URL=https://cms.quill.org
-VITE_ENV=development

--- a/services/QuillLMS/vite.config.ts
+++ b/services/QuillLMS/vite.config.ts
@@ -1,29 +1,16 @@
-import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
-import replace from '@rollup/plugin-replace';
-//import react from '@vitejs/plugin-react';
 import fs from 'fs/promises';
 import path, { resolve } from 'path';
-import friendlyTypeImports from 'rollup-plugin-friendly-type-imports';
-import { createLogger, defineConfig, loadEnv } from 'vite';
-import RubyPlugin from 'vite-plugin-ruby';
 
-const logger = createLogger();
-const originalWarning = logger.warn;
-logger.warn = (msg, options) => {
-  return;
-  if (msg.includes('vite:css') && msg.includes(' is empty')) return;
-  originalWarning(msg, options);
-};
+import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+import friendlyTypeImports from 'rollup-plugin-friendly-type-imports';
+import { defineConfig, loadEnv } from 'vite';
+import RubyPlugin from 'vite-plugin-ruby';
 
 export default defineConfig(({command, mode}) => {
   // Load env file based on `mode` in the current working directory.
   // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
   const env = loadEnv(mode, process.cwd(), '')
-  //const env_stuff = {...process.env, ...loadEnv(mode, process.cwd())};
-  // console.log("--")
-  // console.log(process.env)
-  // console.log("--")
-
 
   const railsEnv = process.env.RAILS_ENV || process.env.NODE_ENV
   const pusherKey = process.env.PUSHER_KEY;


### PR DESCRIPTION
## WHAT
- remove unused config code in vite.config.ts
- remove unused Vite env vars 

## WHY
- cleanup
- we use `.env` + `vite.config.ts` for local Vite env vars. The `.env.development` was used during Vite exploration but never implemented.

## HOW
`rm` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links

### What have you done to QA this feature?
- [x] login with gmail
-  [x] in Network tab, ensure no asset 404s on homepage

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - config changes only
Have you deployed to Staging? | about to
Self-Review: Have you done an initial self-review of the code below on Github? |
