### PR TITLE
evidence activity results page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/student_results.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/student_results.scss
@@ -40,7 +40,7 @@
     border-radius: 8px;
   }
 
-  .activity-name-and-overall-score, .results-section, .keep-practicing-section {
+  .activity-name-and-overall-score, .results-section, .keep-practicing-section, .evidence-scoring-guide {
     padding: 32px;
     &:not(:last-of-type) {
       border-bottom: 1px solid $quill-grey-15;
@@ -94,16 +94,67 @@
     }
   }
 
-  .keep-practicing-section {
+  .keep-practicing-section, .evidence-scoring-guide {
     border-radius: 8px;
     border: 1px solid $quill-grey-15;
     margin-top: 32px;
+  }
+
+  .keep-practicing-section {
     display: flex;
     align-items: center;
     gap: 16px;
     p {
       font-size: 16px;
       margin-top: 8px;
+    }
+  }
+
+  .evidence-scoring-guide {
+    h2 {
+      text-align: center;
+      margin-bottom: 24px;
+    }
+    .score-keys {
+      display: flex;
+      gap: 32px;
+    }
+    .score-key {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+      flex: 1;
+      p {
+        font-size: 13px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: normal;
+      }
+      div {
+        min-width: 44px;
+        height: 44px;
+        border-radius: 8px;
+      }
+      .green {
+        background-color: $quill-green-vibrant-50;
+      }
+      .yellow {
+        background-color: $quill-gold;
+      }
+      .red {
+        background-color: $quill-red;
+      }
+    }
+  }
+
+  @media (max-width: 850px) {
+    padding: 64px 32px;
+    .score-keys, .header-buttons {
+      flex-direction: column;
+      align-items: center;
+    }
+    .score-key p {
+      max-width: 300px;
     }
   }
 }

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/activitySurvey.tsx
@@ -81,7 +81,7 @@ const MultipleChoiceOption = ({ text, selectedMultipleChoiceOptions, setSelected
   )
 }
 
-const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyResponse, setSubmittedActivitySurvey, }) => {
+const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyResponse, setSubmittedActivitySurvey, resultPageUrl, }) => {
   const [selectedEmoji, setSelectedEmoji] = React.useState(null)
   const [selectedMultipleChoiceOptions, setSelectedMultipleChoiceOptions] = React.useState([])
 
@@ -128,7 +128,7 @@ const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyRespo
     saveActivitySurveyResponse({ sessionID, activitySurveyResponse, callback, })
   }
 
-  function handleLinkClick() { window.location.href = process.env.DEFAULT_URL }
+  function handleLinkClick() { window.location.href = resultPageUrl }
 
   let activitySurveyHeader
   let multipleChoiceSection
@@ -168,7 +168,7 @@ const ActivitySurvey = ({ activity, dispatch, sessionID, saveActivitySurveyRespo
         {multipleChoiceSection}
       </div>
       <div className="button-section">
-        <a className="focus-on-dark" href={process.env.DEFAULT_URL} onClick={handleLinkClick}>Skip</a>
+        <a className="focus-on-dark" href={resultPageUrl} onClick={handleLinkClick}>Skip</a>
         <button className={sendButtonClassName} onClick={handleSend} type="button">Send</button>
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/activitySlides/thankYouSlide.tsx
@@ -4,7 +4,7 @@ import useFocus from '../../../Shared/hooks/useFocus'
 
 const applaudingSrc = `${process.env.CDN_URL}/images/pages/evidence/applauding.svg`
 
-const ThankYouSlide = () => {
+const ThankYouSlide = ({ resultPageUrl, }) => {
   const [containerRef, setContainerFocus] = useFocus()
 
   React.useEffect(() => {
@@ -12,7 +12,7 @@ const ThankYouSlide = () => {
   }, [])
 
   const backToDashboard = () => {
-    window.location.href = process.env.DEFAULT_URL
+    window.location.href = resultPageUrl
   }
 
   return (
@@ -25,7 +25,7 @@ const ThankYouSlide = () => {
         <img alt="Two hands clapping together" src={applaudingSrc} />
       </div>
       <div className="button-section">
-        <a className='quill-button-archived large secondary outlined focus-on-dark' href={process.env.DEFAULT_URL} onClick={backToDashboard}>Back to my dashboard</a>
+        <a className='quill-button-archived large secondary outlined focus-on-dark' href={resultPageUrl} onClick={backToDashboard}>Back to my dashboard</a>
       </div>
     </div>
   )

--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/activityFollowUp.tsx
@@ -10,8 +10,10 @@ const ActivityFollowUp = ({ activity, dispatch, responses, sessionID, saveActivi
 
   function onClickNext() { setShowActivitySurvey(true) }
 
+  const resultPageUrl = `${process.env.DEFAULT_URL}/activity_sessions/${sessionID}`
+
   if (submittedActivitySurvey && !previewMode) {
-    return <ThankYouSlide />
+    return <ThankYouSlide resultPageUrl={resultPageUrl} />
   }
 
   if (showActivitySurvey && !previewMode) {
@@ -19,6 +21,7 @@ const ActivityFollowUp = ({ activity, dispatch, responses, sessionID, saveActivi
       <ActivitySurvey
         activity={activity}
         dispatch={dispatch}
+        resultPageUrl={resultPageUrl}
         saveActivitySurveyResponse={saveActivitySurveyResponse}
         sessionID={sessionID}
         setSubmittedActivitySurvey={setSubmittedActivitySurvey}

--- a/services/QuillLMS/client/app/bundles/Teacher/components/activities/results_page/results_icon.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/activities/results_page/results_icon.jsx
@@ -30,10 +30,13 @@ const ResultsIcon = ({ activityType, percentage, }) => {
       case 'diagnostic':
         img = 'tool-diagnostic-white.svg'
         break;
+      case 'evidence':
+        img = 'tool-evidence-white.svg'
+        break;
       default:
         img = 'tool-proofreader-white.svg'
     }
-    return `${process.env.CDN_URL}/images/tools/${img}`
+    return `${process.env.CDN_URL}/images/icons/s/${img}`
   }
 
   return (

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/ResultsPage.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/ResultsPage.jsx
@@ -6,6 +6,7 @@ import ScrollToTop from '../components/shared/scroll_to_top'
 import { proficiencyCutoffsAsPercentage } from '../../../modules/proficiency_cutoffs';
 
 const diagnosticActivityType = 'diagnostic'
+const evidenceActivityType = 'evidence'
 
 const ResultsPage = ({
   activityName,
@@ -24,6 +25,7 @@ const ResultsPage = ({
   activitySessionId,
 }) => {
   const isDiagnostic = activityType === diagnosticActivityType
+  const isEvidence = activityType === evidenceActivityType
 
   const cutOff = proficiencyCutoffsAsPercentage();
 
@@ -44,6 +46,30 @@ const ResultsPage = ({
       <div className="results-section">
         <h2>{sectionHeader}</h2>
         {targetSkillElements}
+      </div>
+    )
+  }
+
+  const renderEvidenceScoringGuide = () => {
+    if (!isEvidence) { return }
+
+    return (
+      <div className="evidence-scoring-guide">
+        <h2>How Reading for Evidence Scoring Works</h2>
+        <div className="score-keys">
+          <div className="score-key">
+            <div className="green" />
+            <p>Earn a green score by reaching a strong response on all three prompts</p>
+          </div>
+          <div className="score-key">
+            <div className="yellow" />
+            <p>Reaching a strong response on one or two prompts will result in a yellow score</p>
+          </div>
+          <div className="score-key">
+            <div className="red" />
+            <p>Not reaching a strong response on any prompt will result in a red score</p>
+          </div>
+        </div>
       </div>
     )
   }
@@ -142,6 +168,7 @@ const ResultsPage = ({
           </div>
           {bottomSection()}
         </div>
+        {renderEvidenceScoringGuide()}
         {renderKeepPracticingSection()}
       </div>
     </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/ResultsPage.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/ResultsPage.test.jsx
@@ -52,6 +52,11 @@ describe('ResultsPage container', () => {
     expect(asFragment()).toMatchSnapshot()
   });
 
+  test('renders correctly when activityType is evidence', () => {
+    const { asFragment, } = render(<ResultsPage {...sharedProps} activityType='evidence' />);
+    expect(asFragment()).toMatchSnapshot()
+  });
+
   test('renders the Keep practicing section when the percentage is below the proficiency threshold', () => {
     render(<ResultsPage {...sharedProps} percentage={0.5} />);
     expect(screen.getByRole('heading', { name: /keep practicing!/i })).toBeInTheDocument()

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/ResultsPage.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/ResultsPage.test.jsx.snap
@@ -45,7 +45,7 @@ exports[`ResultsPage container renders correctly when activityType is diagnostic
             >
               <img
                 alt="activity-type"
-                src="undefined/images/tools/tool-diagnostic-white.svg"
+                src="undefined/images/icons/s/tool-diagnostic-white.svg"
               />
             </div>
           </div>
@@ -125,7 +125,7 @@ exports[`ResultsPage container renders correctly when showExactScore is false 1`
             >
               <img
                 alt="activity-type"
-                src="undefined/images/tools/tool-proofreader-white.svg"
+                src="undefined/images/icons/s/tool-proofreader-white.svg"
               />
             </div>
           </div>
@@ -250,7 +250,7 @@ exports[`ResultsPage container renders correctly when showExactScore is true 1`]
             >
               <img
                 alt="activity-type"
-                src="undefined/images/tools/tool-proofreader-white.svg"
+                src="undefined/images/icons/s/tool-proofreader-white.svg"
               />
             </div>
           </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/ResultsPage.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/__tests__/__snapshots__/ResultsPage.test.jsx.snap
@@ -68,6 +68,169 @@ exports[`ResultsPage container renders correctly when activityType is diagnostic
 </DocumentFragment>
 `;
 
+exports[`ResultsPage container renders correctly when activityType is evidence 1`] = `
+<DocumentFragment>
+  <div
+    class="results-page-container white-background-accommodate-footer"
+  >
+    <div
+      id="results-page"
+    >
+      <div
+        class="top-section"
+      >
+        <h1>
+          Activity Complete!
+        </h1>
+        <div
+          class="header-buttons"
+        >
+          <a
+            class="quill-button-archived primary contained large focus-on-light"
+            href="/"
+          >
+            Return to dashboard
+          </a>
+          <a
+            class="quill-button-archived secondary outlined large focus-on-light"
+            href="/activity_sessions/1/student_activity_report"
+          >
+            View results
+          </a>
+          <a
+            class="quill-button-archived secondary outlined large focus-on-light"
+            href="/activity_sessions/classroom_units/undefined/activities/undefined"
+          >
+            Replay activity
+          </a>
+        </div>
+      </div>
+      <div
+        class="activity-results"
+      >
+        <div
+          class="activity-name-and-overall-score"
+        >
+          <div>
+            <h2>
+              Cool Activity
+            </h2>
+          </div>
+          <div
+            class="results-icon-container"
+          >
+            <div
+              class="icon"
+              style="background-color: rgb(235, 153, 17);"
+            >
+              <img
+                alt="activity-type"
+                src="undefined/images/icons/s/tool-evidence-white.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="results-section"
+        >
+          <h2>
+            Proficient
+          </h2>
+          <div
+            class="target-skill"
+          >
+            <span>
+              Capitalizing Geographic Names
+            </span>
+            <span />
+          </div>
+        </div>
+        <div
+          class="results-section"
+        >
+          <h2>
+            Keep Practicing
+          </h2>
+          <div
+            class="target-skill"
+          >
+            <span>
+              Capitalizing Dates
+            </span>
+            <span />
+          </div>
+          <div
+            class="target-skill"
+          >
+            <span>
+              Capitalizing Holidays
+            </span>
+            <span />
+          </div>
+        </div>
+      </div>
+      <div
+        class="evidence-scoring-guide"
+      >
+        <h2>
+          How Reading for Evidence Scoring Works
+        </h2>
+        <div
+          class="score-keys"
+        >
+          <div
+            class="score-key"
+          >
+            <div
+              class="green"
+            />
+            <p>
+              Earn a green score by reaching a strong response on all three prompts
+            </p>
+          </div>
+          <div
+            class="score-key"
+          >
+            <div
+              class="yellow"
+            />
+            <p>
+              Reaching a strong response on one or two prompts will result in a yellow score
+            </p>
+          </div>
+          <div
+            class="score-key"
+          >
+            <div
+              class="red"
+            />
+            <p>
+              Not reaching a strong response on any prompt will result in a red score
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="keep-practicing-section"
+      >
+        <img
+          alt=""
+          src="undefined/images/pages/student_results_page/pencil_illustration.svg"
+        />
+        <div>
+          <h2>
+            Keep practicing!
+          </h2>
+          <p>
+            Becoming a strong writer takes practice. You kept going and finished the activity! By practicing, you will continue to improve and build your skills.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`ResultsPage container renders correctly when showExactScore is false 1`] = `
 <DocumentFragment>
   <div


### PR DESCRIPTION
## WHAT
Update Evidence so that we link back to the student results page, not just the dashboard, and update the student results page to show a special scoring box when it's an Evidence activity.

## WHY
This is part of the Evidence scoring project.

## HOW
Just start passing the correct link around the frontend, and CSS/React updates to the results page.

### Screenshots
<img width="1259" alt="Screenshot 2024-08-12 at 11 46 06 AM" src="https://github.com/user-attachments/assets/3f2072c5-9594-4f25-bf18-646599460005">

### Notion Card Links
https://www.notion.so/quill/Evidence-Scoring-Part-5-Turn-on-the-Activity-Results-Page-for-Students-d3b7675f7a61494289901afb47e75a54?pvs=4

### What have you done to QA this feature?
Tested locally, will have Jamie and Jack QA on staging when the project is code-complete.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - will deploy everything to staging at once
Self-Review: Have you done an initial self-review of the code below on Github? | YES
