### PR TITLE
import prop correctly for ell translations

### DIFF
--- a/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/studentDiagnostic.jsx
+++ b/services/QuillLMS/client/app/bundles/Diagnostic/components/eslDiagnostic/studentDiagnostic.jsx
@@ -405,7 +405,7 @@ export class ELLStudentDiagnostic extends React.Component {
 
   render() {
     const { error, saved, } = this.state
-    const { dispatch, match, playDiagnostic, t, previewMode, isOnMobile, handleTogglePreview } = this.props;
+    const { dispatch, match, playDiagnostic, translate, previewMode, isOnMobile, handleTogglePreview } = this.props;
     const { params } = match;
     const { diagnosticID } = params;
 


### PR DESCRIPTION
## WHAT
Fix prop import so it's defined in component.

## WHY
This error was causing the page not to load.

## HOW
Just change it from "t" to "translate".

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/ELL-Starter-Diagnostics-not-loading-after-student-selects-a-language-efa199f555694cc39a83e5aa7821d62e

### What have you done to QA this feature?
Confirmed that a student can progress past the language selection screen.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
