### PR TITLE
Increase size of the Quill logo on Evidence preview page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Evidence/styles/headerStyling.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/headerStyling.scss
@@ -27,9 +27,7 @@
     border-right: 1px solid #0b9d88;
     .left-side {
       display: flex;
-      .quill-tooltip-trigger {
-        padding-top: 7px;
-      }
+      align-items: center;
     }
     #teacher-preview-menu-button {
       margin-left: 16px;

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/headerStyling.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/headerStyling.scss
@@ -27,6 +27,9 @@
     border-right: 1px solid #0b9d88;
     .left-side {
       display: flex;
+      .quill-tooltip-trigger {
+        padding-top: 7px;
+      }
     }
     #teacher-preview-menu-button {
       margin-left: 16px;
@@ -64,7 +67,7 @@
   }
 
   img {
-    height: 25px;
+    height: 40px;
   }
 
   .right-side-container {


### PR DESCRIPTION
## WHAT
Increase the height of the Quill logo on the Evidence activity preview page, and slightly move the adjacent tooltip down to accommodate for the height increase.

## WHY
This logo is currently too small and doesn't look good on the page.

## HOW
Just two small CSS changes.

### Screenshots
![Screenshot 2024-08-21 at 2 08 57 PM](https://github.com/user-attachments/assets/39e598c4-8ae8-4961-b7e5-f71e6814543d)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=06cc44af29864b83a56ddd1ade78325a&pm=c

### What have you done to QA this feature?
Deploy to staging and ensure the size is as desired.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO - small change.
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
