### PR TITLE
Add new environment to deploy and config scripts

### DIFF
--- a/services/QuillLMS/deploy.sh
+++ b/services/QuillLMS/deploy.sh
@@ -26,6 +26,11 @@ case $1 in
     HEROKU_APP=empirical-grammar-staging
     URL="https://staging.quill.org/"
     ;;
+  beta)
+    DEPLOY_GIT_BRANCH=deploy-lms-beta
+    HEROKU_APP=quill-lms-beta
+    URL="https://beta.quill.org/"
+    ;;
   dan)
     DEPLOY_GIT_BRANCH=deploy-lms-dan
     HEROKU_APP=quill-lms-dan

--- a/services/QuillLMS/lib/tasks/staging_config.rake
+++ b/services/QuillLMS/lib/tasks/staging_config.rake
@@ -67,6 +67,7 @@ namespace :staging_config do
 
     STAGING_APP = 'empirical-grammar-staging'
     STAGING_PERSONAL_APPS = %w[
+      quill-lms-beta
       quill-lms-brendan
       quill-lms-cissy
       quill-lms-dan


### PR DESCRIPTION
## WHAT
Add a new `beta` staging environment to our deploy and config scripts
## WHY
So that developers can deploy to the new environment easily, and so that it can stay up to date with broader staging configuration changes.
## HOW
- Add a `beta` option the `deploy.sh` script
- Add the `beta` environment to the `staging_config.rake` file that syncs config settings from Staging environments on demand

### Notion Card Links
https://www.notion.so/quill/Add-beta-staging-environment-acc7856e9f524892b8ace30e8cd978e6?pvs=4

### What have you done to QA this feature?
- Test deploy script for new environment, confirming that the code deploys
- Sign in and out in the new environment
- Confirm that Sidekiq jobs process by loading Admin Diagnostic Growth Reports

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, all code changes are purely config-based
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes