### PR TITLE
stop-error-on-completing-unassigned-student-learning-sequences

### DIFF
--- a/services/QuillLMS/app/services/student_learning_sequences/handle_completion.rb
+++ b/services/QuillLMS/app/services/student_learning_sequences/handle_completion.rb
@@ -2,8 +2,6 @@
 
 module StudentLearningSequences
   class HandleCompletion < ApplicationService
-    class MissingSequenceActivityError < StandardError; end
-
     attr_reader :activity_session_id
 
     def initialize(activity_session_id)
@@ -11,9 +9,6 @@ module StudentLearningSequences
     end
 
     def run
-      # TODO: Remove the early return and start using the raise call again after we backfill these records
-      #raise missing_sequence_activity_error unless student_learning_sequence_activity
-      # Temporarily early return instead of raising an error until we run the data backfill
       return unless student_learning_sequence_activity
 
       student_learning_sequence_activity.update(

--- a/services/QuillLMS/app/services/student_learning_sequences/handle_completion.rb
+++ b/services/QuillLMS/app/services/student_learning_sequences/handle_completion.rb
@@ -11,7 +11,10 @@ module StudentLearningSequences
     end
 
     def run
-      raise missing_sequence_activity_error unless student_learning_sequence_activity
+      # TODO: Remove the early return and start using the raise call again after we backfill these records
+      #raise missing_sequence_activity_error unless student_learning_sequence_activity
+      # Temporarily early return instead of raising an error until we run the data backfill
+      return unless student_learning_sequence_activity
 
       student_learning_sequence_activity.update(
         activity_session_id:,

--- a/services/QuillLMS/spec/services/student_learning_sequences/handle_completion_spec.rb
+++ b/services/QuillLMS/spec/services/student_learning_sequences/handle_completion_spec.rb
@@ -13,8 +13,7 @@ module StudentLearningSequences
     let(:activity) { activity_session.activity }
     let(:classroom_unit) { activity_session.classroom_unit }
 
-    # TODO: Re-enable this after we update the raise code in the service post-backfill
-    #it { expect { subject }.to raise_error(described_class::MissingSequenceActivityError) }
+    it { expect { subject }.to_not raise_error }
 
     context 'item was assigned to the sequence previously' do
       let(:student_learning_sequence_activity) { create(:student_learning_sequence_activity, student_learning_sequence:, activity:, classroom_unit:) }

--- a/services/QuillLMS/spec/services/student_learning_sequences/handle_completion_spec.rb
+++ b/services/QuillLMS/spec/services/student_learning_sequences/handle_completion_spec.rb
@@ -13,7 +13,8 @@ module StudentLearningSequences
     let(:activity) { activity_session.activity }
     let(:classroom_unit) { activity_session.classroom_unit }
 
-    it { expect { subject }.to raise_error(described_class::MissingSequenceActivityError) }
+    # TODO: Re-enable this after we update the raise code in the service post-backfill
+    #it { expect { subject }.to raise_error(described_class::MissingSequenceActivityError) }
 
     context 'item was assigned to the sequence previously' do
       let(:student_learning_sequence_activity) { create(:student_learning_sequence_activity, student_learning_sequence:, activity:, classroom_unit:) }


### PR DESCRIPTION
## WHAT
Early return instead of raising an error
## WHY
Not every ActivitySession is expected to be associated with a `StudentLearningSequenceActivity` record, so we want to make sure that there's an early return path for cases where that happens instead of erroring
## HOW
Instead of raising an error when `HandleCompletion` can't find a record to update, just return early

### What have you done to QA this feature?
- Deploy to staging
- Find a non-recommendation Connect ActivitySession
- Pass that ActivitySession id to `StudentLearningSequences::HandleCompletion.run`
- Confirm that there's an early return with no error

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Deploying now
Self-Review: Have you done an initial self-review of the code below on Github? | Yes