### PR TITLE
GenAI - Gemini for GenAI production path

### DIFF
--- a/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Evidence
   module GenAI
     HistoryItem = Struct.new(:user, :assistant, keyword_init: true)

--- a/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai.rb
@@ -2,6 +2,6 @@
 
 module Evidence
   module GenAI
-    HistoryItem = Struct.new(:user, :assistant, keyword_init: true)
+    HistoryItem = Data.define(:user, :assistant)
   end
 end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai.rb
@@ -1,0 +1,5 @@
+module Evidence
+  module GenAI
+    HistoryItem = Struct.new(:user, :assistant, keyword_init: true)
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai/repeated_feedback_checker.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai/repeated_feedback_checker.rb
@@ -4,14 +4,14 @@ module Evidence
   module GenAI
     class RepeatedFeedbackChecker < ApplicationService
       KEY_REPEAT = 'repeat_feedback'
-      MODEL = 'gpt-4o-mini'
 
-      attr_reader :feedback, :history, :optimal
+      attr_reader :feedback, :history, :optimal, :chat_api
 
-      def initialize(feedback:, history: [], optimal: false)
+      def initialize(feedback:, history: [], optimal: false, chat_api: Evidence::OpenAI::Chat)
         @feedback = feedback
         @history = history
         @optimal = optimal
+        @chat_api = chat_api
       end
 
       def run
@@ -24,7 +24,7 @@ module Evidence
 
       private def system_prompt = Evidence::GenAI::RepeatedFeedbackPromptBuilder.run(prompt: nil, history:)
 
-      private def llm_response = Evidence::OpenAI::Chat.run(system_prompt:, entry: feedback, model: MODEL)
+      private def llm_response = chat_api.run(system_prompt:, entry: feedback, model: chat_api::SMALL_MODEL)
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/check/gen_ai.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/check/gen_ai.rb
@@ -3,7 +3,7 @@
 module Evidence
   module Check
     class GenAI < Check::Base
-      CHAT_API = Evidence::OpenAI::Chat
+      CHAT_API = Evidence::Gemini::Chat
       SMALL_MODEL = CHAT_API::SMALL_MODEL
 
       def run

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
@@ -69,8 +69,9 @@ module Evidence
         end.flatten
       end
 
-      private def generation_config = { temperature:, responseMimeType: 'application/json' }
+      private def generation_config = { temperature:, response_mime_type:}
 
+      private def response_mime_type = 'application/json'
       private def model_version = model
       private def instruction = GENERATE_CONTENT
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
@@ -69,7 +69,7 @@ module Evidence
         end.flatten
       end
 
-      private def generation_config = { temperature:, response_mime_type:}
+      private def generation_config = { temperature:, response_mime_type: }
 
       private def response_mime_type = 'application/json'
       private def model_version = model

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
@@ -25,41 +25,6 @@ module Evidence
         @model = model
       end
 
-      def request_body
-        {
-          system_instruction: system_instructions,
-          contents: messages,
-          generationConfig: generation_config,
-          safety_settings: SAFETY_SETTINGS
-        }
-      end
-
-      def body = request_body.to_json
-
-      private def system_instructions = { KEY_PARTS => { KEY_TEXT => system_prompt } }
-      private def messages = [history_messages, current_message].flatten
-      private def current_message = { KEY_ROLE => ROLE_USER, KEY_PARTS => [{ KEY_TEXT => entry }] }
-
-      private def history_messages
-        history.map do |h|
-          [
-            { KEY_ROLE => ROLE_USER, KEY_PARTS => [{ KEY_TEXT => h.user }] },
-            { KEY_ROLE => ROLE_ASSISTANT, KEY_PARTS => [{ KEY_TEXT => h.assistant }] }
-          ]
-        end.flatten
-      end
-
-      private def generation_config
-        {
-          'temperature' => temperature,
-          'responseMimeType': 'application/json'
-        }
-      end
-
-      private def model_version = model
-
-      private def instruction = GENERATE_CONTENT
-
       def cleaned_results
         return nil if response&.body&.nil?
 
@@ -75,6 +40,35 @@ module Evidence
       rescue => e
         raise CleanedResultsError, e.message
       end
+
+      def body = request_body.to_json
+
+      def request_body
+        {
+          system_instruction:,
+          contents:,
+          generationConfig: generation_config,
+          safety_settings:
+        }
+      end
+
+      private def system_instruction = { KEY_PARTS => { KEY_TEXT => system_prompt } }
+      private def contents = [history_messages, current_message].flatten
+      private def current_message = { KEY_ROLE => ROLE_USER, KEY_PARTS => [{ KEY_TEXT => entry }] }
+
+      private def history_messages
+        history.map do |h|
+          [
+            { KEY_ROLE => ROLE_USER, KEY_PARTS => [{ KEY_TEXT => h.user }] },
+            { KEY_ROLE => ROLE_ASSISTANT, KEY_PARTS => [{ KEY_TEXT => h.assistant }] }
+          ]
+        end.flatten
+      end
+
+      private def generation_config = { temperature:, responseMimeType: 'application/json' }
+
+      private def model_version = model
+      private def instruction = GENERATE_CONTENT
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Gemini
+    class Chat < Evidence::ApplicationService
+      include Evidence::Gemini::Concerns::Api
+
+      GENERATE_CONTENT = 'generateContent'
+      DEFAULT_MODEL = 'gemini-1.5-flash-latest'
+      SMALL_MODEL = DEFAULT_MODEL
+
+      KEY_ROLE = 'role'
+      KEY_PARTS = 'parts'
+      KEY_TEXT = 'text'
+      ROLE_USER = 'user'
+      ROLE_ASSISTANT = 'model'
+
+      attr_reader :system_prompt, :entry, :history, :temperature, :model
+
+      def initialize(system_prompt:, entry:, history: [], temperature: 1, model: DEFAULT_MODEL)
+        @system_prompt = system_prompt
+        @entry = entry
+        @history = history
+        @temperature = temperature
+        @model = model
+      end
+
+      def request_body
+        {
+          system_instruction: system_instructions,
+          contents: messages,
+          generationConfig: generation_config,
+          safety_settings: SAFETY_SETTINGS
+        }
+      end
+
+      def body = request_body.to_json
+
+      private def system_instructions = {KEY_PARTS => {KEY_TEXT => system_prompt}}
+      private def messages = [history_messages, current_message].flatten
+      private def current_message = { KEY_ROLE => ROLE_USER, KEY_PARTS => [{KEY_TEXT => entry}] }
+
+      private def history_messages
+        history.map do |h|
+          [
+            { KEY_ROLE => ROLE_USER, KEY_PARTS => [{KEY_TEXT => h.user}] },
+            { KEY_ROLE => ROLE_ASSISTANT, KEY_PARTS => [{KEY_TEXT => h.assistant}] }
+          ]
+        end.flatten
+      end
+
+      private def generation_config
+        {
+          'temperature' => temperature,
+          'responseMimeType': 'application/json'
+        }
+      end
+
+      private def model_version = model
+
+      private def instruction = GENERATE_CONTENT
+
+      def cleaned_results
+        return nil if response&.body&.nil?
+
+        @cleaned_results ||= JSON.parse(result_json_string)
+      end
+
+      private def result_json_string
+        response
+          .parsed_response['candidates']
+          .first
+          .dig('content', 'parts')
+          .first['text']
+      rescue => e
+        raise CleanedResultsError, e.message
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
@@ -8,6 +8,8 @@ module Evidence
       GENERATE_CONTENT = 'generateContent'
       DEFAULT_MODEL = 'gemini-1.5-flash-latest'
       SMALL_MODEL = DEFAULT_MODEL
+      DEFAULT_TEMPERATURE = 1
+      JSON_MIME_TYPE = 'application/json'
 
       KEY_ROLE = 'role'
       KEY_PARTS = 'parts'
@@ -17,7 +19,7 @@ module Evidence
 
       attr_reader :system_prompt, :entry, :history, :temperature, :model
 
-      def initialize(system_prompt:, entry:, history: [], temperature: 1, model: DEFAULT_MODEL)
+      def initialize(system_prompt:, entry:, history: [], temperature: DEFAULT_TEMPERATURE, model: DEFAULT_MODEL)
         @system_prompt = system_prompt
         @entry = entry
         @history = history
@@ -71,7 +73,7 @@ module Evidence
 
       private def generation_config = { temperature:, response_mime_type: }
 
-      private def response_mime_type = 'application/json'
+      private def response_mime_type = JSON_MIME_TYPE
       private def model_version = model
       private def instruction = GENERATE_CONTENT
     end

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
@@ -36,15 +36,15 @@ module Evidence
 
       def body = request_body.to_json
 
-      private def system_instructions = {KEY_PARTS => {KEY_TEXT => system_prompt}}
+      private def system_instructions = { KEY_PARTS => { KEY_TEXT => system_prompt } }
       private def messages = [history_messages, current_message].flatten
-      private def current_message = { KEY_ROLE => ROLE_USER, KEY_PARTS => [{KEY_TEXT => entry}] }
+      private def current_message = { KEY_ROLE => ROLE_USER, KEY_PARTS => [{ KEY_TEXT => entry }] }
 
       private def history_messages
         history.map do |h|
           [
-            { KEY_ROLE => ROLE_USER, KEY_PARTS => [{KEY_TEXT => h.user}] },
-            { KEY_ROLE => ROLE_ASSISTANT, KEY_PARTS => [{KEY_TEXT => h.assistant}] }
+            { KEY_ROLE => ROLE_USER, KEY_PARTS => [{ KEY_TEXT => h.user }] },
+            { KEY_ROLE => ROLE_ASSISTANT, KEY_PARTS => [{ KEY_TEXT => h.assistant }] }
           ]
         end.flatten
       end

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/chat.rb
@@ -26,9 +26,15 @@ module Evidence
       end
 
       def cleaned_results
-        return nil if response&.body&.nil?
+        return nil if response&.body.nil?
 
-        @cleaned_results ||= JSON.parse(result_json_string)
+        @cleaned_results ||= result_json
+      end
+
+      private def result_json
+        JSON.parse(result_json_string)
+      rescue => e
+        raise CleanedResultsError, e.message
       end
 
       private def result_json_string
@@ -37,8 +43,6 @@ module Evidence
           .first
           .dig('content', 'parts')
           .first['text']
-      rescue => e
-        raise CleanedResultsError, e.message
       end
 
       def body = request_body.to_json

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/concerns/api.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/concerns/api.rb
@@ -54,7 +54,9 @@ module Evidence
 
         private def endpoint = "#{BASE_URI}/#{model_version}:#{instruction}?key=#{Evidence::Gemini::API_KEY}"
 
-        private def body = request_body.merge(safety_settings: SAFETY_SETTINGS).to_json
+        private def body = request_body.merge(safety_settings:).to_json
+
+        private def safety_settings = SAFETY_SETTINGS
 
         private def headers = { 'Content-Type' => 'application/json' }
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/chat.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/chat.rb
@@ -42,7 +42,7 @@ module Evidence
       end
 
       def cleaned_results
-        return nil if response&.body&.nil?
+        return nil if response&.body.nil?
 
         @cleaned_results ||= JSON.parse(result_json_string)
       end

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/chat.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/chat.rb
@@ -5,11 +5,10 @@ module Evidence
     class Chat < Evidence::ApplicationService
       include Evidence::OpenAI::Concerns::Api
 
-      HistoryItem = Struct.new(:user, :assistant, keyword_init: true)
-
       ENDPOINT = '/chat/completions'
 
       DEFAULT_MODEL = 'gpt-4-turbo'
+      SMALL_MODEL = 'gpt-4o-mini'
 
       KEY_ROLE = 'role'
       KEY_CONTENT = 'content'
@@ -20,7 +19,7 @@ module Evidence
 
       attr_reader :system_prompt, :entry, :history, :temperature, :model
 
-      def initialize(system_prompt:, entry:, history: [], temperature: 0.5, model: DEFAULT_MODEL)
+      def initialize(system_prompt:, entry:, history: [], temperature: 1, model: DEFAULT_MODEL)
         @system_prompt = system_prompt
         @entry = entry
         @history = history

--- a/services/QuillLMS/engines/evidence/spec/lib/check/gen_ai_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/check/gen_ai_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Evidence::Check::GenAI, type: :service do
 
   before do
     allow(Evidence::GenAI::SystemPromptBuilder).to receive(:run).and_return(system_prompt)
-    allow(Evidence::OpenAI::Chat).to receive(:run).and_return(primary_response, secondary_response)
+    allow(Evidence::Check::GenAI::CHAT_API).to receive(:run).and_return(primary_response, secondary_response)
     allow(Evidence::GenAI::ResponseBuilder).to receive(:run).and_return(response)
     allow(Evidence::GenAI::RepeatedFeedbackChecker).to receive(:run).and_return(false)
   end
@@ -101,8 +101,8 @@ RSpec.describe Evidence::Check::GenAI, type: :service do
 
       it 'returns the correct history items' do
         expected_history = [
-          Evidence::OpenAI::Chat::HistoryItem.new(user: 'History entry 1', assistant: 'History feedback 1'),
-          Evidence::OpenAI::Chat::HistoryItem.new(user: 'History entry 2', assistant: 'History feedback 2')
+          Evidence::GenAI::HistoryItem.new(user: 'History entry 1', assistant: 'History feedback 1'),
+          Evidence::GenAI::HistoryItem.new(user: 'History entry 2', assistant: 'History feedback 2')
         ]
         expect(subject.send(:session_history)).to eq(expected_history)
       end

--- a/services/QuillLMS/engines/evidence/spec/lib/evidence/gemini/chat_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/evidence/gemini/chat_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Evidence::Gemini::Chat, type: :service do
           { 'role' => 'model', 'parts' => [{ 'text' => history.first.assistant }] },
           { 'role' => 'user', 'parts' => [{ 'text' => entry }] }
         ],
-        generationConfig: { temperature: temperature, responseMimeType: 'application/json' },
+        generationConfig: { temperature: temperature, response_mime_type: 'application/json' },
         safety_settings: Evidence::Gemini::Concerns::Api::SAFETY_SETTINGS
       }
     end
@@ -121,7 +121,7 @@ RSpec.describe Evidence::Gemini::Chat, type: :service do
 
     describe '#generation_config' do
       it 'returns the correct generation config' do
-        expect(subject.send(:generation_config)).to eq({ temperature: temperature, responseMimeType: 'application/json' })
+        expect(subject.send(:generation_config)).to eq({ temperature: temperature, response_mime_type: 'application/json' })
       end
     end
 

--- a/services/QuillLMS/engines/evidence/spec/lib/evidence/gemini/chat_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/evidence/gemini/chat_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Evidence::Gemini::Chat, type: :service do
   subject { described_class.new(system_prompt: system_prompt, entry: entry, history: history, temperature: temperature, model: model) }
 
   before do
-    stub_request(:post, "#{Evidence::Gemini::BASE_URI}/#{model}:generateContent?key=").to_return(body: body, headers: headers)
+    stub_request(:post, "#{Evidence::Gemini::BASE_URI}/#{model}:generateContent?key=#{Evidence::Gemini::API_KEY}").to_return(body: body, headers: headers)
   end
 
   describe '#initialize' do

--- a/services/QuillLMS/engines/evidence/spec/lib/evidence/gemini/chat_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/evidence/gemini/chat_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Evidence::Gemini::Chat, type: :service do
+  let(:system_prompt) { 'You are a helpful assistant.' }
+  let(:entry) { 'What is the capital of France?' }
+  let(:history) { [Evidence::GenAI::HistoryItem.new(user: 'Tell me a joke.', assistant: 'Why did the chicken cross the road?')] }
+  let(:temperature) { 0.7 }
+  let(:model) { 'gemini-1.5-flash-latest' }
+  let(:json_response) { '{"answer" : "The capital of France is Paris."}' }
+  let(:body) do
+    {
+      'candidates' => [
+        {
+          'content' => {
+            'parts' => [
+              { 'text' => json_response }
+            ]
+          }
+        }
+      ]
+    }.to_json
+  end
+  let(:headers) { { content_type: 'application/json' } }
+
+  subject { described_class.new(system_prompt: system_prompt, entry: entry, history: history, temperature: temperature, model: model) }
+
+  before do
+    stub_request(:post, "#{Evidence::Gemini::BASE_URI}/#{model}:generateContent?key=").to_return(body: body, headers: headers)
+  end
+
+  describe '#initialize' do
+    it 'initializes with system_prompt, entry, history, temperature, and model' do
+      expect(subject.system_prompt).to eq(system_prompt)
+      expect(subject.entry).to eq(entry)
+      expect(subject.history).to eq(history)
+      expect(subject.temperature).to eq(temperature)
+      expect(subject.model).to eq(model)
+    end
+
+    it 'uses default values when not provided' do
+      chat = described_class.new(system_prompt: system_prompt, entry: entry)
+      expect(chat.history).to eq([])
+      expect(chat.temperature).to eq(1)
+      expect(chat.model).to eq(described_class::DEFAULT_MODEL)
+    end
+  end
+
+  describe '#cleaned_results' do
+    context 'when response is successful' do
+      before { subject.run }
+
+      it 'returns parsed JSON from the response' do
+        expect(subject.cleaned_results).to eq(JSON.parse(json_response))
+      end
+    end
+
+    context 'when response is nil (un-run request)' do
+      it 'returns nil' do
+        expect(subject.cleaned_results).to be_nil
+      end
+    end
+  end
+
+  describe '#body' do
+    it 'returns the request body as JSON' do
+      expect(subject.body).to be_a(String)
+      expect { JSON.parse(subject.body) }.not_to raise_error
+    end
+  end
+
+  describe '#request_body' do
+    let(:expected_body) do
+      {
+        system_instruction: { 'parts' => { 'text' => system_prompt } },
+        contents: [
+          { 'role' => 'user', 'parts' => [{ 'text' => history.first.user }] },
+          { 'role' => 'model', 'parts' => [{ 'text' => history.first.assistant }] },
+          { 'role' => 'user', 'parts' => [{ 'text' => entry }] }
+        ],
+        generationConfig: { temperature: temperature, responseMimeType: 'application/json' },
+        safety_settings: Evidence::Gemini::Concerns::Api::SAFETY_SETTINGS
+      }
+    end
+
+    it 'returns the correct request body structure' do
+      expect(subject.request_body).to eq(expected_body)
+    end
+  end
+
+  describe 'private methods' do
+    describe '#system_instruction' do
+      it 'returns the correct system instruction format' do
+        expect(subject.send(:system_instruction)).to eq({ 'parts' => { 'text' => system_prompt } })
+      end
+    end
+
+    describe '#contents' do
+      it 'returns the correct contents array' do
+        expect(subject.send(:contents).length).to eq(3)
+        expect(subject.send(:contents).last).to eq(subject.send(:current_message))
+      end
+    end
+
+    describe '#current_message' do
+      it 'returns the correct current message format' do
+        expect(subject.send(:current_message)).to eq({ 'role' => 'user', 'parts' => [{ 'text' => entry }] })
+      end
+    end
+
+    describe '#history_messages' do
+      it 'returns the correct history messages format' do
+        expected = [
+          { 'role' => 'user', 'parts' => [{ 'text' => history.first.user }] },
+          { 'role' => 'model', 'parts' => [{ 'text' => history.first.assistant }] }
+        ]
+        expect(subject.send(:history_messages)).to eq(expected)
+      end
+    end
+
+    describe '#generation_config' do
+      it 'returns the correct generation config' do
+        expect(subject.send(:generation_config)).to eq({ temperature: temperature, responseMimeType: 'application/json' })
+      end
+    end
+
+    describe '#model_version' do
+      it 'returns the correct model version' do
+        expect(subject.send(:model_version)).to eq(model)
+      end
+    end
+
+    describe '#instruction' do
+      it 'returns the correct instruction' do
+        expect(subject.send(:instruction)).to eq('generateContent')
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/chat_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/chat_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Evidence::OpenAI::Chat, type: :service do
   let(:system_prompt) { 'You are a helpful assistant.' }
   let(:entry) { 'What is the capital of France?' }
-  let(:history) { [described_class::HistoryItem.new(user: 'Tell me a joke.', assistant: 'Why did the chicken cross the road?')] }
+  let(:history) { [Evidence::GenAI::HistoryItem.new(user: 'Tell me a joke.', assistant: 'Why did the chicken cross the road?')] }
   let(:temperature) { 0.7 }
   let(:json_response) { '{"answer" : "The capital of France is Paris."}' }
   let(:body) { { 'choices' => [{ 'message' => { 'content' => json_response } }] }.to_json }

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/gen_ai/repeated_feedback_checker_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/gen_ai/repeated_feedback_checker_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Evidence::GenAI::RepeatedFeedbackChecker, type: :service do
 
     describe '#llm_response' do
       it 'calls Evidence::OpenAI::Chat.run with the correct parameters' do
-        expect(Evidence::OpenAI::Chat).to receive(:run).with(system_prompt: system_prompt, entry: feedback, model: described_class::MODEL).and_return(llm_response)
+        expect(Evidence::OpenAI::Chat).to receive(:run).with(system_prompt: system_prompt, entry: feedback, model: Evidence::OpenAI::Chat::SMALL_MODEL).and_return(llm_response)
         subject.send(:llm_response)
       end
     end

--- a/services/QuillLMS/lib/tasks/gen_ai_tasks.thor
+++ b/services/QuillLMS/lib/tasks/gen_ai_tasks.thor
@@ -204,7 +204,7 @@ class GenAITasks < Thor
   end
 
   # bundle exec thor gen_a_i_tasks:secondary_prompt_entry 753 'Keep revising! Try to be even more specific. What did Black South African students do to show that they opposed segregated schools?  Read the highlighted text for ideas.'
-  desc "secondary_prompt_entry 256 'some answer from student'", 'Run to see system prompt and feedback for a given prompt / entry'
+  desc "secondary_prompt_entry 256 'some feedback'", 'Run to see system prompt and feedback for a given prompt / entry'
   def secondary_prompt_entry(prompt_id, feedback_primary, template_file: nil)
     prompt = Evidence::Prompt.find(prompt_id)
     system_prompt = Evidence::GenAI::SecondaryFeedbackPromptBuilder.run(prompt:, template_file:)
@@ -242,8 +242,11 @@ class GenAITasks < Thor
       { 'feedback' => 'Clear your response and try again. Can you think of a specific way Korean leaders tried to stop the pirates, using information from the text?' }
     ]
 
+    start_time = Time.zone.now
     check = Evidence::Check::GenAI.new(entry, prompt, previous)
     response = check.run
+    end_time = Time.zone.now
+
 
     puts "System Prompt"
     puts check.send(:system_prompt)
@@ -258,6 +261,7 @@ class GenAITasks < Thor
     puts "Secondary Response: #{check.send(:secondary_feedback_response)}"
     print_line
     puts response
+    puts "Time elapsed: #{end_time - start_time} seconds"
   end
 
   desc 'populate_concepts_and_rules', 'Seed the 3 GenAI concepts, the 6 rules needed by the system'

--- a/services/QuillLMS/lib/tasks/gen_ai_tasks.thor
+++ b/services/QuillLMS/lib/tasks/gen_ai_tasks.thor
@@ -247,7 +247,6 @@ class GenAITasks < Thor
     response = check.run
     end_time = Time.zone.now
 
-
     puts "System Prompt"
     puts check.send(:system_prompt)
     print_line


### PR DESCRIPTION
## WHAT
Add the ability to use Gemini for the GenAI check. This adds a new `Evidence::Gemini::Chat` API wrapper
## WHY
We want to test with Gemini since we are demoing for Google and our Gemini research has had good results. Also like we've been doing with OpenAI, we want to use the system prompt and send the chat history when this is live (which the current API wrapper doesn't do) to (maybe) give enough context so it has a more natural chat.
## HOW
Create a `Evidence::Gemini::Chat` which is different than the `Evidence::Gemini::Completion` used by the `Research` namespace. Following the pattern of before and creating a different API rather than trying to make on class work for both use cases. Also, I made this match the protocol of the OpenAI version of `Chat`, to make switching back and forth easy (change one constant).


### Notion Card Links
https://www.notion.so/quill/Use-Gemini-for-GenAI-checks-3cdcf8001c4849b8916171bdaac4bd53

### What have you done to QA this feature?
I have a thor task `bundle exec thor gen_a_i_tasks:example_check` that runs through the whole pipeline and hits the primary, repeated, and secondary feedback calls. I've been using this as an integration test of sorts, since it prints all the relevant information to the screen (prompts, response, timing). I could convert this to an external_api rspec as well.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying soon.
Self-Review: Have you done an initial self-review of the code below on Github? | yes
