### PR TITLE
Student learning sequence enhancements

### DIFF
--- a/services/QuillLMS/app/models/classroom_unit.rb
+++ b/services/QuillLMS/app/models/classroom_unit.rb
@@ -151,7 +151,9 @@ class ClassroomUnit < ApplicationRecord
   end
 
   private def assign_student_learning_sequences
-    assigned_student_ids.each do |student_id|
+    old_ids, new_ids = saved_change_to_assigned_student_ids
+    newly_assigned = new_ids - old_ids
+    newly_assigned.each do |student_id|
       StudentLearningSequences::HandleAssignmentWorker.perform_async(id, student_id)
     end
   end

--- a/services/QuillLMS/app/models/student_learning_sequence.rb
+++ b/services/QuillLMS/app/models/student_learning_sequence.rb
@@ -11,6 +11,10 @@
 #  initial_classroom_unit_id :integer          not null
 #  user_id                   :integer          not null
 #
+# Indexes
+#
+#  idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e  (user_id,initial_activity_id,initial_classroom_unit_id) UNIQUE
+#
 class StudentLearningSequence < ApplicationRecord
   belongs_to :initial_activity, class_name: 'Activity'
   belongs_to :initial_classroom_unit, class_name: 'ClassroomUnit'

--- a/services/QuillLMS/app/models/student_learning_sequence_activity.rb
+++ b/services/QuillLMS/app/models/student_learning_sequence_activity.rb
@@ -13,6 +13,10 @@
 #  classroom_unit_id            :integer          not null
 #  student_learning_sequence_id :integer          not null
 #
+# Indexes
+#
+#  idx_on_student_learning_sequence_id_classroom_unit__84e420e79d  (student_learning_sequence_id,classroom_unit_id,activity_id) UNIQUE
+#
 class StudentLearningSequenceActivity < ApplicationRecord
   belongs_to :activity
   belongs_to :classroom_unit

--- a/services/QuillLMS/app/services/student_learning_sequences/handle_completion.rb
+++ b/services/QuillLMS/app/services/student_learning_sequences/handle_completion.rb
@@ -18,7 +18,7 @@ module StudentLearningSequences
     end
 
     private def activity = activity_session.activity
-    private def activity_session = @activity_session ||= ActivitySession.includes(:activity, :classroom_unit, :user).find(activity_session_id)
+    private def activity_session = @activity_session ||= ActivitySession.unscoped.includes(:activity, :classroom_unit, :user).find(activity_session_id)
     private def user = activity_session.user
     private def classroom_unit = activity_session.classroom_unit
     private def completed_at = activity_session.completed_at

--- a/services/QuillLMS/db/migrate/20240924151311_add_student_learning_sequence_indexes.rb
+++ b/services/QuillLMS/db/migrate/20240924151311_add_student_learning_sequence_indexes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddStudentLearningSequenceIndexes < ActiveRecord::Migration[7.1]
   def change
     add_index :student_learning_sequences, [:user_id, :initial_activity_id, :initial_classroom_unit_id], unique: true

--- a/services/QuillLMS/db/migrate/20240924151311_add_student_learning_sequence_indexes.rb
+++ b/services/QuillLMS/db/migrate/20240924151311_add_student_learning_sequence_indexes.rb
@@ -1,0 +1,5 @@
+class AddStudentLearningSequenceIndexes < ActiveRecord::Migration[7.1]
+  def change
+    add_index :student_learning_sequences, [:user_id, :initial_activity_id, :initial_classroom_unit_id], unique: true
+  end
+end

--- a/services/QuillLMS/db/migrate/20240924151321_add_student_learning_sequence_activity_indexes.rb
+++ b/services/QuillLMS/db/migrate/20240924151321_add_student_learning_sequence_activity_indexes.rb
@@ -1,0 +1,5 @@
+class AddStudentLearningSequenceActivityIndexes < ActiveRecord::Migration[7.1]
+  def change
+    add_index :student_learning_sequence_activities, [:student_learning_sequence_id, :classroom_unit_id, :activity_id], unique: true
+  end
+end

--- a/services/QuillLMS/db/migrate/20240924151321_add_student_learning_sequence_activity_indexes.rb
+++ b/services/QuillLMS/db/migrate/20240924151321_add_student_learning_sequence_activity_indexes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddStudentLearningSequenceActivityIndexes < ActiveRecord::Migration[7.1]
   def change
     add_index :student_learning_sequence_activities, [:student_learning_sequence_id, :classroom_unit_id, :activity_id], unique: true

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -145,7 +145,7 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
           item timestamp;
         BEGIN
           SELECT created_at INTO as_created_at FROM activity_sessions WHERE id = act_sess;
-
+          
           -- backward compatibility block
           IF as_created_at IS NULL OR as_created_at < timestamp '2013-08-25 00:00:00.000000' THEN
             SELECT SUM(
@@ -160,11 +160,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
                       'epoch' FROM (activity_sessions.completed_at - activity_sessions.started_at)
                     )
                 END) INTO time_spent FROM activity_sessions WHERE id = act_sess AND state='finished';
-
+                
                 RETURN COALESCE(time_spent,0);
           END IF;
-
-
+          
+          
           first_item := NULL;
           last_item := NULL;
           max_item := NULL;
@@ -188,11 +188,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
 
             END IF;
           END LOOP;
-
+          
           IF max_item IS NOT NULL AND first_item IS NOT NULL THEN
             time_spent := time_spent + EXTRACT( EPOCH FROM max_item - first_item );
           END IF;
-
+          
           RETURN time_spent;
         END;
       $$;
@@ -207,7 +207,7 @@ CREATE FUNCTION public.timespent_student(student integer) RETURNS bigint
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (
           SELECT id,timespent_activity_session(id) AS time_spent FROM activity_sessions
-          WHERE activity_sessions.user_id = student
+          WHERE activity_sessions.user_id = student 
           GROUP BY id) as as_ids;
 
       $$;
@@ -3069,38 +3069,6 @@ CREATE SEQUENCE public.evidence_research_gen_ai_comparisons_id_seq
 --
 
 ALTER SEQUENCE public.evidence_research_gen_ai_comparisons_id_seq OWNED BY public.evidence_research_gen_ai_comparisons.id;
-
-
---
--- Name: evidence_research_gen_ai_data_slices; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.evidence_research_gen_ai_data_slices (
-    id bigint NOT NULL,
-    parent_dataset_id integer NOT NULL,
-    child_dataset_id integer NOT NULL,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: evidence_research_gen_ai_data_slices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.evidence_research_gen_ai_data_slices_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: evidence_research_gen_ai_data_slices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.evidence_research_gen_ai_data_slices_id_seq OWNED BY public.evidence_research_gen_ai_data_slices.id;
 
 
 --
@@ -7080,13 +7048,6 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_comparisons ALTER COLUMN id SET
 
 
 --
--- Name: evidence_research_gen_ai_data_slices id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.evidence_research_gen_ai_data_slices ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_data_slices_id_seq'::regclass);
-
-
---
 -- Name: evidence_research_gen_ai_datasets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -8413,14 +8374,6 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_comparisons
 
 
 --
--- Name: evidence_research_gen_ai_data_slices evidence_research_gen_ai_data_slices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.evidence_research_gen_ai_data_slices
-    ADD CONSTRAINT evidence_research_gen_ai_data_slices_pkey PRIMARY KEY (id);
-
-
---
 -- Name: evidence_research_gen_ai_datasets evidence_research_gen_ai_datasets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9260,6 +9213,20 @@ CREATE INDEX email_idx ON public.users USING gin (email public.gin_trgm_ops);
 --
 
 CREATE UNIQUE INDEX feedback_history_ratings_uniqueness ON public.feedback_history_ratings USING btree (user_id, feedback_history_id);
+
+
+--
+-- Name: idx_on_student_learning_sequence_id_classroom_unit__84e420e79d; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_on_student_learning_sequence_id_classroom_unit__84e420e79d ON public.student_learning_sequence_activities USING btree (student_learning_sequence_id, classroom_unit_id, activity_id);
+
+
+--
+-- Name: idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e ON public.student_learning_sequences USING btree (user_id, initial_activity_id, initial_classroom_unit_id);
 
 
 --
@@ -11686,6 +11653,8 @@ ALTER TABLE ONLY public.learn_worlds_account_course_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240924151321'),
+('20240924151311'),
 ('20240918144926'),
 ('20240830183429'),
 ('20240830183419'),

--- a/services/QuillLMS/spec/models/classroom_unit_spec.rb
+++ b/services/QuillLMS/spec/models/classroom_unit_spec.rb
@@ -214,9 +214,6 @@ describe ClassroomUnit, type: :model, redis: true do
       let(:new_assigned_student_ids) { create_list(:student, 2, classrooms: [classroom]).pluck(:id) }
       let(:call_count) { new_assigned_student_ids.length }
 
-      # ClassroomUnit has validation on it that prevents students from being assigned if they don't have ClassroomsStudents records for the classroom
-      #before { new_assigned_student_ids.map { |student_id| create(:students_classrooms, classroom:, student_id:) } }
-
       it do
         expect(StudentLearningSequences::HandleAssignmentWorker).to receive(:perform_async).exactly(call_count).times
         subject

--- a/services/QuillLMS/spec/models/student_learning_sequence_activity_spec.rb
+++ b/services/QuillLMS/spec/models/student_learning_sequence_activity_spec.rb
@@ -13,6 +13,10 @@
 #  classroom_unit_id            :integer          not null
 #  student_learning_sequence_id :integer          not null
 #
+# Indexes
+#
+#  idx_on_student_learning_sequence_id_classroom_unit__84e420e79d  (student_learning_sequence_id,classroom_unit_id,activity_id) UNIQUE
+#
 require 'rails_helper'
 
 RSpec.describe StudentLearningSequenceActivity, type: :model do

--- a/services/QuillLMS/spec/models/student_learning_sequence_spec.rb
+++ b/services/QuillLMS/spec/models/student_learning_sequence_spec.rb
@@ -11,6 +11,10 @@
 #  initial_classroom_unit_id :integer          not null
 #  user_id                   :integer          not null
 #
+# Indexes
+#
+#  idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e  (user_id,initial_activity_id,initial_classroom_unit_id) UNIQUE
+#
 require 'rails_helper'
 
 RSpec.describe StudentLearningSequence, type: :model do


### PR DESCRIPTION
## WHAT
- Add `unscoped` to lookups of `ActivitySession`
- Tweak the callback that enqueues `HandleAssignmentWorker` jobs to only enqueue newly-assigned student_ids rather than all of them
- Add indexes to `student_learning_sequences` and `student_learning_sequence_activities`
## WHY
- Apparently `ActivitySession` records are occasionally created with `visible: false` which, in the default scope, can't be found by follow-up workers
- This should cut down on unnecessary job runs
- Speed up look-ups during assignment and completion workflows
## HOW
- Add `unscoped` to `ActivitySession.find`
- Compare the old array of `assigned_student_ids` to the new one, and only enqueue workers for new values in the array
- Create multi-column indexes for the two queries that are used to find existing records in the assignment and completion services

### What have you done to QA this feature?
- Assign new activity pack in staging
- Confirm new `StudentLearningSequence` and `StudentLearningSequenceActivity` records are created on assignment
- Complete activity as student
- Confirm that `StudentLearningSequenceActivity` is updated as expected

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes