### PR TITLE
add special capitalization rules to diagnostic progress reports

### DIFF
--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -288,13 +288,21 @@ module PublicProgressReports
     time > 60 ? '> 60' : time
   end
 
+  def format_direction(direction)
+    direction.gsub(/\((.*?)\)/) do |match|
+      match.gsub(/\b\w+\b/) do |word|
+        word == 'I' ? word : word.downcase
+      end
+    end
+  end
+
   # rubocop:disable Metrics/CyclomaticComplexity
   def format_concept_results(activity_session, concept_results)
     concept_results.group_by { |cr| cr.question_number }.map { |_key, cr|
       # if we don't sort them, we can't rely on the first result being the first attemptNum
       # however, it would be more efficient to make them a hash with attempt numbers as keys
       cr.sort! { |x, y| (x.attempt_number || 0) <=> (y.attempt_number || 0) }
-      directfirst = cr.first.concept_result_directions&.text || cr.first.concept_result_instructions&.text || ''
+      directfirst = format_direction(cr.first.concept_result_directions&.text || cr.first.concept_result_instructions&.text || '')
       prompt_text = cr.first.concept_result_prompt&.text
       score = get_score_for_question(cr)
       question_uid = cr.first.extra_metadata&.dig('question_uid')

--- a/services/QuillLMS/app/models/concerns/public_progress_reports.rb
+++ b/services/QuillLMS/app/models/concerns/public_progress_reports.rb
@@ -288,6 +288,8 @@ module PublicProgressReports
     time > 60 ? '> 60' : time
   end
 
+  # Example:
+  # The boy _ the ball (Kick, Kicks, I) -> The boy _ the ball (kick, kicks, I)
   def format_direction(direction)
     direction.gsub(/\((.*?)\)/) do |match|
       match.gsub(/\b\w+\b/) do |word|

--- a/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/public_progress_reports_spec.rb
@@ -282,6 +282,23 @@ describe PublicProgressReports, type: :model do
     end
   end
 
+  describe '#format_direction' do
+    it 'should return empty string when input is empty string' do
+      result = FakeReports.new.format_direction('')
+      expect(result).to eq ''
+    end
+
+    it 'should downcase example words in parentheses' do
+      result = FakeReports.new.format_direction('Lorem ispum. (Kicks, Kick)')
+      expect(result).to eq 'Lorem ispum. (kicks, kick)'
+    end
+
+    it 'should upcase the pronoun <I> when in parentheses' do
+      result = FakeReports.new.format_direction('Lorem ispum. (I, Mine, I)')
+      expect(result).to eq 'Lorem ispum. (I, mine, I)'
+    end
+  end
+
   describe '#generic_questions_for_report' do
     let!(:question1) { create(:question) }
     let!(:question2) { create(:question) }


### PR DESCRIPTION
## WHAT
add special capitalization rules to diagnostic progress reports

## WHY
so that the parenthetical comments like "...(Kick, Kicks)" are correctly capitalized, to avoid teacher confusion 

## HOW
add a sub-formatter method 

### Screenshots
Pre PR:
<img width="1386" alt="Screenshot 2024-09-11 at 1 24 19 PM" src="https://github.com/user-attachments/assets/0a006e64-903f-4110-ab9e-aabce190aa0d">


Post PR:
<img width="1145" alt="Screenshot 2024-09-11 at 1 33 42 PM" src="https://github.com/user-attachments/assets/9a0f7d71-bc09-464f-9361-bd048592b470">

### Notion Card Links
https://www.notion.so/quill/Capitalization-errors-in-teacher-reports-for-fill-in-the-blanks-4f5a5b11051143ec9d59754c6e00105b

### What have you done to QA this feature?
View the demo teacher's diagnostic reports on staging and confirm the change took place

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
