### PR TITLE
record-missing-matview-errors

### DIFF
--- a/services/QuillLMS/app/queries/quill_big_query/materialized_view_query.rb
+++ b/services/QuillLMS/app/queries/quill_big_query/materialized_view_query.rb
@@ -2,6 +2,8 @@
 
 module QuillBigQuery
   class MaterializedViewQuery < Query
+    class BrokenMaterializedViewError < StandardError; end
+
     BROKEN_MATERIALIZED_VIEW_ERRORS = [
       ::Google::Cloud::NotFoundError,
       ::Google::Cloud::InvalidArgumentError
@@ -17,7 +19,8 @@ module QuillBigQuery
 
     def run_query
       query_runner(query)
-    rescue *BROKEN_MATERIALIZED_VIEW_ERRORS
+    rescue *BROKEN_MATERIALIZED_VIEW_ERRORS => e
+      ErrorNotifier.report(BrokenMaterializedViewError.new(e.message))
       query_runner(query_fallback)
     end
 

--- a/services/QuillLMS/spec/queries/quill_big_query/materialized_view_query_spec.rb
+++ b/services/QuillLMS/spec/queries/quill_big_query/materialized_view_query_spec.rb
@@ -38,11 +38,20 @@ describe QuillBigQuery::MaterializedViewQuery do
       expect(subject).to eq(result)
     end
 
-    it 'mat view query error' do
-      expect(runner).to receive(:execute).with(query).and_raise(::Google::Cloud::InvalidArgumentError)
-      expect(runner).to receive(:execute).with(query_fallback).and_return(result)
+    context 'mat view query error' do
+      let(:message) { 'This is the error message.' }
 
-      expect(subject).to eq(result)
+      before do
+        allow(runner).to receive(:execute).with(query).and_raise(::Google::Cloud::InvalidArgumentError, message)
+        allow(runner).to receive(:execute).with(query_fallback).and_return(result)
+      end
+
+      it { expect(subject).to eq(result) }
+
+      it do
+        expect(ErrorNotifier).to receive(:report).with(described_class::BrokenMaterializedViewError.new(message))
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT
Record errors when BigQuery materialized views are missing, and we have to use our fallback logic.
## WHY
This will allow us to track when this happens and set up alerting around those issues.
## HOW
Add a new custom error to the `MateralizedViewQuery` class, and use `ErrorNotifier` to report such errors to NewRelic and Sentry when materialized view fallback code gets triggered.

### Notion Card Links
https://www.notion.so/quill/Threshold-alert-for-BigQuery-fallback-queries-ea6858cd41cc4297879ddea050ece502?pvs=4

### What have you done to QA this feature?
- Deploy to staging
- Ensure that Admin Diagnostic Growth Report pages still load
- Once this is in production, I plan to verify that these errors are being logged in Sentry and NewRelic during our BigQuery data update windows

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | No, small change
Self-Review: Have you done an initial self-review of the code below on Github? | Yes