### PR TITLE
Update styling to not bold student data that gets truncated

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_individual_student_responses.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/progress_reports/diagnostic_individual_student_responses.scss
@@ -129,12 +129,12 @@
         margin-right: 0px;
       }
     }
-    .data-table-row-section:first-of-type {
+    td.data-table-row-section:first-of-type {
       color: $quill-grey-90;
       font-size: 13px;
       font-weight: 600;
     }
-    .data-table-row-section:last-of-type {
+    .data-table-row-section {
       font-size: 13px;
       font-weight: 400;
       line-height: 20px; /* 166.667% */

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/individualStudentResponses.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/individualStudentResponses.test.jsx.snap
@@ -407,32 +407,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -648,32 +627,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -889,32 +847,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -1150,32 +1087,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -1391,32 +1307,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -1652,32 +1547,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -1893,32 +1767,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -2134,32 +1987,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -2375,32 +2207,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -2616,32 +2427,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -2857,32 +2647,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -3098,32 +2867,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -3359,32 +3107,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -3600,32 +3327,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -3861,32 +3567,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -4102,32 +3787,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -4363,32 +4027,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -4604,32 +4247,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -4865,32 +4487,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -5106,32 +4707,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -5347,32 +4927,11 @@ exports[`IndividualStudentResponses component should render for a post-test 1`] 
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -5757,32 +5316,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -5998,32 +5536,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -6239,32 +5756,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -6500,32 +5996,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -6741,32 +6216,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -7002,32 +6456,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -7243,32 +6676,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -7484,32 +6896,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -7725,32 +7116,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -7966,32 +7336,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -8207,32 +7556,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -8448,32 +7776,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -8709,32 +8016,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -8950,32 +8236,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -9211,32 +8476,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -9452,32 +8696,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -9713,32 +8936,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -9954,32 +9156,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -10215,32 +9396,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -10456,32 +9616,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"
@@ -10697,32 +9836,11 @@ exports[`IndividualStudentResponses component should render for a pre-test 1`] =
             <tr
               class="data-table-row  "
             >
-              <td>
-                <span
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="quill-tooltip-trigger "
-                  role="button"
-                  style="width: 66px; min-width: 66px; text-align: left;"
-                  tabindex="0"
-                >
-                  <span
-                    class="data-table-row-section undefined"
-                    style="width: 66px; min-width: 66px; text-align: left;"
-                  >
-                    Directions
-                  </span>
-                  <span
-                    class="quill-tooltip-wrapper"
-                  >
-                    <span
-                      aria-live="polite"
-                      class="quill-tooltip"
-                      id="tooltip"
-                      role="tooltip"
-                    />
-                  </span>
-                </span>
+              <td
+                class="data-table-row-section undefined"
+                style="width: 66px; min-width: 66px; text-align: left;"
+              >
+                Directions
               </td>
               <td
                 class="data-table-row-section undefined"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/individualStudentResponses.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/individualStudentResponses.tsx
@@ -34,7 +34,8 @@ const QuestionTable = ({ question, }) => {
       name: `Question ${question_number}`,
       attribute: 'label',
       width: '66px',
-      tooltipText: "The questions are grouped into skills for this report. The question number indicates the order in which students complete the questions."
+      tooltipText: "The questions are grouped into skills for this report. The question number indicates the order in which students complete the questions.",
+      noTooltip: true
     },
     {
       name: "",


### PR DESCRIPTION
## WHAT
Update styling to not bold student data that gets truncated
## WHY
It's not obvious why this text gets bolded to the user, and it appears to be an unintended consequence of an over-zealous selector (that's supposed to apply to the row label in this report; e.g. "Directions").  The logic that handles overly-long text (truncating it and providing a hover tooltip with the full text) puts the data into a structure that gets that same selector applied.
## HOW
- Add a `noTooltip` param to the right-most column in order to ensure that the tooltip logic doesn't get applied to labels that are known to fit in the table (this was erroneously happening for "Directions", making the CSS selector logic very difficult)
- Tighten up the restrictions on the bolding selector and slightly broaden the "default" selector

### Screenshots
![image](https://github.com/user-attachments/assets/c873db96-aff5-41ff-9c14-f7bf3cadb23c)
![image](https://github.com/user-attachments/assets/0a131b98-3f23-47d6-bd97-c977def6d5e7)

### Notion Card Links
https://www.notion.so/quill/New-Diagnostic-Engineering-Tasks-ef849d3f473a4a11a675081a89556a75?pvs=4#97999eadc7e6447d922ed557fe32f5e3

### What have you done to QA this feature?
- Load a report for a teacher+diagnostic combo that is known to have this issue
- Ensure that the left-column (row labels) remain bold
- Ensure that the right column (student content) is never bolded
- - Even in cases where text is truncated and a tooltip is applied to the text

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Snapshots
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes