### PR TITLE
Fix bug in Vitally stats where classrooms with multiple teachers are double counted

### DIFF
--- a/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
+++ b/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
@@ -14,7 +14,9 @@ module VitallySchoolStats
       .joins('JOIN classrooms_teachers ON classrooms_teachers.classroom_id=classrooms.id')
       .joins('JOIN schools_users ON schools_users.user_id = classrooms_teachers.user_id')
       .joins('JOIN schools ON schools_users.school_id=schools.id')
-      .where(state: 'finished').where('schools.id = ?', school.id)
+      .where(state: 'finished')
+      .where('classrooms_teachers.role = ?', ClassroomsTeacher::ROLE_TYPES[:owner])
+      .where('schools.id = ?', school.id)
   end
 
   private def activities_finished_query
@@ -22,12 +24,14 @@ module VitallySchoolStats
       .joins(classroom_unit: { classroom_unscoped: { classrooms_teachers: { user: :schools_users } } })
       .joins(:activity)
       .where(state: 'finished')
+      .where('classrooms_teachers.role = ?', ClassroomsTeacher::ROLE_TYPES[:owner])
       .where('schools_users.school_id = ?', school.id)
   end
 
   def activities_assigned_query
     @activities_assigned ||= ClassroomUnit.joins(classroom_unscoped: { teachers: :school }, unit: :activities)
       .where('schools.id = ?', school.id)
+      .where('classrooms_teachers.role = ?', ClassroomsTeacher::ROLE_TYPES[:owner])
       .select('assigned_student_ids', 'activities.id', 'unit_activities.created_at')
   end
 end

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -190,7 +190,7 @@ class School < ApplicationRecord
   end
 
   def students
-    User.joins(student_in_classroom: { teachers: :school }).where(schools: { id: id }).distinct
+    User.joins(student_in_classroom: { teachers: :school }).where(schools: { id: id }).where(classrooms_teachers: {role: ClassroomsTeacher::ROLE_TYPES[:owner]}).distinct
   end
 
   def detach_from_existing_district_admins(district)

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -190,7 +190,10 @@ class School < ApplicationRecord
   end
 
   def students
-    User.joins(student_in_classroom: { teachers: :school }).where(schools: { id: id }).where(classrooms_teachers: { role: ClassroomsTeacher::ROLE_TYPES[:owner] }).distinct
+    User.joins(student_in_classroom: { teachers: :school })
+      .where(schools: { id: id })
+      .where(classrooms_teachers: { role: ClassroomsTeacher::ROLE_TYPES[:owner] })
+      .distinct
   end
 
   def detach_from_existing_district_admins(district)

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -190,7 +190,7 @@ class School < ApplicationRecord
   end
 
   def students
-    User.joins(student_in_classroom: { teachers: :school }).where(schools: { id: id }).where(classrooms_teachers: {role: ClassroomsTeacher::ROLE_TYPES[:owner]}).distinct
+    User.joins(student_in_classroom: { teachers: :school }).where(schools: { id: id }).where(classrooms_teachers: {role: ClassroomsTeacher::ROLE_TYPES[:owner] }).distinct
   end
 
   def detach_from_existing_district_admins(district)

--- a/services/QuillLMS/app/models/school.rb
+++ b/services/QuillLMS/app/models/school.rb
@@ -190,7 +190,7 @@ class School < ApplicationRecord
   end
 
   def students
-    User.joins(student_in_classroom: { teachers: :school }).where(schools: { id: id }).where(classrooms_teachers: {role: ClassroomsTeacher::ROLE_TYPES[:owner] }).distinct
+    User.joins(student_in_classroom: { teachers: :school }).where(schools: { id: id }).where(classrooms_teachers: { role: ClassroomsTeacher::ROLE_TYPES[:owner] }).distinct
   end
 
   def detach_from_existing_district_admins(district)

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -220,7 +220,7 @@ describe VitallyIntegration::SerializeVitallySalesAccount do
     let!(:old_classroom_unit) { create(:classroom_unit, classroom: classroom) }
     let!(:classroom_teachers) do
       [
-        create(:classrooms_teacher, user: teacher, classroom: classroom),
+        create(:classrooms_teacher, user: teacher, classroom: classroom, role: 'owner'),
         create(:classrooms_teacher, user: teacher2, classroom: classroom, role: 'coteacher')
       ]
     end
@@ -275,6 +275,25 @@ describe VitallyIntegration::SerializeVitallySalesAccount do
       end
 
       it { expect(results[:traits][:active_students]).to eq(2) }
+    end
+
+    context 'when teachers are merely coteachers and not owners of the classroom' do
+
+      it 'does not double count activities finished and active students' do
+        classroom_teachers[0].update(role: 'coteacher')
+        classroom_teachers[1].update(role: 'coteacher')
+
+        expect(results[:traits]).to include(
+          active_students: 0,
+          active_students_this_year: 0,
+          total_students: 0,
+          total_students_this_year: 0,
+          activities_finished: 0,
+          activities_finished_this_year: 0,
+          activities_per_student: 0,
+          activities_per_student_this_year: 0
+        )
+      end
     end
   end
 

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -278,10 +278,9 @@ describe VitallyIntegration::SerializeVitallySalesAccount do
     end
 
     context 'when teachers are merely coteachers and not owners of the classroom' do
-      it 'does not double count activities finished and active students' do
-        classroom_teachers[0].update(role: 'coteacher')
-        classroom_teachers[1].update(role: 'coteacher')
+      let!(:classroom_teachers) { create_list(:classrooms_teacher, 2, classroom:, role: 'coteacher') }
 
+      it 'does not double count activities finished and active students' do
         expect(results[:traits]).to include(
           active_students: 0,
           active_students_this_year: 0,

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -278,7 +278,6 @@ describe VitallyIntegration::SerializeVitallySalesAccount do
     end
 
     context 'when teachers are merely coteachers and not owners of the classroom' do
-
       it 'does not double count activities finished and active students' do
         classroom_teachers[0].update(role: 'coteacher')
         classroom_teachers[1].update(role: 'coteacher')

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_organization_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_organization_spec.rb
@@ -406,9 +406,7 @@ describe VitallyIntegration::SerializeVitallySalesOrganization do
       end
 
       context 'excludes classrooms where teacher is coteacher' do
-        before do
-          classroom_teacher1.update(role: 'coteacher')
-        end
+        let!(:classroom_teacher1) { create(:classrooms_teacher, user: teacher1, classroom: classroom1, role: 'coteacher') }
 
         it 'activities completed all time' do
           expect(described_class.new(district).data[:traits][:activities_completed_all_time]).to eq(0)

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_organization_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_organization_spec.rb
@@ -13,7 +13,7 @@ describe VitallyIntegration::SerializeVitallySalesOrganization do
     let!(:school1) { create(:school, district: district) }
     let!(:teacher1) { create(:teacher, school: school1) }
     let!(:classroom1) { create(:classroom) }
-    let!(:classroom_teacher1) { create(:classrooms_teacher, user: teacher1, classroom: classroom1) }
+    let!(:classroom_teacher1) { create(:classrooms_teacher, user: teacher1, classroom: classroom1, role: 'owner') }
     let!(:student1) { create(:student, student_in_classroom: [classroom1]) }
     let!(:student2) { create(:student, student_in_classroom: [classroom1]) }
     let!(:diagnostic) { create(:diagnostic_activity) }
@@ -402,6 +402,24 @@ describe VitallyIntegration::SerializeVitallySalesOrganization do
 
         it 'active students all time' do
           expect(described_class.new(district).data[:traits][:active_students_all_time]).to eq(2)
+        end
+      end
+
+      context 'excludes classrooms where teacher is coteacher' do
+        before do
+          classroom_teacher1.update(role: 'coteacher')
+        end
+
+        it 'activities completed all time' do
+          expect(described_class.new(district).data[:traits][:activities_completed_all_time]).to eq(0)
+        end
+
+        it 'activities completed per student all time' do
+          expect(described_class.new(district).data[:traits][:activities_completed_per_student_all_time]).to eq(0)
+        end
+
+        it 'active students all time' do
+          expect(described_class.new(district).data[:traits][:active_students_all_time]).to eq(0)
         end
       end
     end


### PR DESCRIPTION
## WHAT
For schools and districts, we currently have a bug in the Vitally data aggregation. We're counting data twice when we have a classroom with multiple teachers because each teacher connected to the classroom gets aggregated into the query. To remedy this, we need to add a WHERE clause to filter for only classrooms where the teacher is the owner.

I also found this same bug in the Schools.students function, which I also fixed.

## WHY
We're currently double-counting some classrooms, which causes the Vitally numbers overall to be inflated for all schools and districts when it comes to activities and active students.

## HOW
Filter for classrooms where the teacher is the owner only.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Audit-Vitally-sync-calculations-to-make-sure-we-re-not-multi-counting-records-when-joining-on-classr-59019fb038a042a7b472c75dbfc564b1

### What have you done to QA this feature?
Deployed to staging, I also tested the queries generated by the new code in Metabase to ensure that the numbers returned by the new query match up to the number in the Usage Snapshots reports.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
