### PR TITLE
update featured activity packs page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_minis/unit_template_minis.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/unit_templates/unit_template_minis/unit_template_minis.scss
@@ -42,9 +42,6 @@
         width: 140px;
       }
     }
-    .dropdown-container:nth-of-type(2) {
-      width: 325px;
-    }
   }
 
   .pack-type-header, .top-card-margin-top {
@@ -55,7 +52,6 @@
 
   .type-options {
     display: flex;
-    width: 668px;
     justify-content: space-between;
     a {
       line-height: 1;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/assignmentFlowConstants.tsx
@@ -258,6 +258,11 @@ export const ACTIVITY_PACK_TYPES = [
     types: ['Language Skill Review', 'Language Skills for Writing Genres', 'Language Skills Themed Practice']
   },
   {
+    name: 'Proofreading',
+    id: 'proofreading',
+    types: [DAILY_PROOFREADING]
+  },
+  {
     name: 'Whole Class Lessons',
     id: 'whole-class'
   },

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_classification_filters.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/activity_classification_filters.test.tsx.snap
@@ -5916,6 +5916,1499 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
       }
       grouping={
         Object {
+          "group": "Independent: Proofreading",
+          "keys": Array [
+            "passage",
+          ],
+        }
+      }
+      handleActivityClassificationFilterChange={[Function]}
+      key="Independent: Proofreading"
+      uniqueActivityClassifications={
+        Array [
+          Object {
+            "alias": "Quill Connect",
+            "description": "Combine Sentences",
+            "id": 5,
+            "key": "connect",
+          },
+        ]
+      }
+    >
+      <section
+        className="toggle-section activity-classification-toggle"
+      >
+        <div
+          className="top-level filter-row"
+        >
+          <div>
+            <button
+              aria-label="Toggle menu"
+              className="interactive-wrapper focus-on-light filter-toggle-button"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                className="is-closed"
+                src="undefined/images/icons/dropdown.svg"
+              />
+            </button>
+            <div
+              className="focus-on-light quill-checkbox disabled"
+            />
+            <span>
+              Independent: Proofreading
+            </span>
+          </div>
+          <span>
+            (
+            0
+            )
+          </span>
+        </div>
+        <span />
+      </section>
+    </ActivityClassificationToggle>
+    <ActivityClassificationToggle
+      activityClassificationFilters={Array []}
+      filteredActivities={
+        Array [
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=627",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about Hernan Cortes. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 627,
+            "name": "Hernan Cortes",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 171,
+                "level": 1,
+                "name": "Hernan Cortes & the Aztec Empire",
+                "parent_id": 93,
+              },
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqcjgL00W0ro-Wr4Bts",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=628",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the Maya civilization. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 628,
+            "name": "Maya Mystery",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqcdV5JA9uUSY09VvOP",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=629",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Tenochtitlan Origin Myth. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 629,
+            "name": "Tenochtitlan Origin Myth",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+              Object {
+                "id": 315,
+                "level": 1,
+                "name": "Tenochtitlán Origin Myth",
+                "parent_id": 28,
+              },
+            ],
+            "uid": "-KqcY9ZUJ7gdReZw7C93",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=630",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Royal Road. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 630,
+            "name": "The Royal Road",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqcTJxEiuq07PJzbDIc",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=617",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about Emperor Hui Zong's defeat. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 617,
+            "name": "Hui Zong's Defeat",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 184,
+                "level": 1,
+                "name": "Hui Zong's Defeat",
+                "parent_id": 93,
+              },
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqilM2xWovC-Hudmvjn",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=619",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the unification of China under Shihuangdi. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 619,
+            "name": "Shihuangdi Unifies China",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqigC-G1kUp_pEeQJjl",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=616",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the inventions during the Tang Dynasty. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 616,
+            "name": "Tang Dynasty Inventions",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqiiQTci2gs9zhx2tIA",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=618",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Mongol invasion of China. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 618,
+            "name": "The Mongol Invasion of China",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-Kqisu7eUfGfGvjRvT2W",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=608",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences to create 6 sentences about Marco Polo. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 608,
+            "name": "The Travels of Marco Polo",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 368,
+                "level": 1,
+                "name": "Marco Polo",
+                "parent_id": 93,
+              },
+            ],
+            "uid": "-KqZ_8tESejeyBmj-_pO",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=860",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences to create 5 sentences about Hernando de Soto. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 860,
+            "name": "Hernando de Soto",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 173,
+                "level": 1,
+                "name": "Hernando de Soto",
+                "parent_id": 93,
+              },
+            ],
+            "uid": "-KhO2hv2Wl8rVCHp1B1G",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=605",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about Magellan's trip around the globe. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 605,
+            "name": "Magellan",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 116,
+                "level": 1,
+                "name": "Magellan",
+                "parent_id": 93,
+              },
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqZiV1bnPe48h6gyYss",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=606",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences to create 5 sentences about the Jamestown settlement. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 606,
+            "name": "Jamestown",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqcJOzHDYUrioJ6fPlR",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=642",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about humanism. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 642,
+            "name": "Humanism",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqZldiOXNWbJNFvIRY-",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=640",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the beginnings of the Renaissance in Italy. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 640,
+            "name": "Renaissance Beginnings in Italy",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqZpAZ8UMhwZp_3ezqw",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=641",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the Medici family. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 641,
+            "name": "The Medici Family",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+              Object {
+                "id": 350,
+                "level": 1,
+                "name": "The Medici Family",
+                "parent_id": 93,
+              },
+            ],
+            "uid": "-KqZvArG8422vhwB7rIo",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=643",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Northern Renaissance. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 643,
+            "name": "The Northern Renaissance",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqdGWI1rgvtQBg2vIb0",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=728",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the beginning of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 728,
+            "name": "The War Begins at Lexington and Concord",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqY7BQmhDn71y-E-s3C",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=731",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the final battle of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 731,
+            "name": "The War Ends at Yorktown",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqYK5A0fNos0ZbUjjOu",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=729",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the Battle of Bunker Hill. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 729,
+            "name": "Turning Point: Bunker Hill",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 385,
+                "level": 1,
+                "name": "The Battle of Bunker Hill",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqYNoENpFXSttDu-xPf",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=730",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Battle of Saratoga. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 730,
+            "name": "Turning Point: Saratoga",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 386,
+                "level": 1,
+                "name": "The Battle of Saratoga",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqYPpC3o3JeeuhQadBF",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 24,
+              "name": "History: Causes of the American Revolution",
+            },
+            "activity_category_id": 24,
+            "activity_category_name": "History: Causes of the American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=477",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 4 new compound or complex sentences that include modifying phrases and compound predicates.",
+            "flags": "{production}",
+            "id": 477,
+            "name": "The Stamp Act",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 363,
+                "level": 1,
+                "name": "The Stamp Act",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KbvuSGyq6ANjB6cSzpQ",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 24,
+              "name": "History: Causes of the American Revolution",
+            },
+            "activity_category_id": 24,
+            "activity_category_name": "History: Causes of the American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=476",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 6 new compound or complex sentences that include modifying phrases and compound predicates.",
+            "flags": "{production}",
+            "id": 476,
+            "name": "The Boston Massacre",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 321,
+                "level": 1,
+                "name": "The Boston Massacre",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-Kbk-mjzTNeqWbvVG9zI",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 24,
+              "name": "History: Causes of the American Revolution",
+            },
+            "activity_category_id": 24,
+            "activity_category_name": "History: Causes of the American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=478",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 5 new compound or complex sentences that include modifying phrases and compound predicates.",
+            "flags": "{production}",
+            "id": 478,
+            "name": "The Boston Tea Party",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 322,
+                "level": 1,
+                "name": "The Boston Tea Party",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-Kbvv3WS6vGNkeW7d6dt",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=584",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about the Iroquois Confederacy. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 584,
+            "name": "The Iroquois Confederacy",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 346,
+                "level": 1,
+                "name": "The Iroquois Confederacy",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqZdYHq5N9O1OYfzZbl",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=585",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the importance of the buffalo to the Native American tribes living on the Great Plains. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 585,
+            "name": "The Importance of the Buffalo",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 345,
+                "level": 1,
+                "name": "Buffalo",
+                "parent_id": 13,
+              },
+            ],
+            "uid": "-KqZWcwJndWJBU-U3ehj",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=586",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about Ishi of the Yahi people. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 586,
+            "name": "Ishi",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 195,
+                "level": 1,
+                "name": "Ishi & the Yahi People",
+                "parent_id": 17,
+              },
+            ],
+            "uid": "-KqZh2mwDeSPLCxp2UAT",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=587",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences 5 times to create sentences about the Dawes Act. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 587,
+            "name": "The Dawes Act",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 325,
+                "level": 1,
+                "name": "The Dawes Act",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqZaKPdDL_-tnCUDIlX",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=613",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about asteroids. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 613,
+            "name": "Asteroids",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 88,
+                "level": 1,
+                "name": "Asteroids",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 89,
+                "level": 1,
+                "name": "Astronomy",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-KqZUaz7rINZ8fNssJ6r",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=614",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about Ham and Alan Shepard of the NASA space program. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 614,
+            "name": "Ham and Alan Shepard",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 78,
+                "level": 1,
+                "name": "Space Exploration",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 168,
+                "level": 1,
+                "name": "Ham & Alan Shepard",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-KqZR__u2hpJ2z8cIch-",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=615",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about eclipses. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 615,
+            "name": "Eclipses",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 89,
+                "level": 1,
+                "name": "Astronomy",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 153,
+                "level": 1,
+                "name": "Eclipses",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-KqZFTXwQ5MCZMH9-bUN",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=756",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about the International Space Station. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 756,
+            "name": "International Space Station",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 78,
+                "level": 1,
+                "name": "Space Exploration",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 193,
+                "level": 1,
+                "name": "The International Space Station",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-LAo-erEroO6r6XV1tAV",
+          },
+        ]
+      }
+      grouping={
+        Object {
           "group": "Whole Class Instruction",
           "keys": Array [
             "lessons",
@@ -11976,6 +13469,1504 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
           <span>
             (
             31
+            )
+          </span>
+        </div>
+        <span />
+      </section>
+    </ActivityClassificationToggle>
+    <ActivityClassificationToggle
+      activityClassificationFilters={
+        Array [
+          "diagnostic",
+          "connect",
+        ]
+      }
+      filteredActivities={
+        Array [
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=627",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about Hernan Cortes. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 627,
+            "name": "Hernan Cortes",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 171,
+                "level": 1,
+                "name": "Hernan Cortes & the Aztec Empire",
+                "parent_id": 93,
+              },
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqcjgL00W0ro-Wr4Bts",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=628",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the Maya civilization. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 628,
+            "name": "Maya Mystery",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqcdV5JA9uUSY09VvOP",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=629",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Tenochtitlan Origin Myth. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 629,
+            "name": "Tenochtitlan Origin Myth",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+              Object {
+                "id": 315,
+                "level": 1,
+                "name": "Tenochtitlán Origin Myth",
+                "parent_id": 28,
+              },
+            ],
+            "uid": "-KqcY9ZUJ7gdReZw7C93",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=630",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Royal Road. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 630,
+            "name": "The Royal Road",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqcTJxEiuq07PJzbDIc",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=617",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about Emperor Hui Zong's defeat. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 617,
+            "name": "Hui Zong's Defeat",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 184,
+                "level": 1,
+                "name": "Hui Zong's Defeat",
+                "parent_id": 93,
+              },
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqilM2xWovC-Hudmvjn",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=619",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the unification of China under Shihuangdi. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 619,
+            "name": "Shihuangdi Unifies China",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqigC-G1kUp_pEeQJjl",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=616",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the inventions during the Tang Dynasty. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 616,
+            "name": "Tang Dynasty Inventions",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqiiQTci2gs9zhx2tIA",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=618",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Mongol invasion of China. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 618,
+            "name": "The Mongol Invasion of China",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-Kqisu7eUfGfGvjRvT2W",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=608",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences to create 6 sentences about Marco Polo. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 608,
+            "name": "The Travels of Marco Polo",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 368,
+                "level": 1,
+                "name": "Marco Polo",
+                "parent_id": 93,
+              },
+            ],
+            "uid": "-KqZ_8tESejeyBmj-_pO",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=860",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences to create 5 sentences about Hernando de Soto. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 860,
+            "name": "Hernando de Soto",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 173,
+                "level": 1,
+                "name": "Hernando de Soto",
+                "parent_id": 93,
+              },
+            ],
+            "uid": "-KhO2hv2Wl8rVCHp1B1G",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=605",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about Magellan's trip around the globe. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 605,
+            "name": "Magellan",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 116,
+                "level": 1,
+                "name": "Magellan",
+                "parent_id": 93,
+              },
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqZiV1bnPe48h6gyYss",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=606",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences to create 5 sentences about the Jamestown settlement. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 606,
+            "name": "Jamestown",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqcJOzHDYUrioJ6fPlR",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=642",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about humanism. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 642,
+            "name": "Humanism",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqZldiOXNWbJNFvIRY-",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=640",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the beginnings of the Renaissance in Italy. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 640,
+            "name": "Renaissance Beginnings in Italy",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqZpAZ8UMhwZp_3ezqw",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=641",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the Medici family. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 641,
+            "name": "The Medici Family",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+              Object {
+                "id": 350,
+                "level": 1,
+                "name": "The Medici Family",
+                "parent_id": 93,
+              },
+            ],
+            "uid": "-KqZvArG8422vhwB7rIo",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=643",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Northern Renaissance. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 643,
+            "name": "The Northern Renaissance",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqdGWI1rgvtQBg2vIb0",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=728",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the beginning of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 728,
+            "name": "The War Begins at Lexington and Concord",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqY7BQmhDn71y-E-s3C",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=731",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the final battle of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 731,
+            "name": "The War Ends at Yorktown",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqYK5A0fNos0ZbUjjOu",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=729",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the Battle of Bunker Hill. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 729,
+            "name": "Turning Point: Bunker Hill",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 385,
+                "level": 1,
+                "name": "The Battle of Bunker Hill",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqYNoENpFXSttDu-xPf",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=730",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Battle of Saratoga. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 730,
+            "name": "Turning Point: Saratoga",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 386,
+                "level": 1,
+                "name": "The Battle of Saratoga",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqYPpC3o3JeeuhQadBF",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 24,
+              "name": "History: Causes of the American Revolution",
+            },
+            "activity_category_id": 24,
+            "activity_category_name": "History: Causes of the American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=477",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 4 new compound or complex sentences that include modifying phrases and compound predicates.",
+            "flags": "{production}",
+            "id": 477,
+            "name": "The Stamp Act",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 363,
+                "level": 1,
+                "name": "The Stamp Act",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KbvuSGyq6ANjB6cSzpQ",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 24,
+              "name": "History: Causes of the American Revolution",
+            },
+            "activity_category_id": 24,
+            "activity_category_name": "History: Causes of the American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=476",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 6 new compound or complex sentences that include modifying phrases and compound predicates.",
+            "flags": "{production}",
+            "id": 476,
+            "name": "The Boston Massacre",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 321,
+                "level": 1,
+                "name": "The Boston Massacre",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-Kbk-mjzTNeqWbvVG9zI",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 24,
+              "name": "History: Causes of the American Revolution",
+            },
+            "activity_category_id": 24,
+            "activity_category_name": "History: Causes of the American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=478",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 5 new compound or complex sentences that include modifying phrases and compound predicates.",
+            "flags": "{production}",
+            "id": 478,
+            "name": "The Boston Tea Party",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 322,
+                "level": 1,
+                "name": "The Boston Tea Party",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-Kbvv3WS6vGNkeW7d6dt",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=584",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about the Iroquois Confederacy. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 584,
+            "name": "The Iroquois Confederacy",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 346,
+                "level": 1,
+                "name": "The Iroquois Confederacy",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqZdYHq5N9O1OYfzZbl",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=585",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the importance of the buffalo to the Native American tribes living on the Great Plains. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 585,
+            "name": "The Importance of the Buffalo",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 345,
+                "level": 1,
+                "name": "Buffalo",
+                "parent_id": 13,
+              },
+            ],
+            "uid": "-KqZWcwJndWJBU-U3ehj",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=586",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about Ishi of the Yahi people. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 586,
+            "name": "Ishi",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 195,
+                "level": 1,
+                "name": "Ishi & the Yahi People",
+                "parent_id": 17,
+              },
+            ],
+            "uid": "-KqZh2mwDeSPLCxp2UAT",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=587",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences 5 times to create sentences about the Dawes Act. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 587,
+            "name": "The Dawes Act",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 325,
+                "level": 1,
+                "name": "The Dawes Act",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqZaKPdDL_-tnCUDIlX",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=613",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about asteroids. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 613,
+            "name": "Asteroids",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 88,
+                "level": 1,
+                "name": "Asteroids",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 89,
+                "level": 1,
+                "name": "Astronomy",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-KqZUaz7rINZ8fNssJ6r",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=614",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about Ham and Alan Shepard of the NASA space program. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 614,
+            "name": "Ham and Alan Shepard",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 78,
+                "level": 1,
+                "name": "Space Exploration",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 168,
+                "level": 1,
+                "name": "Ham & Alan Shepard",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-KqZR__u2hpJ2z8cIch-",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=615",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about eclipses. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 615,
+            "name": "Eclipses",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 89,
+                "level": 1,
+                "name": "Astronomy",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 153,
+                "level": 1,
+                "name": "Eclipses",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-KqZFTXwQ5MCZMH9-bUN",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=756",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about the International Space Station. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 756,
+            "name": "International Space Station",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 78,
+                "level": 1,
+                "name": "Space Exploration",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 193,
+                "level": 1,
+                "name": "The International Space Station",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-LAo-erEroO6r6XV1tAV",
+          },
+        ]
+      }
+      grouping={
+        Object {
+          "group": "Independent: Proofreading",
+          "keys": Array [
+            "passage",
+          ],
+        }
+      }
+      handleActivityClassificationFilterChange={[Function]}
+      key="Independent: Proofreading"
+      uniqueActivityClassifications={
+        Array [
+          Object {
+            "alias": "Quill Connect",
+            "description": "Combine Sentences",
+            "id": 5,
+            "key": "connect",
+          },
+        ]
+      }
+    >
+      <section
+        className="toggle-section activity-classification-toggle"
+      >
+        <div
+          className="top-level filter-row"
+        >
+          <div>
+            <button
+              aria-label="Toggle menu"
+              className="interactive-wrapper focus-on-light filter-toggle-button"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                className="is-closed"
+                src="undefined/images/icons/dropdown.svg"
+              />
+            </button>
+            <div
+              className="focus-on-light quill-checkbox disabled"
+            />
+            <span>
+              Independent: Proofreading
+            </span>
+          </div>
+          <span>
+            (
+            0
             )
           </span>
         </div>
@@ -19488,6 +22479,1499 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
           <span>
             (
             31
+            )
+          </span>
+        </div>
+        <span />
+      </section>
+    </ActivityClassificationToggle>
+    <ActivityClassificationToggle
+      activityClassificationFilters={Array []}
+      filteredActivities={
+        Array [
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=627",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about Hernan Cortes. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 627,
+            "name": "Hernan Cortes",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 171,
+                "level": 1,
+                "name": "Hernan Cortes & the Aztec Empire",
+                "parent_id": 93,
+              },
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqcjgL00W0ro-Wr4Bts",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=628",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the Maya civilization. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 628,
+            "name": "Maya Mystery",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqcdV5JA9uUSY09VvOP",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=629",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Tenochtitlan Origin Myth. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 629,
+            "name": "Tenochtitlan Origin Myth",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+              Object {
+                "id": 315,
+                "level": 1,
+                "name": "Tenochtitlán Origin Myth",
+                "parent_id": 28,
+              },
+            ],
+            "uid": "-KqcY9ZUJ7gdReZw7C93",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 20,
+              "name": "History: Maya, Aztec, Inca",
+            },
+            "activity_category_id": 20,
+            "activity_category_name": "History: Maya, Aztec, Inca",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=630",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Royal Road. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 630,
+            "name": "The Royal Road",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 172,
+                "level": 1,
+                "name": "Maya, Aztec, & Inca Civilizations",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqcTJxEiuq07PJzbDIc",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=617",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about Emperor Hui Zong's defeat. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 617,
+            "name": "Hui Zong's Defeat",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 184,
+                "level": 1,
+                "name": "Hui Zong's Defeat",
+                "parent_id": 93,
+              },
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqilM2xWovC-Hudmvjn",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=619",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the unification of China under Shihuangdi. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 619,
+            "name": "Shihuangdi Unifies China",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqigC-G1kUp_pEeQJjl",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=616",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the inventions during the Tang Dynasty. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 616,
+            "name": "Tang Dynasty Inventions",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqiiQTci2gs9zhx2tIA",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 19,
+              "name": "History: Chinese Dynasties",
+            },
+            "activity_category_id": 19,
+            "activity_category_name": "History: Chinese Dynasties",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=618",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Mongol invasion of China. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 618,
+            "name": "The Mongol Invasion of China",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 185,
+                "level": 1,
+                "name": "Chinese Dynasties",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-Kqisu7eUfGfGvjRvT2W",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=608",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences to create 6 sentences about Marco Polo. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 608,
+            "name": "The Travels of Marco Polo",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 368,
+                "level": 1,
+                "name": "Marco Polo",
+                "parent_id": 93,
+              },
+            ],
+            "uid": "-KqZ_8tESejeyBmj-_pO",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=860",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences to create 5 sentences about Hernando de Soto. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 860,
+            "name": "Hernando de Soto",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 173,
+                "level": 1,
+                "name": "Hernando de Soto",
+                "parent_id": 93,
+              },
+            ],
+            "uid": "-KhO2hv2Wl8rVCHp1B1G",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=605",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about Magellan's trip around the globe. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 605,
+            "name": "Magellan",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 116,
+                "level": 1,
+                "name": "Magellan",
+                "parent_id": 93,
+              },
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqZiV1bnPe48h6gyYss",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 23,
+              "name": "History: Age of Exploration",
+            },
+            "activity_category_id": 23,
+            "activity_category_name": "History: Age of Exploration",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=606",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences to create 5 sentences about the Jamestown settlement. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 606,
+            "name": "Jamestown",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 117,
+                "level": 1,
+                "name": "The Age of Exploration",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqcJOzHDYUrioJ6fPlR",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=642",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about humanism. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 642,
+            "name": "Humanism",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqZldiOXNWbJNFvIRY-",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=640",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the beginnings of the Renaissance in Italy. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 640,
+            "name": "Renaissance Beginnings in Italy",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqZpAZ8UMhwZp_3ezqw",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=641",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the Medici family. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 641,
+            "name": "The Medici Family",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+              Object {
+                "id": 350,
+                "level": 1,
+                "name": "The Medici Family",
+                "parent_id": 93,
+              },
+            ],
+            "uid": "-KqZvArG8422vhwB7rIo",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 22,
+              "name": "History: The Renaissance",
+            },
+            "activity_category_id": 22,
+            "activity_category_name": "History: The Renaissance",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=643",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Northern Renaissance. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 643,
+            "name": "The Northern Renaissance",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 187,
+                "level": 1,
+                "name": "The Renaissance",
+                "parent_id": 48,
+              },
+            ],
+            "uid": "-KqdGWI1rgvtQBg2vIb0",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=728",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the beginning of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 728,
+            "name": "The War Begins at Lexington and Concord",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqY7BQmhDn71y-E-s3C",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=731",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the final battle of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 731,
+            "name": "The War Ends at Yorktown",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqYK5A0fNos0ZbUjjOu",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=729",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about the Battle of Bunker Hill. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 729,
+            "name": "Turning Point: Bunker Hill",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 385,
+                "level": 1,
+                "name": "The Battle of Bunker Hill",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqYNoENpFXSttDu-xPf",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 25,
+              "name": "History: American Revolution",
+            },
+            "activity_category_id": 25,
+            "activity_category_name": "History: American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=730",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the Battle of Saratoga. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 730,
+            "name": "Turning Point: Saratoga",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 386,
+                "level": 1,
+                "name": "The Battle of Saratoga",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqYPpC3o3JeeuhQadBF",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 24,
+              "name": "History: Causes of the American Revolution",
+            },
+            "activity_category_id": 24,
+            "activity_category_name": "History: Causes of the American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=477",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 4 new compound or complex sentences that include modifying phrases and compound predicates.",
+            "flags": "{production}",
+            "id": 477,
+            "name": "The Stamp Act",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 363,
+                "level": 1,
+                "name": "The Stamp Act",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KbvuSGyq6ANjB6cSzpQ",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 24,
+              "name": "History: Causes of the American Revolution",
+            },
+            "activity_category_id": 24,
+            "activity_category_name": "History: Causes of the American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=476",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 6 new compound or complex sentences that include modifying phrases and compound predicates.",
+            "flags": "{production}",
+            "id": 476,
+            "name": "The Boston Massacre",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 321,
+                "level": 1,
+                "name": "The Boston Massacre",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-Kbk-mjzTNeqWbvVG9zI",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 24,
+              "name": "History: Causes of the American Revolution",
+            },
+            "activity_category_id": 24,
+            "activity_category_name": "History: Causes of the American Revolution",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=478",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 5 new compound or complex sentences that include modifying phrases and compound predicates.",
+            "flags": "{production}",
+            "id": 478,
+            "name": "The Boston Tea Party",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 119,
+                "level": 1,
+                "name": "The American Revolution",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 322,
+                "level": 1,
+                "name": "The Boston Tea Party",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-Kbvv3WS6vGNkeW7d6dt",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=584",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about the Iroquois Confederacy. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 584,
+            "name": "The Iroquois Confederacy",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 346,
+                "level": 1,
+                "name": "The Iroquois Confederacy",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqZdYHq5N9O1OYfzZbl",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=585",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about the importance of the buffalo to the Native American tribes living on the Great Plains. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 585,
+            "name": "The Importance of the Buffalo",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 345,
+                "level": 1,
+                "name": "Buffalo",
+                "parent_id": 13,
+              },
+            ],
+            "uid": "-KqZWcwJndWJBU-U3ehj",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=586",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 7 sentences about Ishi of the Yahi people. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 586,
+            "name": "Ishi",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 195,
+                "level": 1,
+                "name": "Ishi & the Yahi People",
+                "parent_id": 17,
+              },
+            ],
+            "uid": "-KqZh2mwDeSPLCxp2UAT",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 21,
+              "name": "History: Native Americans",
+            },
+            "activity_category_id": 21,
+            "activity_category_name": "History: Native Americans",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=587",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Students combine sentences 5 times to create sentences about the Dawes Act. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 587,
+            "name": "The Dawes Act",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 65,
+                "level": 1,
+                "name": "Native Americans",
+                "parent_id": 45,
+              },
+              Object {
+                "id": 325,
+                "level": 1,
+                "name": "The Dawes Act",
+                "parent_id": 45,
+              },
+            ],
+            "uid": "-KqZaKPdDL_-tnCUDIlX",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=613",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about asteroids. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 613,
+            "name": "Asteroids",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 88,
+                "level": 1,
+                "name": "Asteroids",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 89,
+                "level": 1,
+                "name": "Astronomy",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-KqZUaz7rINZ8fNssJ6r",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=614",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about Ham and Alan Shepard of the NASA space program. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 614,
+            "name": "Ham and Alan Shepard",
+            "readability_grade_level": "8th-9th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 78,
+                "level": 1,
+                "name": "Space Exploration",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 168,
+                "level": 1,
+                "name": "Ham & Alan Shepard",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-KqZR__u2hpJ2z8cIch-",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=615",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 6 sentences about eclipses. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 615,
+            "name": "Eclipses",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 89,
+                "level": 1,
+                "name": "Astronomy",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 153,
+                "level": 1,
+                "name": "Eclipses",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-KqZFTXwQ5MCZMH9-bUN",
+          },
+          Object {
+            "activity_category": Object {
+              "id": 26,
+              "name": "Science: What's in Our Universe?",
+            },
+            "activity_category_id": 26,
+            "activity_category_name": "Science: What's in Our Universe?",
+            "activity_classification": Object {
+              "alias": "Quill Connect",
+              "description": "Combine Sentences",
+              "id": 5,
+              "key": "connect",
+            },
+            "anonymous_path": "/activity_sessions/anonymous?activity_id=756",
+            "content_partners": Array [
+              Object {
+                "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                "id": 1,
+                "name": "Core Knowledge",
+              },
+            ],
+            "description": "Combine sentences to create 5 sentences about the International Space Station. This is an advanced, un-cued sentence combining activity.",
+            "flags": "{production}",
+            "id": 756,
+            "name": "International Space Station",
+            "readability_grade_level": "6th-7th",
+            "standard_level": Object {
+              "id": 13,
+              "name": "7th Grade CCSS",
+            },
+            "standard_level_name": "7th Grade CCSS",
+            "standard_name": "87",
+            "topics": Array [
+              Object {
+                "id": 78,
+                "level": 1,
+                "name": "Space Exploration",
+                "parent_id": 90,
+              },
+              Object {
+                "id": 193,
+                "level": 1,
+                "name": "The International Space Station",
+                "parent_id": 90,
+              },
+            ],
+            "uid": "-LAo-erEroO6r6XV1tAV",
+          },
+        ]
+      }
+      grouping={
+        Object {
+          "group": "Independent: Proofreading",
+          "keys": Array [
+            "passage",
+          ],
+        }
+      }
+      handleActivityClassificationFilterChange={[Function]}
+      key="Independent: Proofreading"
+      uniqueActivityClassifications={
+        Array [
+          Object {
+            "alias": "Quill Connect",
+            "description": "Combine Sentences",
+            "id": 5,
+            "key": "connect",
+          },
+        ]
+      }
+    >
+      <section
+        className="toggle-section activity-classification-toggle"
+      >
+        <div
+          className="top-level filter-row"
+        >
+          <div>
+            <button
+              aria-label="Toggle menu"
+              className="interactive-wrapper focus-on-light filter-toggle-button"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                className="is-closed"
+                src="undefined/images/icons/dropdown.svg"
+              />
+            </button>
+            <div
+              className="focus-on-light quill-checkbox disabled"
+            />
+            <span>
+              Independent: Proofreading
+            </span>
+          </div>
+          <span>
+            (
+            0
             )
           </span>
         </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/index.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/index.test.tsx.snap
@@ -13201,6 +13201,1499 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
                 grouping={
                   Object {
+                    "group": "Independent: Proofreading",
+                    "keys": Array [
+                      "passage",
+                    ],
+                  }
+                }
+                handleActivityClassificationFilterChange={[Function]}
+                key="Independent: Proofreading"
+                uniqueActivityClassifications={
+                  Array [
+                    Object {
+                      "alias": "Quill Connect",
+                      "description": "Combine Sentences",
+                      "id": 5,
+                      "key": "connect",
+                    },
+                  ]
+                }
+              >
+                <section
+                  className="toggle-section activity-classification-toggle"
+                >
+                  <div
+                    className="top-level filter-row"
+                  >
+                    <div>
+                      <button
+                        aria-label="Toggle menu"
+                        className="interactive-wrapper focus-on-light filter-toggle-button"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <img
+                          alt=""
+                          className="is-closed"
+                          src="undefined/images/icons/dropdown.svg"
+                        />
+                      </button>
+                      <div
+                        className="focus-on-light quill-checkbox disabled"
+                      />
+                      <span>
+                        Independent: Proofreading
+                      </span>
+                    </div>
+                    <span>
+                      (
+                      0
+                      )
+                    </span>
+                  </div>
+                  <span />
+                </section>
+              </ActivityClassificationToggle>
+              <ActivityClassificationToggle
+                activityClassificationFilters={Array []}
+                filteredActivities={
+                  Array [
+                    Object {
+                      "activity_category": Object {
+                        "id": 20,
+                        "name": "History: Maya, Aztec, Inca",
+                      },
+                      "activity_category_id": 20,
+                      "activity_category_name": "History: Maya, Aztec, Inca",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=627",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about Hernan Cortes. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 627,
+                      "name": "Hernan Cortes",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 171,
+                          "level": 1,
+                          "name": "Hernan Cortes & the Aztec Empire",
+                          "parent_id": 93,
+                        },
+                        Object {
+                          "id": 172,
+                          "level": 1,
+                          "name": "Maya, Aztec, & Inca Civilizations",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqcjgL00W0ro-Wr4Bts",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 20,
+                        "name": "History: Maya, Aztec, Inca",
+                      },
+                      "activity_category_id": 20,
+                      "activity_category_name": "History: Maya, Aztec, Inca",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=628",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about the Maya civilization. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 628,
+                      "name": "Maya Mystery",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 172,
+                          "level": 1,
+                          "name": "Maya, Aztec, & Inca Civilizations",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqcdV5JA9uUSY09VvOP",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 20,
+                        "name": "History: Maya, Aztec, Inca",
+                      },
+                      "activity_category_id": 20,
+                      "activity_category_name": "History: Maya, Aztec, Inca",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=629",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Tenochtitlan Origin Myth. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 629,
+                      "name": "Tenochtitlan Origin Myth",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 172,
+                          "level": 1,
+                          "name": "Maya, Aztec, & Inca Civilizations",
+                          "parent_id": 48,
+                        },
+                        Object {
+                          "id": 315,
+                          "level": 1,
+                          "name": "Tenochtitlán Origin Myth",
+                          "parent_id": 28,
+                        },
+                      ],
+                      "uid": "-KqcY9ZUJ7gdReZw7C93",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 20,
+                        "name": "History: Maya, Aztec, Inca",
+                      },
+                      "activity_category_id": 20,
+                      "activity_category_name": "History: Maya, Aztec, Inca",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=630",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Royal Road. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 630,
+                      "name": "The Royal Road",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 172,
+                          "level": 1,
+                          "name": "Maya, Aztec, & Inca Civilizations",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqcTJxEiuq07PJzbDIc",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 19,
+                        "name": "History: Chinese Dynasties",
+                      },
+                      "activity_category_id": 19,
+                      "activity_category_name": "History: Chinese Dynasties",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=617",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about Emperor Hui Zong's defeat. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 617,
+                      "name": "Hui Zong's Defeat",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 184,
+                          "level": 1,
+                          "name": "Hui Zong's Defeat",
+                          "parent_id": 93,
+                        },
+                        Object {
+                          "id": 185,
+                          "level": 1,
+                          "name": "Chinese Dynasties",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqilM2xWovC-Hudmvjn",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 19,
+                        "name": "History: Chinese Dynasties",
+                      },
+                      "activity_category_id": 19,
+                      "activity_category_name": "History: Chinese Dynasties",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=619",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the unification of China under Shihuangdi. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 619,
+                      "name": "Shihuangdi Unifies China",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 185,
+                          "level": 1,
+                          "name": "Chinese Dynasties",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqigC-G1kUp_pEeQJjl",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 19,
+                        "name": "History: Chinese Dynasties",
+                      },
+                      "activity_category_id": 19,
+                      "activity_category_name": "History: Chinese Dynasties",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=616",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the inventions during the Tang Dynasty. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 616,
+                      "name": "Tang Dynasty Inventions",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 185,
+                          "level": 1,
+                          "name": "Chinese Dynasties",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqiiQTci2gs9zhx2tIA",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 19,
+                        "name": "History: Chinese Dynasties",
+                      },
+                      "activity_category_id": 19,
+                      "activity_category_name": "History: Chinese Dynasties",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=618",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Mongol invasion of China. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 618,
+                      "name": "The Mongol Invasion of China",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 185,
+                          "level": 1,
+                          "name": "Chinese Dynasties",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-Kqisu7eUfGfGvjRvT2W",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 23,
+                        "name": "History: Age of Exploration",
+                      },
+                      "activity_category_id": 23,
+                      "activity_category_name": "History: Age of Exploration",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=608",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Students combine sentences to create 6 sentences about Marco Polo. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 608,
+                      "name": "The Travels of Marco Polo",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 117,
+                          "level": 1,
+                          "name": "The Age of Exploration",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 368,
+                          "level": 1,
+                          "name": "Marco Polo",
+                          "parent_id": 93,
+                        },
+                      ],
+                      "uid": "-KqZ_8tESejeyBmj-_pO",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 23,
+                        "name": "History: Age of Exploration",
+                      },
+                      "activity_category_id": 23,
+                      "activity_category_name": "History: Age of Exploration",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=860",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Students combine sentences to create 5 sentences about Hernando de Soto. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 860,
+                      "name": "Hernando de Soto",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 117,
+                          "level": 1,
+                          "name": "The Age of Exploration",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 173,
+                          "level": 1,
+                          "name": "Hernando de Soto",
+                          "parent_id": 93,
+                        },
+                      ],
+                      "uid": "-KhO2hv2Wl8rVCHp1B1G",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 23,
+                        "name": "History: Age of Exploration",
+                      },
+                      "activity_category_id": 23,
+                      "activity_category_name": "History: Age of Exploration",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=605",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about Magellan's trip around the globe. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 605,
+                      "name": "Magellan",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 116,
+                          "level": 1,
+                          "name": "Magellan",
+                          "parent_id": 93,
+                        },
+                        Object {
+                          "id": 117,
+                          "level": 1,
+                          "name": "The Age of Exploration",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqZiV1bnPe48h6gyYss",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 23,
+                        "name": "History: Age of Exploration",
+                      },
+                      "activity_category_id": 23,
+                      "activity_category_name": "History: Age of Exploration",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=606",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Students combine sentences to create 5 sentences about the Jamestown settlement. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 606,
+                      "name": "Jamestown",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 117,
+                          "level": 1,
+                          "name": "The Age of Exploration",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqcJOzHDYUrioJ6fPlR",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 22,
+                        "name": "History: The Renaissance",
+                      },
+                      "activity_category_id": 22,
+                      "activity_category_name": "History: The Renaissance",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=642",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about humanism. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 642,
+                      "name": "Humanism",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 187,
+                          "level": 1,
+                          "name": "The Renaissance",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqZldiOXNWbJNFvIRY-",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 22,
+                        "name": "History: The Renaissance",
+                      },
+                      "activity_category_id": 22,
+                      "activity_category_name": "History: The Renaissance",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=640",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the beginnings of the Renaissance in Italy. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 640,
+                      "name": "Renaissance Beginnings in Italy",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 187,
+                          "level": 1,
+                          "name": "The Renaissance",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqZpAZ8UMhwZp_3ezqw",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 22,
+                        "name": "History: The Renaissance",
+                      },
+                      "activity_category_id": 22,
+                      "activity_category_name": "History: The Renaissance",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=641",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about the Medici family. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 641,
+                      "name": "The Medici Family",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 187,
+                          "level": 1,
+                          "name": "The Renaissance",
+                          "parent_id": 48,
+                        },
+                        Object {
+                          "id": 350,
+                          "level": 1,
+                          "name": "The Medici Family",
+                          "parent_id": 93,
+                        },
+                      ],
+                      "uid": "-KqZvArG8422vhwB7rIo",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 22,
+                        "name": "History: The Renaissance",
+                      },
+                      "activity_category_id": 22,
+                      "activity_category_name": "History: The Renaissance",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=643",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Northern Renaissance. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 643,
+                      "name": "The Northern Renaissance",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 187,
+                          "level": 1,
+                          "name": "The Renaissance",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqdGWI1rgvtQBg2vIb0",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 25,
+                        "name": "History: American Revolution",
+                      },
+                      "activity_category_id": 25,
+                      "activity_category_name": "History: American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=728",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about the beginning of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 728,
+                      "name": "The War Begins at Lexington and Concord",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqY7BQmhDn71y-E-s3C",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 25,
+                        "name": "History: American Revolution",
+                      },
+                      "activity_category_id": 25,
+                      "activity_category_name": "History: American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=731",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the final battle of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 731,
+                      "name": "The War Ends at Yorktown",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqYK5A0fNos0ZbUjjOu",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 25,
+                        "name": "History: American Revolution",
+                      },
+                      "activity_category_id": 25,
+                      "activity_category_name": "History: American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=729",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about the Battle of Bunker Hill. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 729,
+                      "name": "Turning Point: Bunker Hill",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 385,
+                          "level": 1,
+                          "name": "The Battle of Bunker Hill",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqYNoENpFXSttDu-xPf",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 25,
+                        "name": "History: American Revolution",
+                      },
+                      "activity_category_id": 25,
+                      "activity_category_name": "History: American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=730",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Battle of Saratoga. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 730,
+                      "name": "Turning Point: Saratoga",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 386,
+                          "level": 1,
+                          "name": "The Battle of Saratoga",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqYPpC3o3JeeuhQadBF",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 24,
+                        "name": "History: Causes of the American Revolution",
+                      },
+                      "activity_category_id": 24,
+                      "activity_category_name": "History: Causes of the American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=477",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 4 new compound or complex sentences that include modifying phrases and compound predicates.",
+                      "flags": "{production}",
+                      "id": 477,
+                      "name": "The Stamp Act",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 363,
+                          "level": 1,
+                          "name": "The Stamp Act",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KbvuSGyq6ANjB6cSzpQ",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 24,
+                        "name": "History: Causes of the American Revolution",
+                      },
+                      "activity_category_id": 24,
+                      "activity_category_name": "History: Causes of the American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=476",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 6 new compound or complex sentences that include modifying phrases and compound predicates.",
+                      "flags": "{production}",
+                      "id": 476,
+                      "name": "The Boston Massacre",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 321,
+                          "level": 1,
+                          "name": "The Boston Massacre",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-Kbk-mjzTNeqWbvVG9zI",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 24,
+                        "name": "History: Causes of the American Revolution",
+                      },
+                      "activity_category_id": 24,
+                      "activity_category_name": "History: Causes of the American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=478",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 5 new compound or complex sentences that include modifying phrases and compound predicates.",
+                      "flags": "{production}",
+                      "id": 478,
+                      "name": "The Boston Tea Party",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 322,
+                          "level": 1,
+                          "name": "The Boston Tea Party",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-Kbvv3WS6vGNkeW7d6dt",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 21,
+                        "name": "History: Native Americans",
+                      },
+                      "activity_category_id": 21,
+                      "activity_category_name": "History: Native Americans",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=584",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 5 sentences about the Iroquois Confederacy. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 584,
+                      "name": "The Iroquois Confederacy",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 65,
+                          "level": 1,
+                          "name": "Native Americans",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 346,
+                          "level": 1,
+                          "name": "The Iroquois Confederacy",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqZdYHq5N9O1OYfzZbl",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 21,
+                        "name": "History: Native Americans",
+                      },
+                      "activity_category_id": 21,
+                      "activity_category_name": "History: Native Americans",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=585",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the importance of the buffalo to the Native American tribes living on the Great Plains. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 585,
+                      "name": "The Importance of the Buffalo",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 65,
+                          "level": 1,
+                          "name": "Native Americans",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 345,
+                          "level": 1,
+                          "name": "Buffalo",
+                          "parent_id": 13,
+                        },
+                      ],
+                      "uid": "-KqZWcwJndWJBU-U3ehj",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 21,
+                        "name": "History: Native Americans",
+                      },
+                      "activity_category_id": 21,
+                      "activity_category_name": "History: Native Americans",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=586",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about Ishi of the Yahi people. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 586,
+                      "name": "Ishi",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 65,
+                          "level": 1,
+                          "name": "Native Americans",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 195,
+                          "level": 1,
+                          "name": "Ishi & the Yahi People",
+                          "parent_id": 17,
+                        },
+                      ],
+                      "uid": "-KqZh2mwDeSPLCxp2UAT",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 21,
+                        "name": "History: Native Americans",
+                      },
+                      "activity_category_id": 21,
+                      "activity_category_name": "History: Native Americans",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=587",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Students combine sentences 5 times to create sentences about the Dawes Act. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 587,
+                      "name": "The Dawes Act",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 65,
+                          "level": 1,
+                          "name": "Native Americans",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 325,
+                          "level": 1,
+                          "name": "The Dawes Act",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqZaKPdDL_-tnCUDIlX",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 26,
+                        "name": "Science: What's in Our Universe?",
+                      },
+                      "activity_category_id": 26,
+                      "activity_category_name": "Science: What's in Our Universe?",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=613",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 5 sentences about asteroids. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 613,
+                      "name": "Asteroids",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 88,
+                          "level": 1,
+                          "name": "Asteroids",
+                          "parent_id": 90,
+                        },
+                        Object {
+                          "id": 89,
+                          "level": 1,
+                          "name": "Astronomy",
+                          "parent_id": 90,
+                        },
+                      ],
+                      "uid": "-KqZUaz7rINZ8fNssJ6r",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 26,
+                        "name": "Science: What's in Our Universe?",
+                      },
+                      "activity_category_id": 26,
+                      "activity_category_name": "Science: What's in Our Universe?",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=614",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 5 sentences about Ham and Alan Shepard of the NASA space program. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 614,
+                      "name": "Ham and Alan Shepard",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 78,
+                          "level": 1,
+                          "name": "Space Exploration",
+                          "parent_id": 90,
+                        },
+                        Object {
+                          "id": 168,
+                          "level": 1,
+                          "name": "Ham & Alan Shepard",
+                          "parent_id": 90,
+                        },
+                      ],
+                      "uid": "-KqZR__u2hpJ2z8cIch-",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 26,
+                        "name": "Science: What's in Our Universe?",
+                      },
+                      "activity_category_id": 26,
+                      "activity_category_name": "Science: What's in Our Universe?",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=615",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about eclipses. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 615,
+                      "name": "Eclipses",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 89,
+                          "level": 1,
+                          "name": "Astronomy",
+                          "parent_id": 90,
+                        },
+                        Object {
+                          "id": 153,
+                          "level": 1,
+                          "name": "Eclipses",
+                          "parent_id": 90,
+                        },
+                      ],
+                      "uid": "-KqZFTXwQ5MCZMH9-bUN",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 26,
+                        "name": "Science: What's in Our Universe?",
+                      },
+                      "activity_category_id": 26,
+                      "activity_category_name": "Science: What's in Our Universe?",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=756",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 5 sentences about the International Space Station. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 756,
+                      "name": "International Space Station",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 78,
+                          "level": 1,
+                          "name": "Space Exploration",
+                          "parent_id": 90,
+                        },
+                        Object {
+                          "id": 193,
+                          "level": 1,
+                          "name": "The International Space Station",
+                          "parent_id": 90,
+                        },
+                      ],
+                      "uid": "-LAo-erEroO6r6XV1tAV",
+                    },
+                  ]
+                }
+                grouping={
+                  Object {
                     "group": "Whole Class Instruction",
                     "keys": Array [
                       "lessons",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/__tests__/__snapshots__/mobile_filter_menu.test.tsx.snap
@@ -15309,6 +15309,1499 @@ Combine simple sentences to create 5 new compound or complex sentences that incl
                 }
                 grouping={
                   Object {
+                    "group": "Independent: Proofreading",
+                    "keys": Array [
+                      "passage",
+                    ],
+                  }
+                }
+                handleActivityClassificationFilterChange={[Function]}
+                key="Independent: Proofreading"
+                uniqueActivityClassifications={
+                  Array [
+                    Object {
+                      "alias": "Quill Connect",
+                      "description": "Combine Sentences",
+                      "id": 5,
+                      "key": "connect",
+                    },
+                  ]
+                }
+              >
+                <section
+                  className="toggle-section activity-classification-toggle"
+                >
+                  <div
+                    className="top-level filter-row"
+                  >
+                    <div>
+                      <button
+                        aria-label="Toggle menu"
+                        className="interactive-wrapper focus-on-light filter-toggle-button"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <img
+                          alt=""
+                          className="is-closed"
+                          src="undefined/images/icons/dropdown.svg"
+                        />
+                      </button>
+                      <div
+                        className="focus-on-light quill-checkbox disabled"
+                      />
+                      <span>
+                        Independent: Proofreading
+                      </span>
+                    </div>
+                    <span>
+                      (
+                      0
+                      )
+                    </span>
+                  </div>
+                  <span />
+                </section>
+              </ActivityClassificationToggle>
+              <ActivityClassificationToggle
+                activityClassificationFilters={Array []}
+                filteredActivities={
+                  Array [
+                    Object {
+                      "activity_category": Object {
+                        "id": 20,
+                        "name": "History: Maya, Aztec, Inca",
+                      },
+                      "activity_category_id": 20,
+                      "activity_category_name": "History: Maya, Aztec, Inca",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=627",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about Hernan Cortes. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 627,
+                      "name": "Hernan Cortes",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 171,
+                          "level": 1,
+                          "name": "Hernan Cortes & the Aztec Empire",
+                          "parent_id": 93,
+                        },
+                        Object {
+                          "id": 172,
+                          "level": 1,
+                          "name": "Maya, Aztec, & Inca Civilizations",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqcjgL00W0ro-Wr4Bts",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 20,
+                        "name": "History: Maya, Aztec, Inca",
+                      },
+                      "activity_category_id": 20,
+                      "activity_category_name": "History: Maya, Aztec, Inca",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=628",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about the Maya civilization. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 628,
+                      "name": "Maya Mystery",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 172,
+                          "level": 1,
+                          "name": "Maya, Aztec, & Inca Civilizations",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqcdV5JA9uUSY09VvOP",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 20,
+                        "name": "History: Maya, Aztec, Inca",
+                      },
+                      "activity_category_id": 20,
+                      "activity_category_name": "History: Maya, Aztec, Inca",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=629",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Tenochtitlan Origin Myth. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 629,
+                      "name": "Tenochtitlan Origin Myth",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 172,
+                          "level": 1,
+                          "name": "Maya, Aztec, & Inca Civilizations",
+                          "parent_id": 48,
+                        },
+                        Object {
+                          "id": 315,
+                          "level": 1,
+                          "name": "Tenochtitlán Origin Myth",
+                          "parent_id": 28,
+                        },
+                      ],
+                      "uid": "-KqcY9ZUJ7gdReZw7C93",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 20,
+                        "name": "History: Maya, Aztec, Inca",
+                      },
+                      "activity_category_id": 20,
+                      "activity_category_name": "History: Maya, Aztec, Inca",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=630",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Royal Road. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 630,
+                      "name": "The Royal Road",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 172,
+                          "level": 1,
+                          "name": "Maya, Aztec, & Inca Civilizations",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqcTJxEiuq07PJzbDIc",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 19,
+                        "name": "History: Chinese Dynasties",
+                      },
+                      "activity_category_id": 19,
+                      "activity_category_name": "History: Chinese Dynasties",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=617",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about Emperor Hui Zong's defeat. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 617,
+                      "name": "Hui Zong's Defeat",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 184,
+                          "level": 1,
+                          "name": "Hui Zong's Defeat",
+                          "parent_id": 93,
+                        },
+                        Object {
+                          "id": 185,
+                          "level": 1,
+                          "name": "Chinese Dynasties",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqilM2xWovC-Hudmvjn",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 19,
+                        "name": "History: Chinese Dynasties",
+                      },
+                      "activity_category_id": 19,
+                      "activity_category_name": "History: Chinese Dynasties",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=619",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the unification of China under Shihuangdi. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 619,
+                      "name": "Shihuangdi Unifies China",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 185,
+                          "level": 1,
+                          "name": "Chinese Dynasties",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqigC-G1kUp_pEeQJjl",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 19,
+                        "name": "History: Chinese Dynasties",
+                      },
+                      "activity_category_id": 19,
+                      "activity_category_name": "History: Chinese Dynasties",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=616",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the inventions during the Tang Dynasty. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 616,
+                      "name": "Tang Dynasty Inventions",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 185,
+                          "level": 1,
+                          "name": "Chinese Dynasties",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqiiQTci2gs9zhx2tIA",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 19,
+                        "name": "History: Chinese Dynasties",
+                      },
+                      "activity_category_id": 19,
+                      "activity_category_name": "History: Chinese Dynasties",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=618",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Mongol invasion of China. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 618,
+                      "name": "The Mongol Invasion of China",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 185,
+                          "level": 1,
+                          "name": "Chinese Dynasties",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-Kqisu7eUfGfGvjRvT2W",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 23,
+                        "name": "History: Age of Exploration",
+                      },
+                      "activity_category_id": 23,
+                      "activity_category_name": "History: Age of Exploration",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=608",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Students combine sentences to create 6 sentences about Marco Polo. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 608,
+                      "name": "The Travels of Marco Polo",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 117,
+                          "level": 1,
+                          "name": "The Age of Exploration",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 368,
+                          "level": 1,
+                          "name": "Marco Polo",
+                          "parent_id": 93,
+                        },
+                      ],
+                      "uid": "-KqZ_8tESejeyBmj-_pO",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 23,
+                        "name": "History: Age of Exploration",
+                      },
+                      "activity_category_id": 23,
+                      "activity_category_name": "History: Age of Exploration",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=860",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Students combine sentences to create 5 sentences about Hernando de Soto. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 860,
+                      "name": "Hernando de Soto",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 117,
+                          "level": 1,
+                          "name": "The Age of Exploration",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 173,
+                          "level": 1,
+                          "name": "Hernando de Soto",
+                          "parent_id": 93,
+                        },
+                      ],
+                      "uid": "-KhO2hv2Wl8rVCHp1B1G",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 23,
+                        "name": "History: Age of Exploration",
+                      },
+                      "activity_category_id": 23,
+                      "activity_category_name": "History: Age of Exploration",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=605",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about Magellan's trip around the globe. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 605,
+                      "name": "Magellan",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 116,
+                          "level": 1,
+                          "name": "Magellan",
+                          "parent_id": 93,
+                        },
+                        Object {
+                          "id": 117,
+                          "level": 1,
+                          "name": "The Age of Exploration",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqZiV1bnPe48h6gyYss",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 23,
+                        "name": "History: Age of Exploration",
+                      },
+                      "activity_category_id": 23,
+                      "activity_category_name": "History: Age of Exploration",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=606",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Students combine sentences to create 5 sentences about the Jamestown settlement. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 606,
+                      "name": "Jamestown",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 117,
+                          "level": 1,
+                          "name": "The Age of Exploration",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqcJOzHDYUrioJ6fPlR",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 22,
+                        "name": "History: The Renaissance",
+                      },
+                      "activity_category_id": 22,
+                      "activity_category_name": "History: The Renaissance",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=642",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about humanism. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 642,
+                      "name": "Humanism",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 187,
+                          "level": 1,
+                          "name": "The Renaissance",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqZldiOXNWbJNFvIRY-",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 22,
+                        "name": "History: The Renaissance",
+                      },
+                      "activity_category_id": 22,
+                      "activity_category_name": "History: The Renaissance",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=640",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the beginnings of the Renaissance in Italy. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 640,
+                      "name": "Renaissance Beginnings in Italy",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 187,
+                          "level": 1,
+                          "name": "The Renaissance",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqZpAZ8UMhwZp_3ezqw",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 22,
+                        "name": "History: The Renaissance",
+                      },
+                      "activity_category_id": 22,
+                      "activity_category_name": "History: The Renaissance",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=641",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about the Medici family. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 641,
+                      "name": "The Medici Family",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 187,
+                          "level": 1,
+                          "name": "The Renaissance",
+                          "parent_id": 48,
+                        },
+                        Object {
+                          "id": 350,
+                          "level": 1,
+                          "name": "The Medici Family",
+                          "parent_id": 93,
+                        },
+                      ],
+                      "uid": "-KqZvArG8422vhwB7rIo",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 22,
+                        "name": "History: The Renaissance",
+                      },
+                      "activity_category_id": 22,
+                      "activity_category_name": "History: The Renaissance",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=643",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Northern Renaissance. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 643,
+                      "name": "The Northern Renaissance",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 187,
+                          "level": 1,
+                          "name": "The Renaissance",
+                          "parent_id": 48,
+                        },
+                      ],
+                      "uid": "-KqdGWI1rgvtQBg2vIb0",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 25,
+                        "name": "History: American Revolution",
+                      },
+                      "activity_category_id": 25,
+                      "activity_category_name": "History: American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=728",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about the beginning of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 728,
+                      "name": "The War Begins at Lexington and Concord",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqY7BQmhDn71y-E-s3C",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 25,
+                        "name": "History: American Revolution",
+                      },
+                      "activity_category_id": 25,
+                      "activity_category_name": "History: American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=731",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the final battle of the American Revolution. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 731,
+                      "name": "The War Ends at Yorktown",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqYK5A0fNos0ZbUjjOu",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 25,
+                        "name": "History: American Revolution",
+                      },
+                      "activity_category_id": 25,
+                      "activity_category_name": "History: American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=729",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about the Battle of Bunker Hill. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 729,
+                      "name": "Turning Point: Bunker Hill",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 385,
+                          "level": 1,
+                          "name": "The Battle of Bunker Hill",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqYNoENpFXSttDu-xPf",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 25,
+                        "name": "History: American Revolution",
+                      },
+                      "activity_category_id": 25,
+                      "activity_category_name": "History: American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=730",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the Battle of Saratoga. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 730,
+                      "name": "Turning Point: Saratoga",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 386,
+                          "level": 1,
+                          "name": "The Battle of Saratoga",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqYPpC3o3JeeuhQadBF",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 24,
+                        "name": "History: Causes of the American Revolution",
+                      },
+                      "activity_category_id": 24,
+                      "activity_category_name": "History: Causes of the American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=477",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 4 new compound or complex sentences that include modifying phrases and compound predicates.",
+                      "flags": "{production}",
+                      "id": 477,
+                      "name": "The Stamp Act",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 363,
+                          "level": 1,
+                          "name": "The Stamp Act",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KbvuSGyq6ANjB6cSzpQ",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 24,
+                        "name": "History: Causes of the American Revolution",
+                      },
+                      "activity_category_id": 24,
+                      "activity_category_name": "History: Causes of the American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=476",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 6 new compound or complex sentences that include modifying phrases and compound predicates.",
+                      "flags": "{production}",
+                      "id": 476,
+                      "name": "The Boston Massacre",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 321,
+                          "level": 1,
+                          "name": "The Boston Massacre",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-Kbk-mjzTNeqWbvVG9zI",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 24,
+                        "name": "History: Causes of the American Revolution",
+                      },
+                      "activity_category_id": 24,
+                      "activity_category_name": "History: Causes of the American Revolution",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=478",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Content: The American Revolution
+Level: Advanced - no joining words provided
+
+Combine simple sentences to create 5 new compound or complex sentences that include modifying phrases and compound predicates.",
+                      "flags": "{production}",
+                      "id": 478,
+                      "name": "The Boston Tea Party",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 119,
+                          "level": 1,
+                          "name": "The American Revolution",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 322,
+                          "level": 1,
+                          "name": "The Boston Tea Party",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-Kbvv3WS6vGNkeW7d6dt",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 21,
+                        "name": "History: Native Americans",
+                      },
+                      "activity_category_id": 21,
+                      "activity_category_name": "History: Native Americans",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=584",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 5 sentences about the Iroquois Confederacy. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 584,
+                      "name": "The Iroquois Confederacy",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 65,
+                          "level": 1,
+                          "name": "Native Americans",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 346,
+                          "level": 1,
+                          "name": "The Iroquois Confederacy",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqZdYHq5N9O1OYfzZbl",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 21,
+                        "name": "History: Native Americans",
+                      },
+                      "activity_category_id": 21,
+                      "activity_category_name": "History: Native Americans",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=585",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about the importance of the buffalo to the Native American tribes living on the Great Plains. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 585,
+                      "name": "The Importance of the Buffalo",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 65,
+                          "level": 1,
+                          "name": "Native Americans",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 345,
+                          "level": 1,
+                          "name": "Buffalo",
+                          "parent_id": 13,
+                        },
+                      ],
+                      "uid": "-KqZWcwJndWJBU-U3ehj",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 21,
+                        "name": "History: Native Americans",
+                      },
+                      "activity_category_id": 21,
+                      "activity_category_name": "History: Native Americans",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=586",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 7 sentences about Ishi of the Yahi people. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 586,
+                      "name": "Ishi",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 65,
+                          "level": 1,
+                          "name": "Native Americans",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 195,
+                          "level": 1,
+                          "name": "Ishi & the Yahi People",
+                          "parent_id": 17,
+                        },
+                      ],
+                      "uid": "-KqZh2mwDeSPLCxp2UAT",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 21,
+                        "name": "History: Native Americans",
+                      },
+                      "activity_category_id": 21,
+                      "activity_category_name": "History: Native Americans",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=587",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Students combine sentences 5 times to create sentences about the Dawes Act. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 587,
+                      "name": "The Dawes Act",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 65,
+                          "level": 1,
+                          "name": "Native Americans",
+                          "parent_id": 45,
+                        },
+                        Object {
+                          "id": 325,
+                          "level": 1,
+                          "name": "The Dawes Act",
+                          "parent_id": 45,
+                        },
+                      ],
+                      "uid": "-KqZaKPdDL_-tnCUDIlX",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 26,
+                        "name": "Science: What's in Our Universe?",
+                      },
+                      "activity_category_id": 26,
+                      "activity_category_name": "Science: What's in Our Universe?",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=613",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 5 sentences about asteroids. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 613,
+                      "name": "Asteroids",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 88,
+                          "level": 1,
+                          "name": "Asteroids",
+                          "parent_id": 90,
+                        },
+                        Object {
+                          "id": 89,
+                          "level": 1,
+                          "name": "Astronomy",
+                          "parent_id": 90,
+                        },
+                      ],
+                      "uid": "-KqZUaz7rINZ8fNssJ6r",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 26,
+                        "name": "Science: What's in Our Universe?",
+                      },
+                      "activity_category_id": 26,
+                      "activity_category_name": "Science: What's in Our Universe?",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=614",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 5 sentences about Ham and Alan Shepard of the NASA space program. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 614,
+                      "name": "Ham and Alan Shepard",
+                      "readability_grade_level": "8th-9th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 78,
+                          "level": 1,
+                          "name": "Space Exploration",
+                          "parent_id": 90,
+                        },
+                        Object {
+                          "id": 168,
+                          "level": 1,
+                          "name": "Ham & Alan Shepard",
+                          "parent_id": 90,
+                        },
+                      ],
+                      "uid": "-KqZR__u2hpJ2z8cIch-",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 26,
+                        "name": "Science: What's in Our Universe?",
+                      },
+                      "activity_category_id": 26,
+                      "activity_category_name": "Science: What's in Our Universe?",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=615",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 6 sentences about eclipses. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 615,
+                      "name": "Eclipses",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 89,
+                          "level": 1,
+                          "name": "Astronomy",
+                          "parent_id": 90,
+                        },
+                        Object {
+                          "id": 153,
+                          "level": 1,
+                          "name": "Eclipses",
+                          "parent_id": 90,
+                        },
+                      ],
+                      "uid": "-KqZFTXwQ5MCZMH9-bUN",
+                    },
+                    Object {
+                      "activity_category": Object {
+                        "id": 26,
+                        "name": "Science: What's in Our Universe?",
+                      },
+                      "activity_category_id": 26,
+                      "activity_category_name": "Science: What's in Our Universe?",
+                      "activity_classification": Object {
+                        "alias": "Quill Connect",
+                        "description": "Combine Sentences",
+                        "id": 5,
+                        "key": "connect",
+                      },
+                      "anonymous_path": "/activity_sessions/anonymous?activity_id=756",
+                      "content_partners": Array [
+                        Object {
+                          "description": "Core Knowledge is a free and open-source curriculum. Quill provides activities aligned with their language arts, social studies, and science books.",
+                          "id": 1,
+                          "name": "Core Knowledge",
+                        },
+                      ],
+                      "description": "Combine sentences to create 5 sentences about the International Space Station. This is an advanced, un-cued sentence combining activity.",
+                      "flags": "{production}",
+                      "id": 756,
+                      "name": "International Space Station",
+                      "readability_grade_level": "6th-7th",
+                      "standard_level": Object {
+                        "id": 13,
+                        "name": "7th Grade CCSS",
+                      },
+                      "standard_level_name": "7th Grade CCSS",
+                      "standard_name": "87",
+                      "topics": Array [
+                        Object {
+                          "id": 78,
+                          "level": 1,
+                          "name": "Space Exploration",
+                          "parent_id": 90,
+                        },
+                        Object {
+                          "id": 193,
+                          "level": 1,
+                          "name": "The International Space Station",
+                          "parent_id": 90,
+                        },
+                      ],
+                      "uid": "-LAo-erEroO6r6XV1tAV",
+                    },
+                  ]
+                }
+                grouping={
+                  Object {
                     "group": "Whole Class Instruction",
                     "keys": Array [
                       "lessons",

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/shared.ts
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/create_unit/custom_activity_pack/shared.ts
@@ -21,6 +21,10 @@ export const activityClassificationGroupings = [
     keys: ['connect', 'sentence', 'passage']
   },
   {
+    group: 'Independent: Proofreading',
+    keys: ['passage']
+  },
+  {
     group: 'Whole Class Instruction',
     keys: ['lessons']
   },

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unit_template_minis.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/__tests__/__snapshots__/unit_template_minis.test.jsx.snap
@@ -61,31 +61,6 @@ exports[`UnitTemplateMinis component should render dropdowns when on mobile 1`] 
               }
             />
             <DropdownInput
-              className="category-dropdown"
-              label="Pack type"
-              options={
-                Array [
-                  Object {
-                    "label": "All",
-                    "link": "/assign/featured-activity-packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "Diagnostic",
-                    "link": "/assign/featured-activity-packs?category=Diagnostic",
-                    "value": 9,
-                  },
-                ]
-              }
-              value={
-                Object {
-                  "label": "All",
-                  "link": "/assign/featured-activity-packs",
-                  "value": null,
-                }
-              }
-            />
-            <DropdownInput
               className="category-dropdown view-options"
               handleChange={[Function]}
               label="View"
@@ -272,31 +247,6 @@ exports[`UnitTemplateMinis component should render without createYourOwn mini wh
                     "label": "10th-12th",
                     "link": "/activities/packs?gradeLevel=10th-12th",
                     "value": "10th-12th",
-                  },
-                ]
-              }
-              value={
-                Object {
-                  "label": "All",
-                  "link": "/activities/packs",
-                  "value": null,
-                }
-              }
-            />
-            <DropdownInput
-              className="category-dropdown"
-              label="Pack type"
-              options={
-                Array [
-                  Object {
-                    "label": "All",
-                    "link": "/activities/packs",
-                    "value": null,
-                  },
-                  Object {
-                    "label": "Diagnostic",
-                    "link": "/activities/packs?category=Diagnostic",
-                    "value": 9,
                   },
                 ]
               }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_minis.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_template_minis.jsx
@@ -50,48 +50,20 @@ export default class UnitTemplateMinis extends React.Component {
     return _.uniqBy(models, 'id');
   }
 
-  generateCategoryOptions(gradeLevel, selectedTypeId) {
-    const { data, } = this.props
-    const usedCategories = Object.values(data.displayedModels).map(dm => dm.unit_template_category.name)
-    const usedUniqueCategories = usedCategories.filter((v, i, a) => {
-      if(!v) { return }
-      return a.indexOf(v) === i
-    })
-    const sortedUsedCategories = usedUniqueCategories.sort((a,b) => (a && b) ? a.localeCompare(b) : (a < b) ? -1 : 1)
-    const categoryOrder = [ALL].concat(sortedUsedCategories)
-    return categoryOrder.map((name) => {
-      const category = data.categories.find(cat => cat.name === name)
-      if (category) {
-        category.label = category.name
-        return {
-          label: category.name,
-          value: category.id,
-          link: `${this.getIndexLink()}${this.generateQueryString(category, gradeLevel, selectedTypeId)}`
-        }
-      } else {
-        return {
-          label: name,
-          value: null,
-          link: `${this.getIndexLink()}${this.generateQueryString(category, gradeLevel, selectedTypeId)}`
-        }
-      }
-    })
-  }
-
-  generateGradeLevelOptions(currentCategory, selectedTypeId) {
+  generateGradeLevelOptions(selectedTypeId) {
     return [ALL].concat(GRADE_LEVEL_LABELS).map((level) => {
       if (level === ALL) {
         return {
           label: level,
           value: null,
-          link: `${this.getIndexLink()}${this.generateQueryString(currentCategory, null, selectedTypeId)}`
+          link: `${this.getIndexLink()}${this.generateQueryString(null, selectedTypeId)}`
         }
       }
 
       return {
         label: level,
         value: level,
-        link: `${this.getIndexLink()}${this.generateQueryString(currentCategory, level, selectedTypeId)}`
+        link: `${this.getIndexLink()}${this.generateQueryString(level, selectedTypeId)}`
       }
     })
   }
@@ -233,12 +205,8 @@ export default class UnitTemplateMinis extends React.Component {
     }
   }
 
-  generateQueryString(category, gradeLevel, typeId=null) {
+  generateQueryString(gradeLevel, typeId=null) {
     let qs = ''
-
-    if (category) {
-      qs = `?category=${category.label}`
-    }
 
     if (gradeLevel) {
       const gradeLevelQuery = `gradeLevel=${gradeLevel}`
@@ -259,11 +227,8 @@ export default class UnitTemplateMinis extends React.Component {
 
   renderFilterOptions() {
     const { onMobile, currentView } = this.state
-    const { types, selectedTypeId, data, selectCategory, selectGradeLevel, } = this.props
-    const categoryOptions = this.generateCategoryOptions(data.selectedGradeLevel, selectedTypeId)
-    const currentCategory = categoryOptions.find(cat => cat.value && cat.value === data.selectedCategoryId)
-
-    const gradeLevelOptions = this.generateGradeLevelOptions(currentCategory, selectedTypeId)
+    const { types, selectedTypeId, data, selectGradeLevel, } = this.props
+    const gradeLevelOptions = this.generateGradeLevelOptions(selectedTypeId)
     const currentGradeLevel = gradeLevelOptions.find(cat => cat.value && cat.value === data.selectedGradeLevel)
 
     const viewOptions = [GRID_VIEW_OPTION, LIST_VIEW_OPTION]
@@ -272,7 +237,7 @@ export default class UnitTemplateMinis extends React.Component {
 
     const typeOptions = types.map(type => {
       const { id, name, } = type
-      const qs = this.generateQueryString(currentCategory, data.selectedGradeLevel, id)
+      const qs = this.generateQueryString(data.selectedGradeLevel, id)
       return (
         <Link
           className={`focus-on-light ${selectedTypeId === id ? 'active' : ''}`}
@@ -284,7 +249,7 @@ export default class UnitTemplateMinis extends React.Component {
 
     const typeOptionsForDropdown = types.map(type => {
       const { id, name } = type;
-      const qs = this.generateQueryString(currentCategory, data.selectedGradeLevel, id)
+      const qs = this.generateQueryString(data.selectedGradeLevel, id)
       return {
         label: this.getLabelName(name),
         value: `${baseLink}${qs}`
@@ -295,7 +260,7 @@ export default class UnitTemplateMinis extends React.Component {
     const allPacksLink = (
       <Link
         className={`focus-on-light ${!selectedTypeId ? 'active' : null}`}
-        to={`${baseLink}${this.generateQueryString(currentCategory, data.selectedGradeLevel)}`}
+        to={`${baseLink}${this.generateQueryString(data.selectedGradeLevel)}`}
       >All Packs</Link>
     );
 
@@ -322,13 +287,6 @@ export default class UnitTemplateMinis extends React.Component {
             label="Grade level range"
             options={gradeLevelOptions}
             value={currentGradeLevel || gradeLevelOptions[0]}
-          />
-          <DropdownInput
-            className="category-dropdown"
-            handleChange={selectCategory}
-            label="Pack type"
-            options={categoryOptions}
-            value={currentCategory || categoryOptions[0]}
           />
           <DropdownInput
             className="category-dropdown view-options"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_templates_manager.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/assignment_flow/unit_templates_manager/unit_templates_manager.jsx
@@ -35,7 +35,6 @@ export default class UnitTemplatesManager extends React.Component {
         model: null,
         model_id: null,
         relatedModels: [],
-        selectedCategoryId: null,
         selectedGradeLevel: null,
         lastActivityAssigned: null,
         grade: getParameterByName('grade'),
@@ -88,21 +87,19 @@ export default class UnitTemplatesManager extends React.Component {
     })
   }
 
-  filterModels = (category, grade, typeId, gradeLevelRange) => {
+  filterModels = (grade, typeId, gradeLevelRange) => {
     const { unitTemplatesManager, } = this.state
     let displayedModels = unitTemplatesManager.models
+
     if (grade) {
       displayedModels = this.modelsInGrade(grade)
     }
-    if (category) {
-      displayedModels = displayedModels.filter(ut => ut.unit_template_category.name === category)
-    }
     if (typeId) {
       const selectedType = ACTIVITY_PACK_TYPES.find(t => t.id === typeId)
-      const { name } = selectedType
+      const { name, types, } = selectedType
       displayedModels = displayedModels.filter(ut => {
         const { type, unit_template_category } = ut
-        if(typeId === 'independent-practice') {
+        if(['proofreading', 'independent-practice'].includes(typeId)) {
           return selectedType.types.includes(unit_template_category.name)
         } else if(unit_template_category) {
           return unit_template_category.name === name
@@ -129,16 +126,6 @@ export default class UnitTemplatesManager extends React.Component {
     window.scrollTo(0, 0);
   }
 
-  selectCategory = category => {
-    const { history, } = this.props
-    const { unitTemplatesManager, } = this.state
-    const newUnitTemplatesManager = unitTemplatesManager
-    newUnitTemplatesManager.selectedCategoryId = category.value
-    this.setState({ unitTemplatesManager: newUnitTemplatesManager })
-
-    history.push(category.link)
-  };
-
   selectGradeLevel = gradeLevel => {
     const { history, } = this.props
     const { unitTemplatesManager, } = this.state
@@ -160,14 +147,13 @@ export default class UnitTemplatesManager extends React.Component {
       return <LoadingIndicator />
     }
 
-    const { category, grade, type, gradeLevel, } = this.parsedQueryParams()
-    const displayedModels = this.filterModels(category, grade, type, gradeLevel)
+    const { grade, type, gradeLevel, } = this.parsedQueryParams()
+    const displayedModels = this.filterModels(grade, type, gradeLevel)
     return (
       <UnitTemplateMinis
         actions={this.unitTemplatesManagerActions()}
         data={unitTemplatesManager}
         displayedModels={displayedModels}
-        selectCategory={this.selectCategory}
         selectedTypeId={type}
         selectGradeLevel={this.selectGradeLevel}
         signedInTeacher={signedInTeacher}
@@ -218,10 +204,10 @@ export default class UnitTemplatesManager extends React.Component {
     }
     this.updateUnitTemplatesManager(newHash)
 
-    const { category, grade, type, gradeLevel, } = this.parsedQueryParams()
+    const { grade, type, gradeLevel, } = this.parsedQueryParams()
 
-    if (category || grade || type || gradeLevel) {
-      this.filterModels(category, grade, type, gradeLevel)
+    if (grade || type || gradeLevel) {
+      this.filterModels(grade, type, gradeLevel)
     }
   };
 

--- a/services/QuillLMS/client/app/bundles/Teacher/styles/article-spotlight.scss
+++ b/services/QuillLMS/client/app/bundles/Teacher/styles/article-spotlight.scss
@@ -29,6 +29,9 @@
     .preview-card-link {
       display: block;
       height: min-content;
+      .quill-button {
+        bottom: 10px;
+      }
     }
     .preview-card {
       height: auto;
@@ -42,7 +45,7 @@
         }
       }
       .preview-card-footer {
-        padding-bottom: 8px;
+        padding: 16px;
       }
     }
     .content-section {


### PR DESCRIPTION
## WHAT
Remove Pack Type filter from the Featured Activity Packs page, because it was adding confusion, and add Proofreader as one of the filter options.

## WHY
Having these different filter options allowed users to get the page into a state where it showed no packs, causing confusion.

## HOW
Remove all category options and add a new Proofreader option, which still filters by category (in the same way independent practice did already).

### Screenshots
<img width="1462" alt="Screenshot 2024-08-30 at 12 10 46 PM" src="https://github.com/user-attachments/assets/a4352d08-4585-4a10-a81e-fb1076f1e854">

### Notion Card Links
https://www.notion.so/quill/Featured-Activity-Pack-Page-Usability-Update-f4e52c5c9a8b4737997621a1a56f9037?pvs=4

### What have you done to QA this feature?
Tested on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
