### PR TITLE
fix-teacher-diagnostic-report-visual-bug

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
+++ b/services/QuillLMS/app/assets/stylesheets/shared/tabs.scss
@@ -289,6 +289,10 @@
   }
 }
 
+@media (min-width: 930px) {
+  .hide-on-desktop:not(.premium-tab-small) { display: none !important; }
+}
+
 @media (min-width: 930px) and (max-width: 1040px) {
   #teacher-nav-tabs li a {
       padding: 3px 20px 3px;


### PR DESCRIPTION
## WHAT
Re-add a CSS rule that was mistakenly removed
## WHY
This rule was accidentally removed as part of a bigger set of clean-up changes around `premium-tab` class selectors, but didn't need to be.
## HOW
Copy and paste the code from and old branch.

### Screenshots
![image](https://github.com/user-attachments/assets/cc250959-2f69-4b32-aaff-152be6a55cb8)

### Notion Card Links
https://www.notion.so/quill/Diagnostic-styling-issue-114d42e6f94180d4ae17e0d0f72df259

### What have you done to QA this feature?
- On local, navigate through all sections of the teacher diagnostic report and confirm that these drop-downs don't show on desktop screen widths
- Repeat tests on staging

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | No, this is purely a visual change
Have you deployed to Staging? | Yes
Self-Review: Have you done an initial self-review of the code below on Github? | Yes