### PR TITLE
Update styling of "New scoring standards" banner

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/post_checklist.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/teacher_dashboard/post_checklist.scss
@@ -46,6 +46,9 @@
       background-color: #f5f5f5;
     }
   }
+  .banner-container {
+    margin-bottom: 32px;
+  }
   main {
     max-width: 834px;
     section {

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
@@ -25,8 +25,8 @@ export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHead
   return(
     <div className={`banner-container ${bannerStyle}`}>
       <div className="left-side-container">
-        {tagText && <div className="upper-section">
-          <p className="tag">{tagText}</p>
+        {(tagText || secondaryHeaderText) && <div className="upper-section">
+          {tagText && <p className="tag">{tagText}</p>}
           {secondaryHeaderText && <p className="secondary-header">{secondaryHeaderText}</p>}
         </div>}
         <p className="primary-header">{primaryHeaderText}</p>

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
@@ -47,7 +47,7 @@ export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHead
         </div>
       </div>
       <img alt={icon.alt} className="banner-icon" src={icon.src} />
-      {closeIconSrc && <button aria-label={closeAria} className="interactive-wrapper close-button" onClick={handleCloseCard} type="button"><img alt="" src={closeIconSrc} /></button>}
+      {handleCloseCard && <button aria-label={closeAria} className="interactive-wrapper close-button" onClick={handleCloseCard} type="button"><img alt="" src={closeIconSrc} /></button>}
     </div>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
@@ -7,6 +7,9 @@ interface BannerProps {
   primaryHeaderText: string,
   secondaryHeaderText?: string,
   bodyText: string,
+  closeAria?: string,
+  closeIconSrc?: string,
+  handleCloseCard?: () => void,
   icon: {
     alt: string,
     src: string
@@ -21,7 +24,7 @@ interface BannerProps {
   bannerStyle: string
 }
 
-export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHeaderText, bodyText, icon, buttons, bannerStyle }: BannerProps) => {
+export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHeaderText, bodyText, icon, buttons, bannerStyle, closeIconSrc, handleCloseCard, closeAria }: BannerProps) => {
   return(
     <div className={`banner-container ${bannerStyle}`}>
       <div className="left-side-container">
@@ -44,6 +47,7 @@ export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHead
         </div>
       </div>
       <img alt={icon.alt} className="banner-icon" src={icon.src} />
+      {closeIconSrc && <button aria-label={closeAria} className="interactive-wrapper close-button" onClick={handleCloseCard} type="button"><img alt="" src={closeIconSrc} /></button>}
     </div>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
@@ -3,6 +3,7 @@
   justify-content: space-between;
   padding: 20px;
   border-radius: 8px;
+  position: relative;
   .left-side-container {
     .upper-section {
       display: flex;
@@ -15,7 +16,7 @@
         border-radius: 5px;
         font-size: 9px;
         font-weight: 700;
-        margin: 0;
+        margin: 0px 8px 0px 0px;
         text-transform: uppercase;
       }
       .secondary-header {
@@ -71,6 +72,12 @@
         }
       }
     }
+  }
+  .close-button {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    filter: brightness(0%);
   }
   &.green {
     background-color: $quill-green-1;

--- a/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
@@ -23,7 +23,7 @@
         text-transform: uppercase;
         font-size: 12px;
         font-weight: 700;
-        margin: 0px 0px 0px 8px;
+        margin: 0px 0px 0px 0px;
       }
     }
     .primary-header {

--- a/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
@@ -98,6 +98,21 @@
       color: $quill-gold-dark;
     }
   }
+  &.gold-secondary {
+    background-color: $quill-gold-1;
+    border: 1px solid $quill-gold-dark-10;
+    .tag, .quill-button-archived {
+      background-color: $quill-white !important;
+      color: $quill-gold-dark !important;
+      border: 1px solid $quill-gold-dark-10;
+    }
+    .quill-button-archived:hover {
+      background-color: $quill-white !important;
+    }
+    .secondary-header {
+      color: $quill-gold-dark;
+    }
+  }
   &.viridian {
     background-color: $quill-viridian-1;
     border: 1px solid $quill-viridian-20;

--- a/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
@@ -77,7 +77,6 @@
     position: absolute;
     top: 20px;
     right: 20px;
-    filter: brightness(0%);
   }
   &.green {
     background-color: $quill-green-1;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/promotional_card.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/promotional_card.test.tsx.snap
@@ -260,52 +260,87 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
   <ScoringUpdatesCard
     handleCloseCard={[Function]}
   >
-    <section
-      className="scoring-updates-card"
+    <PostNavigationBanner
+      bannerStyle="gold-secondary"
+      bodyText=""
+      buttons={
+        Array [
+          Object {
+            "href": "undefined/teacher-center/quill-scoring-updates-2023",
+            "standardButtonStyle": true,
+            "target": "_blank",
+            "text": "Learn more about Quill's updates to activity scores",
+          },
+        ]
+      }
+      closeAria="Hide card until next school year"
+      closeIconSrc="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+      handleCloseCard={[Function]}
+      icon={
+        Object {
+          "alt": "Image of a school building",
+          "src": "https://assets.quill.org/images/banners/large-school-campus-gold.svg",
+        }
+      }
+      primaryHeaderText="Educators, we have updated our approach to scoring activities"
+      secondaryHeaderText="Update for the 2023-2024 school year"
     >
-      <div>
-        <div
-          className="badge-section"
-        >
-          <span
-            className="title-tag"
-          >
-            UPDATE FOR THE 2023-2024 SCHOOL YEAR
-          </span>
-        </div>
-        <h2>
-          Educators, we have updated our approach to scoring activities
-        </h2>
-        <div
-          className="link-section"
-        >
-          <a
-            href="undefined/teacher-center/quill-scoring-updates-2023"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <span>
-              Learn more about Quill's updates to activity scores
-            </span>
-            <img
-              alt="Arrow pointing right icon"
-              src="undefined/images/icons/icons-arrow-back.svg"
-            />
-          </a>
-        </div>
-      </div>
-      <button
-        aria-label="Hide card until next school year"
-        className="interactive-wrapper close-button"
-        onClick={[Function]}
-        type="button"
+      <div
+        className="banner-container gold-secondary"
       >
+        <div
+          className="left-side-container"
+        >
+          <div
+            className="upper-section"
+          >
+            <p
+              className="secondary-header"
+            >
+              Update for the 2023-2024 school year
+            </p>
+          </div>
+          <p
+            className="primary-header"
+          >
+            Educators, we have updated our approach to scoring activities
+          </p>
+          <p
+            className="body"
+          />
+          <div
+            className="buttons-container"
+          >
+            <a
+              className="quill-button-archived fun primary contained focus-on-light"
+              href="undefined/teacher-center/quill-scoring-updates-2023"
+              key="button-0"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about Quill's updates to activity scores
+               
+            </a>
+          </div>
+        </div>
         <img
-          alt=""
-          src="undefined/images/pages/dashboard/bulk_archive_close_icon.svg"
+          alt="Image of a school building"
+          className="banner-icon"
+          src="https://assets.quill.org/images/banners/large-school-campus-gold.svg"
         />
-      </button>
-    </section>
+        <button
+          aria-label="Hide card until next school year"
+          className="interactive-wrapper close-button"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            src="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+          />
+        </button>
+      </div>
+    </PostNavigationBanner>
   </ScoringUpdatesCard>
 </PromotionalCard>
 `;
@@ -402,52 +437,87 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
   <ScoringUpdatesCard
     handleCloseCard={[Function]}
   >
-    <section
-      className="scoring-updates-card"
+    <PostNavigationBanner
+      bannerStyle="gold-secondary"
+      bodyText=""
+      buttons={
+        Array [
+          Object {
+            "href": "undefined/teacher-center/quill-scoring-updates-2023",
+            "standardButtonStyle": true,
+            "target": "_blank",
+            "text": "Learn more about Quill's updates to activity scores",
+          },
+        ]
+      }
+      closeAria="Hide card until next school year"
+      closeIconSrc="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+      handleCloseCard={[Function]}
+      icon={
+        Object {
+          "alt": "Image of a school building",
+          "src": "https://assets.quill.org/images/banners/large-school-campus-gold.svg",
+        }
+      }
+      primaryHeaderText="Educators, we have updated our approach to scoring activities"
+      secondaryHeaderText="Update for the 2023-2024 school year"
     >
-      <div>
-        <div
-          className="badge-section"
-        >
-          <span
-            className="title-tag"
-          >
-            UPDATE FOR THE 2023-2024 SCHOOL YEAR
-          </span>
-        </div>
-        <h2>
-          Educators, we have updated our approach to scoring activities
-        </h2>
-        <div
-          className="link-section"
-        >
-          <a
-            href="undefined/teacher-center/quill-scoring-updates-2023"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <span>
-              Learn more about Quill's updates to activity scores
-            </span>
-            <img
-              alt="Arrow pointing right icon"
-              src="undefined/images/icons/icons-arrow-back.svg"
-            />
-          </a>
-        </div>
-      </div>
-      <button
-        aria-label="Hide card until next school year"
-        className="interactive-wrapper close-button"
-        onClick={[Function]}
-        type="button"
+      <div
+        className="banner-container gold-secondary"
       >
+        <div
+          className="left-side-container"
+        >
+          <div
+            className="upper-section"
+          >
+            <p
+              className="secondary-header"
+            >
+              Update for the 2023-2024 school year
+            </p>
+          </div>
+          <p
+            className="primary-header"
+          >
+            Educators, we have updated our approach to scoring activities
+          </p>
+          <p
+            className="body"
+          />
+          <div
+            className="buttons-container"
+          >
+            <a
+              className="quill-button-archived fun primary contained focus-on-light"
+              href="undefined/teacher-center/quill-scoring-updates-2023"
+              key="button-0"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about Quill's updates to activity scores
+               
+            </a>
+          </div>
+        </div>
         <img
-          alt=""
-          src="undefined/images/pages/dashboard/bulk_archive_close_icon.svg"
+          alt="Image of a school building"
+          className="banner-icon"
+          src="https://assets.quill.org/images/banners/large-school-campus-gold.svg"
         />
-      </button>
-    </section>
+        <button
+          aria-label="Hide card until next school year"
+          className="interactive-wrapper close-button"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            src="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+          />
+        </button>
+      </div>
+    </PostNavigationBanner>
   </ScoringUpdatesCard>
 </PromotionalCard>
 `;
@@ -712,52 +782,87 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
   <ScoringUpdatesCard
     handleCloseCard={[Function]}
   >
-    <section
-      className="scoring-updates-card"
+    <PostNavigationBanner
+      bannerStyle="gold-secondary"
+      bodyText=""
+      buttons={
+        Array [
+          Object {
+            "href": "undefined/teacher-center/quill-scoring-updates-2023",
+            "standardButtonStyle": true,
+            "target": "_blank",
+            "text": "Learn more about Quill's updates to activity scores",
+          },
+        ]
+      }
+      closeAria="Hide card until next school year"
+      closeIconSrc="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+      handleCloseCard={[Function]}
+      icon={
+        Object {
+          "alt": "Image of a school building",
+          "src": "https://assets.quill.org/images/banners/large-school-campus-gold.svg",
+        }
+      }
+      primaryHeaderText="Educators, we have updated our approach to scoring activities"
+      secondaryHeaderText="Update for the 2023-2024 school year"
     >
-      <div>
-        <div
-          className="badge-section"
-        >
-          <span
-            className="title-tag"
-          >
-            UPDATE FOR THE 2023-2024 SCHOOL YEAR
-          </span>
-        </div>
-        <h2>
-          Educators, we have updated our approach to scoring activities
-        </h2>
-        <div
-          className="link-section"
-        >
-          <a
-            href="undefined/teacher-center/quill-scoring-updates-2023"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <span>
-              Learn more about Quill's updates to activity scores
-            </span>
-            <img
-              alt="Arrow pointing right icon"
-              src="undefined/images/icons/icons-arrow-back.svg"
-            />
-          </a>
-        </div>
-      </div>
-      <button
-        aria-label="Hide card until next school year"
-        className="interactive-wrapper close-button"
-        onClick={[Function]}
-        type="button"
+      <div
+        className="banner-container gold-secondary"
       >
+        <div
+          className="left-side-container"
+        >
+          <div
+            className="upper-section"
+          >
+            <p
+              className="secondary-header"
+            >
+              Update for the 2023-2024 school year
+            </p>
+          </div>
+          <p
+            className="primary-header"
+          >
+            Educators, we have updated our approach to scoring activities
+          </p>
+          <p
+            className="body"
+          />
+          <div
+            className="buttons-container"
+          >
+            <a
+              className="quill-button-archived fun primary contained focus-on-light"
+              href="undefined/teacher-center/quill-scoring-updates-2023"
+              key="button-0"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about Quill's updates to activity scores
+               
+            </a>
+          </div>
+        </div>
         <img
-          alt=""
-          src="undefined/images/pages/dashboard/bulk_archive_close_icon.svg"
+          alt="Image of a school building"
+          className="banner-icon"
+          src="https://assets.quill.org/images/banners/large-school-campus-gold.svg"
         />
-      </button>
-    </section>
+        <button
+          aria-label="Hide card until next school year"
+          className="interactive-wrapper close-button"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            src="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+          />
+        </button>
+      </div>
+    </PostNavigationBanner>
   </ScoringUpdatesCard>
 </PromotionalCard>
 `;
@@ -854,52 +959,87 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
   <ScoringUpdatesCard
     handleCloseCard={[Function]}
   >
-    <section
-      className="scoring-updates-card"
+    <PostNavigationBanner
+      bannerStyle="gold-secondary"
+      bodyText=""
+      buttons={
+        Array [
+          Object {
+            "href": "undefined/teacher-center/quill-scoring-updates-2023",
+            "standardButtonStyle": true,
+            "target": "_blank",
+            "text": "Learn more about Quill's updates to activity scores",
+          },
+        ]
+      }
+      closeAria="Hide card until next school year"
+      closeIconSrc="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+      handleCloseCard={[Function]}
+      icon={
+        Object {
+          "alt": "Image of a school building",
+          "src": "https://assets.quill.org/images/banners/large-school-campus-gold.svg",
+        }
+      }
+      primaryHeaderText="Educators, we have updated our approach to scoring activities"
+      secondaryHeaderText="Update for the 2023-2024 school year"
     >
-      <div>
-        <div
-          className="badge-section"
-        >
-          <span
-            className="title-tag"
-          >
-            UPDATE FOR THE 2023-2024 SCHOOL YEAR
-          </span>
-        </div>
-        <h2>
-          Educators, we have updated our approach to scoring activities
-        </h2>
-        <div
-          className="link-section"
-        >
-          <a
-            href="undefined/teacher-center/quill-scoring-updates-2023"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <span>
-              Learn more about Quill's updates to activity scores
-            </span>
-            <img
-              alt="Arrow pointing right icon"
-              src="undefined/images/icons/icons-arrow-back.svg"
-            />
-          </a>
-        </div>
-      </div>
-      <button
-        aria-label="Hide card until next school year"
-        className="interactive-wrapper close-button"
-        onClick={[Function]}
-        type="button"
+      <div
+        className="banner-container gold-secondary"
       >
+        <div
+          className="left-side-container"
+        >
+          <div
+            className="upper-section"
+          >
+            <p
+              className="secondary-header"
+            >
+              Update for the 2023-2024 school year
+            </p>
+          </div>
+          <p
+            className="primary-header"
+          >
+            Educators, we have updated our approach to scoring activities
+          </p>
+          <p
+            className="body"
+          />
+          <div
+            className="buttons-container"
+          >
+            <a
+              className="quill-button-archived fun primary contained focus-on-light"
+              href="undefined/teacher-center/quill-scoring-updates-2023"
+              key="button-0"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about Quill's updates to activity scores
+               
+            </a>
+          </div>
+        </div>
         <img
-          alt=""
-          src="undefined/images/pages/dashboard/bulk_archive_close_icon.svg"
+          alt="Image of a school building"
+          className="banner-icon"
+          src="https://assets.quill.org/images/banners/large-school-campus-gold.svg"
         />
-      </button>
-    </section>
+        <button
+          aria-label="Hide card until next school year"
+          className="interactive-wrapper close-button"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            src="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+          />
+        </button>
+      </div>
+    </PostNavigationBanner>
   </ScoringUpdatesCard>
 </PromotionalCard>
 `;
@@ -1164,52 +1304,87 @@ exports[`PromotionalCard container ScoringUpdatesCard rendering behavior when th
   <ScoringUpdatesCard
     handleCloseCard={[Function]}
   >
-    <section
-      className="scoring-updates-card"
+    <PostNavigationBanner
+      bannerStyle="gold-secondary"
+      bodyText=""
+      buttons={
+        Array [
+          Object {
+            "href": "undefined/teacher-center/quill-scoring-updates-2023",
+            "standardButtonStyle": true,
+            "target": "_blank",
+            "text": "Learn more about Quill's updates to activity scores",
+          },
+        ]
+      }
+      closeAria="Hide card until next school year"
+      closeIconSrc="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+      handleCloseCard={[Function]}
+      icon={
+        Object {
+          "alt": "Image of a school building",
+          "src": "https://assets.quill.org/images/banners/large-school-campus-gold.svg",
+        }
+      }
+      primaryHeaderText="Educators, we have updated our approach to scoring activities"
+      secondaryHeaderText="Update for the 2023-2024 school year"
     >
-      <div>
-        <div
-          className="badge-section"
-        >
-          <span
-            className="title-tag"
-          >
-            UPDATE FOR THE 2023-2024 SCHOOL YEAR
-          </span>
-        </div>
-        <h2>
-          Educators, we have updated our approach to scoring activities
-        </h2>
-        <div
-          className="link-section"
-        >
-          <a
-            href="undefined/teacher-center/quill-scoring-updates-2023"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <span>
-              Learn more about Quill's updates to activity scores
-            </span>
-            <img
-              alt="Arrow pointing right icon"
-              src="undefined/images/icons/icons-arrow-back.svg"
-            />
-          </a>
-        </div>
-      </div>
-      <button
-        aria-label="Hide card until next school year"
-        className="interactive-wrapper close-button"
-        onClick={[Function]}
-        type="button"
+      <div
+        className="banner-container gold-secondary"
       >
+        <div
+          className="left-side-container"
+        >
+          <div
+            className="upper-section"
+          >
+            <p
+              className="secondary-header"
+            >
+              Update for the 2023-2024 school year
+            </p>
+          </div>
+          <p
+            className="primary-header"
+          >
+            Educators, we have updated our approach to scoring activities
+          </p>
+          <p
+            className="body"
+          />
+          <div
+            className="buttons-container"
+          >
+            <a
+              className="quill-button-archived fun primary contained focus-on-light"
+              href="undefined/teacher-center/quill-scoring-updates-2023"
+              key="button-0"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Learn more about Quill's updates to activity scores
+               
+            </a>
+          </div>
+        </div>
         <img
-          alt=""
-          src="undefined/images/pages/dashboard/bulk_archive_close_icon.svg"
+          alt="Image of a school building"
+          className="banner-icon"
+          src="https://assets.quill.org/images/banners/large-school-campus-gold.svg"
         />
-      </button>
-    </section>
+        <button
+          aria-label="Hide card until next school year"
+          className="interactive-wrapper close-button"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            src="undefined/images/pages/dashboard/bulk_archive_close_icon_orange.svg"
+          />
+        </button>
+      </div>
+    </PostNavigationBanner>
   </ScoringUpdatesCard>
 </PromotionalCard>
 `;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
@@ -8,7 +8,7 @@ const ScoringUpdatesCard = ({ handleCloseCard, }) => {
   return (
     <PostNavigationBanner
       bannerStyle="premium"
-      bodyText="Quickly archive last year's classes."
+      bodyText=""
       buttons={[
         {
           href: `${process.env.DEFAULT_URL}/teacher-center/quill-scoring-updates-2023`,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
@@ -1,23 +1,26 @@
 import * as React from 'react'
 
-import { arrowPointingRightIcon } from '../../../Shared/index'
+import { PostNavigationBanner } from '../../../Shared'
 
 const closeIconSrc = `${process.env.CDN_URL}/images/pages/dashboard/bulk_archive_close_icon.svg`
 
 const ScoringUpdatesCard = ({ handleCloseCard, }) => {
   return (
-    <section className="scoring-updates-card">
-      <div>
-        <div className="badge-section">
-          <span className="title-tag">UPDATE FOR THE 2023-2024 SCHOOL YEAR</span>
-        </div>
-        <h2>Educators, we have updated our approach to scoring activities</h2>
-        <div className="link-section">
-          <a href={`${process.env.DEFAULT_URL}/teacher-center/quill-scoring-updates-2023`} rel="noopener noreferrer" target="_blank"><span>Learn more about Quill&#39;s updates to activity scores</span><img alt={arrowPointingRightIcon.alt} src={arrowPointingRightIcon.src} /></a>
-        </div>
-      </div>
-      <button aria-label="Hide card until next school year" className="interactive-wrapper close-button" onClick={handleCloseCard} type="button"><img alt="" src={closeIconSrc} /></button>
-    </section>
+    <PostNavigationBanner
+      bannerStyle="premium"
+      bodyText="Quickly archive last year's classes."
+      buttons={[
+        {
+          href: `${process.env.DEFAULT_URL}/teacher-center/quill-scoring-updates-2023`,
+          standardButtonStyle: true,
+          text: "Learn more about Quill's updates to activity scores",
+          target: "_blank"
+        }
+      ]}
+      icon={{ alt: "Image of a school building", src: "https://assets.quill.org/images/banners/large-school-campus-gold.svg" }}
+      primaryHeaderText="Educators, we have updated our approach to scoring activities"
+      secondaryHeaderText="Update for the 2023-2024 school year"
+    />
   )
 }
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { PostNavigationBanner } from '../../../Shared'
 
-const closeIconSrc = `${process.env.CDN_URL}/images/pages/dashboard/bulk_archive_close_icon.svg`
+const closeIconSrc = `${process.env.CDN_URL}/images/pages/dashboard/bulk_archive_close_icon_orange.svg`
 
 const ScoringUpdatesCard = ({ handleCloseCard, }) => {
   return (
@@ -17,6 +17,9 @@ const ScoringUpdatesCard = ({ handleCloseCard, }) => {
           target: "_blank"
         }
       ]}
+      closeAria="Hide card until next school year"
+      closeIconSrc={closeIconSrc}
+      handleCloseCard={handleCloseCard}
       icon={{ alt: "Image of a school building", src: "https://assets.quill.org/images/banners/large-school-campus-gold.svg" }}
       primaryHeaderText="Educators, we have updated our approach to scoring activities"
       secondaryHeaderText="Update for the 2023-2024 school year"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
@@ -7,7 +7,7 @@ const closeIconSrc = `${process.env.CDN_URL}/images/pages/dashboard/bulk_archive
 const ScoringUpdatesCard = ({ handleCloseCard, }) => {
   return (
     <PostNavigationBanner
-      bannerStyle="premium"
+      bannerStyle="gold-secondary"
       bodyText=""
       buttons={[
         {


### PR DESCRIPTION
## WHAT
Update the "we have updated our scoring standards" banner to use the new Banner React component. Update that React component to accept a "close" button with onClick callback.

## WHY
We want this banner to now conform to the same styling standards as the other banners. However, we have to modify the universal component a little to allow for new functionality this banner needs.

## HOW
Update the PostNavigationBanner to display secondary headers even when a tag is not given. Update the component to also accept a "close" button. Update the Standards Banner to use this new PostNavigationBanner.

### Screenshots
![Screenshot 2024-08-12 at 11 56 14 PM](https://github.com/user-attachments/assets/ac5ada6a-4f09-4dd6-93e2-f0e4eff79a66)


### Notion Card Links
https://www.notion.so/quill/Current-School-Year-Banner-on-Teacher-Dashboard-Needs-to-Use-Standard-Banner-Component-fec970b4afd84ca6bc16b8331a1ddf14?pvs=4


### What have you done to QA this feature?
Deploy to staging and check this banner's visual and functionality as well as the older PostNavigation banners to ensure that both old banners and this new banner are displaying properly. Also asked Jack to verify for me on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
 