### PR TITLE
Style, copy and UI updates to Premium Page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_features_table.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_features_table.scss
@@ -3,25 +3,37 @@
   border: solid 1px $quill-grey-5;
   padding: 0px;
   width: 950px;
+  position: relative;
+  top: 150px;
   .header-row {
     padding: 32px 16px 8px;
     line-height: 1.38;
     color: #262626;
     text-align: left;
+    border-left: 1px solid $quill-grey-5;
+    border-right: 1px solid $quill-grey-5;
+    border-top: 1px solid $quill-grey-5;
     h4 {
       font-size: 16px;
       font-weight: 600;
       line-height: 1.38;
       color: #262626;
     }
-    &:not(:first-of-type) {
-      border-top: 1px solid $quill-grey-5;
-    }
+  }
+  .header-row:first-of-type {
+    border-top-left-radius: 5px;
   }
   .premium-features-table-row {
     border-top: 1px solid $quill-grey-5;
+    border-left: 1px solid $quill-grey-5;
+    border-right: 1px solid $quill-grey-5;
     display: flex;
     position: relative;
+  }
+  .premium-features-table-row:last-of-type {
+    border-bottom: 1px solid $quill-grey-5;
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
   }
   .label-and-tooltip {
     display: flex;

--- a/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/premium_page.scss
@@ -204,6 +204,7 @@ li.premium-tab > a:hover {
     width: 100%;
     display: inline-block;
     position: relative;
+    top: -80px;
     .header {
       margin: auto;
       max-width: 656px;
@@ -222,26 +223,41 @@ li.premium-tab > a:hover {
   }
 
   .choose-plan {
-    margin-right: 17px;
-    top: 75px;
+    margin-right: 2px;
     left: 0px;
     position: relative;
     z-index: 4;
     max-width: 360px;
+    padding-top: 20px;
     padding-right: 8px;
     display: inline-block;
     border-radius: 8px;
     justify-content: center;
     flex-direction: column;
     text-align: left;
+    background-color: white;
+    height: 350px;
     h2 {
       font-weight: bold;
       line-height: 38px;
+      font-size: 22px;
+      line-height: 28.69px;
+      width: 320px;
+      color: $quill-black;
+      margin-bottom: 0px;
     }
     p {
-      font-size: 16px;
       line-height: 22px;
-      margin-top: 8px;
+      margin-top: 12px;
+    }
+    .premium-description {
+      font-weight: 400;
+      font-size: 14px;
+      line-height: 22px;
+      color: #262626;
+      ul {
+        margin-top: 12px;
+      }
     }
   }
   .school-premium-badge-container {
@@ -272,11 +288,11 @@ li.premium-tab > a:hover {
     border-bottom: none;
     display: flex;
     border-radius: 8px 8px 0px 0px;
+    height: 350px;
   }
   .pricing-mini {
     background-color: white;
     border-radius: 8px;
-    border-bottom: 1px solid $quill-grey-5;
   }
   .premium-button-container {
     display: flex;
@@ -294,6 +310,24 @@ li.premium-tab > a:hover {
       line-height: 20px;
       color: $quill-grey-50;
       margin-top: 4px;
+    }
+    a:link {
+      text-decoration: none;
+    }
+    a:visited {
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: none;
+    }
+    a:active {
+      text-decoration: none;
+    }
+    a {
+      width: 100%;
+    }
+    .book-call {
+      margin-bottom: 14px;
     }
   }
   .promo-tab {
@@ -319,8 +353,8 @@ li.premium-tab > a:hover {
   }
   h2 {
     font-size: 20px;
-    height: 52px;
-    margin: 0 0 24px;
+    height: 42px;
+    margin: 0px;
     font-weight: bold;
     display: flex;
     align-items: flex-end;
@@ -336,15 +370,14 @@ li.premium-tab > a:hover {
       font-weight: 600;
     }
     .premium-rates {
-      min-height: 90px;
       h3 {
-        margin: 24px 0 8px;
+        margin: 16px 0 0px;
         font-size: 24px;
         line-height: 1.27;
         color: #262626;
       }
       p {
-        margin: 8px 0 24px;
+        margin: 0px 0 16px;
         line-height: 1.43;
         color: $quill-grey-50;
       }
@@ -582,6 +615,21 @@ li.premium-tab > a:hover {
 @media (min-width: 992px) {
   .premium-page {
 
+    .sticky-header {
+      position: sticky;
+      top: -150px;
+      z-index: 4;
+      margin-left: -15px;
+    }
+
+    .sticky-header-background-container {
+      background-color: white;
+      position: relative;
+      top: 150px;
+      padding: 0px;
+      margin: 0px;
+    }
+
     .overview {
       height: min-content;
       width: 950px;
@@ -602,13 +650,13 @@ li.premium-tab > a:hover {
 
     .pricing-minis-container {
       display: inline-flex;
-      position: sticky;
       top: -7px;
       flex-direction: column;
       height: 375px;
       width: 572px;
       align-items: flex-end;
       z-index: 4;
+      float: right;
       &::after, &:after {
         content: '';
         width: 572px;
@@ -702,15 +750,22 @@ li.premium-tab > a:hover {
       margin-bottom: 80px;
     }
 
+    .sticky-header {
+      position: relative;
+      margin-top: 120px;
+      margin-bottom: 40px;
+    }
+
     .choose-plan {
       text-align: center;
       width: 290px;
       margin: 0 auto;
+      background-color: white;
+      height: 375px;
     }
 
     .pricing-minis-container {
       width: 100%;
-      margin-top: 125px;
     }
 
     .pricing-minis {
@@ -719,6 +774,7 @@ li.premium-tab > a:hover {
       border: none;
       align-items: center;
       border: none;
+      height: fit-content;
     }
 
     .pricing-mini {

--- a/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
+++ b/services/QuillLMS/app/views/pages/shared/_premium_main.html.erb
@@ -12,7 +12,6 @@ document.addEventListener('click', function(e) {
 <span id='user-logged-in' data-signed-in= <%= !!current_user%>>
 
 <div class="premium-pricing-guide-page white-background-accommodate-footer" id="first-preview-section">
-  <div class="navbar-divider-bar gold"></div>
   <%= react_component('PremiumPricingGuideApp', props: {
       associatedSchools: @associated_schools,
       eligibleSchools: @eligible_schools,

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/__tests__/__snapshots__/school_and_district_premium_modal.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/__tests__/__snapshots__/school_and_district_premium_modal.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
             Per school, per year
           </p>
           <p>
-            Complete the quote request form to receive a quote via email.
+            Complete the form to connect with a Partnerships Specialist.
           </p>
         </div>
         <a
@@ -210,7 +210,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
             Per school, per year
           </p>
           <p>
-            Complete the quote request form to receive a quote via email.
+            Complete the form to connect with a Partnerships Specialist.
           </p>
         </div>
         <a
@@ -336,7 +336,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage one when th
             Per school, per year
           </p>
           <p>
-            Complete the quote request form to receive a quote via email.
+            Complete the form to connect with a Partnerships Specialist.
           </p>
         </div>
         <a
@@ -467,7 +467,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
             Per school, per year
           </p>
           <p>
-            Complete the quote request form to receive a quote via email.
+            Complete the form to connect with a Partnerships Specialist.
           </p>
         </div>
         <a
@@ -587,7 +587,7 @@ exports[`SchoolAndDistrictPremiumModal component should render stage two when th
             Per school, per year
           </p>
           <p>
-            Complete the quote request form to receive a quote via email.
+            Complete the form to connect with a Partnerships Specialist.
           </p>
         </div>
         <a

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/basic_pricing_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/basic_pricing_mini.jsx
@@ -5,7 +5,7 @@ import IndividualFeaturesTable from './individual_features_table';
 const getStartedButton = (userIsSignedIn) => {
   if (userIsSignedIn) { return }
 
-  return <a className='quill-button-archived medium secondary outlined focus-on-light' href="/account/new">Get started</a>
+  return <a className='quill-button-archived contained medium primary focus-on-light' href="/account/new">Get started</a>
 }
 
 const BasicPricingMini = ({ userIsSignedIn, premiumFeatureData, }) => (

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
@@ -14,6 +14,14 @@ const SchoolPricingMini = ({ plan, premiumFeatureData, showBadges, handleClickPu
         <p>Per school, per year</p>
       </div>
       <div className="premium-button-container">
+        <a href="https://quill.org/request_quote" target="_blank">
+          <button
+            className="quill-button-archived contained medium primary focus-on-light book-call"
+            type="button"
+          >
+            Book a call
+          </button>
+        </a>
         <button
           className="quill-button-archived contained medium primary focus-on-light"
           href="https://quill.org/request_quote"
@@ -24,11 +32,6 @@ const SchoolPricingMini = ({ plan, premiumFeatureData, showBadges, handleClickPu
         </button>
         <p>Request Quote or Buy Now</p>
       </div>
-      {showBadges && <div className="school-premium-badge-container">
-        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Quill Academy</div>
-        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Premium Hub</div>
-        <div className="school-premium-badge"><img alt="Check icon" src={greenCheckSrc} /> Custom reports</div>
-      </div>}
     </section>
     <IndividualFeaturesTable premiumFeatureData={premiumFeatureData} type="school" />
   </div>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_minis/school_pricing_mini.jsx
@@ -14,7 +14,7 @@ const SchoolPricingMini = ({ plan, premiumFeatureData, showBadges, handleClickPu
         <p>Per school, per year</p>
       </div>
       <div className="premium-button-container">
-        <a href="https://quill.org/request_quote" target="_blank">
+        <a href="https://quill.org/request_quote" rel="noopener noreferrer" target="_blank">
           <button
             className="quill-button-archived contained medium primary focus-on-light book-call"
             type="button"

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
@@ -12,22 +12,8 @@ export default class PremiumPricingMinisRow extends React.Component {
   state = {
     subscriptionType: null,
     subscriptionStatus: null,
-    userIsSignedIn: !!Number(document.getElementById('current-user-id').getAttribute('content')),
-    isScrolled: false
+    userIsSignedIn: !!Number(document.getElementById('current-user-id').getAttribute('content'))
   };
-
-  componentDidMount() {
-    window.addEventListener('scroll', this.listenScrollEvent)
-  }
-
-  listenScrollEvent = e => {
-    const { isScrolled, } = this.state
-    if (window.scrollY > VERTICAL_INTERSECTION_OF_PREMIUM_PRICING_ROW_AND_TABLE && !isScrolled && window.innerWidth > MOBILE_WIDTH) {
-      this.setState({isScrolled: true})
-    } else if (window.scrollY < VERTICAL_INTERSECTION_OF_PREMIUM_PRICING_ROW_AND_TABLE && isScrolled) {
-      this.setState({isScrolled: false})
-    }
-  }
 
   render() {
     const {
@@ -40,7 +26,7 @@ export default class PremiumPricingMinisRow extends React.Component {
       onClickPurchasingOptions,
     } = this.props
 
-    const { userIsSignedIn, isScrolled, } = this.state
+    const { userIsSignedIn } = this.state
 
     const premiumFeatureData = premiumFeatures({
       diagnosticActivityCount,
@@ -50,27 +36,38 @@ export default class PremiumPricingMinisRow extends React.Component {
 
     return (
       <React.Fragment>
-        <div className="choose-plan">
-          <h2>Choose the plan that&apos;s right for you</h2>
-          <p>As a nonprofit dedicated to helping students, Quill will always provide 100% of our activities for free.</p>
-        </div>
-        <div className="pricing-minis-container">
-          <div className="pricing-minis">
-            <BasicPricingMini
-              premiumFeatureData={premiumFeatureData}
-              userIsSignedIn={userIsSignedIn}
-            />
-            <TeacherPricingMini
-              buyNowButton={teacherBuyNowButton}
-              plan={stripeTeacherPlan.plan}
-              premiumFeatureData={premiumFeatureData}
-            />
-            <SchoolPricingMini
-              handleClickPurchasingOptions={onClickPurchasingOptions}
-              plan={stripeSchoolPlan.plan}
-              premiumFeatureData={premiumFeatureData}
-              showBadges={!isScrolled}
-            />
+        <div className="sticky-header">
+          <div className="sticky-header-background-container">
+            <div className="choose-plan">
+              <h2>Go Premium to improve student writing</h2>
+              <div className="premium-description">
+                <p>As a nonprofit, Quill provides all activities for free, forever.</p>
+                <p>Quill Premium provides schools and districts with:</p>
+                <ul>
+                  <li>Advanced reporting</li>
+                  <li>Professional learning</li>
+                  <li>Priority tech support</li>
+                </ul>
+              </div>
+            </div>
+            <div className="pricing-minis-container">
+              <div className="pricing-minis">
+                <BasicPricingMini
+                  premiumFeatureData={premiumFeatureData}
+                  userIsSignedIn={userIsSignedIn}
+                />
+                <TeacherPricingMini
+                  buyNowButton={teacherBuyNowButton}
+                  plan={stripeTeacherPlan.plan}
+                  premiumFeatureData={premiumFeatureData}
+                />
+                <SchoolPricingMini
+                  handleClickPurchasingOptions={onClickPurchasingOptions}
+                  plan={stripeSchoolPlan.plan}
+                  premiumFeatureData={premiumFeatureData}
+                />
+              </div>
+            </div>
           </div>
         </div>
       </React.Fragment>

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/premium_pricing_minis_row.jsx
@@ -35,42 +35,40 @@ export default class PremiumPricingMinisRow extends React.Component {
     })
 
     return (
-      <React.Fragment>
-        <div className="sticky-header">
-          <div className="sticky-header-background-container">
-            <div className="choose-plan">
-              <h2>Go Premium to improve student writing</h2>
-              <div className="premium-description">
-                <p>As a nonprofit, Quill provides all activities for free, forever.</p>
-                <p>Quill Premium provides schools and districts with:</p>
-                <ul>
-                  <li>Advanced reporting</li>
-                  <li>Professional learning</li>
-                  <li>Priority tech support</li>
-                </ul>
-              </div>
+      <div className="sticky-header">
+        <div className="sticky-header-background-container">
+          <div className="choose-plan">
+            <h2>Go Premium to improve student writing</h2>
+            <div className="premium-description">
+              <p>As a nonprofit, Quill provides all activities for free, forever.</p>
+              <p>Quill Premium provides schools and districts with:</p>
+              <ul>
+                <li>Advanced reporting</li>
+                <li>Professional learning</li>
+                <li>Priority tech support</li>
+              </ul>
             </div>
-            <div className="pricing-minis-container">
-              <div className="pricing-minis">
-                <BasicPricingMini
-                  premiumFeatureData={premiumFeatureData}
-                  userIsSignedIn={userIsSignedIn}
-                />
-                <TeacherPricingMini
-                  buyNowButton={teacherBuyNowButton}
-                  plan={stripeTeacherPlan.plan}
-                  premiumFeatureData={premiumFeatureData}
-                />
-                <SchoolPricingMini
-                  handleClickPurchasingOptions={onClickPurchasingOptions}
-                  plan={stripeSchoolPlan.plan}
-                  premiumFeatureData={premiumFeatureData}
-                />
-              </div>
+          </div>
+          <div className="pricing-minis-container">
+            <div className="pricing-minis">
+              <BasicPricingMini
+                premiumFeatureData={premiumFeatureData}
+                userIsSignedIn={userIsSignedIn}
+              />
+              <TeacherPricingMini
+                buyNowButton={teacherBuyNowButton}
+                plan={stripeTeacherPlan.plan}
+                premiumFeatureData={premiumFeatureData}
+              />
+              <SchoolPricingMini
+                handleClickPurchasingOptions={onClickPurchasingOptions}
+                plan={stripeSchoolPlan.plan}
+                premiumFeatureData={premiumFeatureData}
+              />
             </div>
           </div>
         </div>
-      </React.Fragment>
+      </div>
     );
   }
 }

--- a/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_and_district_premium_modal.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/premium/school_and_district_premium_modal.tsx
@@ -151,7 +151,7 @@ const SchoolAndDistrictPremiumModal = ({ stripeSchoolPlan, eligibleSchools, hand
             <div className="premium-rates">
               <h3>${stripeSchoolPlan.plan.price_in_dollars}</h3>
               <p>Per school, per year</p>
-              <p>Complete the quote request form to receive a quote via email.</p>
+              <p>Complete the form to connect with a Partnerships Specialist.</p>
             </div>
             {requestSchoolQuoteButton}
           </div>


### PR DESCRIPTION
## WHAT
Change the copy, styling and some of the UI on the Premium page.

## WHY
We want this page to contain up-to-date information regarding Premium and be easy to read.

## HOW
Update some of the information, remove some outdated information and change some wording.
Make the left side of the page sticky to the top as the user scrolls, instead of just the right side with the three premium options.
Update some of the styling, spacing and border UI to reflect our new design file.

### Screenshots
![Screenshot 2024-09-27 at 6 10 26 PM](https://github.com/user-attachments/assets/96492a9f-1bd1-40b8-aa9b-69b758fc470d)
![Screenshot 2024-09-27 at 6 10 16 PM](https://github.com/user-attachments/assets/fa87eaaa-3541-4ac8-abad-fd9192c026f0)
![Screenshot 2024-09-27 at 6 11 38 PM](https://github.com/user-attachments/assets/49d84600-d844-4a65-b8bb-922c72485ae1)


### Notion Card Links
https://www.notion.so/quill/Schools-Districts-Project-Updates-to-Premium-Pricing-Page-Better-Messaging-around-Premium-Benef-5837806eb40e4830818e7908731ed953?pvs=4

### What have you done to QA this feature?
Deploy to staging and test scrolling on both Desktop and Mobile formats. Also asked Jack to do a review with me to confirm the styling changes.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
