### PR TITLE
fix bug where growth results are not loading

### DIFF
--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
@@ -263,11 +263,11 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
     if(!total_correct_questions_count && total_correct_questions_count !== 0) { return NOT_AVAILABLE }
 
     if (total_pre_correct_questions_count) {
-      const countOfPreSkillsProficienct = skill_groups.filter(skillGroup => skillGroup.pre_test_proficiency === PROFICIENCY).length
-      const countOfSkillsToPractice = skill_groups.length - countOfPreSkillsProficienct
+      const countOfPreSkillsProficient = skill_groups.filter(skillGroup => skillGroup.pre_test_proficiency === PROFICIENCY).length
+      const countOfSkillsToPractice = skill_groups.length - countOfPreSkillsProficient
       return (
         <div className="skills-correct-element">
-          <p>{countOfPreSkillsProficienct} of {skill_groups.length} {pluralize(countOfSkillsProficient, "Skill", "Skills")}</p>
+          <p>{countOfPreSkillsProficient} of {skill_groups.length} {pluralize(countOfPreSkillsProficient, "Skill", "Skills")}</p>
           {!!countOfSkillsToPractice && <p>({countOfSkillsToPractice} {pluralize({countOfSkillsToPractice}, "Skill", "Skills")} to Practice)</p>}
         </div>
       )


### PR DESCRIPTION
## WHAT
Fix bug where responses page for diagnostic growth report was not loading.

## WHY
High-priority bug ticket.

## HOW
Use a defined variable (and fix typo).

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/Student-responses-report-for-growth-diagnostics-not-loading-97a80a409630408b9469e9b76bdfe147?pvs=6&n=activity_block_edited&n=slack

### What have you done to QA this feature?
Confirmed that it is now loading locally.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  Manually tested
Have you deployed to Staging? | NO -  tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
