### PR TITLE
Back apply evidence question scores

### DIFF
--- a/services/QuillLMS/app/workers/evidence_update_scoring_worker.rb
+++ b/services/QuillLMS/app/workers/evidence_update_scoring_worker.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class EvidenceUpdateScoringWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: SidekiqQueue::MIGRATION
+
+  attr_reader :concept_results
+
+  def perform(activity_session_id)
+    @concept_results = ConceptResult.where(activity_session_id:)
+
+    return if concept_results.empty?
+    return if unscored?
+
+    process_grouped_by_question
+  end
+
+  private def unscored? = concept_results.first.question_score.nil?
+  private def updated_score(question_results) = last_attempt_correct?(question_results) ? 1.0 : 0.0
+
+  private def process_grouped_by_question
+    concept_results.group_by(&:question_number).values.each do |question_results|
+      # All cases in the old scoring system that were 100s are still 100s in the updated system
+      next if question_results.first.question_score == 1
+
+      update_scores(question_results)
+    end
+  end
+
+  private def update_scores(question_results)
+    question_score = updated_score(question_results)
+
+    question_results.each do |concept_result|
+      next if concept_result.question_score == question_score
+
+      concept_result.update(question_score:)
+    end
+  end
+
+  private def last_attempt_correct?(question_results)
+    last_attempt = question_results.map(&:attempt_number).max
+
+    # If a student didn't need all five of their attempts, they must have gotten the question right
+    return true if last_attempt < 5
+
+    # If a student uses five attempts, they count as getting the question correct if all concept_results for the last attempt are correct, and incorrect if any concept_results are incorrect
+    question_results.select { |cr| cr.attempt_number == last_attempt }
+      .map(&:correct)
+      .all?
+  end
+end

--- a/services/QuillLMS/lib/tasks/temporary/evidence.rake
+++ b/services/QuillLMS/lib/tasks/temporary/evidence.rake
@@ -6,9 +6,8 @@ namespace :evidence do
       .joins(:activity)
       .where(activity: { classification: ActivityClassification.evidence })
       .where(completed_at: ..DateTime.new(2023, 11, 15))
-      .pluck(:id)
-      .find_each do |id|
-      EvidenceUpdateScoringWorker.perform_async(id)
+      .find_each do |concept_result|
+      EvidenceUpdateScoringWorker.perform_async(concept_result.activity_session_id)
     end
   end
 end

--- a/services/QuillLMS/lib/tasks/temporary/evidence.rake
+++ b/services/QuillLMS/lib/tasks/temporary/evidence.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :evidence do
+  task backfill_new_question_score_methodology: :environment do
+    ActivitySession
+      .joins(:activity)
+      .where(activity: { classification: ActivityClassification.evidence })
+      .where(completed_at: ..DateTime.new(2023, 11, 15))
+      .pluck(:id)
+      .find_each do |id|
+      EvidenceUpdateScoringWorker.perform_async(id)
+    end
+  end
+end

--- a/services/QuillLMS/lib/tasks/temporary/evidence.rake
+++ b/services/QuillLMS/lib/tasks/temporary/evidence.rake
@@ -6,8 +6,8 @@ namespace :evidence do
       .joins(:activity)
       .where(activity: { classification: ActivityClassification.evidence })
       .where(completed_at: ..DateTime.new(2023, 11, 15))
-      .find_each do |concept_result|
-      EvidenceUpdateScoringWorker.perform_async(concept_result.activity_session_id)
+      .find_each do |activity_session|
+      EvidenceUpdateScoringWorker.perform_async(activity_session.id)
     end
   end
 end

--- a/services/QuillLMS/spec/workers/evidence_update_scoring_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/evidence_update_scoring_worker_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EvidenceUpdateScoringWorker do
+  subject { described_class.new.perform(activity_session_id) }
+
+  let(:attempts) { 1..5 }
+  let(:final_correct) { true }
+  let(:question_score) { 0.5 }
+  let(:activity_session) { create(:activity_session) }
+  let(:activity_session_id) { activity_session.id }
+  let(:base_concept_results) do
+    attempts.map do |attempt_number|
+      create(:concept_result,
+        activity_session:,
+        attempt_number:,
+        question_score:,
+        correct: attempt_number == attempts.last ? final_correct : false)
+    end
+  end
+  let(:concept_results) { base_concept_results }
+  let(:final_attempt) { concept_results.last }
+
+  before do
+    allow(ConceptResult).to receive(:where).with(activity_session_id:).and_return(concept_results)
+  end
+
+  describe '#perform' do
+    it { expect { subject }.to change(final_attempt, :question_score).from(question_score).to(1.0) }
+
+    context 'no concept_results found' do
+      let(:concept_results) { [] }
+
+      it do
+        expect(concept_results).not_to receive(:group_by)
+        subject
+      end
+    end
+
+    context 'old concept_results are unscored' do
+      let(:question_score) { nil }
+
+      it do
+        expect(concept_results).not_to receive(:group_by)
+        subject
+      end
+    end
+
+    context 'fewer than 5 attempts' do
+      let(:attempts) { 1..4 }
+
+      it { expect { subject }.to change(final_attempt, :question_score).from(question_score).to(1.0) }
+    end
+
+    context 'fifth attempt incorrect' do
+      let(:final_correct) { false }
+
+      it { expect { subject }.to change(final_attempt, :question_score).from(question_score).to(0) }
+    end
+
+    context 'fifth attempt both correct and incorrect' do
+      let!(:concept_result) do
+        base_concept_results.push(create(:concept_result,
+          activity_session:,
+          question_score:,
+          correct: !final_correct,
+          attempt_number: attempts.last))
+      end
+
+      it { expect { subject }.to change(final_attempt, :question_score).from(question_score).to(0) }
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
- Add a worker to look at `ConceptResults` for a given `ActivitySession` and update the `question_score` values based on updated scoring logic
- Add a temporary Rake task to enqueue all old Evidence ActivitySessions for evaluation by this new worker
## WHY
The "new" scoring logic was implemented in November 2023, and better reflects our philosophy of what constitutes student success than the old scoring logic (which we implemented when we never thought we'd "use" scoring).  While it's unlikely that many, if any, users will be looking at scoring data this old, it's still worth updating in case we change our minds later.
## HOW
- Using an `ActivitySession` id, pull all of its `ConceptResults`, group them by `question_number`, calculate a score for that question based on the logic of 100% if the student got an optimal response in 5 attempts, and 0% if they had a non-optimal response on their fifth attempt.  Then save that updated score to the `question_score` value for the relevant `ConceptResults`
- Create a Rake task to find all `ActivitySessions` completed prior to 2023-11-15, a few days after we deployed the new logic for scoring to production.  This should catch all of the records scored with the old style, and no-op on the items that already have the new style assigned.

### Notion Card Links
https://www.notion.so/quill/Scoring-Change-Tag-Evidence-Sessions-As-Optimal-When-5th-Attempt-is-Optimal-Backfill-5d9a8b503ee544bdb9b789e212b6ae62?pvs=4

### What have you done to QA this feature?
- Deploy to staging
- Find five example Evidence ActivitySessions with the old scoring applied (139626058,139659873,139707729,139714240,139717600)
- Run Rake task (~10 minutes to enqueue all records)
- Confirm queued jobs (to ballpark queue size: 456,822)
- Turn on `migration` workers in the staging environment
- Benchmark job process rate to estimate total completion time (2 1x workers, ~50 minutes)
- Confirm that the five example ActivitySessions have new scoring applied

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes