### PR TITLE
fix weird bug with fill in blank centering

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputStyleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputStyleHelpers.tsx
@@ -6,8 +6,6 @@ export function generateSpan(text) {
   span.style.marginLeft = '1px' // this fixes a bug caused by the browser somehow misinterpreting which letters belong to which element
   span.style.visibility = 'hidden'
   span.textContent = text
-  console.log('text', text)
-  console.log('span.textContent', span.textContent)
 
   document.body.appendChild(span);
 

--- a/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputStyleHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/fillInBlankInputStyleHelpers.tsx
@@ -2,8 +2,12 @@ export function generateSpan(text) {
   const span = document.createElement('span');
 
   span.style.fontSize = '24px'; // matches the font size for the fill in the blank inputs and must be adjusted if they change
-  span.style.visibility = 'hidden';
+
+  span.style.marginLeft = '1px' // this fixes a bug caused by the browser somehow misinterpreting which letters belong to which element
+  span.style.visibility = 'hidden'
   span.textContent = text
+  console.log('text', text)
+  console.log('span.textContent', span.textContent)
 
   document.body.appendChild(span);
 


### PR DESCRIPTION
## WHAT
Fix very strange bug where the browser was attaching leading "t"s to the previous span. Don't ask me why.

## WHY
We want the sizing to be accurate (removing a letter was squishing the text in the blank, making it look like there was no padding on the right).

## HOW
Trick the browser into separating them better by adding 1px of margin.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fill-in-the-blank-centering-issue-26907ecb67e34d22b34f36f249c2407e

### What have you done to QA this feature?
Tested that typing all manner of input into fill in the blanks works.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
