### PR TITLE
fix-teacher-diagnostic-student-report-ordering

### DIFF
--- a/services/QuillLMS/app/controllers/concerns/results_summary.rb
+++ b/services/QuillLMS/app/controllers/concerns/results_summary.rb
@@ -8,7 +8,7 @@ module ResultsSummary
 
   def results_summary(activity_id, classroom_id, unit_id)
     activity = Activity.find(activity_id)
-    @skill_groups = activity.skill_groups
+    @skill_groups = activity.skill_groups.order(:order_number)
     set_activity_sessions_and_assigned_students_for_activity_classroom_and_unit(activity_id, classroom_id, unit_id, hashify_activity_sessions: true)
     @skill_group_summaries = @skill_groups.map do |skill_group|
       {

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -128,6 +128,21 @@ describe ResultsSummary do
         ]
       })
     end
+
+    context 'multiple skill groups' do
+      subject { results_summary(unit_activity.activity_id, classroom.id, nil) }
+
+      let(:activity) { unit_activity.activity }
+      let(:order_number) { skill_group_activity.skill_group.order_number - 1 }
+      let(:skill_group2) { create(:skill_group, order_number:) }
+      let!(:skill_group_activity2) { create(:skill_group_activity, activity:, skill_group: skill_group2) }
+
+      let(:expected_result) { activity.skill_groups.order(:order_number).map(&:name) }
+
+      it 'should order skill_group_summaries by order_number' do
+        expect(subject[:skill_group_summaries].map{|sg| sg[:name]}).to eq(expected_result)
+      end
+    end
   end
 
   describe '#student_results' do

--- a/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
+++ b/services/QuillLMS/spec/controllers/concerns/results_summary_spec.rb
@@ -140,7 +140,7 @@ describe ResultsSummary do
       let(:expected_result) { activity.skill_groups.order(:order_number).map(&:name) }
 
       it 'should order skill_group_summaries by order_number' do
-        expect(subject[:skill_group_summaries].map{|sg| sg[:name]}).to eq(expected_result)
+        expect(subject[:skill_group_summaries].map { |sg| sg[:name] }).to eq(expected_result)
       end
     end
   end


### PR DESCRIPTION

## WHAT
Explicitly sort Skill Groups by order_number
## WHY
So that Curriculum specification controls the displayed order of skills, since those are sequenced
## HOW
Add an explicit `order` clause to the code that fetches diagnostic activity Skill Groups

### Screenshots
OLD
![image](https://github.com/user-attachments/assets/6917d0c0-a6f4-4712-81a8-02b852c3a043)
NEW
![image](https://github.com/user-attachments/assets/a045fe08-84d8-4796-9c63-42191c9cdde1)

### Notion Card Links
https://www.notion.so/quill/2024-Long-Term-Diagnostic-Bugs-Fixes-For-Mid-August-f7440092d6924dfcb8ae2f28c03f1475?pvs=4#b9ec1338a58b4032bd34a58b161ba996

### What have you done to QA this feature?
- Ensure that Student Report for Teacher Diagnostics shows skill columns in the intended order (defined by `order_by` on `skill_group_activities`)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes