### PR TITLE
quill-button expansion

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/styles/button.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/button.scss
@@ -200,8 +200,15 @@
     min-width: 73px;
   }
   &.large {
-    @include display-xs;
+    @include display-s;
     height: 44px;
     min-width: 89px;
+    border-radius: 10px;
+  }
+  &.extra-large {
+    @include display-m;
+    height: 56px;
+    min-width: 122px;
+    border-radius: 12px;
   }
 }

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/buttons.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/__tests__/__snapshots__/buttons.test.tsx.snap
@@ -113,6 +113,29 @@ exports[`Buttons it should render 1`] = `
             quill-button large contained
           </p>
         </div>
+        <div
+          class="option-container"
+        >
+          <p
+            class="option-label"
+          >
+            Extra Large (XL)
+          </p>
+          <div
+            class="quill-button-container"
+          >
+            <button
+              class="quill-button focus-on-light extra-large contained"
+            >
+              Button
+            </button>
+          </div>
+          <p
+            class="option-label"
+          >
+            quill-button extra-large contained
+          </p>
+        </div>
       </div>
       <h4
         class="style-guide-h4"

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/buttons.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/buttons.tsx
@@ -4,7 +4,7 @@ import { DISABLED, HOVER } from "../../../Shared";
 
 const DEFAULT = 'default'
 const BUTTON = 'Button'
-const SIZES = [{ label: 'Extra Small (XS)', value: 'extra-small' }, { label: 'Small', value: 'small' }, { label: 'Medium', value: 'medium' }, { label: 'Large', value: 'large' }]
+const SIZES = [{ label: 'Extra Small (XS)', value: 'extra-small' }, { label: 'Small', value: 'small' }, { label: 'Medium', value: 'medium' }, { label: 'Large', value: 'large' }, { label: 'Extra Large (XL)', value: 'extra-large' }, ]
 const STATES = [DEFAULT, HOVER, DISABLED]
 const COLORS = ['green', 'gold', 'maroon', 'blue', 'teal', 'viridian', 'purple', 'violet', 'red', 'grey']
 const WHITE_STAR_ICON_SRC = 'https://assets.quill.org/images/icons/xs/star-white.svg'


### PR DESCRIPTION
## WHAT
Adjust styling for large buttons, add XL styling, and add both to backpack.

## WHY
We need the XL buttons for a project I'm about to start.

## HOW
CSS.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
<img width="642" alt="Screenshot 2024-09-03 at 12 52 52 PM" src="https://github.com/user-attachments/assets/02f81f10-9f3a-4560-87ff-eea415026de2">

### What have you done to QA this feature?
Looked at the buttons in Backpack.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
