### PR TITLE
Translations/ Connect intro page updates

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/renderForQuestions/renderFormForAnswer.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/renderForQuestions/renderFormForAnswer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal } from '../../../Shared/index';
+import { Modal, showTranslations } from '../../../Shared/index';
 import getAnswerState from './answerState';
 import EndState from './renderEndState.jsx';
 import TextEditor from './renderTextEditor.jsx';
@@ -72,7 +72,9 @@ export default class RenderFormForAnswer extends React.Component {
       handleChange,
       spellCheck,
       value,
-      isAdmin
+      isAdmin,
+      showTranslation,
+      translate
     } = this.props
     let content
     let button
@@ -91,7 +93,7 @@ export default class RenderFormForAnswer extends React.Component {
     } else if (nextQuestionButton) { // if you're going to next, it is the end state
       button = nextQuestionButton;
     } else {
-      const message = 'Get feedback'
+      const message = showTranslation ? translate('buttons^get feedback') : 'Get feedback'
       button = (
         <button
           className={`quill-button-archived focus-on-light large primary contained ${toggleDisabled}`}

--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
@@ -11,6 +11,7 @@ import PlaySentenceFragment from './sentenceFragment.jsx';
 import { requestPost, requestPut, } from '../../../../modules/request/index';
 import {
   CLICK,
+  ENGLISH,
   KEYDOWN,
   KEYPRESS,
   LanguageSelectionPage,
@@ -447,7 +448,7 @@ export class Lesson extends React.Component {
     const { params } = match
     const { lessonID, } = params;
     const studentSession = getParameterByName('student', window.location.href);
-    const showTranslation = language && availableLanguages?.includes(language)
+    const showTranslation = language && availableLanguages?.includes(language) && language !== ENGLISH
     let component;
 
     if (!this.dataHasLoaded()) {
@@ -515,6 +516,8 @@ export class Lesson extends React.Component {
             previewMode={previewMode}
             question={question}
             questionToPreview={questionToPreview}
+            showTranslation={showTranslation}
+            translate={translate}
           />
         );
       }

--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/question.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/question.tsx
@@ -39,6 +39,8 @@ interface PlayLessonQuestionProps {
   question: any;
   questionToPreview: any;
   key: any;
+  showTranslation: boolean;
+  translate: (input: string) => string;
 }
 
 interface PlayLessonQuestionState {
@@ -89,7 +91,7 @@ export default class PlayLessonQuestion extends React.Component<PlayLessonQuesti
   }
 
   shouldComponentUpdate(nextProps: PlayLessonQuestionProps, nextState: PlayLessonQuestionState) {
-    const { question, } = this.props
+    const { question, showTranslation } = this.props
     const { response, finished, multipleChoice, responses} = this.state
     if (question !== nextProps.question) {
       return true;
@@ -100,6 +102,8 @@ export default class PlayLessonQuestion extends React.Component<PlayLessonQuesti
     } else if (multipleChoice !== nextState.multipleChoice) {
       return true;
     } else if (responses !== nextState.responses) {
+      return true;
+    } else if (showTranslation !== nextProps.showTranslation) {
       return true;
     }
     return false;
@@ -293,25 +297,30 @@ export default class PlayLessonQuestion extends React.Component<PlayLessonQuesti
   }
 
   renderNextQuestionButton = () => {
-    const { isLastQuestion, } = this.props
-    const buttonText = isLastQuestion ? 'Next' : 'Next question'
+    const { isLastQuestion, showTranslation, translate } = this.props
+    let buttonText = isLastQuestion ? 'Next' : 'Next question'
+    buttonText = showTranslation ? translate(`buttons^${buttonText.toLowerCase()}`) : buttonText
     const disabledStatus = this.getDisabledStatus();
     const disabledStyle = disabledStatus ? 'disabled' : '';
     return (<button className={`quill-button-archived focus-on-light primary contained large ${disabledStyle}`} disabled={disabledStatus} onClick={this.handleNextQuestionClick} type="button">{buttonText}</button>);
   }
 
   renderFinishedQuestionButton = () => {
+    const { showTranslation, translate } = this.props
+    const buttonText = showTranslation ? translate('buttons^next') : 'Next'
     const nextF = () => {
       this.setState({ finished: true, });
     };
-    return (<button className="quill-button-archived focus-on-light primary contained large" onClick={nextF} type="button">Next</button>);
+    return (<button className="quill-button-archived focus-on-light primary contained large" onClick={nextF} type="button">{buttonText}</button>);
   }
 
   renderMultipleChoiceButton = () => {
+    const { showTranslation, translate } = this.props
+    const buttonText = showTranslation ? translate('buttons^next') : 'Next'
     const nextF = () => {
       this.setState({ multipleChoice: true, });
     };
-    return (<button className="quill-button-archived focus-on-light primary contained large" onClick={nextF} type="button">Next</button>);
+    return (<button className="quill-button-archived focus-on-light primary contained large" onClick={nextF} type="button">{buttonText}</button>);
   }
 
   finishQuestion = () => {
@@ -384,7 +393,8 @@ export default class PlayLessonQuestion extends React.Component<PlayLessonQuesti
   }
 
   render() {
-    const { question, isAdmin, previewMode } = this.props
+    const { question, isAdmin, previewMode, showTranslation, translate } = this.props
+    console.log("🚀 ~ PlayLessonQuestion ~ render ~ showTranslation:", showTranslation)
     const { response, finished, multipleChoice, multipleChoiceCorrect, multipleChoiceResponseOptions  } = this.state
     const questionID = question.key;
 
@@ -404,7 +414,9 @@ export default class PlayLessonQuestion extends React.Component<PlayLessonQuesti
         sentenceFragments: this.renderSentenceFragments(),
         cues: this.renderCues(),
         className: 'fubar',
-        previewMode
+        previewMode,
+        showTranslation,
+        translate
       };
       let component;
       const maxAttemptsSubmitted = question.attempts && question.attempts.length > 4;

--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/question.tsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/question.tsx
@@ -394,7 +394,6 @@ export default class PlayLessonQuestion extends React.Component<PlayLessonQuesti
 
   render() {
     const { question, isAdmin, previewMode, showTranslation, translate } = this.props
-    console.log("🚀 ~ PlayLessonQuestion ~ render ~ showTranslation:", showTranslation)
     const { response, finished, multipleChoice, multipleChoiceCorrect, multipleChoiceResponseOptions  } = this.state
     const questionID = question.key;
 

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/__tests__/__snapshots__/register.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/__tests__/__snapshots__/register.test.tsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Register it should render default Connect intro 1`] = `
+<DocumentFragment>
+  <section
+    class="student"
+    style="padding-top: 20px;"
+  >
+    <div
+      class="container"
+    >
+      <h2
+        class="title is-3 register"
+      >
+        Welcome to Quill Connect!
+      </h2>
+      <div
+        class="register-container"
+      >
+        <ul
+          class="register-list"
+        >
+          <li>
+            Combine the sentences together into one sentence.
+          </li>
+          <li>
+            You may add or remove words.
+          </li>
+          <li>
+            There is often more than one correct answer.
+          </li>
+          <li>
+            Remember to use correct spelling, capitalization, and punctuation!
+          </li>
+        </ul>
+        <button
+          class="quill-button-archived focus-on-light primary contained large"
+          type="button"
+        >
+          Resume
+        </button>
+        <br />
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`Register it should render lesson specific intro 1`] = `
+<DocumentFragment>
+  <section
+    class="student"
+    style="padding-top: 20px;"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="landing-page-html"
+      >
+        test landing page
+      </div>
+      <button
+        class="quill-button-archived focus-on-light primary contained large"
+        type="button"
+      >
+        Resume
+      </button>
+    </div>
+  </section>
+</DocumentFragment>
+`;

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/__tests__/register.test.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/__tests__/register.test.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { Register } from "../register";
+
+const mockProps = {
+  lesson: {
+    questions: [],
+    questionType: '',
+    landingPageHtml: null
+  },
+  startActivity: jest.fn(),
+  resumeActivity: jest.fn(),
+  session: {},
+  translate: jest.fn(),
+  showTranslation: false
+}
+
+describe('Register', () => {
+  test('it should render default Connect intro', () => {
+    const { asFragment } = render(<Register {...mockProps} />);
+    expect(asFragment()).toMatchSnapshot();
+    const heading = screen.getByRole('heading', {
+      name: /welcome to quill connect!/i
+    });
+    expect(heading).toBeInTheDocument()
+  })
+  test('it should render lesson specific intro', () => {
+    mockProps.lesson.questionType = 'fillInBlank'
+    mockProps.lesson.landingPageHtml = 'test landing page'
+    const { asFragment } = render(<Register {...mockProps} />);
+    expect(asFragment()).toMatchSnapshot();
+    const landingPageText = screen.getByText(/test landing page/i);
+    expect(landingPageText).toBeInTheDocument()
+  })
+})

--- a/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/studentLessons/register.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+const FILL_IN_BLANK = 'fillInBlank'
+
 class Register extends React.Component<any, any> {
   constructor(props) {
     super(props)
@@ -12,6 +14,9 @@ class Register extends React.Component<any, any> {
 
   componentDidMount() {
     const { previewMode, lesson } = this.props;
+    if (lesson?.questionType === FILL_IN_BLANK) {
+      this.handleSetShowIntro()
+    }
     if (previewMode) {
       this.startActivity();
     }
@@ -64,7 +69,7 @@ class Register extends React.Component<any, any> {
       onClickFn = this.resume;
       text = showTranslation ? translate('buttons^resume') : 'Resume'
     } else if (showIntro) {
-      // this and the following conditional have the same action because the function handles what should happen next  
+      // this and the following conditional have the same action because the function handles what should happen next
       onClickFn = this.startActivity;
       text = showTranslation ? translate('buttons^begin') : 'Begin'
     } else {
@@ -85,6 +90,88 @@ class Register extends React.Component<any, any> {
     return translations && translations[language];
   }
 
+  renderSentenceFragmentIntro = () => {
+    const { showTranslation, translate } = this.props
+    const { showIntro } = this.state
+    if(showTranslation) {
+      return (
+        <div className="container">
+          <h2 className="title is-3 register">
+            {translate('Quill Connect Fragments Intro^Welcome to Quill Connect Fragments!')}
+          </h2>
+          <div className="register-container">
+            <ul className="register-list">
+              <li>{translate('Quill Connect Fragments Intro^Add to the group of words to make a complete sentence.')}</li>
+              <li>{translate('Quill Connect Fragments Intro^Add the number of words shown in the directions.')}</li>
+              <li>{translate('Quill Connect Fragments Intro^There is often more than one correct answer.')}</li>
+              <li>{translate('Quill Connect Fragments Intro^Remember to use correct spelling, capitalization, and punctuation!')}</li>
+            </ul>
+            {this.renderButton(showIntro)}
+            <br />
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="container">
+        <h2 className="title is-3 register">
+          Welcome to Quill Connect Fragments!
+        </h2>
+        <div className="register-container">
+          <ul className="register-list">
+            <li>Add to the group of words to make a complete sentence.</li>
+            <li>Add the number of words shown in the directions.</li>
+            <li>There is often more than one correct answer.</li>
+            <li>Remember to use correct spelling, capitalization, and punctuation!</li>
+          </ul>
+          {this.renderButton(showIntro)}
+          <br />
+        </div>
+      </div>
+    );
+  }
+
+  renderConnectIntro = () => {
+    const { showTranslation, translate } = this.props
+    const { showIntro } = this.state
+
+    if(showTranslation) {
+      return (
+        <div className="container">
+          <h2 className="title is-3 register">
+            {translate('Quill Connect Intro^Welcome to Quill Connect!')}
+          </h2>
+          <div className="register-container">
+            <ul className="register-list">
+              <li>{translate('Quill Connect Intro^Combine the sentences together into one sentence.')}</li>
+              <li>{translate('Quill Connect Intro^You may add or remove words.')}</li>
+              <li>{translate('Quill Connect Intro^There is often more than one correct answer.')}</li>
+              <li>{translate('Quill Connect Intro^Remember to use correct spelling, capitalization, and punctuation!')}</li>
+            </ul>
+            {this.renderButton(showIntro)}
+            <br />
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="container">
+        <h2 className="title is-3 register">
+          Welcome to Quill Connect!
+        </h2>
+        <div className="register-container">
+          <ul className="register-list">
+            <li>Combine the sentences together into one sentence.</li>
+            <li>You may add or remove words.</li>
+            <li>There is often more than one correct answer.</li>
+            <li>Remember to use correct spelling, capitalization, and punctuation!</li>
+          </ul>
+          {this.renderButton(showIntro)}
+          <br />
+        </div>
+      </div>
+    );
+  }
 
   renderIntro = () => {
     const { lesson } = this.props
@@ -104,41 +191,9 @@ class Register extends React.Component<any, any> {
         </div>
       );
     } else if (hasSentenceFragment) {
-      return (
-        <div className="container">
-          <h2 className="title is-3 register">
-            Welcome to Quill Connect Fragments!
-          </h2>
-          <div className="register-container">
-            <ul className="register-list">
-              <li>Add to the group of words to make a complete sentence.</li>
-              <li>Add the number of words shown in the directions.</li>
-              <li>There is often more than one correct answer.</li>
-              <li>Remember to use correct spelling, capitalization, and punctuation!</li>
-            </ul>
-            {this.renderButton(showIntro)}
-            <br />
-          </div>
-        </div>
-      );
+      return this.renderSentenceFragmentIntro()
     } else {
-      return (
-        <div className="container">
-          <h2 className="title is-3 register">
-            Welcome to Quill Connect!
-          </h2>
-          <div className="register-container">
-            <ul className="register-list">
-              <li>Combine the sentences together into one sentence.</li>
-              <li>You may add or remove words.</li>
-              <li>There is often more than one correct answer.</li>
-              <li>Remember to use correct spelling, capitalization, and punctuation!</li>
-            </ul>
-            {this.renderButton(showIntro)}
-            <br />
-          </div>
-        </div>
-      );
+      return this.renderConnectIntro()
     }
   }
 

--- a/services/QuillLMS/client/app/bundles/Shared/libs/translations/modules/spanish/translation.json
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/translations/modules/spanish/translation.json
@@ -11,6 +11,20 @@
         "save and exit": "Save and exit / Guardar y salir",
         "start activity": "Start activity / Iniciar actividad"
     },
+    "Quill Connect Fragments Intro": {
+        "Welcome to Quill Connect Fragments!": "¡Bienvenido a Quill Connect Fragments!",
+        "Add to the group of words to make a complete sentence.": "Agrega al grupo de palabras para formar una oración completa.",
+        "Add the number of words shown in the directions.": "Agrega el número de palabras indicado en las instrucciones.",
+        "There is often more than one correct answer.": "A menudo hay más de una respuesta correcta.",
+        "Remember to use correct spelling, capitalization, and punctuation!": "¡Recuerda usar la ortografía, mayúsculas y puntuación correctas!"
+    },
+    "Quill Connect Intro": {
+        "Welcome to Quill Connect!": "¡Bienvenido a Quill Connect!",
+        "Combine the sentences together into one sentence.": "Combina las oraciones en una sola oración.",
+        "You may add or remove words.": "Puedes agregar o eliminar palabras.",
+        "There is often more than one correct answer.": "A menudo hay más de una respuesta correcta.",
+        "Remember to use correct spelling, capitalization, and punctuation!": "¡Recuerda usar la ortografía, la capitalización y la puntuación correctas!"
+    },
     "ELL Starter Fill in the Blank": {
         "header": "Rellena el espacio en blanco",
         "text": "En esta sección, cada oración tendrá uno, dos o tres espacios en blanco. Rellenarás cada espacio en blanco con una de las palabras de la lista o lo dejarás en blanco si no se necesita ninguna palabra. Escribe las palabras que elijas en los cuadros. ¡Recuerda revisar tu ortografía! ¡Empecemos!"


### PR DESCRIPTION
## WHAT
tweak logic for Connect intro pages so skip to lesson specific landing pages only for fill in blank activities; add additional translation logic for buttons

## WHY
this is the flow that is expected and this is part of the larger translation project work

## HOW
add check on activity for `questionType` equal to `fillInBlank` as well as add button translations for sentence combining question component

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Connect-landing-page-showing-up-for-Fill-in-the-blank-activities-33d72cfc9bcc45b48ce857e328c0c7b1?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
tested on staging with several different activities activity flow behavior is as expected (also had Rachel test and verify that the intro behavior is as expected)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
