### PR TITLE
Add ability to hide guidelines

### DIFF
--- a/services/QuillLMS/db/migrate/20240821210256_add_visible_to_guidelines.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240821210256_add_visible_to_guidelines.evidence.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240821205700)
+class AddVisibleToGuidelines < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_guidelines, :visible, :boolean, default: true, null: false
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3188,7 +3188,8 @@ CREATE TABLE public.evidence_research_gen_ai_guidelines (
     text text NOT NULL,
     stem_vault_id integer NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    visible boolean DEFAULT true NOT NULL
 );
 
 
@@ -12143,6 +12144,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240714215711'),
 ('20240801134426'),
 ('20240805190219'),
-('20240808123813');
+('20240808123813'),
+('20240821210256');
 
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/guidelines_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/guidelines_controller.rb
@@ -19,6 +19,12 @@ module Evidence
           end
         end
 
+        def hide
+          @guideline = Guideline.find(params[:id])
+          @guideline.update(visible: false)
+          redirect_to @guideline.stem_vault
+        end
+
         private def guideline_params
           params
             .require(:research_gen_ai_guideline)

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/stem_vaults_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/stem_vaults_controller.rb
@@ -22,6 +22,8 @@ module Evidence
         def show
           @stem_vault = StemVault.find(params[:id])
           @datasets = @stem_vault.datasets.order(id: :desc)
+          @optimal_guidelines = @stem_vault.guidelines.optimal.visible
+          @suboptimal_guidelines = @stem_vault.guidelines.suboptimal.visible
         end
 
         private def activity = @activity ||= Activity.find(params[:activity_id])

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/trials_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/trials_controller.rb
@@ -11,7 +11,8 @@ module Evidence
           @llms = LLM.all
           @llm_prompt_templates = LLMPromptTemplate.all
           @g_evals = GEval.selectable
-          @guidelines = dataset.stem_vault.guidelines
+          @optimal_guidelines = dataset.stem_vault.guidelines.optimal.visible
+          @suboptimal_guidelines = dataset.stem_vault.guidelines.suboptimal.visible
           @prompt_examples = dataset.prompt_examples
         end
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/guideline.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/guideline.rb
@@ -7,6 +7,7 @@
 #  id                         :bigint           not null, primary key
 #  curriculum_assigned_status :string           not null
 #  text                       :text             not null
+#  visible                    :boolean          default(TRUE), not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  stem_vault_id              :integer          not null
@@ -25,7 +26,14 @@ module Evidence
         validates :stem_vault_id, presence: true
         validates :text, presence: true
 
+        scope :visible, -> { where(visible: true) }
+        scope :archived, -> { where(visible: false) }
+
         def self.assigned_status_column = :curriculum_assigned_status
+
+        def archive! = update!(archived: true)
+
+        def unarchive! = update!(archived: false)
 
         def to_s = text
       end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/guideline.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/guideline.rb
@@ -31,10 +31,6 @@ module Evidence
 
         def self.assigned_status_column = :curriculum_assigned_status
 
-        def archive! = update!(archived: true)
-
-        def unarchive! = update!(archived: false)
-
         def to_s = text
       end
     end

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
@@ -8,10 +8,10 @@
   <p><%= @dataset %></p>
 
 
-  <h3>Optimal Count</h3>
+  <h3>Optimal Test Count</h3>
   <p><%= @dataset.optimal_count %></p>
 
-  <h3>Suboptimal Count</h3>
+  <h3>Suboptimal Test Count</h3>
   <p><%= @dataset.suboptimal_count %></p>
   <hr/>
 
@@ -33,11 +33,11 @@
             <th>Trial Number</th>
             <th>Created</th>
             <th>Prompt Template</th>
-            <th>Optimal Examples</th>
-            <th>Sub-Optimal Feedback Examples</th>
+            <th>Optimal Prompt Example Count</th>
+            <th>Suboptimal Prompt Example Count</th>
             <th>Guidelines</th>
             <th>Optimal Accuracy</th>
-            <th>Sub-Optimal Accuracy</th>
+            <th>Suboptimal Accuracy</th>
             <th>Model</th>
             <th>GEval Average</th>
             <th>Status</th>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/stem_vaults/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/stem_vaults/show.html.erb
@@ -53,32 +53,29 @@
   </h3>
   <ul>
     <% @optimal_guidelines.each do |guideline| %>
-      <%= form_with(url: hide_research_gen_ai_stem_vault_guideline_path(@stem_vault, guideline), method: :patch, class: 'guideline-form') do |form| %>
+      <%= form_with(url: hide_research_gen_ai_stem_vault_guideline_path(@stem_vault, guideline), method: :patch, class: 'guideline-form') do |f| %>
         <li id="guideline_<%= guideline.id %>" class="guideline-item">
           <div class="guideline-content">
             <%= guideline %>
           </div>
-          <%= form.submit 'Hide', class: 'hide-button', data: { confirm: 'Are you sure you want to hide this guideline?' } %>
+          <%= f.submit 'Hide', class: 'hide-button', data: { confirm: 'Are you sure you want to hide this guideline?' } %>
         </li>
       <% end %>
     <% end %>
   </ul>
 
-
   <h3>
     Suboptimal Guidelines
     <%= link_to 'new', new_research_gen_ai_stem_vault_guideline_path(@stem_vault), class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
   </h3>
-
-
   <ul>
     <% @suboptimal_guidelines.each do |guideline| %>
-      <%= form_with(url: hide_research_gen_ai_stem_vault_guideline_path(@stem_vault, guideline), method: :patch, class: 'guideline-form') do |form| %>
+      <%= form_with(url: hide_research_gen_ai_stem_vault_guideline_path(@stem_vault, guideline), method: :patch, class: 'guideline-form') do |f| %>
         <li id="guideline_<%= guideline.id %>" class="guideline-item">
           <div class="guideline-content">
             <%= guideline %>
           </div>
-          <%= form.submit 'Hide', class: 'hide-button', data: { confirm: 'Are you sure you want to hide this guideline?' } %>
+          <%= f.submit 'Hide', class: 'hide-button', data: { confirm: 'Are you sure you want to hide this guideline?' } %>
         </li>
       <% end %>
     <% end %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/stem_vaults/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/stem_vaults/show.html.erb
@@ -52,19 +52,35 @@
     <%= link_to 'new', new_research_gen_ai_stem_vault_guideline_path(@stem_vault), class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
   </h3>
   <ul>
-    <% @stem_vault.guidelines.optimal.each do |guideline| %>
-      <li><%= guideline %></li>
+    <% @optimal_guidelines.each do |guideline| %>
+      <%= form_with(url: hide_research_gen_ai_stem_vault_guideline_path(@stem_vault, guideline), method: :patch, class: 'guideline-form') do |form| %>
+        <li id="guideline_<%= guideline.id %>" class="guideline-item">
+          <div class="guideline-content">
+            <%= guideline %>
+          </div>
+          <%= form.submit 'Hide', class: 'hide-button', data: { confirm: 'Are you sure you want to hide this guideline?' } %>
+        </li>
+      <% end %>
     <% end %>
   </ul>
+
 
   <h3>
     Suboptimal Guidelines
     <%= link_to 'new', new_research_gen_ai_stem_vault_guideline_path(@stem_vault), class: 'new-link', target: '_blank', style: 'margin-right: 20px;' %>
   </h3>
 
+
   <ul>
-    <% @stem_vault.guidelines.suboptimal.each do |guideline| %>
-      <li><%= guideline %></li>
+    <% @suboptimal_guidelines.each do |guideline| %>
+      <%= form_with(url: hide_research_gen_ai_stem_vault_guideline_path(@stem_vault, guideline), method: :patch, class: 'guideline-form') do |form| %>
+        <li id="guideline_<%= guideline.id %>" class="guideline-item">
+          <div class="guideline-content">
+            <%= guideline %>
+          </div>
+          <%= form.submit 'Hide', class: 'hide-button', data: { confirm: 'Are you sure you want to hide this guideline?' } %>
+        </li>
+      <% end %>
     <% end %>
   </ul>
 </div>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/new.html.erb
@@ -59,7 +59,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @guidelines.optimal.each do |guideline| %>
+        <% @optimal_guidelines.each do |guideline| %>
           <tr>
             <td>
               <%= f.check_box :guideline_ids, { multiple: true }, guideline.id, nil %>
@@ -93,7 +93,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @guidelines.suboptimal.each do |guideline| %>
+        <% @suboptimal_guidelines.each do |guideline| %>
           <tr>
             <td>
               <%= f.check_box :guideline_ids, { multiple: true }, guideline.id, nil %>

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -48,7 +48,10 @@ Evidence::Engine.routes.draw do
       resources :llm_prompt_templates, only: [:new, :create, :show, :index, :edit, :update]
 
       resources :stem_vaults, only: [] do
-        resources :guidelines, only: [:new, :create]
+        resources :guidelines, only: [:new, :create] do
+          member { patch :hide }
+        end
+
         resources :datasets, only: [:new, :create, :show], shallow: true
       end
 

--- a/services/QuillLMS/engines/evidence/db/migrate/20240821205700_add_visible_to_guidelines.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240821205700_add_visible_to_guidelines.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVisibleToGuidelines < ActiveRecord::Migration[7.0]
+  def change
+    add_column :evidence_research_gen_ai_guidelines, :visible, :boolean, default: true, null: false
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1112,7 +1112,8 @@ CREATE TABLE public.evidence_research_gen_ai_guidelines (
     text text NOT NULL,
     stem_vault_id integer NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    visible boolean DEFAULT true NOT NULL
 );
 
 
@@ -2652,6 +2653,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240714214900'),
 ('20240801134328'),
 ('20240805185650'),
-('20240808123536');
+('20240808123536'),
+('20240821205700');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/guidelines.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/guidelines.rb
@@ -7,6 +7,7 @@
 #  id                         :bigint           not null, primary key
 #  curriculum_assigned_status :string           not null
 #  text                       :text             not null
+#  visible                    :boolean          default(TRUE), not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  stem_vault_id              :integer          not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/guideline_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/guideline_spec.rb
@@ -7,6 +7,7 @@
 #  id                         :bigint           not null, primary key
 #  curriculum_assigned_status :string           not null
 #  text                       :text             not null
+#  visible                    :boolean          default(TRUE), not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  stem_vault_id              :integer          not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
@@ -114,10 +114,10 @@ module Evidence
           end
 
           it 'handles errors and updates status to failed' do
-            allow(batch).to receive(:on).and_raise(StandardError.new("Test error"))
+            allow(batch).to receive(:on).and_raise(StandardError.new('Test error'))
             subject
             expect(trial.status).to eq('failed')
-            expect(trial.trial_errors).to include("Test error")
+            expect(trial.trial_errors).to include('Test error')
           end
         end
       end


### PR DESCRIPTION
## WHAT
* Add `visible` field to `Evidence::Research::GenAI::Guideline`
* Add the ability to hide guidelines within a given stem vault

## WHY
* This attribute will keep track of which guidelines are shown in the UI during trial creation
* Guidelines can become not as useful and their presence in the UI clutters up the selection process

## HOW
* Add migration with boolean `visible` attribute
* Add 'hide' button next to all guidelines.  When a user clicks the button, set the guideline's visible status to false.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Tested on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
