### PR TITLE
Tiny style change for Evidence captions

### DIFF
--- a/services/QuillLMS/client/app/assets/styles/tool-section.scss
+++ b/services/QuillLMS/client/app/assets/styles/tool-section.scss
@@ -23,7 +23,7 @@ $tool-grey: #f8f9f9;
   }
   &.text-quill-teal:hover {
     color: $quill-white;
-    background-color: rgba(255, 255, 255, 0.38)
+    background-color: $quill-teal;
   }
 }
 

--- a/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
+++ b/services/QuillLMS/client/app/bundles/Evidence/styles/activity.scss
@@ -54,8 +54,8 @@
         }
         .quill-tooltip-trigger {
           margin-left: 24px;
-          font-size: 14px;
-          color: #808080;
+          font-size: 13px;
+          color: $quill-grey-50;
           .image-attribution-tooltip {
             border-bottom: dashed 1px #808080;
           }


### PR DESCRIPTION
## WHAT
Small style change in Evidence captions and background color of a button

## WHY
To match new styling requirements

## HOW
Change font size and color of captions on Evidence activity images

### Screenshots
![Screenshot 2024-09-30 at 3 42 12 PM](https://github.com/user-attachments/assets/4de3fa2a-a5b7-4d82-a70b-05107bf9cf34)
![Screenshot 2024-09-30 at 5 16 12 PM](https://github.com/user-attachments/assets/352b30b5-9fe1-4878-b3c7-408e7c8b1483)


### Notion Card Links
https://www.notion.so/quill/Evidence-UI-Update-Image-Attribution-UI-e05e12c6cb5e409cb87f970e4c83c30a?pvs=4
https://www.notion.so/quill/Evidence-UI-Update-Image-Attribution-UI-e05e12c6cb5e409cb87f970e4c83c30a?pvs=4

### What have you done to QA this feature?
Deploy to staging and check visuals

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No - tiny change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
