### PR TITLE
Fix Vitally Stats calculations to include archived classrooms

### DIFF
--- a/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
+++ b/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
@@ -26,7 +26,7 @@ module VitallySchoolStats
   end
 
   def activities_assigned_query
-    @activities_assigned ||= ClassroomUnit.joins(classroom: { teachers: :school }, unit: :activities)
+    @activities_assigned ||= ClassroomUnit.joins(classroom_unscoped: { teachers: :school }, unit: :activities)
       .where('schools.id = ?', school.id)
       .select('assigned_student_ids', 'activities.id', 'unit_activities.created_at')
   end

--- a/services/QuillLMS/spec/services/vitally_integration/previous_year_school_datum_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/previous_year_school_datum_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe VitallyIntegration::PreviousYearSchoolDatum, type: :model do
       expect(described_class.new(school, year).calculate_data).to include(expected_data)
     end
 
-    it 'should include archived classrooms' do 
+    it 'should include archived classrooms' do
       archived_classroom = create(:classroom, created_at: Date.new(year, 10, 1), visible: false)
-      classroom_unit = create(:classroom_unit, unit: unit, classroom: archived_classroom, created_at: Date.new(year, 10, 1), assigned_student_ids: [student.id, student2.id]) 
+      classroom_unit = create(:classroom_unit, unit: unit, classroom: archived_classroom, created_at: Date.new(year, 10, 1), assigned_student_ids: [student.id, student2.id])
       create(:classrooms_teacher, user: teacher, classroom: archived_classroom)
       create(:students_classrooms, student: student, classroom: archived_classroom)
       create(:students_classrooms, student: student2, classroom: archived_classroom)
@@ -106,6 +106,6 @@ RSpec.describe VitallyIntegration::PreviousYearSchoolDatum, type: :model do
 
       teacher_data = described_class.new(school, year).calculate_data
       expect(teacher_data).to include(expected_data)
-    end 
+    end
   end
 end

--- a/services/QuillLMS/spec/services/vitally_integration/previous_year_school_datum_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/previous_year_school_datum_spec.rb
@@ -87,5 +87,25 @@ RSpec.describe VitallyIntegration::PreviousYearSchoolDatum, type: :model do
       }
       expect(described_class.new(school, year).calculate_data).to include(expected_data)
     end
+
+    it 'should include archived classrooms' do 
+      archived_classroom = create(:classroom, created_at: Date.new(year, 10, 1), visible: false)
+      classroom_unit = create(:classroom_unit, unit: unit, classroom: archived_classroom, created_at: Date.new(year, 10, 1), assigned_student_ids: [student.id, student2.id]) 
+      create(:classrooms_teacher, user: teacher, classroom: archived_classroom)
+      create(:students_classrooms, student: student, classroom: archived_classroom)
+      create(:students_classrooms, student: student2, classroom: archived_classroom)
+
+      create(:unit_activity, unit: unit, activity: post_diagnostic_activity, created_at: Date.new(year, 10, 1))
+      create(:unit_activity, unit: unit, activity: pre_diagnostic_activity, created_at: Date.new(year, 10, 1))
+
+      expected_data = {
+        evidence_activities_assigned: 4,
+        pre_diagnostics_assigned: 4,
+        post_diagnostics_assigned: 4
+      }
+
+      teacher_data = described_class.new(school, year).calculate_data
+      expect(teacher_data).to include(expected_data)
+    end 
   end
 end


### PR DESCRIPTION
## WHAT
The Vitally function calculating number of activities assigned for a school wasn't correctly including archived classrooms. This PR fixes that so the calculation now includes archived classrooms as well as visible classrooms.

## WHY
We should always include archived classrooms in this count, especially because some of the stats are calculated for previous years where most classrooms in the dataset will have been archived.

## HOW
Just use "classrooms_unscoped" in the ActiveRecord query instead of "classrooms" since it bypasses the default scope `visible: true`.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Tested this on my staging site to verify the correct data.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
