### PR TITLE
fix bug with starting connect activities

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/__tests__/components/__snapshots__/register.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Shared/__tests__/components/__snapshots__/register.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Register it should render with translations 1`] = `
         class="quill-button-archived focus-on-light primary contained large"
         type="button"
       >
-        Start activity
+        Begin
       </button>
     </div>
   </section>
@@ -49,7 +49,7 @@ exports[`Register it should render without translations 1`] = `
         class="quill-button-archived focus-on-light primary contained large"
         type="button"
       >
-        Start activity
+        Begin
       </button>
     </div>
   </section>

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 class Register extends React.Component<any, any> {
   constructor(props) {
     super(props)
@@ -11,11 +12,8 @@ class Register extends React.Component<any, any> {
 
   componentDidMount() {
     const { previewMode, lesson } = this.props;
-    if(previewMode) {
+    if (previewMode) {
       this.startActivity();
-    }
-    if (lesson.landingPageHtml && this.landingPageHtmlHasText()) {
-      this.handleSetShowIntro();
     }
   }
 
@@ -32,8 +30,9 @@ class Register extends React.Component<any, any> {
   }
 
   startActivity = () => {
+    const { showIntro, } = this.state
     const { lesson, startActivity, } = this.props
-    if (lesson.landingPageHtml && this.landingPageHtmlHasText()) {
+    if (lesson.landingPageHtml && this.landingPageHtmlHasText() && !showIntro) {
       this.setState({ showIntro: true, });
     } else {
       startActivity();
@@ -56,7 +55,7 @@ class Register extends React.Component<any, any> {
     return false;
   }
 
-  renderButton = (showIntro: boolean) => {
+  renderButton = (showIntro) => {
     const { session, translate, showTranslation } = this.props
     let onClickFn, text;
 
@@ -64,6 +63,10 @@ class Register extends React.Component<any, any> {
       // resume session if one is passed
       onClickFn = this.resume;
       text = showTranslation ? translate('buttons^resume') : 'Resume'
+    } else if (showIntro) {
+      // this and the following conditional have the same action because the function handles what should happen next  
+      onClickFn = this.startActivity;
+      text = showTranslation ? translate('buttons^begin') : 'Begin'
     } else {
       // otherwise begin new session
       onClickFn = this.startActivity;


### PR DESCRIPTION
## WHAT
Fix bug where students can't start Connect activities, and also a related bug where we are always skipping the initial introductory Connect page.

## WHY
We want students to have the normal flow here.

## HOW
Make sure conditional that determines whether to start or not takes the state into account, and remove the code that was always setting that state to be true.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/When-students-click-the-Start-activity-button-for-Quill-Connect-activities-the-activities-do-not-st-cef4ac7955304eccbfeea7a9398225c5?pvs=5

### What have you done to QA this feature?
Tested locally that it is possible to both start and resume Connect activities.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | NO - tiny change 
Self-Review: Have you done an initial self-review of the code below on Github? | YES
