### PR TITLE
Add temperature setting to trial

### DIFF
--- a/services/QuillLMS/db/migrate/20240823212106_add_temperature_to_trials.evidence.rb
+++ b/services/QuillLMS/db/migrate/20240823212106_add_temperature_to_trials.evidence.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20240823204315)
+class AddTemperatureToTrials < ActiveRecord::Migration[6.1]
+  def up
+    add_column :evidence_research_gen_ai_trials, :temperature, :float
+
+    Evidence::Research::GenAI::Trial.update_all(temperature: 1.0)
+
+    change_column_null :evidence_research_gen_ai_trials, :temperature, false
+  end
+
+  def down
+    remove_column :evidence_research_gen_ai_trials, :temperature
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3638,7 +3638,8 @@ CREATE TABLE public.evidence_research_gen_ai_trials (
     updated_at timestamp(6) without time zone NOT NULL,
     trial_duration double precision,
     evaluation_duration double precision,
-    number integer NOT NULL
+    number integer NOT NULL,
+    temperature double precision NOT NULL
 );
 
 
@@ -12147,6 +12148,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240805190219'),
 ('20240808123813'),
 ('20240821210256'),
-('20240822145310');
+('20240822145310'),
+('20240823212106');
 
 

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/trials_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/trials_controller.rb
@@ -19,7 +19,7 @@ module Evidence
         def create
           llm_prompt = LLMPrompt.create_from_template!(dataset_id:, guideline_ids:, llm_prompt_template_id:, prompt_example_ids:)
 
-          trial = dataset.trials.new(llm_id:, llm_prompt:)
+          trial = dataset.trials.new(llm_id:, llm_prompt:, temperature:)
           trial.results = { g_eval_ids: [g_eval_id] }
 
           if trial.save
@@ -46,11 +46,19 @@ module Evidence
         private def llm_id = trial_params[:llm_id]
         private def llm_prompt_template_id = trial_params[:llm_prompt_template_id]
         private def prompt_example_ids = trial_params[:prompt_example_ids]&.reject(&:blank?)&.map(&:to_i) || []
+        private def temperature = trial_params[:temperature]
 
         private def trial_params
           params
             .require(:research_gen_ai_trial)
-            .permit(:g_eval_id, :llm_id, :llm_prompt_template_id, guideline_ids: [], prompt_example_ids: [])
+            .permit(
+              :g_eval_id,
+              :llm_id,
+              :llm_prompt_template_id,
+              :temperature,
+              guideline_ids: [],
+              prompt_example_ids: []
+            )
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm.rb
@@ -49,7 +49,7 @@ module Evidence
 
         def completion_client = VENDOR_COMPLETION_MAP.fetch(vendor) { raise UnsupportedVendorError }
 
-        def completion(prompt, temperature) = completion_client.run(prompt:, llm: self, temperature: DEFAULT_TEMPERATURE)
+        def completion(prompt, temperature = DEFAULT_TEMPERATURE) = completion_client.run(prompt:, llm: self, temperature:)
 
         def google? = vendor == GOOGLE
         def open_ai? = vendor == OPEN_AI

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm.rb
@@ -18,6 +18,8 @@ module Evidence
       class LLM < ApplicationRecord
         class UnsupportedVendorError < StandardError; end
 
+        DEFAULT_TEMPERATURE = 1.0
+
         GOOGLE_VERSIONS = [
           GEMINI_1_0_PRO = 'gemini-1.0-pro',
           GEMINI_1_5_PRO_LATEST = 'gemini-1.5-pro-latest',
@@ -47,7 +49,7 @@ module Evidence
 
         def completion_client = VENDOR_COMPLETION_MAP.fetch(vendor) { raise UnsupportedVendorError }
 
-        def completion(prompt) = completion_client.run(prompt:, llm: self)
+        def completion(prompt, temperature) = completion_client.run(prompt:, llm: self, temperature: DEFAULT_TEMPERATURE)
 
         def google? = vendor == GOOGLE
         def open_ai? = vendor == OPEN_AI

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/trial.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/trial.rb
@@ -9,6 +9,7 @@
 #  number              :integer          not null
 #  results             :jsonb
 #  status              :string           default("pending"), not null
+#  temperature         :float            not null
 #  trial_duration      :float
 #  trial_errors        :text             default([]), not null, is an Array
 #  created_at          :datetime         not null
@@ -55,7 +56,7 @@ module Evidence
           :trial_start_time,
           :evaluation_start_time
 
-        attr_readonly :llm_id, :llm_prompt_id, :dataset_id
+        attr_readonly :llm_id, :llm_prompt_id, :dataset_id, :temperature
 
         attr_accessor :guideline_ids, :llm_prompt_template_id, :prompt_example_ids, :g_eval_id
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/trial.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/trial.rb
@@ -38,6 +38,7 @@ module Evidence
 
         validates :llm_id, :llm_prompt_id, :dataset_id, presence: true
         validates :status, presence: true, inclusion: { in: STATUSES }
+        validates :temperature, presence: true
 
         delegate :stem_vault, to: :dataset
         delegate :conjunction, :name, to: :stem_vault

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
@@ -48,6 +48,7 @@
                   Prompt Template:
                   <%= link_to llm_prompt.llm_prompt_template, llm_prompt.llm_prompt_template %>
                 </li>
+                <li>Temperature: <%= trial.temperature %></li>
               </ul>
             </div>
             <%= render 'confusion_matrix', matrix: trial.confusion_matrix %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
@@ -33,6 +33,7 @@
             <th>Trial Number</th>
             <th>Created</th>
             <th>Prompt Template</th>
+            <th>Temperature</th>
             <th>Optimal Prompt Example Count</th>
             <th>Suboptimal Prompt Example Count</th>
             <th>Guidelines</th>
@@ -53,6 +54,7 @@
               <td><%= "Trial #{trial.number}" %></td>
               <td><%= date_helper(trial.created_at) %></td>
               <td><%= llm_prompt.name %></td>
+              <td><%= trial.temperature %></td>
               <td><%= llm_prompt.optimal_examples_count %></td>
               <td><%= llm_prompt.suboptimal_examples_count %></td>
               <td><%= llm_prompt.guidelines_count %></td>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/new.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/new.html.erb
@@ -38,6 +38,13 @@
     <%= f.collection_select :g_eval_id, @g_evals, :id, :to_s, { required: true } %>
   </div>
 
+  <div class="field-spacing">
+    <label>Temperature: (lower is less random)</label>
+    <br>
+    <%= f.range_field :temperature, min: 0.0, max: 2.0, step: 0.25, value: 1.0, id: 'trial_temperature' %>
+    <output id="temperature_value">1.0</output>
+  </div>
+
   <br>
   <div class="field-spacing optimal-section">
     <h3>
@@ -234,10 +241,30 @@
   th {
     background-color: #f2f2f2;
   }
+
+  .field-spacing {
+    margin-bottom: 15px;
+  }
+
+  input[type="range"] {
+    width: 100%;
+    max-width: 200px;
+  }
+
+  output {
+    margin-left: 10px;
+  }
 </style>
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
+    const temperatureSlider = document.getElementById('trial_temperature');
+    const temperatureOutput = document.getElementById('temperature_value');
+
+    temperatureSlider.addEventListener('input', function() {
+      temperatureOutput.textContent = this.value;
+    });
+
     function handleSelectAll(selectAllCheckboxId, tableId) {
       const selectAllCheckbox = document.getElementById(selectAllCheckboxId);
       const table = document.getElementById(tableId);

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/show.html.erb
@@ -29,6 +29,9 @@
     <h3>LLM Prompt</h3>
     <p><%= link_to @trial.llm_prompt.name, @trial.llm_prompt %></p>
 
+    <h3>Temperature</h3>
+    <p><%= @trial.temperature %></p>
+
     <% if @g_evals %>
       <h3>G-eval</h3>
       <% @g_evals.each do |g_eval| %>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/trials/show.html.erb
@@ -6,16 +6,6 @@
 
 <div class="container">
   <div class="column">
-    <h2>
-      Trial
-      <% if @trial.failed? %>
-        <%= button_to 'Retry',
-              retry_research_gen_ai_dataset_trial_path(dataset: @dataset, trial: @trial),
-              method: :post,
-              data: { confirm: 'Are you sure you want to retry this trial?' }
-        %>
-      <% end %>
-    </h2>
     <p><%= datetime_helper(@trial.created_at) %></p>
 
     <h3>Stem Vault</h3>

--- a/services/QuillLMS/engines/evidence/app/workers/evidence/research/gen_ai/build_llm_example_worker.rb
+++ b/services/QuillLMS/engines/evidence/app/workers/evidence/research/gen_ai/build_llm_example_worker.rb
@@ -14,7 +14,7 @@ module Evidence
 
           api_call_start_time = Time.zone.now
           prompt = trial.llm_prompt.prompt_with_student_response(test_example.student_response)
-          raw_text = trial.llm.completion(prompt)
+          raw_text = trial.llm.completion(prompt, trial.temperature)
           api_call_time = Time.zone.now - api_call_start_time
 
           llm_feedback = LLMFeedbackResolver.run(raw_text:)

--- a/services/QuillLMS/engines/evidence/db/migrate/20240823204315_add_temperature_to_trials.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20240823204315_add_temperature_to_trials.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddTemperatureToTrials < ActiveRecord::Migration[6.1]
+  def up
+    add_column :evidence_research_gen_ai_trials, :temperature, :float
+
+    Evidence::Research::GenAI::Trial.update_all(temperature: 1.0)
+
+    change_column_null :evidence_research_gen_ai_trials, :temperature, false
+  end
+
+  def down
+    remove_column :evidence_research_gen_ai_trials, :temperature
+  end
+end

--- a/services/QuillLMS/engines/evidence/lib/evidence/gemini/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/gemini/completion.rb
@@ -7,11 +7,12 @@ module Evidence
 
       GENERATE_CONTENT = 'generateContent'
 
-      attr_accessor :llm, :prompt
+      attr_reader :llm, :prompt, :temperature
 
-      def initialize(llm:, prompt:)
+      def initialize(llm:, prompt:, temperature:)
         @llm = llm
         @prompt = prompt
+        @temperature = temperature
       end
 
       def request_body
@@ -22,7 +23,10 @@ module Evidence
                 { 'text' => prompt }
               ]
             }
-          ]
+          ],
+          'generationConfig' => {
+            'temperature' => temperature
+          }
         }.merge(llm.request_body_customizations)
       end
 

--- a/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/open_ai/completion.rb
@@ -7,11 +7,12 @@ module Evidence
 
       ENDPOINT = '/chat/completions'
 
-      attr_reader :prompt, :llm
+      attr_reader :prompt, :llm, :temperature
 
-      def initialize(prompt:, llm:)
+      def initialize(prompt:, llm:, temperature:)
         @prompt = prompt
         @llm = llm
+        @temperature = temperature
       end
 
       def endpoint = ENDPOINT
@@ -29,6 +30,7 @@ module Evidence
           messages: [
             { role: 'user', content: prompt }
           ],
+          temperature:
         }.merge(llm.request_body_customizations)
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/trials_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/trials_controller_spec.rb
@@ -27,6 +27,7 @@ module Evidence
 
           let(:num_prompt_examples) { rand(1..3) }
           let(:prompt_example_ids) { create_list(:evidence_research_gen_ai_prompt_example, num_prompt_examples).map(&:id) }
+          let(:temperature) { rand(0.0..2.0) }
 
           subject do
             post :create, params: {
@@ -37,6 +38,7 @@ module Evidence
                 llm_id:,
                 llm_prompt_template_id:,
                 prompt_example_ids:,
+                temperature:
               }
             }
           end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1562,7 +1562,8 @@ CREATE TABLE public.evidence_research_gen_ai_trials (
     updated_at timestamp(6) without time zone NOT NULL,
     trial_duration double precision,
     evaluation_duration double precision,
-    number integer NOT NULL
+    number integer NOT NULL,
+    temperature double precision NOT NULL
 );
 
 
@@ -2656,6 +2657,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240805185650'),
 ('20240808123536'),
 ('20240821205700'),
-('20240822145206');
+('20240822145206'),
+('20240823204315');
 
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/trials.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/trials.rb
@@ -9,6 +9,7 @@
 #  number              :integer          not null
 #  results             :jsonb
 #  status              :string           default("pending"), not null
+#  temperature         :float            not null
 #  trial_duration      :float
 #  trial_errors        :text             default([]), not null, is an Array
 #  created_at          :datetime         not null
@@ -26,6 +27,7 @@ module Evidence
           llm { association :evidence_research_gen_ai_llm }
           llm_prompt { association :evidence_research_gen_ai_llm_prompt }
           dataset { association :evidence_research_gen_ai_dataset }
+          temperature { 1.0 }
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/lib/open_ai/completion_spec.rb
@@ -6,10 +6,11 @@ module Evidence
   module OpenAI
     RSpec.describe Completion do
       Evidence::Research::GenAI::LLM::OPEN_AI_VERSIONS.each do |version|
-        subject { described_class.new(prompt:, llm:) }
+        subject { described_class.new(prompt:, llm:, temperature:) }
 
         let(:prompt) { 'some prompt' }
         let(:llm) { create(:evidence_research_gen_ai_llm, :open_ai, version:) }
+        let(:temperature) { 0.5 }
 
         context 'test endpoint', external_api: true do
           it { expect { subject.run }.not_to raise_error }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
@@ -9,6 +9,7 @@
 #  number              :integer          not null
 #  results             :jsonb
 #  status              :string           default("pending"), not null
+#  temperature         :float            not null
 #  trial_duration      :float
 #  trial_errors        :text             default([]), not null, is an Array
 #  created_at          :datetime         not null
@@ -32,12 +33,14 @@ module Evidence
         it { should validate_presence_of(:llm_id) }
         it { should validate_presence_of(:llm_prompt_id) }
         it { should validate_presence_of(:dataset_id) }
+        it { should validate_presence_of(:temperature) }
 
         it { should validate_inclusion_of(:status).in_array(described_class::STATUSES) }
 
         it { should have_readonly_attribute(:llm_id) }
         it { should have_readonly_attribute(:llm_prompt_id) }
         it { should have_readonly_attribute(:dataset_id) }
+        it { should have_readonly_attribute(:temperature) }
 
         it { should belong_to(:llm) }
         it { should belong_to(:llm_prompt) }


### PR DESCRIPTION
## WHAT
Add the ability to set the temperature for a given trial

## WHY
Temperature settings allow us to vary the randomness of LLM responses.  Lower temperature is less random than higher ones.
[OpenAI](https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature) and [Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig) specify a range of 0.0 to 2.0

## HOW
Add a temperature field to trial.  Pass that parameter to the appropriate LLM when generating a response.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Tested on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
