### PR TITLE
Translations/ remove feature flag

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
@@ -24,7 +24,6 @@ import {
   Spinner,
   TeacherPreviewMenuButton,
   VISIBILITYCHANGE,
-  hasTranslationFlag,
   roundValuesToSeconds,
 } from '../../../Shared/index';
 import { clearData, loadData, nextQuestion, resumePreviousSession, setCurrentQuestion, submitResponse, updateCurrentQuestion } from '../../actions.js';
@@ -548,7 +547,7 @@ export class Lesson extends React.Component {
           translate={translate}
         />
       );
-    } else if (availableLanguages?.length > 1 && hasTranslationFlag() && !language) {
+    } else if (availableLanguages?.length > 1 && !language) {
       component = (<LanguageSelectionPage
         dispatch={dispatch}
         handlePageLoaded={this.onLanguagePageLoad}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -20,7 +20,6 @@ import {
   MOUSEMOVE,
   SCROLL,
   VISIBILITYCHANGE,
-  hasTranslationFlag,
   roundValuesToSeconds,
 } from '../../../Shared/index';
 import { startListeningToConcepts } from '../../actions/concepts';
@@ -393,7 +392,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         }
         if (saving || (!grammarActivities && !proofreaderSessionId)) { return <LoadingSpinner /> }
 
-        if (availableLanguages && hasTranslationFlag() && !language) {
+        if (availableLanguages && !language) {
           return (
             <LanguageSelectionPage
               dispatch={dispatch}

--- a/services/QuillLMS/client/app/bundles/Shared/components/translations/languageSelectionPage.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/translations/languageSelectionPage.tsx
@@ -6,7 +6,7 @@ import { Events } from '../../../Diagnostic/modules/analytics';
 
 interface LanguageSelectionPageProps {
   questionCount?: number,
-  dispatch: (any) => void,
+  dispatch: Function,
   setLanguage: (language: string) => void,
   previewMode: boolean,
   beginActivity?: () => void,

--- a/services/QuillLMS/client/app/bundles/Shared/index.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/index.tsx
@@ -152,7 +152,6 @@ export {
   formatAnswerStringForReport,
   getlanguageOptions,
   renderSaveAndExitButton,
-  hasTranslationFlag,
   showTranslations,
   pluralize,
   renderExplanation

--- a/services/QuillLMS/client/app/bundles/Shared/libs/index.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/index.ts
@@ -44,4 +44,4 @@ export {
   sortByLevenshteinAndOptimal,
   extractConceptResultsFromResponse
 } from './responseTools'
-export { getlanguageOptions, renderSaveAndExitButton, hasTranslationFlag, showTranslations, renderExplanation } from './translations/helpers'
+export { getlanguageOptions, renderSaveAndExitButton, showTranslations, renderExplanation } from './translations/helpers'

--- a/services/QuillLMS/client/app/bundles/Shared/libs/translations/helpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/translations/helpers.tsx
@@ -26,15 +26,8 @@ export function renderSaveAndExitButton({ isELLDiagnostic, language, languageOpt
   return <a className="quill-button medium contained white focus-on-dark" href={`${process.env.DEFAULT_URL}/profile`}>{buttonText}</a>
 }
 
-// Temporary feature flag until we are ready to ship this.
-export const hasTranslationFlag = (): boolean => {
-  const urlParams = new URLSearchParams(window.location.search)
-  if (urlParams.get('showTranslations') !== 'true') return false;
-  return true;
-};
-
 export const showTranslations = (language, languageOptions): boolean => {
-  return hasTranslationFlag() && !!languageOptions && !!language && Object.keys(languageOptions).length > 1;
+  return !!languageOptions && !!language && Object.keys(languageOptions).length > 1;
 };
 
 const getTranslatedConceptsFeedbackData = (key, conceptsFeedback, showTranslation) => {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/promotional_card.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/promotional_card.test.tsx.snap
@@ -274,13 +274,8 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
             New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
           </li>
           <li>
-            Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+            All ELL practice activities now provide bilingual translation to Spanish
           </li>
-          <ul>
-            <li>
-              Diagnostics continue to support 16 languages
-            </li>
-          </ul>
         </ul>
       }
       buttons={
@@ -329,13 +324,8 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
                 New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
               </li>
               <li>
-                Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+                All ELL practice activities now provide bilingual translation to Spanish
               </li>
-              <ul>
-                <li>
-                  Diagnostics continue to support 16 languages
-                </li>
-              </ul>
             </ul>
           </p>
           <div
@@ -481,13 +471,8 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
             New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
           </li>
           <li>
-            Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+            All ELL practice activities now provide bilingual translation to Spanish
           </li>
-          <ul>
-            <li>
-              Diagnostics continue to support 16 languages
-            </li>
-          </ul>
         </ul>
       }
       buttons={
@@ -536,13 +521,8 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
                 New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
               </li>
               <li>
-                Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+                All ELL practice activities now provide bilingual translation to Spanish
               </li>
-              <ul>
-                <li>
-                  Diagnostics continue to support 16 languages
-                </li>
-              </ul>
             </ul>
           </p>
           <div
@@ -856,13 +836,8 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
             New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
           </li>
           <li>
-            Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+            All ELL practice activities now provide bilingual translation to Spanish
           </li>
-          <ul>
-            <li>
-              Diagnostics continue to support 16 languages
-            </li>
-          </ul>
         </ul>
       }
       buttons={
@@ -911,13 +886,8 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
                 New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
               </li>
               <li>
-                Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+                All ELL practice activities now provide bilingual translation to Spanish
               </li>
-              <ul>
-                <li>
-                  Diagnostics continue to support 16 languages
-                </li>
-              </ul>
             </ul>
           </p>
           <div
@@ -1063,13 +1033,8 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
             New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
           </li>
           <li>
-            Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+            All ELL practice activities now provide bilingual translation to Spanish
           </li>
-          <ul>
-            <li>
-              Diagnostics continue to support 16 languages
-            </li>
-          </ul>
         </ul>
       }
       buttons={
@@ -1118,13 +1083,8 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
                 New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
               </li>
               <li>
-                Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+                All ELL practice activities now provide bilingual translation to Spanish
               </li>
-              <ul>
-                <li>
-                  Diagnostics continue to support 16 languages
-                </li>
-              </ul>
             </ul>
           </p>
           <div
@@ -1438,13 +1398,8 @@ exports[`PromotionalCard container SchoolYearUpdatesCard rendering behavior when
             New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
           </li>
           <li>
-            Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+            All ELL practice activities now provide bilingual translation to Spanish
           </li>
-          <ul>
-            <li>
-              Diagnostics continue to support 16 languages
-            </li>
-          </ul>
         </ul>
       }
       buttons={
@@ -1493,13 +1448,8 @@ exports[`PromotionalCard container SchoolYearUpdatesCard rendering behavior when
                 New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)
               </li>
               <li>
-                Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish
+                All ELL practice activities now provide bilingual translation to Spanish
               </li>
-              <ul>
-                <li>
-                  Diagnostics continue to support 16 languages
-                </li>
-              </ul>
             </ul>
           </p>
           <div

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/school_year_updates_card.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/school_year_updates_card.tsx
@@ -13,10 +13,7 @@ const SchoolYearUpdatesCard = ({ handleCloseCard, }) => {
           <li>Content improvements for all Diagnostics</li>
           <li>Quill Reading for Evidence now provides green, yellow, and red scores for students and teachers</li>
           <li>New High School Reading for Evidence Offerings: Social Studies (World History) and Interdisciplinary Science (Building AI Knowledge)</li>
-          <li>Coming soon: All ELL Practice Activities will provide bilingual translation to Spanish</li>
-          <ul>
-            <li>Diagnostics continue to support 16 languages</li>
-          </ul>
+          <li>All ELL practice activities now provide bilingual translation to Spanish</li>
         </ul>
       }
       buttons={[


### PR DESCRIPTION
## WHAT
remove feature flag for translated Connect and Grammar activities

## WHY
this is the last step before releasing the translation feature!

## HOW
just remove the temporary `hasTranslationFlag` function

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
tested on staging that translated activities have language options and translate as expected

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small change, manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
