### PR TITLE
fix hyphenated surname bug

### DIFF
--- a/services/QuillLMS/app/pdfs/login_pdf.rb
+++ b/services/QuillLMS/app/pdfs/login_pdf.rb
@@ -169,7 +169,7 @@ class LoginPdf < Prawn::Document
     elsif student.signed_up_with_google?
       'N/A (Log in with Google)'
     elsif student.authenticate(student.last_name)
-      student.last_name.capitalize.to_s
+      student.last_name
     else
       'N/A (Custom Password)'
     end

--- a/services/QuillLMS/spec/pdfs/login_pdf_spec.rb
+++ b/services/QuillLMS/spec/pdfs/login_pdf_spec.rb
@@ -64,6 +64,18 @@ describe LoginPdf do
     end
   end
 
+  describe '#render_password_for_student' do
+    context 'student authenticated by last name' do
+      let(:hyphenated_surname_student) { create(:student, :with_generated_password, name: 'Laszlo Moholy-Nagy') }
+      let(:classroom) { create(:classroom, students: [hyphenated_surname_student]) }
+
+      it 'should return the name in the case format persisted in the database' do
+        result = LoginPdf.new(classroom).render_password_for_student(hyphenated_surname_student)
+        expect(result).to eq 'Moholy-Nagy'
+      end
+    end
+  end
+
   describe 'student name is not whitespace delineable' do
     let(:students) { [create(:student, name: 'betty'), create(:student)] }
     let(:classroom) { create(:classroom, students: students) }


### PR DESCRIPTION
## WHAT
Bug fix. 

## WHY
The Login PDF suggests that a student with surname "Maholy-Nagy" has password "Maholy-nagy", which is incorrect.

## HOW
Remove buggy logic from PDF generator. 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Student-Login-Password-Capitalization-Error-with-Hyphenated-Names-c872d71a87484c6a9e88963bf506ad8f

### What have you done to QA this feature?
On staging, add students with a hyphenated last name and ensure they can log in with the password displayed in the PDF guide.


PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
