### PR TITLE
fix lessons-server build script

### DIFF
--- a/services/QuillLessonsServer/package.json
+++ b/services/QuillLessonsServer/package.json
@@ -9,7 +9,7 @@
     "serve": "node lib/index.js",
     "start:dev": "./rethink_local.sh start; PORT=3200 RETHINKDB_HOSTS=localhost:28015 nodemon src/index.js --exec babel-node src/index.js; ./rethink_local.sh stop",
     "test": "jest test",
-    "heroku-postbuild": "[ $NODE_ENV = staging ] && npm prune --production"
+    "heroku-postbuild": "[ $NODE_ENV = staging ] && npm prune --production ; :"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## WHAT
Deja vu - see https://github.com/empirical-org/Empirical-Core/pull/11840

## WHY
Fix build script 

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
n/a

### What have you done to QA this feature?
ensure that staging build succeeds when `NODE_ENV=production`, then revert the env var

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - config change only
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
