### PR TITLE
Fix Connect resume bugs

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/__tests__/components/__snapshots__/register.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Shared/__tests__/components/__snapshots__/register.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Register it should render with translations 1`] = `
         Conjunto oraciones
       </div>
       <button
-        class="quill-button-archived focus-on-light large primary contained"
+        class="quill-button-archived focus-on-light primary contained large"
         type="button"
       >
         Start activity
@@ -46,7 +46,7 @@ exports[`Register it should render without translations 1`] = `
         Joining sentences
       </div>
       <button
-        class="quill-button-archived focus-on-light large primary contained"
+        class="quill-button-archived focus-on-light primary contained large"
         type="button"
       >
         Start activity

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
@@ -40,11 +40,6 @@ class Register extends React.Component<any, any> {
     }
   }
 
-  handleStartLessonClick = () => {
-    const { startActivity, } = this.props
-    startActivity();
-  }
-
   resume = () => {
     const { resumeActivity, session, } = this.props
     resumeActivity(session);
@@ -65,10 +60,6 @@ class Register extends React.Component<any, any> {
     const { session, translate, showTranslation } = this.props
     let onClickFn, text;
 
-    if(showIntro) {
-      const buttonText = showTranslation ? translate('buttons^start activity') : 'Start activity'
-      return <button className="quill-button-archived focus-on-light large primary contained" onClick={this.handleStartLessonClick} type="button">{buttonText}</button>
-    }
     if (session) {
       // resume session if one is passed
       onClickFn = this.resume;
@@ -76,7 +67,7 @@ class Register extends React.Component<any, any> {
     } else {
       // otherwise begin new session
       onClickFn = this.startActivity;
-      text = showTranslation ? translate('buttons^begin') : 'Begin'
+      text = showTranslation ? translate('buttons^start activity') : 'Start activity'
     }
     return (
       <button className="quill-button-archived focus-on-light primary contained large" onClick={onClickFn} type="button">

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
@@ -87,56 +87,19 @@ class Register extends React.Component<any, any> {
     const { lesson } = this.props
     const { showIntro, hasSentenceFragment, } = this.state
     const translatedText = this.translatedText()
-    if (showIntro) {
-      return (
-        <div className="container">
-          <div className="landing-page-html" dangerouslySetInnerHTML={{ __html: lesson.landingPageHtml, }} />
-          {translatedText && (
-            <React.Fragment>
-              <hr />
-              <div className="landing-page-html" dangerouslySetInnerHTML={{ __html: translatedText }} />
-            </React.Fragment>
-          )}
-          {this.renderButton(showIntro)}
-        </div>
-      );
-    } else if (hasSentenceFragment) {
-      return (
-        <div className="container">
-          <h2 className="title is-3 register">
-            Welcome to Quill Connect Fragments!
-          </h2>
-          <div className="register-container">
-            <ul className="register-list">
-              <li>Add to the group of words to make a complete sentence.</li>
-              <li>Add the number of words shown in the directions.</li>
-              <li>There is often more than one correct answer.</li>
-              <li>Remember to use correct spelling, capitalization, and punctuation!</li>
-            </ul>
-            {this.renderButton(showIntro)}
-            <br />
-          </div>
-        </div>
-      );
-    } else {
-      return (
-        <div className="container">
-          <h2 className="title is-3 register">
-            Welcome to Quill Connect!
-          </h2>
-          <div className="register-container">
-            <ul className="register-list">
-              <li>Combine the sentences together into one sentence.</li>
-              <li>You may add or remove words.</li>
-              <li>There is often more than one correct answer.</li>
-              <li>Remember to use correct spelling, capitalization, and punctuation!</li>
-            </ul>
-            {this.renderButton(showIntro)}
-            <br />
-          </div>
-        </div>
-      );
-    }
+
+    return (
+      <div className="container">
+        <div className="landing-page-html" dangerouslySetInnerHTML={{ __html: lesson.landingPageHtml, }} />
+        {translatedText && (
+          <React.Fragment>
+            <hr />
+            <div className="landing-page-html" dangerouslySetInnerHTML={{ __html: translatedText }} />
+          </React.Fragment>
+        )}
+        {this.renderButton(showIntro)}
+      </div>
+    );
   }
 
   render() {

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
@@ -87,19 +87,56 @@ class Register extends React.Component<any, any> {
     const { lesson } = this.props
     const { showIntro, hasSentenceFragment, } = this.state
     const translatedText = this.translatedText()
-
-    return (
-      <div className="container">
-        <div className="landing-page-html" dangerouslySetInnerHTML={{ __html: lesson.landingPageHtml, }} />
-        {translatedText && (
-          <React.Fragment>
-            <hr />
-            <div className="landing-page-html" dangerouslySetInnerHTML={{ __html: translatedText }} />
-          </React.Fragment>
-        )}
-        {this.renderButton(showIntro)}
-      </div>
-    );
+    if (showIntro) {
+      return (
+        <div className="container">
+          <div className="landing-page-html" dangerouslySetInnerHTML={{ __html: lesson.landingPageHtml, }} />
+          {translatedText && (
+            <React.Fragment>
+              <hr />
+              <div className="landing-page-html" dangerouslySetInnerHTML={{ __html: translatedText }} />
+            </React.Fragment>
+          )}
+          {this.renderButton(showIntro)}
+        </div>
+      );
+    } else if (hasSentenceFragment) {
+      return (
+        <div className="container">
+          <h2 className="title is-3 register">
+            Welcome to Quill Connect Fragments!
+          </h2>
+          <div className="register-container">
+            <ul className="register-list">
+              <li>Add to the group of words to make a complete sentence.</li>
+              <li>Add the number of words shown in the directions.</li>
+              <li>There is often more than one correct answer.</li>
+              <li>Remember to use correct spelling, capitalization, and punctuation!</li>
+            </ul>
+            {this.renderButton(showIntro)}
+            <br />
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div className="container">
+          <h2 className="title is-3 register">
+            Welcome to Quill Connect!
+          </h2>
+          <div className="register-container">
+            <ul className="register-list">
+              <li>Combine the sentences together into one sentence.</li>
+              <li>You may add or remove words.</li>
+              <li>There is often more than one correct answer.</li>
+              <li>Remember to use correct spelling, capitalization, and punctuation!</li>
+            </ul>
+            {this.renderButton(showIntro)}
+            <br />
+          </div>
+        </div>
+      );
+    }
   }
 
   render() {


### PR DESCRIPTION
## WHAT
Update the logic used for starting Connect activities so that we don't bypass `resume` calls when generating translation text.

Additionally, remove some dead code that can never be triggered.  Specifically, `showIntro` is always true for Connect activities in production, so there's no need for the fallbacks.
## WHY
`showIntro` is always true, so this code was resulting in all clicks to start a Connect activity from the landing page starting the activity from the beginning even if there was an in-flight session available.
## HOW
Move the translation logic into an existing no-in-flight-session logic flow.

### Notion Card Links
https://www.notion.so/quill/Unable-to-save-progress-when-pressing-the-Save-and-Exit-button-and-resuming-a-Quill-Connect-activity-b1808666a2134afead2fad6aa17ece8a

### What have you done to QA this feature?
- Start a new Connect activity
- Answer one questions
- Save and Exit
- Resume activity
- Confirm that the activity starts on the second question (instead of the first, which it has been doing)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes