### PR TITLE
minor evidence ui changes for scoring

### DIFF
--- a/packages/quill-cdn/assets/images/evidence/evidence-report.svg
+++ b/packages/quill-cdn/assets/images/evidence/evidence-report.svg
@@ -1,0 +1,97 @@
+<svg width="580" height="270" viewBox="0 0 580 270" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="no-grades">
+<g id="n-check">
+<path id="Path" d="M520.28 115.76C520.76 117.68 521 119.84 521 122C521 135.2 510.2 146 497 146C483.8 146 473 135.2 473 122C473 108.8 483.8 98 497 98C501.56 98 505.88 99.2 509.72 101.6" stroke="#06806B"/>
+<path id="Path_2" d="M487 117.545L496.6 127L523 101" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="n-check_2">
+<path id="Path_3" d="M122.46 170.32C122.82 171.76 123 173.38 123 175C123 184.9 114.9 193 105 193C95.1 193 87 184.9 87 175C87 165.1 95.1 157 105 157C108.42 157 111.66 157.9 114.54 159.7" stroke="#06806B"/>
+<path id="Path_4" d="M98 171.727L105.2 179L125 159" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="f-check">
+<path id="Path_5" fill-rule="evenodd" clip-rule="evenodd" d="M60.6482 88.4004L36.5279 74.1241L42.7828 63.8688L56.5658 72.0267L77.4151 37.8424L87.7524 43.9608L60.6482 88.4004Z" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="f-check_2">
+<path id="Path_6" fill-rule="evenodd" clip-rule="evenodd" d="M520.8 221L511 211.375L515.2 207.25L520.8 212.75L534.8 199L539 203.125L520.8 221Z" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="d-check">
+<path id="Path_7" d="M27 233L39 245L63 221" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="d-check_2">
+<path id="Path_8" d="M423 204L441 222L477 186" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="d-check_3">
+<path id="Path_9" d="M415 61L420 66L430 56" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="d-check_4">
+<path id="Path_10" d="M123 115L128 120L138 110" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="e-add">
+<path id="Path_11" d="M166 45V76" stroke="#06806B" stroke-linecap="square"/>
+<path id="Path_12" d="M181 60H150" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="e-add_2">
+<path id="Path_13" d="M156.307 222.463L159.457 236.104" stroke="#06806B" stroke-linecap="square"/>
+<path id="Path_14" d="M164.103 227.334L150.462 230.483" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="e-add_3">
+<path id="Path_15" d="M423.5 157V171" stroke="#06806B" stroke-linecap="square"/>
+<path id="Path_16" d="M430 163.5H416" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="e-add_4">
+<path id="Path_17" d="M542.707 31.824L535.207 61.9031" stroke="#06806B" stroke-linecap="square"/>
+<path id="Path_18" d="M552.904 48.7951L522.824 41.2955" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="e-add_5">
+<path id="Path_19" d="M42.2898 133.882L40.7552 155.828" stroke="#06806B" stroke-linecap="square"/>
+<path id="Path_20" d="M51.7436 144.232L29.7972 142.697" stroke="#06806B" stroke-linecap="square"/>
+</g>
+<g id="Group">
+<g id="Layer_3">
+<g id="Group_2">
+<g id="Group_3">
+<g id="Vector" style="mix-blend-mode:multiply" opacity="0.11">
+<path d="M381.236 255.297L217.707 255.283L217.975 50.5137L381.503 50.3799L381.236 255.297Z" fill="#363636"/>
+</g>
+<path id="Vector_2" d="M370.129 37.2589L205.324 37L205 243.135L369.806 243.394L370.129 37.2589Z" fill="#F7F7F7"/>
+</g>
+<g id="Group_4">
+<g id="Group_5">
+<path id="Vector_3" d="M235.156 162.215L243.332 170.391L257.48 154.039" stroke="#33A493" stroke-width="4.4937" stroke-miterlimit="10" stroke-linecap="square"/>
+<g id="Group_6">
+<path id="Vector_4" d="M273.242 156.747H340.03" stroke="#D7D7D7" stroke-width="4.4937" stroke-miterlimit="10" stroke-linecap="square"/>
+<path id="Vector_5" d="M273.242 167.802H318.645" stroke="#D7D7D7" stroke-width="4.4937" stroke-miterlimit="10" stroke-linecap="square"/>
+</g>
+</g>
+<g id="Group_7">
+<path id="Vector_6" d="M249.285 95.8115H233.895V123.676H249.285V95.8115Z" fill="#E86C60"/>
+<path id="Vector_7" d="M272.334 88.4287H256.943V123.677H272.334V88.4287Z" fill="#E86C60"/>
+<path id="Vector_8" d="M295.387 80.0771H279.996V123.676H295.387V80.0771Z" fill="#E86C60"/>
+<path id="Vector_9" d="M318.432 72.5332H303.041V123.676H318.432V72.5332Z" fill="#E86C60"/>
+<path id="Vector_10" d="M341.483 60.9971H326.092V123.676H341.483V60.9971Z" fill="#E86C60"/>
+</g>
+<g id="Group_8">
+<path id="Vector_11" d="M235.156 202.127L243.332 210.303L257.48 193.95" stroke="#33A493" stroke-width="4.4937" stroke-miterlimit="10" stroke-linecap="square"/>
+<g id="Group_9">
+<path id="Vector_12" d="M273.242 196.659H340.03" stroke="#D7D7D7" stroke-width="4.4937" stroke-miterlimit="10" stroke-linecap="square"/>
+<path id="Vector_13" d="M273.242 207.713H327.107" stroke="#D7D7D7" stroke-width="4.4937" stroke-miterlimit="10" stroke-linecap="square"/>
+</g>
+</g>
+</g>
+<g id="Group_10">
+<g id="Group_11" style="mix-blend-mode:multiply" opacity="0.2">
+<path id="Vector_14" opacity="0.59" d="M347.469 224.746C358.413 224.746 368.321 220.31 375.492 213.138C382.664 205.967 387.1 196.058 387.1 185.115C387.1 163.228 369.356 145.483 347.468 145.483C325.579 145.483 307.836 163.227 307.836 185.115C307.836 207.004 325.579 224.747 347.468 224.747L347.469 224.746Z" fill="white" stroke="#363636" stroke-width="0.154331" stroke-miterlimit="10"/>
+<path id="Vector_15" d="M347.469 224.746C358.413 224.746 368.321 220.31 375.492 213.138C382.664 205.967 387.1 196.058 387.1 185.115C387.1 163.228 369.356 145.483 347.468 145.483C325.579 145.483 307.836 163.227 307.836 185.115C307.836 207.004 325.579 224.747 347.468 224.747L347.469 224.746Z" stroke="#363636" stroke-width="12.4586" stroke-miterlimit="10" stroke-linecap="round"/>
+<path id="Vector_16" d="M416.253 253.405L375.494 213.138" stroke="#363636" stroke-width="12.4586" stroke-miterlimit="10" stroke-linecap="square"/>
+</g>
+<g id="Group_12">
+<path id="Vector_17" opacity="0.59" d="M345.922 212.381C356.866 212.381 366.774 207.945 373.945 200.773C381.117 193.602 385.553 183.693 385.553 172.75C385.553 150.863 367.809 133.118 345.921 133.118C324.032 133.118 306.289 150.861 306.289 172.75C306.289 194.639 324.032 212.382 345.921 212.382L345.922 212.381Z" fill="white"/>
+<path id="Vector_18" d="M345.922 212.381C356.866 212.381 366.774 207.945 373.945 200.773C381.117 193.602 385.553 183.693 385.553 172.75C385.553 150.863 367.809 133.118 345.921 133.118C324.032 133.118 306.289 150.861 306.289 172.75C306.289 194.639 324.032 212.382 345.921 212.382L345.922 212.381Z" stroke="#E2AC4B" stroke-width="12.4586" stroke-miterlimit="10" stroke-linecap="round"/>
+<path id="Vector_19" d="M414.706 241.039L373.947 200.771" stroke="#E2AC4B" stroke-width="12.4586" stroke-miterlimit="10" stroke-linecap="square"/>
+</g>
+</g>
+</g>
+</g>
+</g>
+</g>
+</svg>

--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_reports.scss
@@ -372,7 +372,7 @@ $lightgray: #cecece;
     background-color: $quill-blue-5;
   }
 }
-.yellow-score-color, .orange-score-color {
+.orange-score-color {
   background-color: #FFF6E2;
   &:hover {
     background-color: #FEF0D2;

--- a/services/QuillLMS/app/assets/stylesheets/pages/student_results.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_results.scss
@@ -40,7 +40,7 @@
     border-radius: 8px;
   }
 
-  .activity-name-and-overall-score, .results-section, .keep-practicing-section {
+  .activity-name-and-overall-score, .results-section, .keep-practicing-section, .evidence-scoring-guide {
     padding: 32px;
     &:not(:last-of-type) {
       border-bottom: 1px solid $quill-grey-15;
@@ -94,16 +94,67 @@
     }
   }
 
-  .keep-practicing-section {
+  .keep-practicing-section, .evidence-scoring-guide {
     border-radius: 8px;
     border: 1px solid $quill-grey-15;
     margin-top: 32px;
+  }
+
+  .keep-practicing-section {
     display: flex;
     align-items: center;
     gap: 16px;
     p {
       font-size: 16px;
       margin-top: 8px;
+    }
+  }
+
+  .evidence-scoring-guide {
+    h2 {
+      text-align: center;
+      margin-bottom: 24px;
+    }
+    .score-keys {
+      display: flex;
+      gap: 32px;
+    }
+    .score-key {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+      flex: 1;
+      p {
+        font-size: 13px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: normal;
+      }
+      div {
+        min-width: 44px;
+        height: 44px;
+        border-radius: 8px;
+      }
+      .green {
+        background-color: $quill-green-vibrant-50;
+      }
+      .yellow {
+        background-color: $quill-gold;
+      }
+      .red {
+        background-color: $quill-red;
+      }
+    }
+  }
+
+  @media (max-width: 850px) {
+    padding: 64px 32px;
+    .score-keys, .header-buttons {
+      flex-direction: column;
+      align-items: center;
+    }
+    .score-key p {
+      max-width: 300px;
     }
   }
 }

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -222,7 +222,7 @@ module PublicProgressReports
     formatted_concept_results = format_concept_results(activity_session, activity_session.concept_results)
     if [ActivityClassification::LESSONS_KEY, ActivityClassification::DIAGNOSTIC_KEY].include?(classification.key)
       score = get_average_score(formatted_concept_results)
-    elsif [ActivityClassification::EVIDENCE_KEY].include?(classification.key)
+    elsif [ActivityClassification::EVIDENCE_KEY].include?(classification.key) && activity_session.percentage.nil? # handles previous state where evidence sessions didn't get scored
       score = nil
     else
       score = (activity_session.percentage * 100).round

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
@@ -81,7 +81,7 @@ const MultipleChoiceOption = ({ text, selectedMultipleChoiceOptions, setSelected
   )
 }
 
-const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyResponse, setSubmittedActivitySurvey, }) => {
+const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyResponse, setSubmittedActivitySurvey, resultPageUrl, }) => {
   const [selectedEmoji, setSelectedEmoji] = React.useState(null)
   const [selectedMultipleChoiceOptions, setSelectedMultipleChoiceOptions] = React.useState([])
 
@@ -128,7 +128,7 @@ const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyRespo
     saveActivitySurveyResponse({ sessionID, activitySurveyResponse, callback, })
   }
 
-  function handleLinkClick() { window.location.href = process.env.DEFAULT_URL }
+  function handleLinkClick() { window.location.href = resultPageUrl }
 
   let activitySurveyHeader
   let multipleChoiceSection
@@ -168,7 +168,7 @@ const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyRespo
         {multipleChoiceSection}
       </div>
       <div className="button-section">
-        <a className="focus-on-dark" href={process.env.DEFAULT_URL} onClick={handleLinkClick}>Skip</a>
+        <a className="focus-on-dark" href={resultPageUrl} onClick={handleLinkClick}>Skip</a>
         <button className={sendButtonClassName} onClick={handleSend} type="button">Send</button>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/explanationData.ts
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/explanationData.ts
@@ -1,14 +1,14 @@
 export const explanationData = {
   1: {
     buttonText: "Next",
-    header: "This activity is not graded",
+    header: "All writers revise",
     imageData: {
-      imageAlt: "An illustration of an A+ that is crossed out",
-      imageUrl: "images/evidence/no-grades.svg"
+      imageAlt: "An illustration of a pencil circled with a revision",
+      imageUrl: "images/evidence/revising-pencil.svg"
     },
     isBeta: false,
     step: 2,
-    subtext: "This is a safe space to practice your writing, so it won't be graded. Your teacher will see your revisions, but there are no scores or points."
+    subtext: "Your goal is to practice and improve your writing skills.<br /><br />We will provide you with a lot of feedback on your writing. You’ll be able to revise each sentence up to five times so that you can become a stronger writer."
   },
   2: {
     buttonText: "Next",
@@ -23,13 +23,13 @@ export const explanationData = {
   },
   3: {
     buttonText: "Start",
-    header: "All writers revise",
+    header: "Your teacher will see your score and writing",
     imageData: {
-      imageAlt: "An illustration of a pencil circled with a revision",
-      imageUrl: "images/evidence/revising-pencil.svg"
+      imageAlt: "An illustration of a report page with a magnifying glass over it",
+      imageUrl: "images/evidence/evidence-report.svg"
     },
     isBeta: false,
     step: 4,
-    subtext: "You'll be able to revise each sentence up to five times. We give you feedback because we want to help you write a stronger sentence."
-  }
+    subtext: "Once the activity is complete, both you and your teacher will see a report with your score and your responses for each prompt."
+  },
 }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/explanationSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/explanationSlide.tsx
@@ -15,15 +15,15 @@ export const ExplanationSlide = ({ slideData, onHandleClick }) => {
   }, [slideData])
 
   return(
-    <div className="explanation-slide-container">
+    <div className={`explanation-slide-container step-${step}`}>
       <section className="no-focus-outline" id="information-section" ref={containerRef} tabIndex={-1}>
-        <p aria-hidden={true} className="subtext">Good to know</p>
+        <p aria-hidden={true} className="good-to-know">Good to know</p>
         <section id="header-container">
           <h1>{header}</h1>
           {isBeta && <div id="beta-tag">BETA</div>}
         </section>
         <img alt={imageAlt} id="image" src={`${process.env.CDN_URL}/${imageUrl}`} />
-        <p className="subtext">{subtext}</p>
+        <p className="subtext" dangerouslySetInnerHTML={{ __html: subtext, }} />
       </section>
       <Footer buttonText={buttonText} onHandleClick={onHandleClick} step={step} />
     </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/footer.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/footer.tsx
@@ -10,7 +10,7 @@ export const Footer = ({ buttonText, onHandleClick, step }) => {
     <section id="button-container">
       <span />
       <button className="quill-button-archived large secondary outlined focus-on-dark" onClick={handleClick} type="submit">{buttonText}</button>
-      <div id="step-indictator-container">
+      <div id="step-indicator-container">
         <div className={`step-indicator ${step === 1 ? 'active' : ''}`} />
         <div className={`step-indicator ${step === 2 ? 'active' : ''}`} />
         <div className={`step-indicator ${step === 3 ? 'active' : ''}`} />

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/postActivitySlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/postActivitySlide.tsx
@@ -76,18 +76,11 @@ export const PostActivitySlide = ({ handleClick, previewMode, prompts, responses
         <img alt="An illustration of a party popper" id="celebration-vector" src={`${process.env.CDN_URL}/images/evidence/party-celebration.svg`} />
         <p id="revision-text">You have completed the activity!</p>
         <p className="slide-sub-text" id="second-sub-text">Be proud of the work you did today, and celebrate your success! This practice will help you grow as a reader and a writer. The more you practice, the stronger your critical thinking, reading, and writing skills will be.</p>
-        <section id="reminder-badge-section">
-          <img alt="An illustration of an A+ that is crossed out" id="grade-badge" src={`${process.env.CDN_URL}/images/evidence/paper-check.svg`} />
-          <section id="reminder-text-section">
-            <p className="sub-header-text">Reminder about grades</p>
-            <p className="sub-header-subtext">This is practice, so your teacher will see your revisions, but Quill won&apos;t assign you a grade.</p>
-          </section>
-        </section>
       </section>
       <section className="responses-exemplars-container">
         <section className="review-response-header-section">
-          <p className="sub-header-text">Reflect on your work</p>
-          <p className="sub-header-subtext">There are many different ways to use evidence in your writing. Consider how your responses compare to the strong examples. In what ways are they similar or different? Notice the ideas, the phrasing, and the tone of voice, and think about how you could use because, but, and so in your future writing.</p>
+          <p className="sub-header-text">Here are some examples of strong responses</p>
+          <p className="sub-header-subtext">There are many different ways to use evidence in your writing.</p>
         </section>
         {renderResponseAndExamplarsSection(BECAUSE)}
         {renderResponseAndExamplarsSection(BUT)}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
@@ -4,7 +4,7 @@ import useFocus from '../../../Shared/hooks/useFocus'
 
 const applaudingSrc = `${process.env.CDN_URL}/images/pages/evidence/applauding.svg`
 
-const ThankYouSlide = () => {
+const ThankYouSlide = ({ resultPageUrl, }) => {
   const [containerRef, setContainerFocus] = useFocus()
 
   React.useEffect(() => {
@@ -12,7 +12,7 @@ const ThankYouSlide = () => {
   }, [])
 
   const backToDashboard = () => {
-    window.location.href = process.env.DEFAULT_URL
+    window.location.href = resultPageUrl
   }
 
   return (
@@ -25,7 +25,7 @@ const ThankYouSlide = () => {
         <img alt="Two hands clapping together" src={applaudingSrc} />
       </div>
       <div className="button-section">
-        <a className='quill-button-archived large secondary outlined focus-on-dark' href={process.env.DEFAULT_URL} onClick={backToDashboard}>Back to my dashboard</a>
+        <a className='quill-button-archived large secondary outlined focus-on-dark' href={resultPageUrl} onClick={backToDashboard}>Back to my dashboard</a>
       </div>
     </div>
   )

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
@@ -10,8 +10,10 @@ const ActivityFollowUp = ({ activity, dispatch, responses, sessionID, saveActivi
 
   function onClickNext() { setShowActivitySurvey(true) }
 
+  const resultPageUrl = `${process.env.DEFAULT_URL}/activity_sessions/${sessionID}`
+
   if (submittedActivitySurvey && !previewMode) {
-    return <ThankYouSlide />
+    return <ThankYouSlide resultPageUrl={resultPageUrl} />
   }
 
   if (showActivitySurvey && !previewMode) {
@@ -19,6 +21,7 @@ const ActivityFollowUp = ({ activity, dispatch, responses, sessionID, saveActivi
       <ActivitySurvey
         activity={activity}
         dispatch={dispatch}
+        resultPageUrl={resultPageUrl}
         saveActivitySurveyResponse={saveActivitySurveyResponse}
         sessionID={sessionID}
         setSubmittedActivitySurvey={setSubmittedActivitySurvey}

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/feedback.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/feedback.tsx
@@ -121,8 +121,6 @@ const Feedback: React.SFC = ({ lastSubmittedResponse, prompt, submittedResponses
           <p>Heads up</p>
         </div>
         <p>Our feedback bot is not perfect, and it sometimes might be wrong. If you think the feedback is inaccurate, please click on the “Report a problem” button above.</p>
-        <br />
-        <p>This activity is just for practice, and it is not graded. By practicing and revising on Quill, you are strengthening your writing skills.</p>
       </div>
     )
   }

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/explanationSlide.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/explanationSlide.scss
@@ -7,8 +7,18 @@
   min-height: calc(100vh - 60px);
   .subtext {
     font-size: 20px;
-    font-weight: 600;
-    color: #e1f3f1
+    color: $quill-white;
+    max-width: 580px;
+    font-weight: 700;
+    line-height: 30px;
+  }
+  .good-to-know {
+    color: #B4E2DB;
+    text-align: center;
+    font-size: 20px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 26px;
   }
   #information-section {
     flex: 1;
@@ -19,9 +29,11 @@
     #header-container {
       display: flex;
       align-items: center;
+      margin: 4px 0px 32px;
       h1 {
         font-size: 40px;
-        font-weight: bold;
+        font-weight: 700;
+        line-height: 48px;
         color: $quill-white;
       }
       #beta-tag {
@@ -36,10 +48,8 @@
     }
     #image {
       max-width: 580px;
-      height: 312px;
-    }
-    .subtext {
-      max-width: 496px;
+      height: 270px;
+      margin-bottom: 24px;
     }
     #instructions-container {
       display: flex;
@@ -85,7 +95,7 @@
       margin-left: 96px;
     }
 
-    #step-indictator-container {
+    #step-indicator-container {
       display: flex;
       align-items: center;
       visibility: visible;
@@ -100,6 +110,16 @@
           border-color: $quill-white;
         }
       }
+    }
+  }
+  &.step-3 {
+    .subtext {
+      max-width: 456px;
+    }
+  }
+  &.step-4 {
+    .subtext {
+      max-width: 440px;
     }
   }
 }

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/postActivitySlide.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/postActivitySlide.scss
@@ -12,6 +12,7 @@
     background-color: $quill-white;
     width: 100%;
     max-width: 1200px;
+    margin-top: 24px;
     margin-bottom: 40px;
     border-radius: 6px;
     border: solid 1px $quill-grey-5;
@@ -90,27 +91,6 @@
 
     #celebration-vector {
       margin: 16px 0px 16px 0px;
-    }
-
-    #reminder-badge-section {
-      display: flex;
-      align-items: center;
-      width: 440px;
-      background-color: #e1f3f1;
-      margin: 32px 0px 26px 0px;
-      border-radius: 8px;
-      box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 8px 10px 1px rgba(0, 0, 0, 0.14);
-      transform: rotate(-2deg);
-      #reminder-text-section {
-        padding: 16px 0px;
-        .sub-header-subtext {
-          max-width: 352px;
-        }
-      }
-      #grade-badge {
-        margin: 0px 16px 0px 16px;
-        width: 48px;
-      }
     }
   }
 
@@ -216,16 +196,6 @@
 
 @media (max-width: 600px) {
   .post-activity-slide-container {
-    #information-section {
-      #reminder-badge-section {
-        width: 280px;
-        padding: 0px 16px;
-        margin: 0px 38px 24px 38px;
-        #grade-badge {
-          display: none;
-        }
-      }
-    }
     .responses-exemplars-container {
       .response-exemplars-section {
         .response-section, .exemplars-section {

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/explanationSlide.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/explanationSlide.test.tsx.snap
@@ -1,42 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ExplanationSlide Component should match snapshot 1`] = `
-<div
-  className="explanation-slide-container"
->
-  <section
-    className="no-focus-outline"
-    id="information-section"
-    tabIndex={-1}
+<DocumentFragment>
+  <div
+    class="explanation-slide-container step-1"
   >
-    <p
-      aria-hidden={true}
-      className="subtext"
-    >
-      Good to know
-    </p>
     <section
-      id="header-container"
+      class="no-focus-outline"
+      id="information-section"
+      tabindex="-1"
     >
-      <h1>
-        Test Header
-      </h1>
+      <p
+        aria-hidden="true"
+        class="good-to-know"
+      >
+        Good to know
+      </p>
+      <section
+        id="header-container"
+      >
+        <h1>
+          Test Header
+        </h1>
+      </section>
+      <img
+        alt="test alt text"
+        id="image"
+        src="undefined/test.com"
+      />
+      <p
+        class="subtext"
+      >
+        test subtext
+      </p>
     </section>
-    <img
-      alt="test alt text"
-      id="image"
-      src="undefined/test.com"
-    />
-    <p
-      className="subtext"
+    <section
+      id="button-container"
     >
-      test subtext
-    </p>
-  </section>
-  <Footer
-    buttonText="Next"
-    onHandleClick={[MockFunction]}
-    step={1}
-  />
-</div>
+      <span />
+      <button
+        class="quill-button-archived large secondary outlined focus-on-dark"
+        type="submit"
+      >
+        Next
+      </button>
+      <div
+        id="step-indicator-container"
+      >
+        <div
+          class="step-indicator active"
+        />
+        <div
+          class="step-indicator "
+        />
+        <div
+          class="step-indicator "
+        />
+        <div
+          class="step-indicator "
+        />
+      </div>
+    </section>
+  </div>
+</DocumentFragment>
 `;

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/postActivitySlide.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/__snapshots__/postActivitySlide.test.tsx.snap
@@ -24,29 +24,6 @@ exports[`PostActivitySlide Component should match snapshot 1`] = `
     >
       Be proud of the work you did today, and celebrate your success! This practice will help you grow as a reader and a writer. The more you practice, the stronger your critical thinking, reading, and writing skills will be.
     </p>
-    <section
-      id="reminder-badge-section"
-    >
-      <img
-        alt="An illustration of an A+ that is crossed out"
-        id="grade-badge"
-        src="undefined/images/evidence/paper-check.svg"
-      />
-      <section
-        id="reminder-text-section"
-      >
-        <p
-          className="sub-header-text"
-        >
-          Reminder about grades
-        </p>
-        <p
-          className="sub-header-subtext"
-        >
-          This is practice, so your teacher will see your revisions, but Quill won't assign you a grade.
-        </p>
-      </section>
-    </section>
   </section>
   <section
     className="responses-exemplars-container"
@@ -57,12 +34,12 @@ exports[`PostActivitySlide Component should match snapshot 1`] = `
       <p
         className="sub-header-text"
       >
-        Reflect on your work
+        Here are some examples of strong responses
       </p>
       <p
         className="sub-header-subtext"
       >
-        There are many different ways to use evidence in your writing. Consider how your responses compare to the strong examples. In what ways are they similar or different? Notice the ideas, the phrasing, and the tone of voice, and think about how you could use because, but, and so in your future writing.
+        There are many different ways to use evidence in your writing.
       </p>
     </section>
     <section

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/explanationSlide.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/activitySlides/explanationSlide.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from 'enzyme';
 import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ExplanationSlide } from '../../../components/activitySlides/explanationSlide';
 
@@ -10,17 +11,17 @@ describe('ExplanationSlide Component', () => {
       header: 'Test Header',
       imageData: {
         imageAlt: 'test alt text',
-        imageUrl: 'test.com'
+        imageUrl: 'test.com',
       },
       isBeta: false,
       step: 1,
-      subtext: 'test subtext'
+      subtext: 'test subtext',
     },
-    onHandleClick: jest.fn()
-  }
-  let component = shallow(<ExplanationSlide {...mockProps} />);
+    onHandleClick: jest.fn(),
+  };
 
   it('should match snapshot', () => {
-    expect(component).toMatchSnapshot();
+    const { asFragment } = render(<ExplanationSlide {...mockProps} />);
+    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/container.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/container.test.tsx.snap
@@ -171,7 +171,7 @@ But how can democracies have representative governments unless all or most of th
             Next
           </button>
           <div
-            id="step-indictator-container"
+            id="step-indicator-container"
           >
             <div
               className="step-indicator active"

--- a/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Evidence/tests/components/studentView/__snapshots__/promptStep.test.tsx.snap
@@ -920,10 +920,6 @@ exports[`PromptStep component active state when the max attempts have been reach
               <p>
                 Our feedback bot is not perfect, and it sometimes might be wrong. If you think the feedback is inaccurate, please click on the “Report a problem” button above.
               </p>
-              <br />
-              <p>
-                This activity is just for practice, and it is not graded. By practicing and revising on Quill, you are strengthening your writing skills.
-              </p>
             </div>
           </div>
         </Feedback>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/activities/results_page/results_icon.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/activities/results_page/results_icon.jsx
@@ -30,10 +30,13 @@ const ResultsIcon = ({ activityType, percentage, }) => {
       case 'diagnostic':
         img = 'tool-diagnostic-white.svg'
         break;
+      case 'evidence':
+        img = 'tool-evidence-white.svg'
+        break;
       default:
         img = 'tool-proofreader-white.svg'
     }
-    return `${process.env.CDN_URL}/images/tools/${img}`
+    return `${process.env.CDN_URL}/images/icons/s/${img}`
   }
 
   return (

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/activity_icon_with_tooltip.jsx
@@ -107,11 +107,17 @@ export default class ActivityIconWithTooltip extends React.Component {
     this.setState({ showToolTip: false, });
   };
 
+  indicateCompletedButUngradedActivity = () => {
+    const { data, context, } = this.props
+
+    return context === 'scorebook' && (nonRelevantActivityClassificationIds.includes(Number(data.activity_classification_id)) || data.percentage === null)
+  }
+
   altText() {
     const { data, context, } = this.props
 
     if (data.completed_attempts > 0 || data.percentage) {
-      if (context === 'scorebook' && nonRelevantActivityClassificationIds.includes(Number(data.activity_classification_id))) {
+      if (this.indicateCompletedButUngradedActivity()) {
         return `${activityIconDescription(data.activity_classification_id)} in dark blue to indicate that the student completed the activity.`
       } else {
         return `${activityIconDescription(data.activity_classification_id)} in ${gradeColor(parseFloat(data.percentage))} to indicate that the student ${skillDescription(parseFloat(data.percentage))}`
@@ -129,7 +135,7 @@ export default class ActivityIconWithTooltip extends React.Component {
 
   imageName() {
     if (this.props.data.completed_attempts > 0 || this.props.data.percentage) {
-      if (this.props.context === 'scorebook' && nonRelevantActivityClassificationIds.includes(Number(this.props.data.activity_classification_id))) {
+      if (this.indicateCompletedButUngradedActivity()) {
         return  `${activityFromClassificationId(this.getActClassId())}-dark-blue`
       } else {
         return `${activityFromClassificationId(this.getActClassId())}-${gradeColor(parseFloat(this.props.data.percentage))}`

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/__snapshots__/scorebook_tooltip.test.tsx.snap
@@ -1,6 +1,528 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ScorebookTooltip component in student view should render if showExactScores is false  1`] = `
+exports[`ScorebookTooltip component color explanation in student view should display green explanation for evidence activity with high score 1`] = `
+<DocumentFragment>
+  <div
+    class="scorebook-tooltip"
+  >
+    <i
+      class="fas fa-caret-up"
+    />
+    <i
+      class="fas fa-caret-up border-color"
+    />
+    <div
+      class="title"
+    >
+      Capitalizing Holidays, People, & Places - Mixed Topics
+    </div>
+    <div
+      class="main"
+    >
+      <div
+        class="activity-overview"
+      >
+        <div
+          class="activity-details"
+        >
+          <div
+            class="activity-detail"
+          >
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Objectives
+              </p>
+              <p
+                class="description"
+              >
+                Students rewrite sentences, adding the correct capitalization.
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Published
+              </p>
+              <p
+                class="description"
+              >
+                December 10, 2021 at 9:00 am
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Due
+              </p>
+              <p
+                class="description"
+              >
+                N/A
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            1st score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                8 of 10 Target Skills Correct (80%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 12, 2021 at 9:00 am / 2 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            2nd score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                6 of 10 Target Skills Correct (60%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 17, 2021 at 9:00 am / 4 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            Scoring
+          </p>
+          <p
+            class="description"
+          >
+            The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color.
+          </p>
+        </div>
+      </div>
+      <p
+        class="no-data-message"
+      >
+        This activity has not been completed.
+      </p>
+      <div
+        class="activity-tooltip-details-section "
+      >
+        <p
+          class="header"
+        >
+          Why Green?
+        </p>
+        <div
+          class="description-block"
+        >
+          <p>
+            Within five revisions, you wrote a strong response for all prompts.
+          </p>
+        </div>
+      </div>
+      <p
+        class="tooltip-message"
+      >
+        *Your dashboard shows the highest score of all your attempts
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ScorebookTooltip component color explanation in student view should display red explanation for evidence activity with low score 1`] = `
+<DocumentFragment>
+  <div
+    class="scorebook-tooltip"
+  >
+    <i
+      class="fas fa-caret-up"
+    />
+    <i
+      class="fas fa-caret-up border-color"
+    />
+    <div
+      class="title"
+    >
+      Capitalizing Holidays, People, & Places - Mixed Topics
+    </div>
+    <div
+      class="main"
+    >
+      <div
+        class="activity-overview"
+      >
+        <div
+          class="activity-details"
+        >
+          <div
+            class="activity-detail"
+          >
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Objectives
+              </p>
+              <p
+                class="description"
+              >
+                Students rewrite sentences, adding the correct capitalization.
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Published
+              </p>
+              <p
+                class="description"
+              >
+                December 10, 2021 at 9:00 am
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Due
+              </p>
+              <p
+                class="description"
+              >
+                N/A
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            1st score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                8 of 10 Target Skills Correct (80%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 12, 2021 at 9:00 am / 2 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            2nd score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                6 of 10 Target Skills Correct (60%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 17, 2021 at 9:00 am / 4 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            Scoring
+          </p>
+          <p
+            class="description"
+          >
+            The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color.
+          </p>
+        </div>
+      </div>
+      <p
+        class="no-data-message"
+      >
+        This activity has not been completed.
+      </p>
+      <div
+        class="activity-tooltip-details-section "
+      >
+        <p
+          class="header"
+        >
+          Why Red?
+        </p>
+        <div
+          class="description-block"
+        >
+          <p>
+            You did not write a strong response within five revisions on any of the prompts.
+          </p>
+        </div>
+      </div>
+      <p
+        class="tooltip-message"
+      >
+        *Your dashboard shows the highest score of all your attempts
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ScorebookTooltip component color explanation in student view should display yellow explanation for evidence activity with medium score 1`] = `
+<DocumentFragment>
+  <div
+    class="scorebook-tooltip"
+  >
+    <i
+      class="fas fa-caret-up"
+    />
+    <i
+      class="fas fa-caret-up border-color"
+    />
+    <div
+      class="title"
+    >
+      Capitalizing Holidays, People, & Places - Mixed Topics
+    </div>
+    <div
+      class="main"
+    >
+      <div
+        class="activity-overview"
+      >
+        <div
+          class="activity-details"
+        >
+          <div
+            class="activity-detail"
+          >
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Objectives
+              </p>
+              <p
+                class="description"
+              >
+                Students rewrite sentences, adding the correct capitalization.
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Published
+              </p>
+              <p
+                class="description"
+              >
+                December 10, 2021 at 9:00 am
+              </p>
+            </div>
+            <div
+              class="activity-tooltip-details-section no-border-top"
+            >
+              <p
+                class="header"
+              >
+                Due
+              </p>
+              <p
+                class="description"
+              >
+                N/A
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            1st score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                8 of 10 Target Skills Correct (80%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 12, 2021 at 9:00 am / 2 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            2nd score
+          </p>
+          <div
+            class="description-block"
+          >
+            <p
+              class="description"
+            >
+              <span
+                class="percentage"
+              >
+                6 of 10 Target Skills Correct (60%)
+              </span>
+               
+            </p>
+            <p
+              class="description"
+            >
+              December 17, 2021 at 9:00 am / 4 mins
+            </p>
+          </div>
+        </div>
+        <div
+          class="activity-tooltip-details-section "
+        >
+          <p
+            class="header"
+          >
+            Scoring
+          </p>
+          <p
+            class="description"
+          >
+            The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color.
+          </p>
+        </div>
+      </div>
+      <p
+        class="no-data-message"
+      >
+        This activity has not been completed.
+      </p>
+      <div
+        class="activity-tooltip-details-section "
+      >
+        <p
+          class="header"
+        >
+          Why Yellow?
+        </p>
+        <div
+          class="description-block"
+        >
+          <p>
+            Within five revisions, you wrote a strong response for some, but not all, prompts.
+          </p>
+        </div>
+      </div>
+      <p
+        class="tooltip-message"
+      >
+        *Your dashboard shows the highest score of all your attempts
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ScorebookTooltip component in student view should render if showExactScores is false 1`] = `
 <DocumentFragment>
   <div
     class="scorebook-tooltip"
@@ -121,7 +643,7 @@ exports[`ScorebookTooltip component in student view should render if showExactSc
 </DocumentFragment>
 `;
 
-exports[`ScorebookTooltip component in student view should render if the percentage is above the proficient threshold  1`] = `
+exports[`ScorebookTooltip component in student view should render if the percentage is above the proficient threshold 1`] = `
 <DocumentFragment>
   <div
     class="scorebook-tooltip"
@@ -302,7 +824,7 @@ exports[`ScorebookTooltip component in student view should render if the percent
 </DocumentFragment>
 `;
 
-exports[`ScorebookTooltip component in student view should render if the percentage is below the nearly proficient threshold  1`] = `
+exports[`ScorebookTooltip component in student view should render if the percentage is below the nearly proficient threshold 1`] = `
 <DocumentFragment>
   <div
     class="scorebook-tooltip"
@@ -428,7 +950,7 @@ exports[`ScorebookTooltip component in student view should render if the percent
 </DocumentFragment>
 `;
 
-exports[`ScorebookTooltip component in student view should render if the percentage is between the nearly proficient threshold and the proficient threshold  1`] = `
+exports[`ScorebookTooltip component in student view should render if the percentage is between the nearly proficient threshold and the proficient threshold 1`] = `
 <DocumentFragment>
   <div
     class="scorebook-tooltip"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/scorebook_tooltip.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/__tests__/scorebook_tooltip.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
 import * as React from 'react';
-
+import { render, screen } from '@testing-library/react';
 import ScorebookTooltip from '../scorebook_tooltip';
+import { EVIDENCE, } from '../../../../../Shared'
 
 describe('ScorebookTooltip component', () => {
   const mockData = {
@@ -39,78 +39,119 @@ describe('ScorebookTooltip component', () => {
   it('should render', () => {
     const { asFragment } = render(<ScorebookTooltip data={mockData} />);
     expect(asFragment()).toMatchSnapshot();
-  })
+  });
 
   describe('scoring', () => {
     it('should display the scoring information for each session', () => {
       const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
-      expect(screen.getByText(/1st score/i)).toBeInTheDocument()
-      expect(screen.getByText(/December 12, 2021/i)).toBeInTheDocument()
-      expect(screen.getByText(/2 min/i)).toBeInTheDocument()
-      expect(screen.getByText(/2nd score/i)).toBeInTheDocument()
-      expect(screen.getByText(/December 17, 2021/i)).toBeInTheDocument()
-      expect(screen.getByText(/4 min/i)).toBeInTheDocument()
-    })
+      expect(screen.getByText(/1st score/i)).toBeInTheDocument();
+      expect(screen.getByText(/December 12, 2021/i)).toBeInTheDocument();
+      expect(screen.getByText(/2 min/i)).toBeInTheDocument();
+      expect(screen.getByText(/2nd score/i)).toBeInTheDocument();
+      expect(screen.getByText(/December 17, 2021/i)).toBeInTheDocument();
+      expect(screen.getByText(/4 min/i)).toBeInTheDocument();
+    });
+
     it('should display a scoring explanation if it is a Diagnostic activity', () => {
-      mockData.activity_classification_id = 4
+      mockData.activity_classification_id = 4;
       const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
-      expect(screen.getByText(/The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color./i)).toBeInTheDocument()
-    })
-  })
+      expect(screen.getByText(/The Quill Diagnostic is meant to diagnose skills to practice. Students are not provided a color-coded score or percentage score. Teachers see only a percentage score without a color./i)).toBeInTheDocument();
+    });
+  });
 
   describe('key target and skills explanation', () => {
     it('student missed the lesson', () => {
-      mockData.marked_complete = true
-      mockData.completed_attempts = 0
+      mockData.marked_complete = true;
+      mockData.completed_attempts = 0;
       const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
-      expect(screen.getByText(/This student has missed this lesson. To make up this material, you can assign this lesson again to the students who missed it./i)).toBeInTheDocument()
-    })
+      expect(screen.getByText(/This student has missed this lesson. To make up this material, you can assign this lesson again to the students who missed it./i)).toBeInTheDocument();
+    });
+
     it('activity has not been published', () => {
-      mockData.scheduled = true
-      mockData.completed_attempts = null
+      mockData.scheduled = true;
+      mockData.completed_attempts = null;
       const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
-      expect(screen.getByText(/This scheduled activity has not been published./i)).toBeInTheDocument()
-    })
+      expect(screen.getByText(/This scheduled activity has not been published./i)).toBeInTheDocument();
+    });
+
     it('activity is locked', () => {
-      mockData.scheduled = false
-      mockData.locked = true
+      mockData.scheduled = false;
+      mockData.locked = true;
       const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
-      expect(screen.getByText(/This activity is set for staggered release and has not been unlocked by this student./i)).toBeInTheDocument()
-    })
+      expect(screen.getByText(/This activity is set for staggered release and has not been unlocked by this student./i)).toBeInTheDocument();
+    });
+
     it('activity has not been completed', () => {
-      mockData.locked = false
-      mockData.completed_attempts = null
+      mockData.locked = false;
+      mockData.completed_attempts = null;
       const { asFragment } = render(<ScorebookTooltip data={mockData} />);
       expect(asFragment()).toMatchSnapshot();
-      expect(screen.getByText(/This activity has not been completed./i)).toBeInTheDocument()
-    })
-  })
+      expect(screen.getByText(/This activity has not been completed./i)).toBeInTheDocument();
+    });
+  });
 
   describe('in student view', () => {
-    it('should render if the percentage is below the nearly proficient threshold ', () => {
+    it('should render if the percentage is below the nearly proficient threshold', () => {
       const { asFragment } = render(<ScorebookTooltip data={{ ...mockData, percentage: 0 }} inStudentView={true} showExactScores={true} />);
       expect(asFragment()).toMatchSnapshot();
-    })
+    });
 
-    it('should render if the percentage is between the nearly proficient threshold and the proficient threshold ', () => {
+    it('should render if the percentage is between the nearly proficient threshold and the proficient threshold', () => {
       const { asFragment } = render(<ScorebookTooltip data={{ ...mockData, percentage: 0.5 }} inStudentView={true} showExactScores={true} />);
       expect(asFragment()).toMatchSnapshot();
-    })
+    });
 
-    it('should render if the percentage is above the proficient threshold ', () => {
+    it('should render if the percentage is above the proficient threshold', () => {
       const { asFragment } = render(<ScorebookTooltip data={{ ...mockData, percentage: 0.9 }} inStudentView={true} showExactScores={true} />);
       expect(asFragment()).toMatchSnapshot();
-    })
+    });
 
-    it('should render if showExactScores is false ', () => {
+    it('should render if showExactScores is false', () => {
       const { asFragment } = render(<ScorebookTooltip data={{ ...mockData, percentage: 0.9 }} inStudentView={true} showExactScores={false} />);
       expect(asFragment()).toMatchSnapshot();
-    })
+    });
+  });
 
-  })
+  describe('color explanation in student view', () => {
+    it('should display red explanation for evidence activity with low score', () => {
+      const evidenceData = {
+        ...mockData,
+        activity_classification_key: EVIDENCE,
+        percentage: 0.1
+      };
+      const { asFragment } = render(<ScorebookTooltip data={evidenceData} inStudentView={true} showExactScores={true} />);
+      expect(asFragment()).toMatchSnapshot();
+      expect(screen.getByText(/Why Red\?/i)).toBeInTheDocument();
+      expect(screen.getByText(/You did not write a strong response within five revisions on any of the prompts./i)).toBeInTheDocument();
+    });
+
+    it('should display yellow explanation for evidence activity with medium score', () => {
+      const evidenceData = {
+        ...mockData,
+        activity_classification_key: EVIDENCE,
+        percentage: 0.5
+      };
+      const { asFragment } = render(<ScorebookTooltip data={evidenceData} inStudentView={true} showExactScores={true} />);
+      expect(asFragment()).toMatchSnapshot();
+      expect(screen.getByText(/Why Yellow\?/i)).toBeInTheDocument();
+      expect(screen.getByText(/Within five revisions, you wrote a strong response for some, but not all, prompts./i)).toBeInTheDocument();
+    });
+
+    it('should display green explanation for evidence activity with high score', () => {
+      const evidenceData = {
+        ...mockData,
+        activity_classification_key: EVIDENCE,
+        percentage: 0.9
+      };
+      const { asFragment } = render(<ScorebookTooltip data={evidenceData} inStudentView={true} showExactScores={true} />);
+      expect(asFragment()).toMatchSnapshot();
+      expect(screen.getByText(/Why Green\?/i)).toBeInTheDocument();
+      expect(screen.getByText(/Within five revisions, you wrote a strong response for all prompts./i)).toBeInTheDocument();
+    });
+  });
 });

--- a/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/general_components/tooltip/scorebook_tooltip.tsx
@@ -155,7 +155,8 @@ export const ScorebookTooltip = ({ data, inStudentView, showExactScores, }: Scor
   };
 
   function totalScoreOrNot() {
-    const { percentage, sessions } = data
+    const { percentage, sessions, } = data
+
     const hasScoreData = percentage && sessions && sessions.length > 0
     if (hasScoreData && (!inStudentView || showExactScores)) {
       return displayScores()
@@ -173,7 +174,7 @@ export const ScorebookTooltip = ({ data, inStudentView, showExactScores, }: Scor
   }
 
   function colorExplanation() {
-    const { percentage, } = data
+    const { percentage, activity_classification_key, } = data
 
     if (percentage === null) { return }
 
@@ -181,39 +182,54 @@ export const ScorebookTooltip = ({ data, inStudentView, showExactScores, }: Scor
 
     const scoreForComparison = percentage * 100
 
+    const isEvidenceActivity = activity_classification_key === EVIDENCE
+
     let header = 'Why Red?'
-    let descriptionLineOne = 'Rarely Demonstrated Skill'
-    let descriptionLineTwo = `${cutOff.nearlyProficient - 1} - 0% of prompts exhibit skill`
+    let descriptionElements = isEvidenceActivity ?
+      <p>You did not write a strong response within five revisions on any of the prompts.</p> :
+      (
+        <React.Fragment>
+          <p className="description">Rarely Demonstrated Skill</p>
+          <p className="description">{cutOff.nearlyProficient - 1} - 0% of prompts exhibit skill</p>
+        </React.Fragment>
+      )
 
     if (scoreForComparison >= cutOff.proficient) {
       header = 'Why Green?'
-      descriptionLineOne = 'Frequently Demonstrated Skill'
-      descriptionLineTwo = `100 - ${cutOff.proficient}% of prompts exhibit skill`
+      descriptionElements = isEvidenceActivity ?
+        <p>Within five revisions, you wrote a strong response for all prompts.</p> :
+        (
+          <React.Fragment>
+            <p className="description">Frequently Demonstrated Skill</p>
+            <p className="description">100 - {cutOff.proficient}% of prompts exhibit skill</p>
+          </React.Fragment>
+        )
     } else if (scoreForComparison >= cutOff.nearlyProficient) {
       header = 'Why Yellow?'
-      descriptionLineOne = 'Sometimes Demonstrated Skill'
-      descriptionLineTwo = `${cutOff.proficient - 1} - ${cutOff.nearlyProficient}% of prompts exhibit skill`
+      descriptionElements = isEvidenceActivity ?
+        <p>Within five revisions, you wrote a strong response for some, but not all, prompts.</p> :
+        (
+          <React.Fragment>
+            <p className="description">Sometimes Demonstrated Skill</p>
+            <p className="description">{cutOff.proficient - 1} - {cutOff.nearlyProficient}% of prompts exhibit skill</p>
+          </React.Fragment>
+        )
     }
 
     const descriptionElement = (
       <div className="description-block">
-        <p className="description">{descriptionLineOne}</p>
-        <p className="description">{descriptionLineTwo}</p>
+        {descriptionElements}
       </div>
     )
     return <ActivityDetailsSection description={descriptionElement} header={header} />
   }
 
   function tooltipMessage() {
-    const isEvidenceActivity = activity_classification_key === EVIDENCE
-
-    if (inStudentView && !showExactScores && !isEvidenceActivity) { return }
+    if (inStudentView && !showExactScores) { return }
 
     let text = 'Clicking on the activity icon loads the report'
 
-    if (inStudentView && isEvidenceActivity) {
-      text = 'This type of activity is not graded.'
-    } else if (inStudentView && showExactScores) {
+    if (inStudentView && showExactScores) {
       text = '*Your dashboard shows the highest score of all your attempts'
     }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/overview_boxes.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/overview_boxes.jsx
@@ -27,7 +27,7 @@ export default class OverviewBoxes extends React.Component {
     if (group === 'red-score-color') {
       range = '0 - 31%';
       proficiency = 'Rarely demonstrated skill'
-    } else if (group === 'yellow-score-color') {
+    } else if (group === 'orange-score-color') {
       range = '32 - 82%';
       proficiency = 'Sometimes demonstrated skill'
     } else {
@@ -46,7 +46,7 @@ export default class OverviewBoxes extends React.Component {
     // need to list the keys in an array instead of just using a for in
     // loop as we want them in this particular order
     let groupCounts = this.countBoxType();
-    let groups = ['red', 'yellow', 'green', 'blue'];
+    let groups = ['red', 'orange', 'green', 'blue'];
     return groups.map(group => {
       group += '-score-color'
       return this.boxCreator(group, groupCounts[group])

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview.jsx
@@ -56,7 +56,7 @@ export default class extends React.Component {
     let average;
     reportData.forEach((row) => {
       count += 1;
-      if (shouldCountForScoring(row.activity_classification_id)) {
+      if (shouldCountForScoring(row.activity_classification_id) && row.percentage !== null) {
         cumulativeScore += parseFloat(row.percentage);
         countForAverage += 1;
       }
@@ -126,7 +126,7 @@ export default class extends React.Component {
       const csvReportData = [];
       reportData.forEach((row) => {
         const newRow = _.omit(row, keysToOmit);
-        if (shouldCountForScoring(row.activity_classification_id) && row.percentage) {
+        if (shouldCountForScoring(row.activity_classification_id) && row.percentage !== null) {
           newRow.percentage = `${(newRow.percentage * 100).toString()}%`;
         } else if ((row.activity_classification_id === 6 && row.is_a_completed_lesson) || row.percentage) {
           newRow.percentage = 'Completed';

--- a/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/student_scores.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/scorebook/student_scores.jsx
@@ -9,7 +9,7 @@ export const StudentScores = ({ data, premium_state }) => {
     let totalScore = 0;
     let relevantScores = 0;
     data.scores.forEach(score => {
-      if(shouldCountForScoring(score.activity_classification_id) && score.percentage) {
+      if(shouldCountForScoring(score.activity_classification_id) && score.percentage !== null) {
         relevantScores += 1;
         totalScore += parseFloat(score.percentage);
       }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/student_profile/student_profile_unit.jsx
@@ -244,7 +244,7 @@ export default class StudentProfileUnit extends React.Component {
       </span>
     ) : null
 
-    if (EVIDENCE_ACTIVITY_CLASSIFICATION_KEY === activity_classification_key) {
+    if (EVIDENCE_ACTIVITY_CLASSIFICATION_KEY === activity_classification_key && max_percentage === null) {
       return (<div className="score"><div className="completed">{attemptCountIndicator}</div><span>Completed</span></div>)
     }
 
@@ -327,7 +327,8 @@ export default class StudentProfileUnit extends React.Component {
       const sharedTooltipWrapperProps = {
         activity: act,
         exactScoresData,
-        showExactScores: activity_classification_key === EVIDENCE_ACTIVITY_CLASSIFICATION_KEY ? false : showExactScores }
+        showExactScores,
+      }
 
       if (![DIAGNOSTIC_ACTIVITY_CLASSIFICATION_KEY, LESSONS_ACTIVITY_CLASSIFICATION_KEY].includes(activity_classification_key) && !exactScoresDataPending) {
         return {

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/ResultsPage.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/ResultsPage.jsx
@@ -6,6 +6,7 @@ import ScrollToTop from '../components/shared/scroll_to_top'
 import { proficiencyCutoffsAsPercentage } from '../../../modules/proficiency_cutoffs';
 
 const diagnosticActivityType = 'diagnostic'
+const evidenceActivityType = 'evidence'
 
 const ResultsPage = ({
   activityName,
@@ -24,6 +25,7 @@ const ResultsPage = ({
   activitySessionId,
 }) => {
   const isDiagnostic = activityType === diagnosticActivityType
+  const isEvidence = activityType === evidenceActivityType
 
   const cutOff = proficiencyCutoffsAsPercentage();
 
@@ -44,6 +46,30 @@ const ResultsPage = ({
       <div className="results-section">
         <h2>{sectionHeader}</h2>
         {targetSkillElements}
+      </div>
+    )
+  }
+
+  const renderEvidenceScoringGuide = () => {
+    if (!isEvidence) { return }
+
+    return (
+      <div className="evidence-scoring-guide">
+        <h2>How Reading for Evidence Scoring Works</h2>
+        <div className="score-keys">
+          <div className="score-key">
+            <div className="green" />
+            <p>Earn a green score by reaching a strong response on all three prompts</p>
+          </div>
+          <div className="score-key">
+            <div className="yellow" />
+            <p>Reaching a strong response on one or two prompts will result in a yellow score</p>
+          </div>
+          <div className="score-key">
+            <div className="red" />
+            <p>Not reaching a strong response on any prompt will result in a red score</p>
+          </div>
+        </div>
       </div>
     )
   }
@@ -142,6 +168,7 @@ const ResultsPage = ({
           </div>
           {bottomSection()}
         </div>
+        {renderEvidenceScoringGuide()}
         {renderKeepPracticingSection()}
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/ResultsPage.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/ResultsPage.test.jsx
@@ -52,6 +52,11 @@ describe('ResultsPage container', () => {
     expect(asFragment()).toMatchSnapshot()
   });
 
+  test('renders correctly when activityType is evidence', () => {
+    const { asFragment, } = render(<ResultsPage {...sharedProps} activityType='evidence' />);
+    expect(asFragment()).toMatchSnapshot()
+  });
+
   test('renders the Keep practicing section when the percentage is below the proficiency threshold', () => {
     render(<ResultsPage {...sharedProps} percentage={0.5} />);
     expect(screen.getByRole('heading', { name: /keep practicing!/i })).toBeInTheDocument()

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/ResultsPage.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/ResultsPage.test.jsx.snap
@@ -45,7 +45,7 @@ exports[`ResultsPage container renders correctly when activityType is diagnostic
             >
               <img
                 alt="activity-type"
-                src="undefined/images/tools/tool-diagnostic-white.svg"
+                src="undefined/images/icons/s/tool-diagnostic-white.svg"
               />
             </div>
           </div>
@@ -60,6 +60,169 @@ exports[`ResultsPage container renders correctly when activityType is diagnostic
             class="diagnostic-explanation"
           >
             You won’t see a score for diagnostics, but we’ll use the results to create a personalized learning plan just for you. Your teacher will review the results and assign practice activities to help you grow as a writer.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ResultsPage container renders correctly when activityType is evidence 1`] = `
+<DocumentFragment>
+  <div
+    class="results-page-container white-background-accommodate-footer"
+  >
+    <div
+      id="results-page"
+    >
+      <div
+        class="top-section"
+      >
+        <h1>
+          Activity Complete!
+        </h1>
+        <div
+          class="header-buttons"
+        >
+          <a
+            class="quill-button-archived primary contained large focus-on-light"
+            href="/"
+          >
+            Return to dashboard
+          </a>
+          <a
+            class="quill-button-archived secondary outlined large focus-on-light"
+            href="/activity_sessions/1/student_activity_report"
+          >
+            View results
+          </a>
+          <a
+            class="quill-button-archived secondary outlined large focus-on-light"
+            href="/activity_sessions/classroom_units/undefined/activities/undefined"
+          >
+            Replay activity
+          </a>
+        </div>
+      </div>
+      <div
+        class="activity-results"
+      >
+        <div
+          class="activity-name-and-overall-score"
+        >
+          <div>
+            <h2>
+              Cool Activity
+            </h2>
+          </div>
+          <div
+            class="results-icon-container"
+          >
+            <div
+              class="icon"
+              style="background-color: rgb(235, 153, 17);"
+            >
+              <img
+                alt="activity-type"
+                src="undefined/images/icons/s/tool-evidence-white.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="results-section"
+        >
+          <h2>
+            Proficient
+          </h2>
+          <div
+            class="target-skill"
+          >
+            <span>
+              Capitalizing Geographic Names
+            </span>
+            <span />
+          </div>
+        </div>
+        <div
+          class="results-section"
+        >
+          <h2>
+            Keep Practicing
+          </h2>
+          <div
+            class="target-skill"
+          >
+            <span>
+              Capitalizing Dates
+            </span>
+            <span />
+          </div>
+          <div
+            class="target-skill"
+          >
+            <span>
+              Capitalizing Holidays
+            </span>
+            <span />
+          </div>
+        </div>
+      </div>
+      <div
+        class="evidence-scoring-guide"
+      >
+        <h2>
+          How Reading for Evidence Scoring Works
+        </h2>
+        <div
+          class="score-keys"
+        >
+          <div
+            class="score-key"
+          >
+            <div
+              class="green"
+            />
+            <p>
+              Earn a green score by reaching a strong response on all three prompts
+            </p>
+          </div>
+          <div
+            class="score-key"
+          >
+            <div
+              class="yellow"
+            />
+            <p>
+              Reaching a strong response on one or two prompts will result in a yellow score
+            </p>
+          </div>
+          <div
+            class="score-key"
+          >
+            <div
+              class="red"
+            />
+            <p>
+              Not reaching a strong response on any prompt will result in a red score
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="keep-practicing-section"
+      >
+        <img
+          alt=""
+          src="undefined/images/pages/student_results_page/pencil_illustration.svg"
+        />
+        <div>
+          <h2>
+            Keep practicing!
+          </h2>
+          <p>
+            Becoming a strong writer takes practice. You kept going and finished the activity! By practicing, you will continue to improve and build your skills.
           </p>
         </div>
       </div>
@@ -125,7 +288,7 @@ exports[`ResultsPage container renders correctly when showExactScore is false 1`
             >
               <img
                 alt="activity-type"
-                src="undefined/images/tools/tool-proofreader-white.svg"
+                src="undefined/images/icons/s/tool-proofreader-white.svg"
               />
             </div>
           </div>
@@ -250,7 +413,7 @@ exports[`ResultsPage container renders correctly when showExactScore is true 1`]
             >
               <img
                 alt="activity-type"
-                src="undefined/images/tools/tool-proofreader-white.svg"
+                src="undefined/images/icons/s/tool-proofreader-white.svg"
               />
             </div>
           </div>

--- a/services/QuillLMS/client/app/modules/activity_classifications.js
+++ b/services/QuillLMS/client/app/modules/activity_classifications.js
@@ -7,7 +7,6 @@
 export const nonRelevantActivityClassificationIds = [
   4, // Diagnostic
   6, // Lessons
-  9, // Evidence
 ];
 
 export default function shouldCountForScoring(activityClassificationID) {

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -578,4 +578,60 @@ describe PublicProgressReports, type: :model do
       expect(result.length).to eq(1)
     end
   end
+
+  describe '#formatted_score_obj' do
+    let(:activity_session) { create(:activity_session, percentage: 0.75, timespent: 1000) }
+    let(:student) { create(:student) }
+    let(:average_score_on_quill) { 85 }
+    let(:concept_result) { { key_target_skill_concept: { correct: true } } }
+    let(:formatted_concept_results) { [concept_result] }
+    let(:average_score) { 90 }
+
+    before do
+      allow_any_instance_of(FakeReports).to receive(:format_concept_results).and_return(formatted_concept_results)
+      allow_any_instance_of(FakeReports).to receive(:get_average_score).and_return(average_score)
+    end
+
+    shared_examples 'returns rounded percentage' do |classification_key|
+      it "returns the rounded percentage as a whole number for #{classification_key} activities" do
+        classification = create(classification_key)
+
+        score_obj = FakeReports.new.formatted_score_obj(activity_session, classification, student, average_score_on_quill)
+
+        expect(score_obj[:score]).to eq((activity_session.percentage * 100).round)
+      end
+    end
+
+    context 'when calculating score' do
+      it 'returns the result of the average score function for lesson activities' do
+        classification = create(:lesson_classification)
+
+        score_obj = FakeReports.new.formatted_score_obj(activity_session, classification, student, average_score_on_quill)
+
+        expect(score_obj[:score]).to eq(average_score)
+      end
+
+      it 'returns the result of the average score function for diagnostic activities' do
+        classification = create(:diagnostic)
+
+        score_obj = FakeReports.new.formatted_score_obj(activity_session, classification, student, average_score_on_quill)
+
+        expect(score_obj[:score]).to eq(average_score)
+      end
+
+      it 'returns nil for evidence activities with a nil score' do
+        classification = create(:evidence)
+        activity_session.percentage = nil
+
+        score_obj = FakeReports.new.formatted_score_obj(activity_session, classification, student, average_score_on_quill)
+
+        expect(score_obj[:score]).to be_nil
+      end
+
+      include_examples 'returns rounded percentage', :evidence
+      include_examples 'returns rounded percentage', :connect
+      include_examples 'returns rounded percentage', :grammar
+      include_examples 'returns rounded percentage', :proofreader
+    end
+  end
 end


### PR DESCRIPTION
## WHAT
Update copy and remove images and elements that say Evidence is not scored.

## WHY
This will no longer be accurate.

## HOW
Just HTML/CSS changes.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Parts-3-and-4-Evidence-UI-Changes-9f90a3e73c164fe4a6196b540c759893?pvs=4

### What have you done to QA this feature?
Tested locally

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
