### PR TITLE
update sanitize function to accept target, rel, href, and class

### DIFF
--- a/services/QuillLMS/config/application.rb
+++ b/services/QuillLMS/config/application.rb
@@ -75,5 +75,7 @@ module EmpiricalGrammar
     config.active_record.encryption.primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
     config.active_record.encryption.deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
     config.active_record.encryption.key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
+
+    config.action_view.sanitized_allowed_attributes = ['class', 'href', 'target', 'rel']
   end
 end


### PR DESCRIPTION
## WHAT
Update the base sanitize function to accept target, rel, href, and class.

## WHY
The default was stripping out `target` and `rel`, which meant that links wouldn't open in new tabs.

## HOW
Just update the base config.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Inconsistent-link-opening-behavior-between-quill-org-tools-evidence-compared-to-quill-org-social-st-bb6587fb82634305bd5b702aeb841266?pvs=4

### What have you done to QA this feature?
Did a global search for everywhere we use `sanitize` in an erb file, which turns out to only be on this page, so I just tested that the links work as expected there.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | manually tested
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
