### PR TITLE
optimize: student_profile transaction

### DIFF
--- a/services/QuillLMS/app/controllers/profiles_controller.rb
+++ b/services/QuillLMS/app/controllers/profiles_controller.rb
@@ -40,7 +40,7 @@ class ProfilesController < ApplicationController
   def student_profile_data
     classroom_id = params[:current_classroom_id]
 
-    if current_user.classrooms.any? && classroom_id
+    if classroom_id && current_user.classrooms.any?
       render json: {
         scores: student_profile_data_sql(classroom_id),
         next_activity_session:,

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -20,7 +20,6 @@ import KeyMetrics from '../components/student_profile/key_metrics'
 
 class StudentProfile extends React.Component {
   componentDidMount() {
-    console.log("StudentProfile: componentDidMount")
     const {
       fetchStudentProfile,
       fetchStudentsClassrooms,

--- a/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
+++ b/services/QuillLMS/client/app/bundles/Teacher/containers/StudentProfile.jsx
@@ -20,6 +20,7 @@ import KeyMetrics from '../components/student_profile/key_metrics'
 
 class StudentProfile extends React.Component {
   componentDidMount() {
+    console.log("StudentProfile: componentDidMount")
     const {
       fetchStudentProfile,
       fetchStudentsClassrooms,
@@ -29,11 +30,10 @@ class StudentProfile extends React.Component {
     if (classroomId) {
       handleClassroomClick(classroomId);
       fetchStudentProfile(classroomId)
-      fetchStudentsClassrooms();
     } else {
       fetchStudentProfile();
-      fetchStudentsClassrooms();
     }
+    fetchStudentsClassrooms();
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
## WHAT
Lazily evaluate `current_user.classrooms.any?` 

## WHY
- This transaction is one of our highest-traffic transactions. 
- The code path where `classroom_id` is null is triggered on every student login (i.e. the classroom selector view), so the compute savings should be significant 

## HOW
Lazily evaluate `current_user.classrooms.any?` 

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Product-Board-30f97e4eb01246dbb8264253fb385073?p=10dd42e6f941801db084d924df5e4718&pm=s

### What have you done to QA this feature?
On staging, as a student, observe that the call occurs and completes correctly upon login

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no - no logic change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? |
