### PR TITLE
Bug fix/ Grammar CMS test question play

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/testQuestion.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/testQuestion.tsx
@@ -73,8 +73,8 @@ class TestQuestion extends React.Component {
             checkAnswer={this.checkAnswer}
             concepts={this.props.concepts}
             conceptsFeedback={this.props.conceptsFeedback}
-            question={currentQuestion}
             goToNextQuestion={this.reset}
+            question={currentQuestion}
             unansweredQuestions={unansweredQuestions}
           />
         </div>

--- a/services/QuillLMS/client/app/bundles/Grammar/components/questions/testQuestion.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/questions/testQuestion.tsx
@@ -73,7 +73,7 @@ class TestQuestion extends React.Component {
             checkAnswer={this.checkAnswer}
             concepts={this.props.concepts}
             conceptsFeedback={this.props.conceptsFeedback}
-            currentQuestion={currentQuestion}
+            question={currentQuestion}
             goToNextQuestion={this.reset}
             unansweredQuestions={unansweredQuestions}
           />


### PR DESCRIPTION
## WHAT
fix issue preventing test question play in Grammar CMS

## WHY
Curriculum needs this for testing

## HOW
just update a missing prop

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Can-t-play-Grammar-questions-in-CMS-10cd42e6f941804f8b20fdad591e6b64?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
verified on staging that test questions can be played

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
