### PR TITLE
parameterize QLS configs

### DIFF
--- a/services/QuillLessonsServer/src/index.js
+++ b/services/QuillLessonsServer/src/index.js
@@ -3,10 +3,8 @@ import dotenv from 'dotenv';
 import r from 'rethinkdb';
 import socketio from 'socket.io';
 import redis from 'socket.io-redis';
-import fs from 'fs';
 import jwt from 'jsonwebtoken';
 import http from 'http';
-import path from 'path';
 
 import rethinkdbConfig from './config/rethinkdb';
 import { requestHandler } from './config/server';
@@ -37,7 +35,12 @@ const captureSentryMessage = (message) => {
 dotenv.config();
 
 const app = http.createServer(requestHandler);
-const io = socketio(app);
+
+const io = socketio(app, {
+  pingInterval: process.env.PING_INTERVAL || 25000,
+  pingTimeout: process.env.PING_TIMEOUT || 20000,
+});
+
 io.adapter(redis(process.env.REDISCLOUD_URL));
 const port = process.env.PORT;
 


### PR DESCRIPTION
## WHAT
Parameterize socketio ping configs 

## WHY
So that we can tune them without requiring a code change + deployment. Here's an example of how this was successful  in an external team: https://lxcid.com/2017/06/03/socket.io-heroku

## HOW
use env vars 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Address-lessons-server-request-timeout-alerts-7b0690d7e6204b739c20e22fb5c9bf2d

### What have you done to QA this feature?
Log into a Lesson as a teacher. Observe the new values in the socketio handshake:
`101:0{"sid":"gmq48D78MAXzocltAAAB","upgrades":["websocket"],"pingInterval":"15000","pingTimeout":"25000"}2:40`

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - config only
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
