### PR TITLE
pluralize-skills-properly

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/index.tsx
@@ -153,7 +153,8 @@ export {
   getlanguageOptions,
   renderSaveAndExitButton,
   hasTranslationFlag,
-  showTranslations
+  showTranslations,
+  pluralize
 } from './libs/index'
 
 export {

--- a/services/QuillLMS/client/app/bundles/Shared/libs/index.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/index.ts
@@ -37,6 +37,7 @@ export { filterNumbers } from './filterFunctions'
 export { redirectToActivity } from './redirectToActivity'
 export { renderNavList } from './navbarHelpers'
 export { noResultsMessage } from './stringManipulationFunctions'
+export { pluralize } from './pluralize'
 export {
   getStatusForResponse,
   responsesWithStatus,

--- a/services/QuillLMS/client/app/bundles/Shared/libs/pluralize.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/pluralize.ts
@@ -1,0 +1,5 @@
+export const pluralize = (count, word, plural) => {
+  if (count === 1) return word
+
+  return plural
+}

--- a/services/QuillLMS/client/app/bundles/Shared/libs/tests/pluralize.test.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/tests/pluralize.test.ts
@@ -1,0 +1,18 @@
+import { pluralize, } from '../pluralize';
+
+const SINGULAR = 'test'
+const PLURAL = 'tests'
+
+describe('pluralize function', () => {
+  it('returns singular value if count is 1', () => {
+    expect(pluralize(1, SINGULAR, PLURAL)).toBe(SINGULAR);
+  });
+
+  it('returns plural value if count is 0', () => {
+    expect(pluralize(0, SINGULAR, PLURAL)).toBe(PLURAL);
+  });
+
+  it('returns plural if value is greater than 1', () => {
+    expect(pluralize(2, SINGULAR, PLURAL)).toBe(PLURAL);
+  });
+});

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
@@ -13,7 +13,7 @@ import {
 } from './shared';
 
 import { requestGet } from '../../../../../../modules/request/index';
-import { DataTable } from '../../../../../Shared/index';
+import { DataTable, pluralize } from '../../../../../Shared/index';
 import LoadingSpinner from '../../../shared/loading_indicator.jsx';
 
 interface Student {
@@ -267,8 +267,8 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
       const countOfSkillsToPractice = skill_groups.length - countOfPreSkillsProficienct
       return (
         <div className="skills-correct-element">
-          <p>{countOfPreSkillsProficienct} of {skill_groups.length} Skills</p>
-          {!!countOfSkillsToPractice && <p>({countOfSkillsToPractice} Skills to Practice)</p>}
+          <p>{countOfPreSkillsProficienct} of {skill_groups.length} {pluralize(countOfSkillsProficient, "Skill", "Skills")}</p>
+          {!!countOfSkillsToPractice && <p>({countOfSkillsToPractice} {pluralize({countOfSkillsToPractice}, "Skill", "Skills")} to Practice)</p>}
         </div>
       )
     }
@@ -277,7 +277,7 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
     return(
       <div className="skills-correct-element">
         <p>{correct_skill_groups_text}</p>
-        {!!countOfSkillsToPractice && <p>({countOfSkillsToPractice} Skills to Practice)</p>}
+        {!!countOfSkillsToPractice && <p>({countOfSkillsToPractice} {pluralize(countOfSkillsToPractice, "Skill", "Skills")} to Practice)</p>}
       </div>
     )
   }


### PR DESCRIPTION
## WHAT
- Add a pluralize utility method
- Use it for student response reporting around the word "Skill(s)"
## WHY
It's a nice readability feature we should provide if we can
## HOW
- Create a new `Shared/lib` module for pluralization (I modeled the signature off of Rails' `pluralize`)
- Use new module in existing template

### Screenshots
![Screenshot 2024-08-19 at 4 56 32 PM](https://github.com/user-attachments/assets/3e615db1-20e8-49e0-a016-16648477e356)
![Screenshot 2024-08-19 at 4 59 13 PM](https://github.com/user-attachments/assets/b33a9455-b56a-4b64-9246-01a364610f64)

### Notion Card Links
https://www.notion.so/quill/New-Diagnostic-Engineering-Tasks-ef849d3f473a4a11a675081a89556a75?pvs=4#673308dd75f04dc0ba79485810c44238

### What have you done to QA this feature?
Find an example teacher who has a student with only 1 skill to practice, confirm that text is singular as expected.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No test coverage here
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes