### PR TITLE
remove bundler install commands from CCI

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -45,7 +45,6 @@ jobs:
                 name: Bundle Install if cache isn't present.
                 command: |
                   cd services/QuillLMS
-                  gem install bundler:2.3.17
                   # BUNDLE_GEMS__CONTRIBSYS__COM defined in https://circleci.com/gh/empirical-org/Empirical-Core/edit#env-vars
                   bundle config --local gems.contribsys.com ${BUNDLE_GEMS__CONTRIBSYS__COM}
                   bundle check || bundle install --path vendor/bundle
@@ -205,7 +204,6 @@ jobs:
                 name: Bundle Install if cache isn't present.
                 command: |
                   cd services/QuillLMS
-                  gem install bundler:2.3.17
                   # BUNDLE_GEMS__CONTRIBSYS__COM defined in https://circleci.com/gh/empirical-org/Empirical-Core/edit#env-vars
                   bundle config --local gems.contribsys.com ${BUNDLE_GEMS__CONTRIBSYS__COM}
                   bundle check || bundle install --path vendor/bundle
@@ -350,7 +348,6 @@ jobs:
                 name: Bundle Install if cache isn't present.
                 command: |
                   cd services/QuillCMS
-                  gem install bundler:2.3.26
                   bundle config --local gems.contribsys.com ${BUNDLE_GEMS__CONTRIBSYS__COM}
                   bundle check || bundle install --path vendor/bundle
             - save_cache:

--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -3,7 +3,7 @@
 class ActivitySessionsController < ApplicationController
   include HTTParty
   include PublicProgressReports
-  # random change
+
   layout :determine_layout
 
   around_action :force_writer_db_role, only: [:activity_session_from_classroom_unit_and_activity]

--- a/services/QuillLMS/app/controllers/activity_sessions_controller.rb
+++ b/services/QuillLMS/app/controllers/activity_sessions_controller.rb
@@ -3,7 +3,7 @@
 class ActivitySessionsController < ApplicationController
   include HTTParty
   include PublicProgressReports
-
+  # random change
   layout :determine_layout
 
   around_action :force_writer_db_role, only: [:activity_session_from_classroom_unit_and_activity]


### PR DESCRIPTION
## WHAT
Dan's optional comment from https://github.com/empirical-org/Empirical-Core/pull/12270 

Remove bundler version specifications from CircleCI config.

Confirmed this works by inspecting the CI build. Excerpt:

`Bundler 2.4.19 is running, but your lockfile was generated with 2.3.17. Installing Bundler 2.3.17 and restarting using that version.`

## WHY
It's duplicative of Gemfile.lock 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
none

### What have you done to QA this feature?
none - CI only

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  n/a
Have you deployed to Staging? | n/a
Self-Review: Have you done an initial self-review of the code below on Github? |
