### PR TITLE
Fix bug with data export units

### DIFF
--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -635,24 +635,14 @@ module Teacher
   end
 
   def ids_and_names_of_affiliated_units
-    RawSqlRunner.execute(
-      <<-SQL
-        SELECT DISTINCT
-          units.id,
-          units.name
-        FROM classrooms_teachers
-        JOIN classrooms_teachers AS all_affiliated_classrooms
-          ON all_affiliated_classrooms.classroom_id = classrooms_teachers.classroom_id
-        JOIN classrooms
-          ON classrooms.id = all_affiliated_classrooms.classroom_id
-          AND classrooms.visible = TRUE
-        JOIN units
-          ON all_affiliated_classrooms.user_id = units.user_id
-          AND units.visible = TRUE
-        WHERE classrooms_teachers.user_id = #{id}
-        ORDER BY units.name ASC
-      SQL
-    ).to_a
+    Unit
+      .select('units.id, units.name')
+      .joins(classroom_units: { classroom: :classrooms_teachers })
+      .where(classrooms: { visible: true })
+      .where(classrooms_teachers: { user_id: id })
+      .where(visible: true)
+      .order(:name)
+      .as_json
   end
 
   def referral_code


### PR DESCRIPTION
## WHAT
Fix a bug with the Data Export units dropdown

## WHY
It is populated with selectable units that have no data.

## HOW
Fix the query to restrict to classrooms that are visible.  The joins were pulling in extraneous records via the affiliated records alias.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/A-teacher-sees-deleted-activity-packs-in-the-All-activity-packs-dropdown-menu-for-the-Data-Export-fe-d386bb26ae5442d2a51ef9352d49d57d?pvs=4

### What have you done to QA this feature?
I tested this on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | Not yet - deploying now!
Self-Review: Have you done an initial self-review of the code below on Github? | YES
