### PR TITLE
allow-translation-updates

### DIFF
--- a/services/QuillLMS/app/models/concerns/translatable.rb
+++ b/services/QuillLMS/app/models/concerns/translatable.rb
@@ -67,7 +67,7 @@ module Translatable
     return unless translatable_text.is_a?(String) && translatable_text.present?
     return unless translation_mappings.joins(:english_text)
       .where(field_name:)
-      .where(english_text: {text: translatable_text})
+      .where(english_text: { text: translatable_text })
       .empty?
 
     clean_deprecated_translations(translatable_text:, field_name:)
@@ -131,7 +131,7 @@ module Translatable
   private def clean_deprecated_translations(translatable_text:, field_name:)
     translation_mappings.joins(:english_text)
       .where(field_name:)
-      .where.not(english_text: {text: translatable_text})
+      .where.not(english_text: { text: translatable_text })
       .destroy_all
   end
 end

--- a/services/QuillLMS/spec/models/concerns/translatable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/translatable_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Translatable do
 
           before { translatable_object.update(data: { 'test_text' => new_english_text }) }
 
-          it { expect { subject }.to change { translatable_object.reload.translation_mappings } }
+          it { expect { subject }.to change { translatable_object.reload.translation_mappings.pluck(:id) } }
 
           it do
             expect { subject }.to change { translatable_object.reload.english_texts.map(&:text) }

--- a/services/QuillLMS/spec/models/concerns/translatable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/translatable_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Translatable do
     end
   end
 
-  let(:translatable_object) { translatable_class.create(data: { 'test_text' => 'Test text to translate' }) }
+  let(:english_text) { 'Test text to translate' }
+  let(:translatable_object) { translatable_class.create(data: { 'test_text' => english_text }) }
 
   before do
     stub_const('TranslatableTestModel', translatable_class)
@@ -66,6 +67,20 @@ RSpec.describe Translatable do
 
         it 'does not create a new english text' do
           expect { subject }.not_to change(EnglishText, :count)
+        end
+
+        context 'when a translation mapping already exists, but it was generated for a different text' do
+          let(:new_english_text) { 'This is the updated text' }
+
+          before { translatable_object.update(data: { 'test_text' => new_english_text }) }
+
+          it { expect { subject }.to change { translatable_object.reload.translation_mappings } }
+
+          it do
+            expect { subject }.to change { translatable_object.reload.english_texts.map(&:text) }
+              .from([english_text])
+              .to([new_english_text])
+          end
         end
       end
     end


### PR DESCRIPTION
## WHAT
Update translatable concern to translate changes to source text
## WHY
Without this we were basically bailing early on a translation if the object had ever been translated, even if what we're trying to translate is a change in its original text
## HOW
Instead of just exiting early from the translation process if the underlying `field_name` has already been translated, check to see if it's been translated for the existing source text.  If it hasn't, delete the old (now no longer relevant) `translation_mapping` and re-translate the object.

### Notion Card Links
https://www.notion.so/quill/Investigate-whether-the-existing-Rake-task-will-handle-updating-translations-after-re-grading-4d50020dc9b94af2aa1ebe33987c673a?pvs=4
https://www.notion.so/quill/Translations-changes-6dc4b121ceb94109bcd13c07c913ad96

### What have you done to QA this feature?
- Deploy to staging
- Examine an existing question's translations in the API
- Update the feedback for that question
- Re-run the translation rake task in staging
- Manually clear staging cache (these API calls are cached)
- Confirm that the question's translations in the API are updated

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes