### PR TITLE
add no index to home layout

### DIFF
--- a/services/QuillLMS/app/views/layouts/home.html.erb
+++ b/services/QuillLMS/app/views/layouts/home.html.erb
@@ -24,6 +24,10 @@
     <% if Rails.env.development? %>
       <title>[DEV] <%= @title %></title>
       <%= favicon_link_tag 'favicon-dev.ico' %>
+    <% elsif Rails.env.staging? %>
+      <title>[Staging] <%= @title || 'Interactive Writing and Grammar' %></title>
+      <%= favicon_link_tag 'favicon-staging.ico' %>
+      <meta name="robots" content="noindex">
     <% else %>
       <title><%= @title %></title>
       <%= favicon_link_tag 'favicon.ico' %>


### PR DESCRIPTION
## WHAT
Add noindex directive to home layout, as well as _head 

## WHY
because `/` uses the home layout, and not _head

## HOW

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=e6fc04d61b804b74ba99d666ca57ac70&pm=s

### What have you done to QA this feature?
- ensure the directive exists on pkong.quill.org

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - tiny
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
