### PR TITLE
Fix dataset validation flow when save fails

### DIFF
--- a/services/QuillLMS/config/environments/test.rb
+++ b/services/QuillLMS/config/environments/test.rb
@@ -39,7 +39,6 @@ EmpiricalGrammar::Application.configure do
   config.action_mailer.default_url_options = { :host => 'test.yourhost.com' }
 
   config.log_level = :debug
-  config.logger = Logger.new($stdout)
 
   # Used for zeitwerk
   config.eager_load = ENV['CI'].present?

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/datasets_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/research/gen_ai/datasets_controller.rb
@@ -26,11 +26,11 @@ module Evidence
         private def stem_vault = @stem_vault ||= StemVault.find(params[:stem_vault_id])
 
         private def create_dataset_from_file
-          dataset = stem_vault.datasets.new
+          @dataset = stem_vault.datasets.new(dataset_params)
 
-          if dataset.save
-            DatasetImporter.run(dataset:, file:)
-            redirect_to dataset
+          if @dataset.save
+            DatasetImporter.run(dataset: @dataset, file:)
+            redirect_to @dataset
           else
             render :new
           end

--- a/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_validator.rb
+++ b/services/QuillLMS/engines/evidence/app/services/evidence/research/gen_ai/dataset_validator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 module Evidence
   module Research
     module GenAI
@@ -40,7 +42,7 @@ module Evidence
           end
         end
 
-        private def csv = @csv ||= CSV.parse(file.read, headers: true)
+        private def csv = @csv ||= ::CSV.parse(file.read, headers: true)
 
         private def headers_error = format(MISSING_HEADERS_ERROR, missing_headers.join(', '))
 

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/datasets_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/research/gen_ai/datasets_controller_spec.rb
@@ -30,7 +30,7 @@ module Evidence
           end
 
           context 'with file upload' do
-            let(:file) { fixture_file_upload('test.csv', 'text/csv') }
+            let(:file) { fixture_file_upload('evidence/research/gen_ai/dataset.csv', 'text/csv') }
             let(:attributes) { { research_gen_ai_dataset: { file: } } }
 
             it { expect { subject }.to change(Evidence::Research::GenAI::Dataset, :count).by(1) }

--- a/services/QuillLMS/engines/evidence/spec/fixtures/files/evidence/research/gen_ai/dataset.csv
+++ b/services/QuillLMS/engines/evidence/spec/fixtures/files/evidence/research/gen_ai/dataset.csv
@@ -1,0 +1,2 @@
+Student Response,Data Partition,Curriculum Assigned Optimal Status,Curriculum Proposed Feedback,Optional - Curriculum Label,Optional - Highlight,Optional - AutoML Label,Optional - AutoML Primary Feedback,Optional - AutoML Secondary Feedback
+response,test,optimal,good work


### PR DESCRIPTION
## WHAT
Fix a bug with dataset validation flow

## WHY
Errors are not being reported properly when dataset validation fails.

## HOW
Use instance variable so that the @dataset is available when re-rendering :new.  

### Screenshots
![image](https://github.com/user-attachments/assets/76636867-a1f7-4ed9-90a6-8bbe7e7d0600)


### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I have tested on staging the invalid dataset file returns the correct error (see screenshot)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
