### PR TITLE
Add UI for creation of Data Subsets

### DIFF
--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/datasets_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/datasets_controller.rb
@@ -9,15 +9,16 @@ module Evidence
         end
 
         def create
-          if file_upload?
-            create_dataset_from_file
-          elsif data_subset?
+          if data_subset?
             redirect_to DataSubsetBuilder.run(parent_id:, test_example_ids:)
+          elsif file_upload?
+            create_dataset_from_file
           end
         end
 
         def show
           @dataset = Dataset.find(params[:id])
+          @data_subsets = @dataset.data_subsets.order(id: :desc)
           @stem_vault = @dataset.stem_vault
           @trials = @dataset.trials.order(id: :desc)
         end
@@ -43,11 +44,7 @@ module Evidence
         private def test_example_ids = data_subset_params[:test_example_ids]
         private def parent_id = data_subset_params[:parent_id]
 
-        private def data_subset_params
-          params
-            .require(:research_gen_ai_dataset)
-            .permit(:parent_id, test_example_ids: [])
-        end
+        private def data_subset_params = params.permit(:parent_id, test_example_ids: [])
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/datasets_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/datasets_controller.rb
@@ -9,13 +9,10 @@ module Evidence
         end
 
         def create
-          @dataset = stem_vault.datasets.new(dataset_params)
-
-          if @dataset.save
-            DatasetImporter.run(dataset: @dataset, file:)
-            redirect_to @dataset
-          else
-            render :new
+          if file_upload?
+            create_dataset_from_file
+          elsif data_subset?
+            redirect_to DataSubsetBuilder.run(parent_id:, test_example_ids:)
           end
         end
 
@@ -25,9 +22,32 @@ module Evidence
           @trials = @dataset.trials.order(id: :desc)
         end
 
-        private def dataset_params = params.require(:research_gen_ai_dataset).permit(:file)
-        private def file = dataset_params[:file]
         private def stem_vault = @stem_vault ||= StemVault.find(params[:stem_vault_id])
+
+        private def create_dataset_from_file
+          dataset = stem_vault.datasets.new
+
+          if dataset.save
+            DatasetImporter.run(dataset:, file:)
+            redirect_to dataset
+          else
+            render :new
+          end
+        end
+
+        private def file_upload? = file.present?
+        private def file = dataset_params[:file]
+        private def dataset_params = params.require(:research_gen_ai_dataset).permit(:file)
+
+        private def data_subset? = test_example_ids.present? && parent_id.present?
+        private def test_example_ids = data_subset_params[:test_example_ids]
+        private def parent_id = data_subset_params[:parent_id]
+
+        private def data_subset_params
+          params
+            .require(:research_gen_ai_dataset)
+            .permit(:parent_id, test_example_ids: [])
+        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/stem_vaults_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/stem_vaults_controller.rb
@@ -21,7 +21,7 @@ module Evidence
 
         def show
           @stem_vault = StemVault.find(params[:id])
-          @datasets = @stem_vault.datasets.order(id: :desc)
+          @datasets = @stem_vault.datasets.whole.order(id: :desc)
           @optimal_guidelines = @stem_vault.guidelines.optimal.visible
           @suboptimal_guidelines = @stem_vault.guidelines.suboptimal.visible
         end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
@@ -37,11 +37,15 @@ module Evidence
 
         delegate :stem_and_conjunction, to: :stem_vault
 
+        scope :whole, -> { where(parent_id: nil) }
+
         attr_accessor :file
 
         before_validation :set_version
 
-        def dataslices = where(parent_id: id)
+        def data_subsets = self.class.where(parent_id: id)
+        def whole? = parent_id.nil?
+        def subset? = parent_id.present?
 
         def set_version
           existing_version = self.class.where(parent_id:, stem_vault:).order(version: :desc).first&.version
@@ -50,7 +54,7 @@ module Evidence
 
         def test_examples_count = optimal_count + suboptimal_count
 
-        def to_s = "Dataset v#{version}"
+        def to_s = whole? ? "Dataset v#{version}" : "Data Subset v#{version}"
 
         def validate_file_content
           return unless file.present?

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
@@ -22,6 +22,7 @@ module Evidence
         has_many :prompt_examples, dependent: :destroy
         has_many :trials, dependent: :destroy
         has_many :comparisons, dependent: :destroy
+        has_many :data_subsets, class_name: 'Evidence::Research::GenAI::Dataset', foreign_key: 'parent_id'
 
         belongs_to :stem_vault
         belongs_to :parent, class_name: 'Evidence::Research::GenAI::Dataset', optional: true
@@ -43,7 +44,6 @@ module Evidence
 
         before_validation :set_version
 
-        def data_subsets = self.class.where(parent_id: id)
         def whole? = parent_id.nil?
         def subset? = parent_id.present?
 

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
@@ -44,7 +44,7 @@ module Evidence
         def dataslices = where(parent_id: id)
 
         def set_version
-          existing_version = self.class.where(stem_vault: stem_vault).order(version: :desc).first&.version
+          existing_version = self.class.where(parent_id:, stem_vault:).order(version: :desc).first&.version
           self.version = existing_version.is_a?(Integer) ? existing_version + 1 : 1
         end
 

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/data_subset_builder.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/data_subset_builder.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Evidence
+  module Research
+    module GenAI
+      class DataSubsetBuilder < ApplicationService
+        attr_reader :parent_id, :test_example_ids
+
+        def initialize(parent_id:, test_example_ids:)
+          @parent_id = parent_id
+          @test_example_ids = test_example_ids
+        end
+
+        def run
+          ActiveRecord::Base.transaction do
+            copy_prompt_examples
+            copy_selected_test_examples
+            finalize_data_subset
+          end
+          data_subset.reload
+        end
+
+        private def data_subset = @data_subset ||= Dataset.create!(parent_id:, stem_vault_id:)
+        private def parent_dataset = @parent_dataset ||= Dataset.find(parent_id)
+        private def stem_vault_id = parent_dataset.stem_vault_id
+
+        private def copy_prompt_examples
+          parent_dataset.prompt_examples.find_each do |prompt_example|
+            data_subset.prompt_examples.create!(prompt_example.attributes.except('id', 'dataset_id'))
+          end
+        end
+
+        private def copy_selected_test_examples
+          parent_dataset.test_examples.where(id: test_example_ids).find_each do |test_example|
+            data_subset.test_examples.create!(test_example.attributes.except('id', 'dataset_id'))
+          end
+        end
+
+        private def finalize_data_subset
+          optimal_count, suboptimal_count = data_subset.test_examples.partition(&:optimal?).map(&:count)
+
+          Dataset
+            .where(id: data_subset.id)
+            .update_all(locked: true, optimal_count:, suboptimal_count:)
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/application/_confusion_matrix.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/application/_confusion_matrix.html.erb
@@ -1,4 +1,11 @@
 <% if matrix %>
+  <% optimal_correct_count = matrix[0][0] %>
+  <% optimal_incorrect_count = matrix[0][1] %>
+  <% suboptimal_correct_count = matrix[1][1] %>
+  <% suboptimal_incorrect_count = matrix[1][0] %>
+  <% optimal_count = optimal_correct_count + optimal_incorrect_count %>
+  <% suboptimal_count = suboptimal_correct_count + suboptimal_incorrect_count %>
+
   <table style="table-layout: fixed; border-collapse: collapse; border: 1px solid black;">
     <tr class='light-gray' style='text-align: center'>
       <td style="text-align: center"></td>
@@ -9,28 +16,28 @@
     </tr>
     <tr>
       <td class='white curriculum-optimal' style="text-align: center;">Curriculum Optimal</td>
-      <td class='light-green' style="text-align: center;"><%= matrix[0][0] %></td>
-      <td class='dark-red' style="text-align: center;"><%= matrix[0][1] %></td>
-      <td class='white' style="text-align: center;"><%= matrix[0][0] + matrix[0][1] %></td>
+      <td class='light-green' style="text-align: center;"><%= optimal_correct_count %></td>
+      <td class='dark-red' style="text-align: center;"><%= optimal_incorrect_count %></td>
+      <td class='white' style="text-align: center;"><%= optimal_count %></td>
       <td class='white' style="text-align: center;">
-        <% if matrix[0][0] + matrix[0][1] == 0 %>
+        <% if optimal_count.zero? %>
           0%
         <% else %>
-          <%= (100.0 * matrix[0][0] / (matrix[0][0] + matrix[0][1])).round.to_s + '%' %>
+          <%= (100.0 * optimal_correct_count / optimal_count).round.to_s + '%' %>
         <% end %>
       </td>
     </tr>
 
     <tr>
       <td class='white curriculum-suboptimal' style="text-align: center;">Curriculum Sub-Optimal</td>
-      <td class='light-red' style="text-align: center;"><%= matrix[1][0] %></td>
-      <td class='green' style="text-align: center;"><%= matrix[1][1] %></td>
-      <td class='white' style="text-align: center;"><%= matrix[1][0] + matrix[1][1] %></td>
+      <td class='light-red' style="text-align: center;"><%= suboptimal_incorrect_count %></td>
+      <td class='green' style="text-align: center;"><%= suboptimal_correct_count %></td>
+      <td class='white' style="text-align: center;"><%= suboptimal_count %></td>
       <td class='white' style="text-align: center;">
-        <% if matrix[1][0] + matrix[1][1] == 0%>
+        <% if suboptimal_count.zero? %>
           0%
         <% else %>
-          <%= (100.0 * matrix[1][1] / (matrix[1][0] + matrix[1][1])).round.to_s + '%' %>
+          <%= (100.0 * suboptimal_correct_count / suboptimal_count).round.to_s + '%' %>
         <% end %>
       </td>
     </tr>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/application/_confusion_matrix.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/application/_confusion_matrix.html.erb
@@ -12,14 +12,27 @@
       <td class='light-green' style="text-align: center;"><%= matrix[0][0] %></td>
       <td class='dark-red' style="text-align: center;"><%= matrix[0][1] %></td>
       <td class='white' style="text-align: center;"><%= matrix[0][0] + matrix[0][1] %></td>
-      <td class='white' style="text-align: center;"><%= (100.0 * matrix[0][0] / (matrix[0][0] + matrix[0][1])).round.to_s + '%' %></td>
+      <td class='white' style="text-align: center;">
+        <% if matrix[0][0] + matrix[0][1] == 0 %>
+          0%
+        <% else %>
+          <%= (100.0 * matrix[0][0] / (matrix[0][0] + matrix[0][1])).round.to_s + '%' %>
+        <% end %>
+      </td>
     </tr>
+
     <tr>
       <td class='white curriculum-suboptimal' style="text-align: center;">Curriculum Sub-Optimal</td>
       <td class='light-red' style="text-align: center;"><%= matrix[1][0] %></td>
       <td class='green' style="text-align: center;"><%= matrix[1][1] %></td>
       <td class='white' style="text-align: center;"><%= matrix[1][0] + matrix[1][1] %></td>
-      <td class='white' style="text-align: center;"><%= (100.0 * matrix[1][1] / (matrix[1][0] + matrix[1][1])).round.to_s + '%' %></td>
+      <td class='white' style="text-align: center;">
+        <% if matrix[1][0] + matrix[1][1] == 0%>
+          0%
+        <% else %>
+          <%= (100.0 * matrix[1][1] / (matrix[1][0] + matrix[1][1])).round.to_s + '%' %>
+        <% end %>
+      </td>
     </tr>
   </table>
   <div style="clear: both;"></div>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
@@ -25,7 +25,10 @@
   <table>
     <thead style="position: sticky; top: 0; background-color: #fff; z-index: 1;">
       <tr>
-        <th class="dark-border select-column">Select</th>
+        <th class="dark-border select-column">
+          Select all
+          <input type="checkbox" id="select-all-checkbox" onchange="toggleAllVisibleCheckboxes(this)">
+        </th>
         <th class="dark-border example-number-column">#</th>
         <th class="dark-border student-response-column"><%= @comparison.stem_and_conjunction %></th>
         <th class="dark-border feedback-key-column"><%= render 'feedback_key' %></th>
@@ -63,7 +66,8 @@
     </thead>
     <tbody>
       <% @test_examples.each.with_index do |test_example, index| %>
-        <tr class="response-row">          <td class='dark-border'>
+        <tr class="response-row">
+          <td class='dark-border'>
             <%= check_box_tag "test_example_ids[]", test_example.id, false, class: "response-checkbox", form: "data-subset-form", id: "checkbox-#{index}" %>
           </td>
           <td class='dark-border'><%= index + 1 %></td>
@@ -162,6 +166,7 @@
   function filterRows() {
     const filterValue = document.getElementById('filter-dropdown').value;
     const rows = document.querySelectorAll('.response-row');
+    const selectAllCheckbox = document.getElementById('select-all-checkbox');
 
     rows.forEach(row => {
       const checkbox = row.querySelector('.response-checkbox');
@@ -179,20 +184,35 @@
           break;
       }
     });
+
+    selectAllCheckbox.checked = false;
+    updateCreateDataSubsetButton();
   }
 
   function updateCreateDataSubsetButton() {
-    const checkboxes = document.querySelectorAll('.response-checkbox');
+    const checkboxes = document.querySelectorAll('.response-checkbox:not(.hidden)');
     const createButton = document.getElementById('create-data-subset');
     const anyChecked = Array.from(checkboxes).some(checkbox => checkbox.checked);
     createButton.disabled = !anyChecked;
+  }
+
+  function toggleAllVisibleCheckboxes(selectAllCheckbox) {
+    const visibleCheckboxes = document.querySelectorAll('.response-row:not(.hidden) .response-checkbox');
+    visibleCheckboxes.forEach(checkbox => {
+      checkbox.checked = selectAllCheckbox.checked;
+    });
+    updateCreateDataSubsetButton();
   }
 
   document.querySelectorAll('.response-checkbox').forEach(checkbox => {
     checkbox.addEventListener('change', updateCreateDataSubsetButton);
   });
 
-  updateCreateDataSubsetButton();
+  document.getElementById('filter-dropdown').addEventListener('change', () => {
+    const selectAllCheckbox = document.getElementById('select-all-checkbox');
+    selectAllCheckbox.checked = false;
+  });
 
+  updateCreateDataSubsetButton();
   filterRows();
 </script>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/comparisons/show.html.erb
@@ -12,11 +12,16 @@
 <hr>
 
 <div>
-  <select id="filter-dropdown" onchange="filterRows()">
-    <option value="all">Show all</option>
-    <option value="checked">Checked responses only</option>
-    <option value="non-matching">Show Non-Matching (Red) Only</option>
-  </select>
+  <%= form_with url: research_gen_ai_stem_vault_datasets_path(@dataset.stem_vault), method: :post, local: true, id: 'data-subset-form' do |form| %>
+    <select id="filter-dropdown" onchange="filterRows()">
+      <option value="all">Show all</option>
+      <option value="checked">Checked responses only</option>
+      <option value="non-matching">Show Non-Matching (Red) Only</option>
+    </select>
+    <%= form.hidden_field :parent_id, value: @dataset.id %>
+    <%= form.submit "Create Data Subset", id: "create-data-subset", disabled: true %>
+  <% end %>
+
   <table>
     <thead style="position: sticky; top: 0; background-color: #fff; z-index: 1;">
       <tr>
@@ -58,9 +63,8 @@
     </thead>
     <tbody>
       <% @test_examples.each.with_index do |test_example, index| %>
-        <tr class="response-row">
-          <td class='dark-border'>
-            <input type="checkbox" class="response-checkbox" id="checkbox-<%= index %>">
+        <tr class="response-row">          <td class='dark-border'>
+            <%= check_box_tag "test_example_ids[]", test_example.id, false, class: "response-checkbox", form: "data-subset-form", id: "checkbox-#{index}" %>
           </td>
           <td class='dark-border'><%= index + 1 %></td>
           <td class='dark-border'>
@@ -149,6 +153,9 @@
   .feedback-key-column {
     width: 18%;
   }
+  #create-data-subset {
+    margin-left: 10px;
+  }
 </style>
 
 <script>
@@ -173,5 +180,19 @@
       }
     });
   }
+
+  function updateCreateDataSubsetButton() {
+    const checkboxes = document.querySelectorAll('.response-checkbox');
+    const createButton = document.getElementById('create-data-subset');
+    const anyChecked = Array.from(checkboxes).some(checkbox => checkbox.checked);
+    createButton.disabled = !anyChecked;
+  }
+
+  document.querySelectorAll('.response-checkbox').forEach(checkbox => {
+    checkbox.addEventListener('change', updateCreateDataSubsetButton);
+  });
+
+  updateCreateDataSubsetButton();
+
   filterRows();
 </script>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
@@ -7,6 +7,11 @@
   <h2><%= @dataset.model_name.human.titleize %></h2>
   <p><%= @dataset %></p>
 
+  <% if @dataset.subset? %>
+    <h3>Parent Dataset</h3>
+    <p><%= link_to @dataset.parent, research_gen_ai_dataset_path(@dataset.parent) %></p>
+  <% end %>
+
 
   <h3>Optimal Test Count</h3>
   <p><%= @dataset.optimal_count %></p>
@@ -14,6 +19,43 @@
   <h3>Suboptimal Test Count</h3>
   <p><%= @dataset.suboptimal_count %></p>
   <hr/>
+
+  <% if @dataset.whole? %>
+    <h2>
+      Data Subsets
+      <button id="toggle-subsets" class="toggle-button">+</button>
+    </h2>
+
+    <div id="subsets-content" class="expandable-content" style="display: none;">
+      <table>
+        <thead>
+          <tr>
+            <th>Data Subset</th>
+            <th>Created</th>
+            <th>Total Evaluation Responses</th>
+            <th>Optimal</th>
+            <th>Sub-optimal</th>
+            <th>Trials</th>
+            <th>Access</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @data_subsets.each do |data_subset| %>
+            <tr>
+              <td><%= "Data Subset #{data_subset.version}" %></td>
+              <td><%= date_helper(data_subset.created_at) %></td>
+              <td><%= data_subset.optimal_count + data_subset.suboptimal_count %></td>
+              <td><%= data_subset.optimal_count %></td>
+              <td><%= data_subset.suboptimal_count %></td>
+              <td><%= data_subset.trials.count %></td>
+              <td><%= link_to "View", research_gen_ai_dataset_path(data_subset) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <hr>
+  <% end %>
 
   <header>
     <h2>
@@ -76,6 +118,21 @@
   <% end %>
 </div>
 
+<style>
+  .toggle-button {
+    cursor: pointer;
+    background-color: #f0f0f0;
+    border: 1px solid #ccc;
+    padding: 5px 10px;
+    font-size: 0.8em;
+    margin-left: 10px;
+  }
+
+  .expandable-content {
+    transition: opacity 0.3s ease-out;
+  }
+</style>
+
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     const checkboxes = document.querySelectorAll('.compare-checkbox');
@@ -95,4 +152,21 @@
 
     updateCompareButtons();
   });
+
+  const toggleButton = document.getElementById('toggle-subsets');
+  const subsetsContent = document.getElementById('subsets-content');
+
+  if (toggleButton && subsetsContent) {
+    toggleButton.addEventListener('click', function() {
+      if (subsetsContent.style.display === 'none') {
+        subsetsContent.style.display = 'block';
+        toggleButton.textContent = '-';
+        // Optional: Smooth scroll to the content
+        subsetsContent.scrollIntoView({ behavior: 'smooth' });
+      } else {
+        subsetsContent.style.display = 'none';
+        toggleButton.textContent = '+';
+      }
+    });
+  }
 </script>

--- a/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
+++ b/services/QuillLMS/engines/evidence/app/views/evidence/research/gen_ai/datasets/show.html.erb
@@ -161,8 +161,6 @@
       if (subsetsContent.style.display === 'none') {
         subsetsContent.style.display = 'block';
         toggleButton.textContent = '-';
-        // Optional: Smooth scroll to the content
-        subsetsContent.scrollIntoView({ behavior: 'smooth' });
       } else {
         subsetsContent.style.display = 'none';
         toggleButton.textContent = '+';

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -58,8 +58,6 @@ Evidence::Engine.routes.draw do
       resources :datasets, only: [] do
         resources :trials, only: [:new, :create, :show]
         resources :comparisons, only: [:create, :show]
-        resources :data_slices, only: [:create]
-
         resources :prompt_examples, only: [:new, :create]
       end
 

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -58,6 +58,8 @@ Evidence::Engine.routes.draw do
       resources :datasets, only: [] do
         resources :trials, only: [:new, :create, :show]
         resources :comparisons, only: [:create, :show]
+        resources :data_slices, only: [:create]
+
         resources :prompt_examples, only: [:new, :create]
       end
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/datasets_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/datasets_controller_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe DatasetsController, type: :controller do
+        routes { Evidence::Engine.routes }
+
+        let(:user) { double('User') }
+
+        before do
+          allow(controller).to receive(:current_user).and_return(user)
+          allow(user).to receive(:staff?).and_return(is_staff)
+        end
+
+        describe 'POST #create' do
+          subject { post :create, params: { stem_vault_id: }.merge(attributes) }
+
+          let(:stem_vault_id) { create(:evidence_research_gen_ai_stem_vault).id }
+          let(:is_staff) { true }
+
+          context 'as not staff' do
+            let(:is_staff) { false }
+            let(:attributes) { {} }
+
+            it { expect { subject }.not_to change(Dataset, :count) }
+            it { expect(subject).to redirect_to '/' }
+          end
+
+          context 'with file upload' do
+            let(:file) { fixture_file_upload('test.csv', 'text/csv') }
+            let(:attributes) { { research_gen_ai_dataset: { file: } } }
+
+            it { expect { subject }.to change(Evidence::Research::GenAI::Dataset, :count).by(1) }
+
+            it 'redirects to the created dataset' do
+              subject
+              expect(response).to redirect_to(Evidence::Research::GenAI::Dataset.last)
+            end
+
+            it 'calls DatasetImporter' do
+              expect(Evidence::Research::GenAI::DatasetImporter).to receive(:run)
+              subject
+            end
+          end
+
+          context 'with data subset' do
+            let(:dataset) { create(:evidence_research_gen_ai_dataset, stem_vault_id:) }
+            let(:parent_id) { dataset.id }
+            let(:test_examples) { create_list(:evidence_research_gen_ai_test_example, 2, dataset:) }
+            let(:data_subset) { create(:evidence_research_gen_ai_dataset, parent_id:) }
+            let(:test_example_ids) { test_examples.pluck(:id) }
+
+            let(:attributes) { { research_gen_ai_dataset: { parent_id:, test_example_ids: } } }
+
+            before { allow(Evidence::Research::GenAI::DataSubsetBuilder).to receive(:run).and_return(data_subset) }
+
+            it 'redirects to the created data_subset' do
+              subject
+              expect(response).to redirect_to(data_subset)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/datasets_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/datasets_controller_spec.rb
@@ -53,7 +53,7 @@ module Evidence
             let(:data_subset) { create(:evidence_research_gen_ai_dataset, parent_id:) }
             let(:test_example_ids) { test_examples.pluck(:id) }
 
-            let(:attributes) { { research_gen_ai_dataset: { parent_id:, test_example_ids: } } }
+            let(:attributes) { { parent_id:, test_example_ids: } }
 
             before { allow(Evidence::Research::GenAI::DataSubsetBuilder).to receive(:run).and_return(data_subset) }
 

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/prompt_examples.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/prompt_examples.rb
@@ -22,9 +22,9 @@ module Evidence
     module GenAI
       FactoryBot.define do
         factory :evidence_research_gen_ai_prompt_example, class: 'Evidence::Research::GenAI::PromptExample' do
-          student_response { 'This is the student response' }
+          sequence(:student_response) { |n| "This is the student response #{n}" }
           curriculum_assigned_status { TestExample::ASSIGNED_STATUSES.sample }
-          curriculum_proposed_feedback { 'This is the human feedback' }
+          sequence(:curriculum_proposed_feedback) { |n| "This is the human feedback #{n}" }
           dataset { association :evidence_research_gen_ai_dataset }
 
           trait(:optimal) { curriculum_assigned_status { HasAssignedStatus::OPTIMAL } }

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_spec.rb
@@ -40,6 +40,32 @@ module Evidence
         it { have_many(:comparisons).through(:trial_comparisons) }
 
         it { should belong_to(:stem_vault) }
+
+        describe '#set_version' do
+          let(:stem_vault) { create(:evidence_research_gen_ai_stem_vault) }
+
+          context 'when there are no existing datasets' do
+            let(:dataset) { create(factory, stem_vault:) }
+
+            it { expect(dataset.version).to eq(1) }
+          end
+
+          context 'when there are existing datasets with same parents' do
+            let(:dataset) { create(factory, stem_vault:, parent_id: 1) }
+
+            before { create(factory, stem_vault:, parent_id: 1) }
+
+            it { expect(dataset.version).to eq(2) }
+          end
+
+          context 'when there are existing datasets with different parents' do
+            let(:dataset) { create(factory, stem_vault:, parent_id: 1) }
+
+            before { create(factory, stem_vault:, parent_id: 2) }
+
+            it { expect(dataset.version).to eq(1) }
+          end
+        end
       end
     end
   end

--- a/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/data_subset_builder_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/services/evidence/research/gen_ai/data_subset_builder_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe DataSubsetBuilder do
+        subject { described_class.run(parent_id:, test_example_ids:) }
+
+        let!(:dataset) { create(:evidence_research_gen_ai_dataset) }
+        let!(:num_prompt_examples) { 2 }
+        let!(:prompt_examples) { create_list(:evidence_research_gen_ai_prompt_example, num_prompt_examples, dataset:) }
+
+        let(:parent_id) { dataset.id }
+        let(:stem_vault_id) { dataset.stem_vault.id }
+        let(:locked) { true }
+        let(:num_test_optimal) { 3 }
+        let(:num_test_suboptimal) { 2 }
+        let(:optimal_test_examples) { create_list(:evidence_research_gen_ai_test_example, num_test_optimal, :optimal, dataset:) }
+        let(:suboptimal_test_examples) { create_list(:evidence_research_gen_ai_test_example, num_test_suboptimal, :suboptimal, dataset:) }
+        let(:optimal_count) { num_test_optimal - 1 }
+        let(:suboptimal_count) { num_test_suboptimal - 1 }
+        let(:subset_optimal_test_examples) { optimal_test_examples.first(optimal_count) }
+        let(:subset_suboptimal_test_examples) { suboptimal_test_examples.first(suboptimal_count) }
+        let(:subset_test_examples) { subset_optimal_test_examples + subset_suboptimal_test_examples }
+        let(:test_example_ids) { subset_test_examples.pluck(:id) }
+
+        it { expect { subject }.to change(Dataset, :count).by(1) }
+
+        it { is_expected.to be_a(Dataset) }
+
+        it { expect(subject.parent_id).to eq(parent_id) }
+        it { expect(subject.stem_vault_id).to eq(stem_vault_id) }
+        it { expect(subject.optimal_count).to eq(optimal_count) }
+        it { expect(subject.suboptimal_count).to eq(suboptimal_count) }
+        it { expect(subject.prompt_examples.count).to eq(num_prompt_examples) }
+        it { expect(subject.test_examples.count).to eq(optimal_count + suboptimal_count) }
+        it { expect(subject.prompt_examples.pluck(:student_response)).to match_array(prompt_examples.pluck(:student_response)) }
+        it { expect(subject.test_examples.pluck(:student_response)).to match_array(subset_test_examples.pluck(:student_response)) }
+        it { expect(subject.test_examples.pluck(:id)).not_to match_array(test_example_ids) }
+
+        context 'when invalid parent_id is provided' do
+          let(:parent_id) { -1 }
+
+          it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
+        end
+
+        context 'when no test examples are selected' do
+          let(:test_example_ids) { [] }
+
+          it { expect(subject.test_examples).to be_empty }
+          it { expect(subject.optimal_count).to eq(0) }
+          it { expect(subject.suboptimal_count).to eq(0) }
+        end
+
+        context 'when invalid test_example_ids are provided' do
+          let(:test_example_ids) { [-1, -2] }
+
+          it { expect(subject.test_examples).to be_empty }
+          it { expect(subject.optimal_count).to eq(0) }
+          it { expect(subject.suboptimal_count).to eq(0) }
+        end
+
+        context 'when there is a mix of valid and invalid test_example_ids' do
+          let(:test_example_ids) { optimal_test_examples.pluck(:id) + [-1, -2] }
+
+          it { expect(subject.test_examples.count).to eq(optimal_test_examples.count) }
+          it { expect(subject.optimal_count).to eq(optimal_test_examples.count) }
+          it { expect(subject.suboptimal_count).to eq(0) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
* Add 'Create Data Subset' button in comparisons#show page 
* Add DataSubsetBuilder service object
* Update DatasetsController#create to allow creation of subsets
* Update versioning of datasets based on parent_id
* Update views to show subsets within datasets#show page

## WHY
* When comparing trials, it can speed up feedback cycles (and cut down on API calls) by restricting a trial to a subset of test examples
* This service object copies various pieces from the parent dataset over to the new data subset
* Datasets can be created by CSV or this new path using Create Data Subset
* We don't want subsets to have the same versioning as their parents
* Listing the subsets within each particular datasets#show page cuts down on clutter with StemVault#show page

## HOW
* Add a button at the top of the table and monitor for checked rows.  If clicked send a request to datasets#create with the dataset id and the selected test_examples
* Create a new dataset with a copy of all prompt examples and selected test examples from the parent dataset using DataSubsetBuilder
* Add conditional that checks if the creation is file based or subset based
* Update before_create filter to search for existing datasets scoped by parent_id
* Add similar table in stem_vault#show to the dataset#show

### Screenshots
![Screenshot 2024-08-29 at 10 47 03 AM](https://github.com/user-attachments/assets/a0aa91c9-c549-4388-92bb-5c637398b732)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Checked on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
