### PR TITLE
fix source map warnings

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/main.ts
+++ b/services/QuillLMS/client/app/bundles/Shared/quill-marking-logic/src/main.ts
@@ -7,7 +7,7 @@ export {checkFillInTheBlankQuestion} from './libs/graders/fill_in_the_blank'
 export {checkGrammarQuestion} from './libs/graders/grammar'
 export {focusPointMatchHelper} from './libs/matchers/focus_point_match'
 export {incorrectSequenceMatchHelper} from './libs/matchers/incorrect_sequence_match'
-import {Response,
+import type { Response,
   PartialResponse,
   ConceptResult,
   FocusPoint,

--- a/services/QuillLMS/package-lock.json
+++ b/services/QuillLMS/package-lock.json
@@ -20,7 +20,6 @@
         "postcss-scss": "^4.0.6",
         "puppeteer": "^19.5.2",
         "react-csv": "^1.1.2",
-        "rollup-plugin-friendly-type-imports": "^1.0.3",
         "sass": "^1.58.3",
         "ws": "^8.17.1"
       },
@@ -4499,14 +4498,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-friendly-type-imports": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-friendly-type-imports/-/rollup-plugin-friendly-type-imports-1.0.3.tgz",
-      "integrity": "sha512-1QTndk+2vkq0U+uizQersReRh/zyu5fgfE+NeCGxjBE9l89K2erVoAT3TbdGk12iK2QI7X6N+m6jYKqIaSWY9A==",
-      "dependencies": {
-        "typescript": "^4.5.5"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4702,18 +4693,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
@@ -7545,14 +7524,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "rollup-plugin-friendly-type-imports": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-friendly-type-imports/-/rollup-plugin-friendly-type-imports-1.0.3.tgz",
-      "integrity": "sha512-1QTndk+2vkq0U+uizQersReRh/zyu5fgfE+NeCGxjBE9l89K2erVoAT3TbdGk12iK2QI7X6N+m6jYKqIaSWY9A==",
-      "requires": {
-        "typescript": "^4.5.5"
-      }
-    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7688,11 +7659,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "unbzip2-stream": {
       "version": "1.4.3",

--- a/services/QuillLMS/package.json
+++ b/services/QuillLMS/package.json
@@ -50,7 +50,6 @@
     "postcss-scss": "^4.0.6",
     "puppeteer": "^19.5.2",
     "react-csv": "^1.1.2",
-    "rollup-plugin-friendly-type-imports": "^1.0.3",
     "sass": "^1.58.3",
     "ws": "^8.17.1"
   },

--- a/services/QuillLMS/vite.config.ts
+++ b/services/QuillLMS/vite.config.ts
@@ -3,7 +3,6 @@ import path, { resolve } from 'path';
 
 import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
 import replace from '@rollup/plugin-replace';
-import friendlyTypeImports from 'rollup-plugin-friendly-type-imports';
 import { defineConfig, loadEnv } from 'vite';
 import RubyPlugin from 'vite-plugin-ruby';
 
@@ -54,7 +53,6 @@ export default defineConfig(({command, mode}) => {
         'process.env.QUILL_CMS': JSON.stringify(quillCmsUrl)
       }),
       viteCommonjs(),
-      friendlyTypeImports(),
       RubyPlugin(),
     ],
     esbuild: {


### PR DESCRIPTION
## WHAT
- remove Rollup transformer  
- update TypeScript re-export statements with new syntax (which was previous patched by the transformer)

## WHY
- no longer needed, and removing the transformer reduces our Vite build warnings by half 

## HOW
- `rm` 

### Screenshots
These are the warnings that are removed from the build:

```
 [plugin reactpreview-fake-exported-types] Sourcemap is likely to be incorrect: a plugin (reactpreview-fake-exported-types) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
       [plugin reactpreview-fake-exported-types] Sourcemap is likely to be incorrect: a plugin (reactpreview-fake-exported-types) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
       [plugin reactpreview-fake-exported-types] Sourcemap is likely to be incorrect: a plugin (reactpreview-fake-exported-types) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
       [plugin reactpreview-fake-exported-types] Sourcemap is likely to be incorrect: a plugin (reactpreview-fake-exported-types) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin ...
```

### Notion Card Links
none

### What have you done to QA this feature?
- diagnostic report should render 
- login with Google
- complete Evidence question
- complete Connect queestion

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - config change only
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
