### PR TITLE
fix-translated-question-instructions

### DIFF
--- a/services/QuillLMS/app/models/concerns/translatable.rb
+++ b/services/QuillLMS/app/models/concerns/translatable.rb
@@ -77,11 +77,13 @@ module Translatable
   end
 
   def translation(locale: DEFAULT_LOCALE, source_api: OPEN_AI_SOURCE)
-    @translation ||= translations(locale: locale, source_api: source_api)&.first&.translation
+    @translation ||= translations(locale: locale, source_api: source_api, field_name: default_translatable_field)&.first&.translation
   end
 
-  def translations(locale:, source_api:)
-    translated_texts.where(locale: locale).ordered_by_source_api(source_api)
+  def translations(locale:, source_api:, field_name:)
+    translated_texts.joins(:translation_mappings)
+      .where(translation_mappings: { field_name: })
+      .where(locale: locale).ordered_by_source_api(source_api)
   end
 
   def translate!(locale: DEFAULT_LOCALE, source_api: OPEN_AI_SOURCE, force: false)

--- a/services/QuillLMS/app/models/concerns/translatable.rb
+++ b/services/QuillLMS/app/models/concerns/translatable.rb
@@ -80,7 +80,7 @@ module Translatable
     @translation ||= translations(locale: locale, source_api: source_api, field_name: default_translatable_field)&.first&.translation
   end
 
-  def translations(locale:, source_api:, field_name:)
+  def translations(locale:, source_api:, field_name: default_translatable_field)
     translated_texts.joins(:translation_mappings)
       .where(translation_mappings: { field_name: })
       .where(locale: locale).ordered_by_source_api(source_api)

--- a/services/QuillLMS/app/models/concerns/translatable.rb
+++ b/services/QuillLMS/app/models/concerns/translatable.rb
@@ -77,7 +77,7 @@ module Translatable
   end
 
   def translation(locale: DEFAULT_LOCALE, source_api: OPEN_AI_SOURCE)
-    @translation ||= translations(locale: locale, source_api: source_api, field_name: default_translatable_field)&.first&.translation
+    @translation ||= translations(locale: locale, source_api: source_api)&.first&.translation
   end
 
   def translations(locale:, source_api:, field_name: default_translatable_field)

--- a/services/QuillLMS/spec/models/concerns/translatable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/translatable_spec.rb
@@ -124,6 +124,26 @@ RSpec.describe Translatable do
         expect(subject).to eq(translation)
       end
 
+      context 'when there are multiple translation_mappings with different field_names' do
+        let(:translatable_text) { 'Specialized un-translated text' }        
+        let(:non_default_translation) { 'Specialized translated text' }
+        let(:field_name) { 'non_default_field_name' }
+        let(:english_text2) { create(:english_text, text: translatable_text) }
+        let!(:non_default_translated_text) do
+          create(:translated_text,
+            translation: non_default_translation,
+            locale: locale,
+            source_api: source_api,
+            english_text: english_text2)
+        end
+
+        before do 
+          translatable_object.create_translation_mappings_with_text(translatable_text:, field_name:)
+        end
+
+        it { expect(translatable_object.translation).to eq(translation) }
+      end
+
       context 'when there are translations for different locales' do
         let(:other_locale) { 'jp' }
         let!(:other_translated_text) do

--- a/services/QuillLMS/spec/models/concerns/translatable_spec.rb
+++ b/services/QuillLMS/spec/models/concerns/translatable_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Translatable do
       end
 
       context 'when there are multiple translation_mappings with different field_names' do
-        let(:translatable_text) { 'Specialized un-translated text' }        
+        let(:translatable_text) { 'Specialized un-translated text' }
         let(:non_default_translation) { 'Specialized translated text' }
         let(:field_name) { 'non_default_field_name' }
         let(:english_text2) { create(:english_text, text: translatable_text) }
@@ -137,7 +137,7 @@ RSpec.describe Translatable do
             english_text: english_text2)
         end
 
-        before do 
+        before do
           translatable_object.create_translation_mappings_with_text(translatable_text:, field_name:)
         end
 


### PR DESCRIPTION
## WHAT
Filter by field_name when sourcing the base translation value
## WHY
When originally written, this code assumed that a single model instance could only have a single translation associated with it.  This is not the case with questions, which was resulting in an arbitrary associated translation being pulled.  Adding this logic should consistently pull the intended translation.
## HOW
When fetching the `translation` for a translatable model, join to the `translation_mappings` table where we store the `field_name` value.  This value signals which column from the translatable model the translation is for, and each translatable model has a default field name that its `translation` call is expected to fetch.  Add a `where` clause to filter for the default `field_name` when seeking translations so that the default field is always pulled while we rely on supplemental code to fetch translations for non-default fields (see `TranslatableQuestion` concern).

### Notion Card Links
https://www.notion.so/quill/Students-seeing-code-in-Spanish-translations-of-instructions-in-ELL-activities-112d42e6f941803681d3f039ddabfbc0?pvs=4

### What have you done to QA this feature?
- Using old code, fetch a `Question` object that is known to provide the incorrect value for `translation`
- Confirm that it consistently does return the incorrect value
- Using the new code, fetch the same object, confirm that its `translation` value is correct

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | Yes
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes