### PR TITLE
Translations/ blacklist Grammar activities with randomized questions

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/utils/languageList.js
+++ b/services/QuillLMS/client/app/bundles/Shared/utils/languageList.js
@@ -168,5 +168,10 @@ export const ALPHA_TRANSLATED_ACTIVITY_UIDS = [
   "e2c285fd-b973-4d52-a2b3-0cb73b3b6391",
   "4f17260c-c793-4443-8902-0a5f81b92116",
   "7d363347-6ad3-4476-b124-6d0e08182cc8",
-  "54c91530-d44a-4a9a-8ce9-af9c6680fd60"
+  "54c91530-d44a-4a9a-8ce9-af9c6680fd60",
+  // randomized question activities
+  "-KybO7eiRjMiMYYowjtR",
+  "z8WSMBEV9uBRodWd_t-RNA",
+  "-KybNc1Xkj1Yz59OoNaA",
+  "-L0udJg9M0ETmF6k0zJ6"
 ]


### PR DESCRIPTION
## WHAT
blacklist Grammar activities with randomized questions for translation

## WHY
the API doesn't currently account for these types of activities (translation data is always returned as an empty object since questions are fetched for the activity in a different way than standard activities)

## HOW
add UIDs to the alpha translation list

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Feedback-and-instructions-not-translating-for-randomized-grammar-activities-10ad42e6f941804f8a9fdacc2cfeb883?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
tested on staging that translations for these activities are restricted

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
