### PR TITLE
Add order attribute to LLM model

### DIFF
--- a/services/QuillLMS/db/migrate/20240822145310_add_order_to_llm.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240822145310_add_order_to_llm.evidence.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240822145206)
+class AddOrderToLLM < ActiveRecord::Migration[7.0]
+  def up
+    add_column :evidence_research_gen_ai_llms, :order, :integer
+
+    Evidence::Research::GenAI::LLM.reset_column_information
+    Evidence::Research::GenAI::LLM.order(:created_at).each.with_index do |llm, index|
+      llm.update_column(:order, index)
+    end
+
+    change_column_null :evidence_research_gen_ai_llms, :order, false
+  end
+
+  def down
+    remove_column :evidence_research_gen_ai_llms, :order
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3391,7 +3391,8 @@ CREATE TABLE public.evidence_research_gen_ai_llms (
     vendor character varying NOT NULL,
     version character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    "order" integer NOT NULL
 );
 
 
@@ -12145,6 +12146,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240801134426'),
 ('20240805190219'),
 ('20240808123813'),
-('20240821210256');
+('20240821210256'),
+('20240822145310');
 
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llms_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/llms_controller.rb
@@ -4,26 +4,36 @@ module Evidence
   module Research
     module GenAI
       class LLMsController < ApplicationController
+        def index = @llms = LLM.order(:order)
+
         def new
           @llm = LLM.new
         end
 
         def create
-          @llm = LLM.new(llm_params)
+          @llm = LLM.new(llm_create_params)
 
-          if @llm.save
-            redirect_to @llm
-          else
-            render :new
-          end
+          @llm.save ? redirect_to(@llm) : render(:new)
+        end
+
+        def update
+          @llm = LLM.find(params[:id])
+          @llm.update(llm_update_params)
+          redirect_to research_gen_ai_llms_path
         end
 
         def show = @llm = LLM.find(params[:id])
 
-        private def llm_params
+        private def llm_create_params
           params
             .require(:research_gen_ai_llm)
             .permit(:vendor, :version)
+        end
+
+        private def llm_update_params
+          params
+            .require(:research_gen_ai_llm)
+            .permit(:order)
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/trials_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/trials_controller.rb
@@ -8,7 +8,7 @@ module Evidence
 
         def new
           @trial = dataset.trials.new
-          @llms = LLM.all
+          @llms = LLM.order(:order)
           @llm_prompt_templates = LLMPromptTemplate.all
           @g_evals = GEval.selectable
           @optimal_guidelines = dataset.stem_vault.guidelines.optimal.visible

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_llms
 #
 #  id         :bigint           not null, primary key
+#  order      :integer          not null
 #  vendor     :string           not null
 #  version    :string           not null
 #  created_at :datetime         not null
@@ -35,8 +36,11 @@ module Evidence
 
         validates :vendor, presence: true
         validates :version, presence: true
+        validates :order, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
         attr_readonly :vendor, :version
+
+        before_validation :set_default_order
 
         def self.auto_cot = find_by(vendor: OPEN_AI, version: GPT_4_O)
         def self.g_eval = find_by(vendor: GOOGLE, version: GEMINI_1_5_FLASH_LATEST)
@@ -56,6 +60,10 @@ module Evidence
         end
 
         def to_s = "#{vendor}: #{version}"
+
+        private def set_default_order
+          self.order ||= (self.class.maximum(:order) || 0) + 1
+        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
@@ -48,6 +48,7 @@
         <tbody>
           <% @trials.each.with_index(0) do |trial, index| %>
             <% llm_prompt = trial.llm_prompt %>
+            <% next unless llm_prompt %>
             <tr>
               <td><%= "Trial #{trial.number}" %></td>
               <td><%= date_helper(trial.created_at) %></td>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llms/index.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/llms/index.html.erb
@@ -1,0 +1,28 @@
+<h1>
+  LLMs
+  <%= link_to 'new', new_research_gen_ai_llm_path, class: 'new-link', target: '_blank' %>
+</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Vendor</th>
+      <th>Version</th>
+      <th>Order</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @llms.each do |llm| %>
+      <tr>
+        <td><%= llm.vendor %></td>
+        <td><%= llm.version %></td>
+        <td>
+          <%= form_with(model: llm, local: true) do |form| %>
+            <%= form.number_field :order, min: 0 %>
+            <%= form.submit 'Update' %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -43,7 +43,7 @@ Evidence::Engine.routes.draw do
 
   namespace :research do
     namespace :gen_ai do
-      resources :llms, only: [:new, :create, :show, :index]
+      resources :llms, only: [:new, :create, :show, :index, :update]
       resources :llm_prompts, only: [:show]
       resources :llm_prompt_templates, only: [:new, :create, :show, :index, :edit, :update]
 

--- a/services/QuillLMS/engines/evidence/db/migrate/20240822145206_add_order_to_llm.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240822145206_add_order_to_llm.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddOrderToLLM < ActiveRecord::Migration[7.0]
+  def up
+    add_column :evidence_research_gen_ai_llms, :order, :integer
+
+    Evidence::Research::GenAI::LLM.reset_column_information
+    Evidence::Research::GenAI::LLM.order(:created_at).each.with_index do |llm, index|
+      llm.update_column(:order, index)
+    end
+
+    change_column_null :evidence_research_gen_ai_llms, :order, false
+  end
+
+  def down
+    remove_column :evidence_research_gen_ai_llms, :order
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1315,7 +1315,8 @@ CREATE TABLE public.evidence_research_gen_ai_llms (
     vendor character varying NOT NULL,
     version character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    "order" integer NOT NULL
 );
 
 
@@ -2654,6 +2655,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240801134328'),
 ('20240805185650'),
 ('20240808123536'),
-('20240821205700');
+('20240821205700'),
+('20240822145206');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llms.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llms.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_llms
 #
 #  id         :bigint           not null, primary key
+#  order      :integer          not null
 #  vendor     :string           not null
 #  version    :string           not null
 #  created_at :datetime         not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_spec.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_llms
 #
 #  id         :bigint           not null, primary key
+#  order      :integer          not null
 #  vendor     :string           not null
 #  version    :string           not null
 #  created_at :datetime         not null
@@ -79,6 +80,39 @@ module Evidence
               let(:version) { 'some_other_version' }
 
               it { is_expected.to eq({}) }
+            end
+          end
+        end
+
+        describe '#set_default_order' do
+          subject { llm.order }
+
+          let(:llm) { create(factory) }
+
+          it { is_expected.to eq(1) }
+
+          context 'when there are existing LLMs' do
+            let!(:llm1) { create(factory, order: 0) }
+            let!(:llm2) { create(factory, order: max_order) }
+            let(:max_order) { 10 }
+
+            it { is_expected.to eq(max_order + 1) }
+          end
+
+          context 'when order is manually set' do
+            let(:llm) { create(factory, order:) }
+            let(:order) { 100 }
+
+            it { is_expected.to eq(order) }
+          end
+
+          context 'when saving an existing record' do
+            let(:llm) { create(factory, order:) }
+            let(:order) { 5 }
+
+            it 'does not change the order' do
+              llm.touch
+              expect(llm.order).to eq(order)
             end
           end
         end


### PR DESCRIPTION
## WHAT
Add an order integer field to the `Evidence::Research::GenAI::LLM` model.

## WHY
In the LLM dropdown the ordering of LLMs is based on creation date.  The order field will allow prioritization of the most likely LLMs to the top.

## HOW
Create a migration and then add an LLM index template where one can update the order of a particular LLM.

### Screenshots
![Screenshot 2024-08-22 at 8 44 42 AM](https://github.com/user-attachments/assets/492536e1-db81-47a5-a6e9-27f4c6fea6b6)


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Tested on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
