### PR TITLE
Teacher reports/ convert names to clickable chips for Diagnostic student responses

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/data_table.scss
@@ -113,6 +113,19 @@ table.data-table {
         display: inline-block;
       }
     }
+    .student-responses-link {
+      text-decoration: none;
+      &:focus {
+        .data-table-chip {
+          outline: dashed 2px #06806B;
+          outline-offset: 2px;
+          text-decoration: inherit;
+        }
+      }
+      .data-table-chip {
+        margin: 4px;
+      }
+    }
     td {
       .aggregate-row-icon, .aggregate-row-toggle {
         margin-left: 4px;
@@ -126,6 +139,42 @@ table.data-table {
         min-height: 48px;
         display: flex;
         align-items: center;
+      }
+      .data-table-chip {
+        display: flex;
+        align-items: center;
+        border-radius: 4px;
+        padding: 4px 8px 4px 6px;
+        background-color: $quill-green-1;
+        border: 1px solid $quill-green-20;
+        width: min-content;
+        max-width: 100%;
+
+        &:focus {
+          outline-offset: 3px;
+        }
+
+        &:not(.grey):hover {
+          background-color: $quill-green-5;
+        }
+
+        &.grey {
+          background-color: $quill-grey-1;
+          border: 1px solid $quill-grey-15;
+
+          p {
+            color: $quill-grey-90;
+          }
+        }
+
+        p {
+          @include display-xs;
+          color: $quill-green;
+          margin-left: 4px;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          overflow: hidden;
+        }
       }
     }
     &:hover {

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResponsesIndex.test.jsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/__snapshots__/studentResponsesIndex.test.jsx.snap
@@ -1,262 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StudentResponsesIndex component should render when there is no student data 1`] = `
-<BrowserRouter>
-  <Router
-    history={
-      Object {
-        "action": "POP",
-        "block": [Function],
-        "createHref": [Function],
-        "go": [Function],
-        "goBack": [Function],
-        "goForward": [Function],
-        "length": 1,
-        "listen": [Function],
-        "location": Object {
-          "hash": "",
-          "pathname": "/",
-          "search": "",
-          "state": undefined,
-        },
-        "push": [Function],
-        "replace": [Function],
-      }
-    }
+<DocumentFragment>
+  <div
+    class="spinner-container"
   >
-    <StudentResponsesIndex
-      location={
-        Object {
-          "search": "",
-        }
-      }
-      match={
-        Object {
-          "params": Object {
-            "activityId": 0,
-            "classroomId": 6,
-          },
-        }
-      }
-      mobileNavigation={<span />}
-      passedStudents={
-        Array [
-          Object {
-            "name": "Paulo Azevedo",
-          },
-          Object {
-            "name": "Rual Guzman",
-          },
-          Object {
-            "name": "Jacob De Haas",
-          },
-          Object {
-            "name": "Grace Hatton",
-          },
-          Object {
-            "name": "Mary Masters",
-          },
-        ]
-      }
-    >
-      <_default>
-        <div
-          className="spinner-container"
-        >
-          <img
-            alt=""
-            className="spinner"
-            src="/images/loader_still.svg"
-          />
-        </div>
-      </_default>
-    </StudentResponsesIndex>
-  </Router>
-</BrowserRouter>
+    <img
+      alt=""
+      class="spinner"
+      src="/images/loader_still.svg"
+    />
+  </div>
+</DocumentFragment>
 `;
 
 exports[`StudentResponsesIndex component should render when there is student data 1`] = `
-<BrowserRouter>
-  <Router
-    history={
-      Object {
-        "action": "POP",
-        "block": [Function],
-        "createHref": [Function],
-        "go": [Function],
-        "goBack": [Function],
-        "goForward": [Function],
-        "length": 1,
-        "listen": [Function],
-        "location": Object {
-          "hash": "",
-          "pathname": "/",
-          "search": "",
-          "state": undefined,
-        },
-        "push": [Function],
-        "replace": [Function],
-      }
-    }
+<DocumentFragment>
+  <div
+    class="spinner-container"
   >
-    <StudentResponsesIndex
-      location={
-        Object {
-          "search": "",
-        }
-      }
-      match={
-        Object {
-          "params": Object {
-            "activityId": 0,
-            "classroomId": 6,
-          },
-        }
-      }
-      mobileNavigation={<span />}
-      passedStudents={
-        Array [
-          Object {
-            "id": 11115764,
-            "name": "Ja'shonda Abbott",
-            "proficiency": "Proficient",
-            "score": 80,
-          },
-          Object {
-            "id": 11115797,
-            "name": "Paulo Azevedo",
-            "proficiency": "Not yet proficient",
-            "score": 14,
-          },
-          Object {
-            "id": 11115765,
-            "name": "Charlotte Bronte",
-            "proficiency": "Proficient",
-            "score": 100,
-          },
-          Object {
-            "id": 11115774,
-            "name": "Edgar Burroughs",
-            "proficiency": "Proficient",
-            "score": 85,
-          },
-          Object {
-            "id": 11115787,
-            "name": "Kaylesh Chaganlal",
-            "proficiency": "Not yet proficient",
-            "score": 0,
-          },
-          Object {
-            "id": 11115791,
-            "name": "Justin Cole",
-            "proficiency": "Proficient",
-            "score": 95,
-          },
-          Object {
-            "id": 11115784,
-            "name": "Victoria De",
-            "proficiency": "Not yet proficient",
-            "score": 38,
-          },
-          Object {
-            "id": 11115786,
-            "name": "Vishal Dewan",
-            "proficiency": "Not yet proficient",
-            "score": 42,
-          },
-          Object {
-            "name": "Joan Didion",
-          },
-          Object {
-            "id": 11115769,
-            "name": "John Donne",
-            "proficiency": "Nearly proficient",
-            "score": 66,
-          },
-          Object {
-            "name": "Gabriel De La Concordia Garcia",
-          },
-          Object {
-            "name": "Jacob De Haas",
-          },
-          Object {
-            "id": 11115796,
-            "name": "Grace Hatton",
-            "proficiency": "Not yet proficient",
-            "score": 0,
-          },
-          Object {
-            "name": "Tymon Jabłoński",
-          },
-          Object {
-            "name": "Dehab Lee Kassis-washington",
-          },
-          Object {
-            "id": 11115782,
-            "name": "Rudyard Kipling",
-            "proficiency": "Not yet proficient",
-            "score": 38,
-          },
-          Object {
-            "name": "Leone Lafontaine",
-          },
-          Object {
-            "name": "Henry Wadsworth Longfellow",
-          },
-          Object {
-            "name": "Hilary Mantel",
-          },
-          Object {
-            "name": "Daphne Maurier",
-          },
-          Object {
-            "name": "Stephanie Montgomery",
-          },
-          Object {
-            "name": "George Nichols",
-          },
-          Object {
-            "name": "Joyce Oates",
-          },
-          Object {
-            "name": "Banjo Paterson",
-          },
-          Object {
-            "name": "Sarah Pennington",
-          },
-          Object {
-            "name": "Annie Proulx",
-          },
-          Object {
-            "name": "Sarah Scott",
-          },
-          Object {
-            "name": "Zadie Smith",
-          },
-          Object {
-            "name": "Rabindranath Tagore",
-          },
-          Object {
-            "name": "Judy Heier-hammond Name Keeps Going For A Long Long Tim",
-          },
-          Object {
-            "name": "Virginia Walker",
-          },
-        ]
-      }
-    >
-      <_default>
-        <div
-          className="spinner-container"
-        >
-          <img
-            alt=""
-            className="spinner"
-            src="/images/loader_still.svg"
-          />
-        </div>
-      </_default>
-    </StudentResponsesIndex>
-  </Router>
-</BrowserRouter>
+    <img
+      alt=""
+      class="spinner"
+      src="/images/loader_still.svg"
+    />
+  </div>
+</DocumentFragment>
 `;

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/studentResponsesIndex.test.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/__tests__/studentResponsesIndex.test.jsx
@@ -1,5 +1,5 @@
-import { mount } from 'enzyme';
 import React from 'react';
+import { render } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import {
@@ -13,7 +13,7 @@ import { StudentResponsesIndex, } from '../studentResponsesIndex';
 
 describe('StudentResponsesIndex component', () => {
   it('should render when there is no student data', () => {
-    const wrapper = mount(<Router>
+    const { asFragment } = render(<Router>
       <StudentResponsesIndex
         location={dummyLocationData}
         match={dummyMatchData}
@@ -21,11 +21,11 @@ describe('StudentResponsesIndex component', () => {
         passedStudents={passedStudentsWithNoStudentData}
       />
     </Router>)
-    expect(wrapper).toMatchSnapshot()
+    expect(asFragment()).toMatchSnapshot();
   })
 
   it('should render when there is student data', () => {
-    const wrapper = mount(<Router>
+    const { asFragment } = render(<Router>
       <StudentResponsesIndex
         location={dummyLocationData}
         match={dummyMatchData}
@@ -33,6 +33,6 @@ describe('StudentResponsesIndex component', () => {
         passedStudents={passedStudentsWithStudentData}
       />
     </Router>)
-    expect(wrapper).toMatchSnapshot()
+    expect(asFragment()).toMatchSnapshot();
   })
 })

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
@@ -13,7 +13,7 @@ import {
 } from './shared';
 
 import { requestGet } from '../../../../../../modules/request/index';
-import { DataTable, pluralize } from '../../../../../Shared/index';
+import { DataTable, DataTableChip, accountGreenIcon, pluralize } from '../../../../../Shared/index';
 import LoadingSpinner from '../../../shared/loading_indicator.jsx';
 
 interface Student {
@@ -72,14 +72,6 @@ const preTestDesktopHeaders = (isSortable) => ([
     tooltipDescription: preSkillsProficientTooltipText,
     noTooltip: true,
     isSortable
-  },
-  {
-    name: 'Responses',
-    attribute: 'individualResponsesLink',
-    width: S_CELL_WIDTH,
-    noTooltip: true,
-    rowSectionClassName: 'individual-responses-link',
-    headerClassName: 'individual-responses-header'
   }
 ])
 
@@ -155,14 +147,6 @@ const postTestDesktopHeaders = (isSortable) => ([
     tooltipDescription: postSkillsImprovedOrMaintainTooltipText,
     noTooltip: true,
     isSortable
-  },
-  {
-    name: 'Responses',
-    attribute: 'individualResponsesLink',
-    width: S_CELL_WIDTH,
-    noTooltip: true,
-    rowSectionClassName: 'individual-responses-link',
-    headerClassName: 'individual-responses-header'
   }
 ])
 
@@ -312,10 +296,13 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
     )
   }
 
-  function renderIndividualResponsesLink({total_correct_questions_count, id}) {
-    if (total_correct_questions_count === undefined) { return null }
-
-    return <Link className="quill-button-archived fun secondary outlined focus-on-light" to={responsesLink(id)}>View</Link>
+  function renderStudentChip({ total_correct_questions_count, id, name }) {
+    if (total_correct_questions_count === undefined) { return <React.Fragment><span>{name}</span><span className="name-section-subheader">Diagnostic not completed</span></React.Fragment> }
+    return(
+      <Link className="student-responses-link" to={responsesLink(id)}>
+        <DataTableChip icon={accountGreenIcon} label={name} />
+      </Link>
+    )
   }
 
   const responsesLink = (studentId: number) => unitId ? `/diagnostics/${activityId}/classroom/${classroomId}/responses/${studentId}?unit=${unitId}` : `/diagnostics/${activityId}/classroom/${classroomId}/responses/${studentId}`
@@ -330,7 +317,7 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
 
     return {
       id: id || name,
-      name,
+      name: renderStudentChip({ total_correct_questions_count, id, name }),
       alphabeticalName: alphabeticalName(name),
       preToPostImprovedSkills: renderPreToPostImprovedSkillsElement({total_correct_questions_count, total_acquired_skill_groups_count}),
       totalCorrectSkillsCount: total_correct_questions_count,
@@ -341,21 +328,18 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
       preSkillsProficientElement: renderPreSkillsProficient({ total_correct_questions_count, total_pre_correct_questions_count, skill_groups, total_correct_skill_groups_count, correct_skill_groups_text }),
       preSkillsCorrectElement: renderPreSkillsCorrectElement({ total_correct_questions_count, total_pre_correct_questions_count, total_pre_possible_questions_count, total_possible_questions_count }),
       activeDiagnosticSkillsCorrectElement: renderActiveDiagnosticSkillsCorrectElement({ total_correct_questions_count, total_possible_questions_count }),
-      postSkillsImprovedOrMaintained: renderPostSkillsImprovedOrMaintained({ total_pre_possible_questions_count, correct_skill_groups_text, total_acquired_skill_groups_count, total_maintained_skill_group_proficiency_count }),
-      individualResponsesLink: renderIndividualResponsesLink({ total_correct_questions_count, id })
+      postSkillsImprovedOrMaintained: renderPostSkillsImprovedOrMaintained({ total_pre_possible_questions_count, correct_skill_groups_text, total_acquired_skill_groups_count, total_maintained_skill_group_proficiency_count })
     }
   })
 
   const mobileRows = students.map(student => {
     const { name, total_possible_questions_count, total_correct_questions_count, id, } = student
-    const nameElement = total_correct_questions_count !== undefined ? <Link to={responsesLink(id)}>{name}</Link> : <React.Fragment><span>{name}</span><span className="name-section-subheader">Diagnostic not completed</span></React.Fragment>
     return {
       id: id || name,
-      name: nameElement,
+      name: renderStudentChip({ total_correct_questions_count, id, name }),
       alphabeticalName: alphabeticalName(name),
       totalCorrectSkillsCount: total_correct_questions_count,
-      skillsCorrectElement: total_correct_questions_count !== undefined ? <div className="skills-correct-element">{total_correct_questions_count} of {total_possible_questions_count} ({calculateSkillsPercentage(total_correct_questions_count, total_possible_questions_count)}%)</div> : null,
-      individualResponsesLink: total_correct_questions_count !== undefined ? <Link className="quill-button-archived fun secondary outlined focus-on-light" to={responsesLink(id)}>View</Link> : <span className="name-section-subheader">Diagnostic not completed</span>
+      skillsCorrectElement: total_correct_questions_count !== undefined ? <div className="skills-correct-element">{total_correct_questions_count} of {total_possible_questions_count} ({calculateSkillsPercentage(total_correct_questions_count, total_possible_questions_count)}%)</div> : null
     }
   })
 

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
@@ -295,8 +295,13 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
     )
   }
 
-  function renderStudentChip({ total_correct_questions_count, id, name }) {
-    if (total_correct_questions_count === undefined) { return <React.Fragment><span>{name}</span><span className="name-section-subheader">Diagnostic not completed</span></React.Fragment> }
+  function renderStudentChip({ total_correct_questions_count, id, name, isDesktopView }) {
+    if (isDesktopView && total_correct_questions_count === undefined) {
+      return <span>{name}</span>
+    }
+    if (total_correct_questions_count === undefined) {
+      return <React.Fragment><span>{name}</span><span className="name-section-subheader">Diagnostic not completed</span></React.Fragment>
+    }
     return(
       <Link className="student-responses-link" to={responsesLink(id)}>
         <DataTableChip icon={accountGreenIcon} label={name} />
@@ -316,7 +321,7 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
 
     return {
       id: id || name,
-      name: renderStudentChip({ total_correct_questions_count, id, name }),
+      name: renderStudentChip({ total_correct_questions_count, id, name, isDesktopView: true }),
       alphabeticalName: alphabeticalName(name),
       preToPostImprovedSkills: renderPreToPostImprovedSkillsElement({total_correct_questions_count, total_acquired_skill_groups_count}),
       totalCorrectSkillsCount: total_correct_questions_count,
@@ -335,7 +340,7 @@ export const StudentResponsesIndex = ({ passedStudents, match, mobileNavigation,
     const { name, total_possible_questions_count, total_correct_questions_count, id, } = student
     return {
       id: id || name,
-      name: renderStudentChip({ total_correct_questions_count, id, name }),
+      name: renderStudentChip({ total_correct_questions_count, id, name, isDesktopView: false }),
       alphabeticalName: alphabeticalName(name),
       totalCorrectSkillsCount: total_correct_questions_count,
       skillsCorrectElement: total_correct_questions_count !== undefined ? <div className="skills-correct-element">{total_correct_questions_count} of {total_possible_questions_count} ({calculateSkillsPercentage(total_correct_questions_count, total_possible_questions_count)}%)</div> : null

--- a/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/progress_reports/diagnostic_reports/diagnostics/studentResponsesIndex.tsx
@@ -32,8 +32,7 @@ interface Student {
 
 const S_CELL_WIDTH = '176px'
 const M_CELL_WIDTH = '184px'
-const L_CELL_WIDTH = '244px'
-const XL_CELL_WIDTH = '252px'
+const L_CELL_WIDTH = '320px'
 const NOT_AVAILABLE = 'Not available'
 
 const diagnosticNotCompletedElement = (<span>Diagnostic not completed</span>)
@@ -51,7 +50,7 @@ const preTestDesktopHeaders = (isSortable) => ([
     name: '',
     attribute: 'activeDiagnosticSkillsCorrectElement',
     sortAttribute: 'totalCorrectSkillsCount',
-    width: XL_CELL_WIDTH,
+    width: L_CELL_WIDTH,
     rowSectionClassName: 'score-section',
     headerClassName: 'score-header',
     primaryTitle: 'Pre:',
@@ -65,7 +64,7 @@ const preTestDesktopHeaders = (isSortable) => ([
     name: '',
     attribute: 'preSkillsProficientElement',
     sortAttribute: 'totalPreCorrectSkillsCount',
-    width: XL_CELL_WIDTH,
+    width: L_CELL_WIDTH,
     primaryTitle: 'Pre:',
     secondaryTitle: 'Skills Proficient',
     tooltipName: 'Pre: Skills Proficient',


### PR DESCRIPTION
## WHAT
convert names to clickable chips for Diagnostic student responses

## WHY
to match the styling of our other reports

## HOW
convert names to use shared `DataTableChip` component

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="1343" alt="Screen Shot 2024-09-27 at 1 38 15 PM" src="https://github.com/user-attachments/assets/38ee618c-5e01-45cf-a941-17881990e7b5">
<img width="178" alt="Screen Shot 2024-09-27 at 1 37 48 PM" src="https://github.com/user-attachments/assets/29f70d1a-0b45-4ab0-b261-ef06d5f68217">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Teacher-Diagnostic-Report-Design-Update-Make-the-student-name-a-button-in-the-diagnostic-report-to--5bc8454563d74fcf94902bd0a4f9bc67

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
tested locally and on staging that names render as clickable chips for this report

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
