### PR TITLE
fix bug where evidence feedback for so was getting skipped in preview

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Evidence/components/studentView/container.tsx
@@ -468,7 +468,6 @@ export const StudentViewContainer = ({ dispatch, session, isTurk, location, acti
       defaultHandleFinishActivity()
     } else if(previewMode && session.previewSessionStep === SO) {
       dispatch(setPreviewSessionStep('complete'))
-      setCompleteButtonClicked(true)
     }
   }
 


### PR DESCRIPTION
## WHAT
Fix bug where final feedback for "so" question was getting skipped in Preview Mode.

## WHY
We want users to see the final round of feedback, rather than going straight to the completion screen.

## HOW
Remove the call to `setCompleteButtonClicked`, which was causing the issue and didn't seem necessary here (when I removed it and QAed, things worked as expected). 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Evidence-so-feedback-getting-skipped-8a70299aa54943838f69efd1521e187d

### What have you done to QA this feature?
Tested this flow locally.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
 