### PR TITLE
update proofreader regex to match unnecessary space edits

### DIFF
--- a/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/sharedRegexes.ts
+++ b/services/QuillLMS/client/app/bundles/Proofreader/components/proofreaderActivities/sharedRegexes.ts
@@ -1,5 +1,5 @@
 export const startsWithPunctuationRegex = /^[.,\/#!$%\^&\*;:=\-_`~)]/
 
-export const isAnEditRegex = /{\+([^-]+)-([^|]*)\|([^}]*)}/g
+export const isAnEditRegex = /{\+([^|}]*)-([^|]*)\|([^}]*)}/g
 
 export const negativeMatchRegex = /\-(.+)\|/m


### PR DESCRIPTION
## WHAT
Update the regex in Proofreader that looks for edits, because it was matching edits shaped like `{+recipe:-recipe|QWXGVyIz6pk6urN7GuCD9g}` but not `{+- |unnecessarySpace}`.

## WHY
We want these to be counted properly so students can see the full review.

## HOW
Just update the regex so it matches both.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Proofreader-not-showing-all-errors-in-review-stage-9d401a0005e54abbaa4fd3c1dd02e276?d=bda4fda40db140579d6693330cb65527

### What have you done to QA this feature?
Played through an activity where we were seeing the bug and confirmed that it is now working as expected.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
