### PR TITLE
Adgr subscription segment reporting

### DIFF
--- a/services/QuillLMS/app/models/admin_report_filter_selection.rb
+++ b/services/QuillLMS/app/models/admin_report_filter_selection.rb
@@ -29,10 +29,6 @@ class AdminReportFilterSelection < ApplicationRecord
     USAGE_SNAPSHOT_REPORT_PDF = 'usage_snapshot_report_pdf'
   ]
 
-  SEGMENT_MAPPING = {
-    USAGE_SNAPSHOT_REPORT_PDF => 'Usage Snapshot'
-  }
-
   belongs_to :user
 
   has_many :pdf_subscriptions, dependent: :destroy
@@ -40,15 +36,6 @@ class AdminReportFilterSelection < ApplicationRecord
   validates :filter_selections, presence: true
   validates :report, inclusion: { in: REPORTS }
   validates :user_id, presence: true
-
-  def self.segment_admin_report_subscriptions
-    joins(:pdf_subscriptions)
-      .pluck(:report)
-      .uniq
-      .map { |report| SEGMENT_MAPPING[report] }
-      .compact
-      .join(', ')
-  end
 
   def aggregation = filter_selections.dig('group_by_value', 'value')
 

--- a/services/QuillLMS/app/models/segment_integration/user.rb
+++ b/services/QuillLMS/app/models/segment_integration/user.rb
@@ -42,7 +42,7 @@ module SegmentIntegration
         admin_linkedin_or_url: admin_verification_url,
         number_of_schools_administered: schools_admins.any? ? schools_admins.count : nil,
         number_of_districts_administered: district_admins.any? ? district_admins.count : nil,
-        admin_report_subscriptions: premium_admin? ? admin_report_filter_selections.segment_admin_report_subscriptions : nil
+        admin_report_subscriptions: premium_admin? ? segment_admin_report_subscriptions.join(', ') : nil
       }.reject { |_, v| v.nil? }
     end
     # rubocop:enable Metrics/CyclomaticComplexity

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -927,8 +927,6 @@ class User < ApplicationRecord
   end
 
   def segment_admin_report_subscriptions
-    puts admin_report_filter_selections.joins(:pdf_subscriptions).pluck(:report)
-    puts email_subscriptions.pluck(:subscription_type)
     (admin_report_filter_selections
       .joins(:pdf_subscriptions)
       .pluck(:report) +

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -934,6 +934,8 @@ class User < ApplicationRecord
     ).map do |subscription|
       SEGMENT_MAPPING[subscription]
     end
+      .uniq
+      .compact
   end
 
   private def validate_flags

--- a/services/QuillLMS/app/models/user.rb
+++ b/services/QuillLMS/app/models/user.rb
@@ -122,6 +122,11 @@ class User < ApplicationRecord
 
   LEADING_CAPITALIZE_NAMES = %w(van dit)
 
+  SEGMENT_MAPPING = {
+    AdminReportFilterSelection::USAGE_SNAPSHOT_REPORT_PDF => 'Usage Snapshot',
+    EmailSubscription::ADMIN_DIAGNOSTIC_REPORT => 'Admin Diagnostic Growth Report'
+  }
+
   attr_accessor :newsletter,
     :require_password_confirmation_when_password_present,
     :skip_capitalize_names_callback,
@@ -205,6 +210,7 @@ class User < ApplicationRecord
 
   has_many :admin_report_filter_selections, dependent: :destroy
   has_many :pdf_subscriptions, through: :admin_report_filter_selections
+  has_many :email_subscriptions, dependent: :destroy
 
   accepts_nested_attributes_for :auth_credential, :canvas_accounts
 
@@ -918,6 +924,18 @@ class User < ApplicationRecord
 
   def google_student_set_password?
     student? && google_id.present? && password_digest_changed? && password_digest_was.nil?
+  end
+
+  def segment_admin_report_subscriptions
+    puts admin_report_filter_selections.joins(:pdf_subscriptions).pluck(:report)
+    puts email_subscriptions.pluck(:subscription_type)
+    (admin_report_filter_selections
+      .joins(:pdf_subscriptions)
+      .pluck(:report) +
+    email_subscriptions.pluck(:subscription_type)
+    ).map do |subscription|
+      SEGMENT_MAPPING[subscription]
+    end
   end
 
   private def validate_flags

--- a/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
+++ b/services/QuillLMS/spec/models/admin_report_filter_selection_spec.rb
@@ -28,35 +28,6 @@ RSpec.describe AdminReportFilterSelection, type: :model, redis: true do
   it { should validate_presence_of(:filter_selections) }
   it { should validate_inclusion_of(:report).in_array(described_class::REPORTS) }
 
-  describe '.segment_admin_report_subscriptions' do
-    subject { described_class.segment_admin_report_subscriptions }
-
-    it { is_expected.to eq '' }
-
-    context 'when there are pdf subscriptions' do
-      let(:usage_snapshot) { described_class::SEGMENT_MAPPING[described_class::USAGE_SNAPSHOT_REPORT_PDF] }
-
-      before { create(:pdf_subscription) }
-
-      it { is_expected.to eq usage_snapshot }
-
-      context 'when the report type is not mapped to segment' do
-        let(:report) { described_class::USAGE_SNAPSHOT_REPORT }
-        let(:admin_report_filter_selection) { create(:admin_report_filter_selection, report:) }
-
-        before { create(:pdf_subscription, admin_report_filter_selection:) }
-
-        it { is_expected.to eq usage_snapshot }
-      end
-
-      context 'when there are multiple pdf subscriptions' do
-        before { create(:pdf_subscription) }
-
-        it { is_expected.to eq usage_snapshot }
-      end
-    end
-  end
-
   describe 'instance methods' do
     let(:admin_report_filter_selection) { build(:admin_report_filter_selection, :with_default_filters) }
     let(:filter_selections) { admin_report_filter_selection.filter_selections }

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2456,8 +2456,8 @@ RSpec.describe User, type: :model do
     it { is_expected.to eq [] }
 
     context 'has a PDF subscription' do
-      let(:usage_snapshot) { described_class::SEGMENT_MAPPING[pdf_subscription.report] }
-      let(:admin_report_filter_selection) { create(:admin_report_filter_selection) }
+      let(:usage_snapshot) { described_class::SEGMENT_MAPPING[pdf_subscription.admin_report_filter_selection.report] }
+      let(:admin_report_filter_selection) { create(:admin_report_filter_selection, user:,  report: AdminReportFilterSelection::USAGE_SNAPSHOT_REPORT_PDF) }
       let!(:pdf_subscription) { create(:pdf_subscription, admin_report_filter_selection:) }
 
       it { is_expected.to match_array [usage_snapshot] }

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2455,12 +2455,25 @@ RSpec.describe User, type: :model do
 
     it { is_expected.to eq [] }
 
+    context 'has a PDF subscription of a type not in SEGMENT_MAPPING' do
+      let(:admin_report_filter_selection) { create(:admin_report_filter_selection, user:,  report: AdminReportFilterSelection::USAGE_SNAPSHOT_REPORT) }
+      let!(:pdf_subscription) { create(:pdf_subscription, admin_report_filter_selection:) }
+
+      it { is_expected.to eq [] }
+    end
+
     context 'has a PDF subscription' do
       let(:usage_snapshot) { described_class::SEGMENT_MAPPING[pdf_subscription.admin_report_filter_selection.report] }
       let(:admin_report_filter_selection) { create(:admin_report_filter_selection, user:,  report: AdminReportFilterSelection::USAGE_SNAPSHOT_REPORT_PDF) }
       let!(:pdf_subscription) { create(:pdf_subscription, admin_report_filter_selection:) }
 
       it { is_expected.to match_array [usage_snapshot] }
+
+      context 'has a second PDF subscription of the same type' do
+        before { create(:pdf_subscription, admin_report_filter_selection:) }
+
+        it { is_expected.to match_array [usage_snapshot] }
+      end
 
       context 'also has an EmailSubscription' do
         let(:admin_diagnostic_report) { described_class::SEGMENT_MAPPING[email_subscription.subscription_type] }

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -2456,7 +2456,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to eq [] }
 
     context 'has a PDF subscription of a type not in SEGMENT_MAPPING' do
-      let(:admin_report_filter_selection) { create(:admin_report_filter_selection, user:,  report: AdminReportFilterSelection::USAGE_SNAPSHOT_REPORT) }
+      let(:admin_report_filter_selection) { create(:admin_report_filter_selection, user:, report: AdminReportFilterSelection::USAGE_SNAPSHOT_REPORT) }
       let!(:pdf_subscription) { create(:pdf_subscription, admin_report_filter_selection:) }
 
       it { is_expected.to eq [] }
@@ -2464,7 +2464,7 @@ RSpec.describe User, type: :model do
 
     context 'has a PDF subscription' do
       let(:usage_snapshot) { described_class::SEGMENT_MAPPING[pdf_subscription.admin_report_filter_selection.report] }
-      let(:admin_report_filter_selection) { create(:admin_report_filter_selection, user:,  report: AdminReportFilterSelection::USAGE_SNAPSHOT_REPORT_PDF) }
+      let(:admin_report_filter_selection) { create(:admin_report_filter_selection, user:, report: AdminReportFilterSelection::USAGE_SNAPSHOT_REPORT_PDF) }
       let!(:pdf_subscription) { create(:pdf_subscription, admin_report_filter_selection:) }
 
       it { is_expected.to match_array [usage_snapshot] }
@@ -2479,15 +2479,15 @@ RSpec.describe User, type: :model do
         let(:admin_diagnostic_report) { described_class::SEGMENT_MAPPING[email_subscription.subscription_type] }
         let!(:email_subscription) { create(:email_subscription, user:, subscription_type: EmailSubscription::ADMIN_DIAGNOSTIC_REPORT) }
 
-        it { is_expected. to match_array [usage_snapshot, admin_diagnostic_report] }
+        it { is_expected.to match_array [usage_snapshot, admin_diagnostic_report] }
       end
     end
 
     context 'EmailSubscription with no PDF subscription' do
-        let(:admin_diagnostic_report) { described_class::SEGMENT_MAPPING[email_subscription.subscription_type] }
-        let!(:email_subscription) { create(:email_subscription, user:, subscription_type: EmailSubscription::ADMIN_DIAGNOSTIC_REPORT) }
+      let(:admin_diagnostic_report) { described_class::SEGMENT_MAPPING[email_subscription.subscription_type] }
+      let!(:email_subscription) { create(:email_subscription, user:, subscription_type: EmailSubscription::ADMIN_DIAGNOSTIC_REPORT) }
 
-        it { is_expected. to match_array [admin_diagnostic_report] }
+      it { is_expected.to match_array [admin_diagnostic_report] }
     end
   end
 end

--- a/services/QuillLMS/spec/models/user_spec.rb
+++ b/services/QuillLMS/spec/models/user_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe User, type: :model do
   it { should have_one(:auth_credential).dependent(:destroy) }
   it { should have_many(:admin_report_filter_selections).dependent(:destroy) }
   it { should have_many(:pdf_subscriptions).through(:admin_report_filter_selections) }
-  it { should have_mahy(:email_subscriptions).dependent(:destroy) }
+  it { should have_many(:email_subscriptions).dependent(:destroy) }
 
   it { should delegate_method(:name).to(:school).with_prefix(:school) }
   it { should delegate_method(:mail_city).to(:school).with_prefix(:school) }


### PR DESCRIPTION
## WHAT
Add the new subscription type to data we report to Segment (and through Segment, to Vitally)
## WHY
We want to use our analytics platforms to understand how many admins are taking advantage of this new feature
## HOW
With subscriptions now flowing through two different models (`PdfSubscription` and `EmailSubscription`), move the logic that assembles lists of subscription types into the `User` model directly, but use similar logic when assembling the data.

### Notion Card Links
https://www.notion.so/quill/1-Frontend-Email-subscription-for-Admin-Diagnostic-Growth-Report-d7d578f870104d77ac9e95b23ee0ab51?pvs=4#083d2b6d22934209aa2cd01d8d404347

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | No, tested in a local environment using the staging database
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
