### PR TITLE
GenAI Evidence - New static prompt for coral because.

### DIFF
--- a/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai/primary_feedback/static_prompts/673.md
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/gen_ai/primary_feedback/static_prompts/673.md
@@ -10,39 +10,34 @@ The sounds of a coral reef can help scientists monitor its health because
 
 Here is the text students have read, separated by triple backticks:
 Below the ocean's surface, with the right equipment, you can hear pops, clicks, whoops, growls, and croaks. These sounds serve an important purpose: marine animals use them to find food, attract mates, and communicate. They’re also signs of healthy coral reefs.
-
 Coral reefs, which house millions of marine species, are facing serious threats. Pollution, overfishing, and global warming have contributed to their ongoing decline. According to the Coral Reef Alliance, over 75% of reefs are currently at risk, and this number is expected to jump to 90% by 2030.
 
 In order to monitor (keep track of) the health of these important ecosystems, some scientists are exploring an innovative solution: they’re using artificial intelligence, specifically machine learning, to study audio recordings of coral reefs.
 
 What is Machine Learning?
-
 Machine learning is a type of artificial intelligence that allows computer systems to learn from experience, similar to how people do, but at a much faster rate. Programmers give an AI model large amounts of data that can be in the form of pictures, text, numbers, or audio recordings. The AI model then looks for patterns within this data and uses those patterns to make predictions.
-
 One of the many applications of machine learning is analyzing sounds. For example, if an AI model is trained on many audio recordings of people sleeping, it can learn to detect the sounds of snoring or teeth grinding. This kind of technology powers many of the tools we use every day, from digital assistants like Siri to music recognition software that can identify a song’s genre, tempo, or mood. Now, researchers want to use machine learning and audio analysis to keep track of the health of coral reefs.
 
 Listening for Health
-
-Healthy and unhealthy coral reefs sound different from each other. Healthy coral reefs are filled with loud, crackling sounds similar to a campfire, while unhealthy reefs are quieter. “A healthy reef is full of lots of animals that all make noises at different times of day and for different reasons, and you can hear that,” Timothy AC Lamont, a marine biologist, explained in an interview with the Linnean Society. “By contrast, a reef that is degraded will sound eerie and quiet. It’s almost spooky.” Listening to audio recordings of these underwater sounds helps scientists assess the well-being of coral reefs.
+Healthy and unhealthy coral reefs sound different from each other. Healthy coral reefs are filled with loud, crackling sounds similar to a campfire, while unhealthy reefs are quieter. "A healthy reef is full of lots of animals that all make noises at different times of day and for different reasons, and you can hear that," Timothy AC Lamont, a marine biologist, explained in an interview with the Linnean Society. "By contrast, a reef that is degraded will sound eerie and quiet. It’s almost spooky." Listening to audio recordings of these underwater sounds helps scientists assess the well-being of coral reefs.
 
 However, analyzing these recordings can be a slow and labor-intensive task. Traditional approaches require scientists to review recordings one at a time, where they must listen for specific acoustic traits or look at visual representations of the sounds. To add to the challenge, there are hundreds and hundreds of hours of recordings, far too many for scientists to analyze on their own.
 
 Using AI for Audio Analysis
-
-Since coral reef sounds are so helpful for determining their health, some scientists are using machine learning to analyze these sounds more efficiently and accurately. In 2022, Lamont and a team of researchers at the University of Exeter trained a machine learning algorithm using many audio recordings of healthy and unhealthy coral reefs. When they introduced a new set of recordings, the AI model quickly identified reef health with a high rate of accuracy. “It can tell us faster, and more accurately, how the reef is doing,” Ben Williams, the lead author of the study, explained.
+Since coral reef sounds are so helpful for determining their health, some scientists are using machine learning to analyze these sounds more efficiently and accurately. In 2022, Lamont and a team of researchers at the University of Exeter trained a machine learning algorithm using many audio recordings of healthy and unhealthy coral reefs. When they introduced a new set of recordings, the AI model quickly identified reef health with a high rate of accuracy. "It can tell us faster, and more accurately, how the reef is doing," Ben Williams, the lead author of the study, explained.
 
 Calling In Our Corals
-
-Remarkably, sound recordings like these won’t only be used to protect coral reefs—they can even help bring them back to life. Scientists have discovered that playing recordings of healthy reefs can actually attract marine animals back to damaged reefs and speed up their recovery. As Steve Simson, a marine biologist who leads the “Calling In Our Corals” project, put it in an interview with Axios News, "[I]n my lifetime, we've lost half of all of the coral, which means that they're potentially the first ecosystem we could lose completely [...] If you flip that on its head ... they're the first ecosystem we can save."
+Remarkably, sound recordings like these won’t only be used to protect coral reefs—they can even help bring them back to life. Scientists have discovered that playing recordings of healthy reefs can actually attract marine animals back to damaged reefs and speed up their recovery. As Steve Simson, a marine biologist who leads the "Calling In Our Corals" project, put it in an interview with Axios News, "[I]n my lifetime, we've lost half of all of the coral, which means that they're potentially the first ecosystem we could lose completely [...] If you flip that on its head ... they're the first ecosystem we can save."
 
 A response is optimal when:
 states that healthy reefs produce sounds and is specific about what kinds of sounds (for example: loud, crackling, popping, campfire-like).
-states that healthy reefs produce sounds and explains that animals make the sounds in healthy reefs.
+states that healthy reefs make sounds and explains that animals make the sounds in healthy reefs.
 states that unhealthy reefs are quiet. It is not required to explain why they are quiet or to compare them to unhealthy reefs.
 
 A response is sub-optimal when:
-states that unhealthy reefs and healthy reefs sound different without explaining the difference or providing further detail on the sounds of each.
-states that healthy reefs are noisy or produce sounds but provides no more detail about what makes the sounds or what kinds of sounds are made.
+states only that the sounds of a coral reef can help scientists know if the reef is healthy but does not provide a reason why that is the case.
+states only that healthy and unhealthy reefs sound different and does not give an example or describe the sounds made by either.
+states that coral reefs are loud or describes the noises without specifying that it is only the healthy noises that are loud or that make those noises.
 
 Here are some examples of feedback:
 
@@ -140,4 +135,3 @@ Suboptimal Examples
 {:student_response=>"Snoring and teeth grinding noises are detectable by computer models.", :feedback=>"Try clearing your response and starting again. \n\nWhy do the sounds of a coral reef help scientists to know whether it's unhealthy or unhealthy? Check that your response only uses information from the text.", :optimal=>false}
 
 Let's think step by step what type of feedback should be provided for a given student response.
-


### PR DESCRIPTION
## WHAT
A new prompt for Coral Reefs because. This was deployed to `beta` but I want to merge it in to prevent drift in branches.
## WHY
Curriculum found this prompt to work better.
## HOW
Updated text.



### What have you done to QA this feature?
Tested locally, prompt does not throw errors

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, content change
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | Yes
