### PR TITLE
Bug fix/ Grammar translated button text

### DIFF
--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/container.tsx
@@ -395,7 +395,7 @@ export class PlayGrammarContainer extends React.Component<PlayGrammarContainerPr
         }
         if (saving || (!grammarActivities && !proofreaderSessionId)) { return <LoadingSpinner /> }
 
-        if (availableLanguages && !language && !ALPHA_TRANSLATED_ACTIVITY_UIDS.includes(activityUID)) {
+        if (availableLanguages?.length > 1 && !language && !ALPHA_TRANSLATED_ACTIVITY_UIDS.includes(activityUID)) {
           return (
             <LanguageSelectionPage
               dispatch={dispatch}

--- a/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/intro.tsx
+++ b/services/QuillLMS/client/app/bundles/Grammar/components/grammarActivities/intro.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ENGLISH } from '../../../Shared';
 
 interface IntroProps {
   startActivity: () => void;
@@ -85,7 +86,7 @@ export default class Intro extends React.Component<IntroProps, IntroState> {
     const { activity, language, availableLanguages } = this.props
     const { showLandingPage, } = this.state
     const translatedText = this.translatedText()
-    const showTranslatedButton = language && availableLanguages?.includes(language)
+    const showTranslatedButton = language && language !== ENGLISH && availableLanguages?.includes(language)
     if (showLandingPage) {
       return (
         <div className="intro landing-page">


### PR DESCRIPTION
## WHAT
fix translated button text for Grammar activities when English is selected for translated activities

## WHY
we want this text to render as expected

tweak logic for 'showTranslatedButton`

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/English-start-activity-button-showing-code-in-Grammar-activities-113d42e6f9418023a608cffbf8d8f3c0?pvs=4

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
tested on staging that correct text renders for the button

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | small change-- manually tested
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
