### PR TITLE
remove copy about the 2023-2024 school year from the scoring update card

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/promotional_card.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/promotional_card.test.tsx.snap
@@ -283,7 +283,6 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
         }
       }
       primaryHeaderText="Educators, we have updated our approach to scoring activities"
-      secondaryHeaderText="Update for the 2023-2024 school year"
     >
       <div
         className="banner-container gold-secondary"
@@ -291,15 +290,6 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
         <div
           className="left-side-container"
         >
-          <div
-            className="upper-section"
-          >
-            <p
-              className="secondary-header"
-            >
-              Update for the 2023-2024 school year
-            </p>
-          </div>
           <p
             className="primary-header"
           >
@@ -460,7 +450,6 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
         }
       }
       primaryHeaderText="Educators, we have updated our approach to scoring activities"
-      secondaryHeaderText="Update for the 2023-2024 school year"
     >
       <div
         className="banner-container gold-secondary"
@@ -468,15 +457,6 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
         <div
           className="left-side-container"
         >
-          <div
-            className="upper-section"
-          >
-            <p
-              className="secondary-header"
-            >
-              Update for the 2023-2024 school year
-            </p>
-          </div>
           <p
             className="primary-header"
           >
@@ -805,7 +785,6 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
         }
       }
       primaryHeaderText="Educators, we have updated our approach to scoring activities"
-      secondaryHeaderText="Update for the 2023-2024 school year"
     >
       <div
         className="banner-container gold-secondary"
@@ -813,15 +792,6 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
         <div
           className="left-side-container"
         >
-          <div
-            className="upper-section"
-          >
-            <p
-              className="secondary-header"
-            >
-              Update for the 2023-2024 school year
-            </p>
-          </div>
           <p
             className="primary-header"
           >
@@ -982,7 +952,6 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
         }
       }
       primaryHeaderText="Educators, we have updated our approach to scoring activities"
-      secondaryHeaderText="Update for the 2023-2024 school year"
     >
       <div
         className="banner-container gold-secondary"
@@ -990,15 +959,6 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
         <div
           className="left-side-container"
         >
-          <div
-            className="upper-section"
-          >
-            <p
-              className="secondary-header"
-            >
-              Update for the 2023-2024 school year
-            </p>
-          </div>
           <p
             className="primary-header"
           >
@@ -1327,7 +1287,6 @@ exports[`PromotionalCard container ScoringUpdatesCard rendering behavior when th
         }
       }
       primaryHeaderText="Educators, we have updated our approach to scoring activities"
-      secondaryHeaderText="Update for the 2023-2024 school year"
     >
       <div
         className="banner-container gold-secondary"
@@ -1335,15 +1294,6 @@ exports[`PromotionalCard container ScoringUpdatesCard rendering behavior when th
         <div
           className="left-side-container"
         >
-          <div
-            className="upper-section"
-          >
-            <p
-              className="secondary-header"
-            >
-              Update for the 2023-2024 school year
-            </p>
-          </div>
           <p
             className="primary-header"
           >

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/scoring_updates_card.tsx
@@ -22,7 +22,6 @@ const ScoringUpdatesCard = ({ handleCloseCard, }) => {
       handleCloseCard={handleCloseCard}
       icon={{ alt: "Image of a school building", src: "https://assets.quill.org/images/banners/large-school-campus-gold.svg" }}
       primaryHeaderText="Educators, we have updated our approach to scoring activities"
-      secondaryHeaderText="Update for the 2023-2024 school year"
     />
   )
 }


### PR DESCRIPTION
## WHAT
Remove copy about the 2023-2024 school year from the scoring update card on the teacher dashboard.

## WHY
This is confusing to teachers, because we're going into 2024-2025.

## HOW
Delete the prop with that copy.

### Screenshots
<img width="573" alt="Screenshot 2024-08-23 at 9 28 11 AM" src="https://github.com/user-attachments/assets/dc0e555b-fbb0-4611-aa9c-6a2f7b338234">

### Notion Card Links
https://www.notion.so/quill/Could-we-remove-the-update-for-the-23-23-school-year-tag-from-the-scoring-updates-banner-48c9bb1cc1b142d8996e9a5adf5a40c7

### What have you done to QA this feature?
Looked at the dashboard locally to confirm the element is removed and looks okay.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
