### PR TITLE
Evidence GenAI - Return static optimal feedback from rules.

### DIFF
--- a/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai/response_builder.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai/response_builder.rb
@@ -47,6 +47,7 @@ module Evidence
       private def rule = Evidence::Rule.find_by(uid: rule_uid)
       private def rule_uid = rule_set[conjunction]
       private def rule_set = optimal ? RULES_OPTIMAL : RULES_SUBOPTIMAL
+      private def optimal_feedback = prompt.optimal_label_feedback
 
       private def highlight_array
         return [] if highlight_key.nil?
@@ -60,7 +61,11 @@ module Evidence
 
       private def highlight_key = secondary_response[KEY_HIGHLIGHT]
       private def optimal = primary_response[KEY_OPTIMAL]
-      private def feedback = secondary_response[KEY_SECONDARY_FEEDBACK] || primary_response[KEY_FEEDBACK]
+      private def feedback
+        return optimal_feedback if optimal
+
+        secondary_response[KEY_SECONDARY_FEEDBACK] || primary_response[KEY_FEEDBACK]
+      end
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/gen_ai/response_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/gen_ai/response_builder_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Evidence::GenAI::ResponseBuilder, type: :service do
   let(:primary_response) { { 'feedback' => 'Sample feedback', 'optimal' => true } }
-  let(:secondary_response) { { } }
+  let(:secondary_response) { {} }
   let(:entry) { double('Entry') }
-  let(:optimal_label_feedback) { "Great work!" }
+  let(:optimal_label_feedback) { 'Great work!' }
   let(:prompt) { double('Prompt', conjunction: 'because', distinct_automl_highlight_arrays: [['Highlight text 1']], optimal_label_feedback:) }
   let(:rule) { double('Rule', concept_uid: 'sample_concept_uid') }
 
@@ -81,7 +81,7 @@ RSpec.describe Evidence::GenAI::ResponseBuilder, type: :service do
       context 'with secondary feedback' do
         let(:secondary_response) { { 'secondary_feedback' => 'Secondary feedback', 'highlight' => '1' } }
 
-        it { expect(subject.run).to eq(suboptimal_secondary_response)}
+        it { expect(subject.run).to eq(suboptimal_secondary_response) }
       end
     end
   end


### PR DESCRIPTION
## WHAT
We always want to return the same feedback for `optimal` answers currently pulled from the prompt automl rules
## WHY
To cut down on GenAI saying something random when we want a straightforward statement about the skill.
## HOW
Early return for optimal entries.


### Notion Card Links
https://www.notion.so/quill/August-23rd-Feedback-Issues-Coral-Reefs-from-Curriculum-Team-3336a9841cde4570912fcd5ff8c90187

### What have you done to QA this feature?
Ran this in the console and confirmed it used the canned output rather than the GenAI feedback

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  'YES'.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
