### PR TITLE
Translations/ fix bug with question lookup

### DIFF
--- a/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
+++ b/services/QuillLMS/client/app/bundles/Connect/components/studentLessons/lesson.jsx
@@ -219,9 +219,10 @@ export class Lesson extends React.Component {
     const { translated_questions } = questions
     const { currentQuestion, language } = playLesson
     const { question } = currentQuestion;
-    const { key } = question
-    if (translated_questions && language && language !== ENGLISH) {
-      const question_translation = translated_questions[key]
+    const { key, uid } = question
+    const keyOrUid = key || uid
+    if (translated_questions && language && language !== ENGLISH && keyOrUid) {
+      const question_translation = translated_questions[keyOrUid]
       return { ...question, translation: question_translation };
     }
     return question;

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -342,10 +342,11 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
       const { session } = this.props
       if(!session?.currentQuestion) { return null }
       const { currentQuestion, translated_questions } = session
-      const { key } = currentQuestion
+      const { key, uid } = currentQuestion
       let translation
-      if (showTranslation && translated_questions) {
-        translation = translated_questions[key]
+      const keyOrUid = key || uid
+      if (showTranslation && translated_questions && keyOrUid) {
+        translation = translated_questions[keyOrUid]
       }
       if (translation) {
         return { ...currentQuestion, translation }

--- a/services/QuillLMS/client/app/bundles/Shared/styles/feedback.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/feedback.scss
@@ -50,7 +50,7 @@
     background-color: #d3e7bd;
     border-left: 3px solid #498900;
 
-    p, strong, em {
+    p, strong, em, b, div {
       color: #457818;
     }
 
@@ -86,7 +86,7 @@
       }
     }
 
-    p, strong, em {
+    p, strong, em, b, div {
       color: #875a12;
     }
   }


### PR DESCRIPTION
## WHAT
fix bug with question lookup for translations

## WHY
a few questions are passed back with `uid` instead of `key`

## HOW
just add a check for either value to use as the key for the translation lookup

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Grammar-activities-with-translations-breaking-1fe1291d5d5c47e09c3f16cb0191a833?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
verified locally and on staging that the translations render as expected
PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | hotfix
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
