### PR TITLE
Add two new Queue Latency endpoints for NewRelic Pings 

### DIFF
--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -34,7 +34,6 @@ class StatusesController < ApplicationController
     render plain: 'OK'
   end
 
-
   def sidekiq_critical_external_latency
     queues = Sidekiq::Queue.all
     latency_hash = queues.to_h { |q| [q.name, q.latency] }

--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -34,14 +34,6 @@ class StatusesController < ApplicationController
     render plain: 'OK'
   end
 
-  def sidekiq_queue_latency
-    queues = Sidekiq::Queue.all
-    latency_hash = queues.to_h { |q| [q.name, q.latency] }
-
-    response_status = latency_hash.fetch(:critical_external, 0) > ENV.fetch('SIDEKIQ_CRITICAL_EXTERNAL_LATENCY_LIMIT', 60).to_f ? 400 : 200
-
-    render json: latency_hash, status: response_status
-  end
 
   def sidekiq_critical_external_latency
     queues = Sidekiq::Queue.all

--- a/services/QuillLMS/app/controllers/statuses_controller.rb
+++ b/services/QuillLMS/app/controllers/statuses_controller.rb
@@ -38,7 +38,25 @@ class StatusesController < ApplicationController
     queues = Sidekiq::Queue.all
     latency_hash = queues.to_h { |q| [q.name, q.latency] }
 
-    response_status = latency_hash.fetch(:critical_external, 0) > ENV.fetch('SIDEKIQ_CRITICAL_EXTERNAL_LATENCY_LIMIT', 60) ? 400 : 200
+    response_status = latency_hash.fetch(:critical_external, 0) > ENV.fetch('SIDEKIQ_CRITICAL_EXTERNAL_LATENCY_LIMIT', 60).to_f ? 400 : 200
+
+    render json: latency_hash, status: response_status
+  end
+
+  def sidekiq_critical_external_latency
+    queues = Sidekiq::Queue.all
+    latency_hash = queues.to_h { |q| [q.name, q.latency] }
+
+    response_status = latency_hash.fetch(:critical_external, 0) > ENV.fetch('SIDEKIQ_CRITICAL_EXTERNAL_LATENCY_LIMIT', 60).to_f ? 400 : 200
+
+    render json: latency_hash, status: response_status
+  end
+
+  def sidekiq_low_latency
+    queues = Sidekiq::Queue.all
+    latency_hash = queues.to_h { |q| [q.name, q.latency] }
+
+    response_status = latency_hash.fetch(:low, 0) > ENV.fetch('SIDEKIQ_LOW_LATENCY_LIMIT', 60).to_f ? 400 : 200
 
     render json: latency_hash, status: response_status
   end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -965,7 +965,7 @@ EmpiricalGrammar::Application.routes.draw do
   # Uptime status
   resource :status, only: [] do
     collection do
-      get :index, :database, :database_write, :database_follower, :redis_cache, :redis_queue, :sidekiq_queue_latency, :sidekiq_queue_length, :sidekiq_critical_external_latency, :sidekiq_low_latency
+      get :index, :database, :database_write, :database_follower, :redis_cache, :redis_queue, :sidekiq_queue_length, :sidekiq_critical_external_latency, :sidekiq_low_latency
       post :deployment_notification
     end
   end

--- a/services/QuillLMS/config/routes.rb
+++ b/services/QuillLMS/config/routes.rb
@@ -965,7 +965,7 @@ EmpiricalGrammar::Application.routes.draw do
   # Uptime status
   resource :status, only: [] do
     collection do
-      get :index, :database, :database_write, :database_follower, :redis_cache, :redis_queue, :sidekiq_queue_latency, :sidekiq_queue_length
+      get :index, :database, :database_write, :database_follower, :redis_cache, :redis_queue, :sidekiq_queue_latency, :sidekiq_queue_length, :sidekiq_critical_external_latency, :sidekiq_low_latency
       post :deployment_notification
     end
   end

--- a/services/QuillLMS/spec/controllers/statuses_controller_spec.rb
+++ b/services/QuillLMS/spec/controllers/statuses_controller_spec.rb
@@ -52,60 +52,6 @@ describe StatusesController, type: :controller do
     end
   end
 
-  describe '#sidekiq_queue_latency' do
-    let(:queue_doubles) do
-      queue_latency_pairs.map do |name, latency|
-        double(name: name, latency: latency)
-      end
-    end
-
-    before do
-      ENV['SIDEKIQ_CRITICAL_EXTERNAL_LATENCY_LIMIT'] = nil
-    end
-
-    context 'critical_external latency under 60 seconds' do
-      let(:queue_latency_pairs) do
-        {
-          critical: 1.14,
-          critical_external: 0.34,
-          default: 1.44,
-          low: 0,
-          migration: 0
-        }
-      end
-
-      it 'should build a hash of queue.name => queue.latency for each queue' do
-        allow(Sidekiq::Queue).to receive(:all).and_return(queue_doubles)
-
-        get :sidekiq_queue_latency
-
-        expect(response.status).to eq(200)
-        expect(JSON.parse(response.body)).to eq(queue_latency_pairs.stringify_keys)
-      end
-    end
-
-    context 'critical_external_latency is over 60 seconds' do
-      let(:queue_latency_pairs) do
-        {
-          critical: 1.14,
-          critical_external: 66.34,
-          default: 1.44,
-          low: 0,
-          migration: 0
-        }
-      end
-
-      it 'should have a response status of 400 if critical_external latency is over our defined limit' do
-        allow(Sidekiq::Queue).to receive(:all).and_return(queue_doubles)
-
-        get :sidekiq_queue_latency
-
-        expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)).to eq(queue_latency_pairs.stringify_keys)
-      end
-    end
-  end
-
   describe '#sidekiq_critical_external_latency' do
     let(:queue_doubles) do
       queue_latency_pairs.map do |name, latency|


### PR DESCRIPTION
## WHAT
Add two new endpoints to check for queue latency exceeding the limit, for both the critical_external queue and the low queue. Remove the old endpoint.

## WHY
We need to convert some NewRelic alerts to pings, so we need the data from the Sidekiq Queue Latency check endpoints to be more specific -- one endpoint should return 400 only if the critical external queue is too slow, and the other endpoint should return 400 only if the low priority queue is too slow.

## HOW
Split up the existing endpoint into two endpoints, one checking for the critical external queue only and the other checking for the low priority queue only.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Convert-New-Relic-Synthetic-Scripts-to-Pings-71240e4e89cf41729bf137335bc01b06?pvs=4

### What have you done to QA this feature?
Deploy to staging and check hitting both endpoints at the default state with nothing in either queue (should return 200 on both endpoints). Then set the latency limits artificially low via environment variables on staging and verify that both endpoints return a 400.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
