### PR TITLE
Fix for Grammar resumption

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/actions/questions.ts
@@ -1,13 +1,13 @@
 import Pusher from 'pusher-js';
-import { ConceptResult, Response } from '../../Shared/quill-marking-logic/src/main';
 import { push } from 'react-router-redux';
 import _ from 'underscore';
 
-import { FocusPoint, IncorrectSequence, Question, Questions } from '../interfaces/questions';
 import { ActionTypes } from './actionTypes';
 import * as responseActions from './responses';
 import { populateQuestions, setSessionReducerToSavedSession } from './session.ts';
 
+import { FocusPoint, IncorrectSequence, Question, Questions } from '../interfaces/questions';
+import { ConceptResult, Response } from '../../Shared/quill-marking-logic/src/main';
 import { requestGet, requestPost, } from '../../../modules/request/index';
 import {
   FocusPointApi,
@@ -18,9 +18,7 @@ import {
 
 export const startListeningToQuestions = (activityUID?: string, sessionID?: string) => {
   return (dispatch: Function) => {
-    const fetchQuestions = activityUID
-      ? QuestionApi.getAllForActivity(activityUID)
-      : QuestionApi.getAllForType(GRAMMAR_QUESTION_TYPE);
+    const fetchQuestions = QuestionApi.getAllForType(GRAMMAR_QUESTION_TYPE);
 
     fetchQuestions.then((questions: Array<Question>) => {
       if (questions) {

--- a/services/QuillLMS/client/app/bundles/Grammar/tests/actions/questions.test.ts
+++ b/services/QuillLMS/client/app/bundles/Grammar/tests/actions/questions.test.ts
@@ -6,13 +6,10 @@ jest.mock('../../libs/questions_api', () => ({
   IncorrectSequenceApi: mockIncorrectSequenceApi,
   QuestionApi: mockQuestionApi,
 }))
-
 import { mockDispatch as dispatch, } from '../__mocks__/dispatch'
-
 import {
   GRAMMAR_QUESTION_TYPE
 } from '../../libs/questions_api'
-
 import {
   deleteFocusPoint,
   deleteIncorrectSequence,
@@ -33,12 +30,6 @@ describe('Questions actions', () => {
     it('should call QuestionApi.getAllForType()', () => {
       dispatch(startListeningToQuestions())
       expect(mockQuestionApi.getAllForType).toHaveBeenLastCalledWith(GRAMMAR_QUESTION_TYPE)
-    })
-
-    it('should call QuestionApi.getAllForActivity if an activity ID is passd in', () => {
-      const MOCK_UID = "23"
-      dispatch(startListeningToQuestions(MOCK_UID))
-      expect(mockQuestionApi.getAllForActivity).toHaveBeenLastCalledWith(MOCK_UID)
     })
   })
 


### PR DESCRIPTION
## WHAT
Remove code to conditionally load only selected questions instead of all questions on activity load
## WHY
Some Grammar activities are defined not by an array of `questions` in their `data` JSON blob, but by an array of `concepts`, instead.  In these cases the activity does some magic to find questions from the list of all questions that match those concepts to run through the actual activity.  So in order for activities with this structure to work, we need to have loaded all questions into the session to fetch them from.

Note that this works on new (non-resuming) sessions because the code that tries to handle normalization/denormalization of the `ActiveActivitySession` is where these assumptions break down.  There's probably a way to figure out which type of Activity that you're looking at and dynamically use one of these methods or the other still, but I wanted to get a fix out faster, and this is basically just a reversion to how we were running these activities a month ago, so shouldn't have a huge impact on performance.
## HOW
Revert code to the more expensive, but broader query for all questions for all Grammar activities.

### Notion Card Links
https://www.notion.so/quill/Perpetual-loading-symbol-when-pressing-the-Save-and-exit-button-and-resuming-a-Quill-Grammar-activ-12853db5131c46699bc903d4232f6fdb?d=a06d035d2a60453a819315ecfcff8f6a

### What have you done to QA this feature?
- Using an activity known to cause issues in production
- Assign activity to test student
- Answer first question with test student
- Save & Exit
- Resume activity
- Ensure start on question 2

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No test coverage on this section
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes