### PR TITLE
Update new indexes not to be unique

### DIFF
--- a/services/QuillLMS/app/models/student_learning_sequence.rb
+++ b/services/QuillLMS/app/models/student_learning_sequence.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e  (user_id,initial_activity_id,initial_classroom_unit_id) UNIQUE
+#  idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e  (user_id,initial_activity_id,initial_classroom_unit_id)
 #
 class StudentLearningSequence < ApplicationRecord
   belongs_to :initial_activity, class_name: 'Activity'

--- a/services/QuillLMS/app/models/student_learning_sequence_activity.rb
+++ b/services/QuillLMS/app/models/student_learning_sequence_activity.rb
@@ -15,7 +15,8 @@
 #
 # Indexes
 #
-#  idx_on_student_learning_sequence_id_classroom_unit__84e420e79d  (student_learning_sequence_id,classroom_unit_id,activity_id) UNIQUE
+#  idx_on_classroom_unit_id_activity_id_e74613431d  (classroom_unit_id,activity_id)
+#  idx_on_student_learning_sequence_id_63827699e9   (student_learning_sequence_id)
 #
 class StudentLearningSequenceActivity < ApplicationRecord
   belongs_to :activity

--- a/services/QuillLMS/db/migrate/20240924151311_add_student_learning_sequence_indexes.rb
+++ b/services/QuillLMS/db/migrate/20240924151311_add_student_learning_sequence_indexes.rb
@@ -2,6 +2,6 @@
 
 class AddStudentLearningSequenceIndexes < ActiveRecord::Migration[7.1]
   def change
-    add_index :student_learning_sequences, [:user_id, :initial_activity_id, :initial_classroom_unit_id], unique: true
+    add_index :student_learning_sequences, [:user_id, :initial_activity_id, :initial_classroom_unit_id]
   end
 end

--- a/services/QuillLMS/db/migrate/20240924151321_add_student_learning_sequence_activity_indexes.rb
+++ b/services/QuillLMS/db/migrate/20240924151321_add_student_learning_sequence_activity_indexes.rb
@@ -2,6 +2,7 @@
 
 class AddStudentLearningSequenceActivityIndexes < ActiveRecord::Migration[7.1]
   def change
-    add_index :student_learning_sequence_activities, [:student_learning_sequence_id, :classroom_unit_id, :activity_id], unique: true
+    add_index :student_learning_sequence_activities, [:classroom_unit_id, :activity_id]
+    add_index :student_learning_sequence_activities, [:student_learning_sequence_id]
   end
 end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -9216,17 +9216,24 @@ CREATE UNIQUE INDEX feedback_history_ratings_uniqueness ON public.feedback_histo
 
 
 --
--- Name: idx_on_student_learning_sequence_id_classroom_unit__84e420e79d; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_on_classroom_unit_id_activity_id_e74613431d; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_on_student_learning_sequence_id_classroom_unit__84e420e79d ON public.student_learning_sequence_activities USING btree (student_learning_sequence_id, classroom_unit_id, activity_id);
+CREATE INDEX idx_on_classroom_unit_id_activity_id_e74613431d ON public.student_learning_sequence_activities USING btree (classroom_unit_id, activity_id);
+
+
+--
+-- Name: idx_on_student_learning_sequence_id_63827699e9; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_student_learning_sequence_id_63827699e9 ON public.student_learning_sequence_activities USING btree (student_learning_sequence_id);
 
 
 --
 -- Name: idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e ON public.student_learning_sequences USING btree (user_id, initial_activity_id, initial_classroom_unit_id);
+CREATE INDEX idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e ON public.student_learning_sequences USING btree (user_id, initial_activity_id, initial_classroom_unit_id);
 
 
 --

--- a/services/QuillLMS/spec/models/student_learning_sequence_activity_spec.rb
+++ b/services/QuillLMS/spec/models/student_learning_sequence_activity_spec.rb
@@ -15,7 +15,8 @@
 #
 # Indexes
 #
-#  idx_on_student_learning_sequence_id_classroom_unit__84e420e79d  (student_learning_sequence_id,classroom_unit_id,activity_id) UNIQUE
+#  idx_on_classroom_unit_id_activity_id_e74613431d  (classroom_unit_id,activity_id)
+#  idx_on_student_learning_sequence_id_63827699e9   (student_learning_sequence_id)
 #
 require 'rails_helper'
 

--- a/services/QuillLMS/spec/models/student_learning_sequence_spec.rb
+++ b/services/QuillLMS/spec/models/student_learning_sequence_spec.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e  (user_id,initial_activity_id,initial_classroom_unit_id) UNIQUE
+#  idx_on_user_id_initial_activity_id_initial_classroo_868ab8c89e  (user_id,initial_activity_id,initial_classroom_unit_id)
 #
 require 'rails_helper'
 


### PR DESCRIPTION

## WHAT
- Update new indexes not to be unique
- Split one of the indexes
## WHY
There are examples in production where there are duplicate records, which we'll need to clean up later
## HOW
- Remove `unique` from definition
- Pull a column out of one of the combo-indexes and put it in its own index because we may do separate lookups on that value

### What have you done to QA this feature?
- Assign activity to student
- Confirm new records are created
- Complete activity as student
- Confirm records are updated

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No behavior change
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes