### PR TITLE
Unignore vitally organizations

### DIFF
--- a/services/QuillLMS/app/models/cron.rb
+++ b/services/QuillLMS/app/models/cron.rb
@@ -47,6 +47,7 @@ class Cron
 
     # third party analytics
     SyncVitallyWorker.perform_async
+    VitallyIntegration::UnignoreActiveOrganizationsWorker.perform_async
     LearnWorldsIntegration::SyncOrchestratorWorker.perform_async
     CalculateAndCacheSchoolsDataForSegmentWorker.perform_async
     SendSegmentIdentifyCallForAllAdminsWorker.perform_async

--- a/services/QuillLMS/app/services/vitally_integration/unignore_organization.rb
+++ b/services/QuillLMS/app/services/vitally_integration/unignore_organization.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module VitallyIntegration
+  class UnignoreOrganization < ApplicationService
+    attr_reader :api, :district_id
+
+    def initialize(district_id)
+      @district_id = district_id
+    end
+
+    def run
+      # We use a create call here with externalId because update calls require the proprietary Vitally ID which we don't store,
+      # but Vitally makes an update call on the backend when creating with an externalId that's already used for a record.
+      api.create(
+        RestApi::ENDPOINT_ORGANIZATIONS,
+        payload
+      )
+    end
+
+    private def api = @api ||= RestApi.new
+    private def district = @district ||= District.find(district_id)
+    private def external_id = district.id.to_s
+    private def name = district.name
+
+    private def payload
+      {
+        externalId: external_id,
+        name:,
+        traits: {
+          unignore_org: true
+        }
+      }
+    end
+  end
+end

--- a/services/QuillLMS/app/services/vitally_integration/unignore_organization.rb
+++ b/services/QuillLMS/app/services/vitally_integration/unignore_organization.rb
@@ -2,7 +2,7 @@
 
 module VitallyIntegration
   class UnignoreOrganization < ApplicationService
-    attr_reader :api, :district_id
+    attr_reader :district_id
 
     def initialize(district_id)
       @district_id = district_id

--- a/services/QuillLMS/app/workers/vitally_integration/unignore_active_organizations_worker.rb
+++ b/services/QuillLMS/app/workers/vitally_integration/unignore_active_organizations_worker.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module VitallyIntegration
+  class UnignoreActiveOrganizationsWorker
+    include Sidekiq::Worker
+
+    def perform
+      active_districts.each.with_index do |district, index|
+        UnignoreOrganizationWorker.perform_in(index.seconds, district.id)
+      end
+    end
+
+    private def now = @now ||= DateTime.current
+    private def active_start = now - 24.hours
+    private def active_end = now
+
+    private def active_districts
+      District.joins(
+        schools: {
+          users: {
+            classrooms_teachers: {
+              classroom: {
+                students_classrooms: :student
+              }
+            }
+          }
+        }
+      ).where(
+        # students_students_classroom is the alias that the above join generates for student records
+        students_students_classrooms: {
+          last_sign_in: active_start..active_end
+        }
+      ).distinct
+    end
+  end
+end

--- a/services/QuillLMS/app/workers/vitally_integration/unignore_organization_worker.rb
+++ b/services/QuillLMS/app/workers/vitally_integration/unignore_organization_worker.rb
@@ -9,4 +9,3 @@ module VitallyIntegration
     end
   end
 end
-

--- a/services/QuillLMS/app/workers/vitally_integration/unignore_organization_worker.rb
+++ b/services/QuillLMS/app/workers/vitally_integration/unignore_organization_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module VitallyIntegration
+  class UnignoreOrganizationWorker
+    include Sidekiq::Worker
+
+    def perform(district_id)
+      UnignoreOrganization.run(district_id)
+    end
+  end
+end
+

--- a/services/QuillLMS/spec/models/cron_spec.rb
+++ b/services/QuillLMS/spec/models/cron_spec.rb
@@ -150,6 +150,11 @@ RSpec.describe Cron, type: :model do
       Cron.interval_1_day
     end
 
+    it do
+      expect(VitallyIntegration::UnignoreActiveOrganizationsWorker).to receive(:perform_async)
+      Cron.interval_1_day
+    end
+
     it 'enqueues TeacherNotifications::EnqueueUsersForRollupEmailWorker' do
       # Don't actually call run_friday because we don't want to trigger the
       # WEEKLY rollup logic

--- a/services/QuillLMS/spec/services/vitally_integration/unignore_organization_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/unignore_organization_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module VitallyIntegration
+  describe UnignoreOrganization do
+    subject { described_class.run(district.id) }
+
+    let(:district) { create(:district) }
+    let(:api_double) { double }
+    let(:expected_payload) do
+      {
+        externalId: district.id.to_s,
+        name: district.name,
+        traits: {
+          unignore_org: true
+        }
+      }
+    end
+
+    before { allow(RestApi).to receive(:new).and_return(api_double) }
+
+    it do
+      expect(api_double).to receive(:create)
+        .with(RestApi::ENDPOINT_ORGANIZATIONS, expected_payload)
+      subject
+    end
+  end
+end

--- a/services/QuillLMS/spec/workers/vitally_integration/unignore_active_organizations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/vitally_integration/unignore_active_organizations_worker_spec.rb
@@ -29,4 +29,3 @@ module VitallyIntegration
     end
   end
 end
-

--- a/services/QuillLMS/spec/workers/vitally_integration/unignore_active_organizations_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/vitally_integration/unignore_active_organizations_worker_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module VitallyIntegration
+  describe UnignoreActiveOrganizationsWorker do
+    subject { described_class.new.perform }
+
+    let(:active_sign_in) { DateTime.current - 1.hour }
+    let(:active_student) { create(:student, last_sign_in: active_sign_in) }
+    let(:active_classroom) { create(:classroom, students: [active_student]) }
+    let(:active_school) { create(:school, users: active_classroom.reload.teachers) }
+    let(:inactive_sign_in) { DateTime.current - 100.hours }
+    let(:inactive_student) { create(:student, last_sign_in: inactive_sign_in) }
+    let(:inactive_classroom) { create(:classroom, students: [inactive_student]) }
+    let(:inactive_school) { create(:school, users: inactive_classroom.reload.teachers) }
+
+    let!(:active_district) { create(:district, schools: [active_school]) }
+    let!(:inactive_district) { create(:district, schools: [inactive_school]) }
+
+    it do
+      expect(UnignoreOrganizationWorker).to receive(:perform_in).with(anything, active_district.id)
+      subject
+    end
+
+    it do
+      expect(UnignoreOrganizationWorker).not_to receive(:perform_in).with(anything, inactive_district.id)
+      subject
+    end
+  end
+end
+

--- a/services/QuillLMS/spec/workers/vitally_integration/unignore_organization_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/vitally_integration/unignore_organization_worker_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module VitallyIntegration
+  describe UnignoreOrganizationWorker do
+    subject { described_class.new.perform(district.id) }
+
+    let(:district) { create(:district) }
+
+    it do
+      expect(UnignoreOrganization).to receive(:run).with(district.id)
+      subject
+    end
+  end
+end
+

--- a/services/QuillLMS/spec/workers/vitally_integration/unignore_organization_worker_spec.rb
+++ b/services/QuillLMS/spec/workers/vitally_integration/unignore_organization_worker_spec.rb
@@ -14,4 +14,3 @@ module VitallyIntegration
     end
   end
 end
-


### PR DESCRIPTION
## WHAT
- Add a service to update the `unignore_org` trait on Vitally organizations
- Add a worker to pass-through to that service to allow for some amount of timing and retry control
- Add a worker to identify all "active" `Districts` each day (using the logic we use for `last_active` in Vitally reporting which is Districts which have  student that signed in within the past 24 hours)
- Enqueue the identifying worker using the Cron model to run it each day
## WHY
For money-saving reasons we've marked a bunch of Vitally Organizations (what we call Districts in the LMS) as ignored, but that value is not currently updated if something happens to "activate" that district, so even once they become active they aren't being marked active in Vitally.  Currently this requires someone in Partnerships to manually identify and flag these inactive-to-active transitions in Vitally, but we should automate this process.
## HOW
- On daily Cron, identify all Districts that have had a student sign-on in the last 24 hours
- For each district, send an API request to Vitally to set this the custom `unignore_org` trait which should start tracking the organization in Vitally again
- Note that we use `perform_in` to space out these requests because the Vitally RestAPI is rate-limited

### Notion Card Links
https://www.notion.so/quill/ea241f31a84c4b79ad56e83e99f7ee93?v=5c9c8e0172ec46499385d655b9e1d9de&p=df60f9a3b4284e068ae9cce09c856e82&pm=s

### What have you done to QA this feature?
- Given that Vitally's web panel uses some amount of caching, I've tested this in pieces:
- - Confirm that the query used to find "active" Districts works as expected and identifies the Districts we want it to
- - Confirm that the `UnignoreOrganization` service updates the data as expected by then using the Rails console to fetch that organization from the Vitally API and confirm that the value has updated as intended

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes