### PR TITLE
Fix bug with student reports page

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/reactTable/reactTable.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/reactTable/reactTable.tsx
@@ -34,7 +34,7 @@ export const NumberFilterInput = ({ handleChange, label, column }: NumberFilterI
         aria-label={label}
         onChange={e => handleChange(column.id, e.target.value)}
         placeholder={`0-5, >1, <1`}
-        style={{width: '100px', marginRight: '0.5rem'}}
+        style={{ width: '100px', marginRight: '0.5rem' }}
         type="text"
         value={column.filterValue || ''}
       />
@@ -70,7 +70,7 @@ interface ReactTableProps {
   defaultPageSize?: number,
   disableSortBy?: boolean,
   currentPage?: number,
-  defaultSorted?: string | {id: string, desc: boolean }[],
+  defaultSorted?: string | { id: string, desc: boolean }[],
   onSortedChange?: (sortBy: string) => void,
   onPageChange?: (pageIndex: number) => void,
   onFiltersChange?: (filters: []) => void,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/student_overview_table.jsx
@@ -97,8 +97,8 @@ export default class StudentOveriewTable extends React.Component {
         resizable: false,
         maxWidth: activityNameHeaderWidth,
         Cell: ({ row }) => {
-          const { original, activity_id } = row
-          const { id, name, classroom_unit_id, completed_at, activity_classification_id } = original
+          const { original, } = row
+          const { id, name, classroom_unit_id, completed_at, activity_classification_id, activity_id } = original
           const icon = this.activityClassificationIcon(activity_classification_id)
           const link = completed_at ? `/teachers/progress_reports/report_from_classroom_unit_and_activity_and_user/cu/${classroom_unit_id}/user/${studentId}/a/${activity_id}` : null
           return renderTooltipRow({ icon, id, label: name, link, headerWidth: activityNameHeaderWidth })


### PR DESCRIPTION
## WHAT
Fix a bug where StudentReports page is giving a spinning wheel.

## WHY
The page is constructing a url with nil activity_id

## HOW
Fix the destructuring of object to pull the activity_id appropriately.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/When-a-teacher-looks-at-the-Activity-Analysis-Student-reports-and-Questions-reports-through-a-stud-103d42e6f94180479c53c9aa1d5c9fe4?pvs=4

### What have you done to QA this feature?
Checked on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
