### PR TITLE
Fix bug involving Evidence::Activity preview text with <br/> tags

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/libs/activityPreviewHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/activityPreviewHelpers.tsx
@@ -282,6 +282,7 @@ export const renderQuestions = ({
 
 function transformNode(node, _index) {
   if (node.type === 'tag') {
+    if (node.name === 'br') { return ''; }
     if (node.name === 'strong' || node.name === 'em') { node.name = 'i'; }
     if (node.name === 'mark') { node.name = 'span' }
 


### PR DESCRIPTION
## WHAT
Fix a bug with the evidence preview panel display where Activity passage text contains `<br/>` tags.

## WHY
The ReactHtmlParser fails when encountering `<br/>` nodes. 

## HOW
Replace the nodes with ''.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Fix-activity-preview-text-with-Surge-Barriers-5d552486185e47bfa5aaa400e7e740a9?pvs=4

### What have you done to QA this feature?
I've confirmed that this works on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.  Manual check
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
