### PR TITLE
Cleanup vite import cycles

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/helpfulTips.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/helpfulTips.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { expandIcon } from '../../index'
+import { expandIcon } from '../../images';
 
 const lightbulbIcon = <img alt="Lightbulb icon for helpful tips" src={`${process.env.CDN_URL}/images/pages/activity_analysis/lightbulb.svg`} />
 

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/textEditor.tsx
@@ -10,8 +10,8 @@ import { decode } from 'html-entities';
 import * as Immutable from 'immutable';
 import * as React from 'react';
 
-import { richButtonsPlugin, } from '../../index';
 import addLinkPluginPlugin from "../draftJSCustomPlugins/addLinkPlugin";
+import { richButtonsPlugin } from '../draftJSRichButtonsPlugin';
 
 const HIGHLIGHT = 'highlight'
 const HIGHLIGHTABLE = 'HIGHLIGHTABLE'

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/tooltip.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { onMobile } from '../..'
+import { onMobile } from '../../libs/onMobile';
 
 interface TooltipProps {
   isTabbable?: boolean,

--- a/services/QuillLMS/client/app/bundles/Shared/libs/activityPreviewHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/activityPreviewHelpers.tsx
@@ -3,7 +3,6 @@ import { stripHtml } from "string-strip-html";
 import clip from "text-clipper";
 import ReactHtmlParser from 'react-html-parser';
 
-//import { BECAUSE, BUT, CHECKLIST, Feedback, INTRODUCTION, READ_AND_HIGHLIGHT, SO, getLatestAttempt } from '../../Shared/index';
 import { QuestionObject, Activity } from '../interfaces';
 import { PromptInterface } from '../../Staff/interfaces/evidenceInterfaces';
 import { getLatestAttempt } from './getLatestAttempt';

--- a/services/QuillLMS/client/app/bundles/Shared/libs/activityPreviewHelpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/activityPreviewHelpers.tsx
@@ -3,9 +3,12 @@ import { stripHtml } from "string-strip-html";
 import clip from "text-clipper";
 import ReactHtmlParser from 'react-html-parser';
 
-import { BECAUSE, BUT, CHECKLIST, Feedback, INTRODUCTION, READ_AND_HIGHLIGHT, SO, getLatestAttempt } from '../../Shared/index';
+//import { BECAUSE, BUT, CHECKLIST, Feedback, INTRODUCTION, READ_AND_HIGHLIGHT, SO, getLatestAttempt } from '../../Shared/index';
 import { QuestionObject, Activity } from '../interfaces';
 import { PromptInterface } from '../../Staff/interfaces/evidenceInterfaces';
+import { getLatestAttempt } from './getLatestAttempt';
+import { Feedback } from '../components/renderForQuestions';
+import { BECAUSE, BUT, CHECKLIST, INTRODUCTION, READ_AND_HIGHLIGHT, SO } from '../utils/constants';
 
 export const getCurrentQuestion = ({ action, answeredQuestions, questionSet, unansweredQuestions }) => {
   const { data, question } = action;

--- a/services/QuillLMS/client/app/bundles/Shared/libs/translations/helpers.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/libs/translations/helpers.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ENGLISH } from '../../utils/languageList'
-import { ConceptExplanation, defaultLanguages } from '../..';
+import { ConceptExplanation } from '../../components/feedback/conceptExplanation';
+import { defaultLanguages } from '../../utils/languageList.js'
 
 export const getlanguageOptions = (translations) => ([
   { value: ENGLISH, label: ENGLISH },


### PR DESCRIPTION
## WHAT
- reduces Vite 're-export' warnings from 590 lines to 212 lines (the remaining lines require deeper refactors that will ship later, separately)

## WHY
- our build is cluttered with warnings, and there is a risk that the patterns vite warns about could cause problems in our build. 

## HOW
- remove mutual imports. This usually happens when an index file `parent` imports `child`, but child also imports function `foo` from `parent` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links


### What have you done to QA this feature?
- [x] login with gmail
- [x] play a Connect question
- [x] play an Evidence question
- [x] login as teacher, confirm top level Diagnostic reports render

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | no - no logic change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
