### PR TITLE
handle invalid plagiarism texts

### DIFF
--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`RulePlagiarismAttributes component should render RulePlagiarismAttribut
   <p
     className="all-errors-message"
   >
-    This plagiarism text does not match the associated activity text. This means that it will not trigger the plagiarism feedback as intended. Please update the text above.
+    This plagiarism text does not match the associated activity text. This means that it may not trigger the plagiarism feedback as intended. Please update the text above.
   </p>
   <PlagiarismTextEditor
     index={1}
@@ -22,7 +22,7 @@ exports[`RulePlagiarismAttributes component should render RulePlagiarismAttribut
   <p
     className="all-errors-message"
   >
-    This plagiarism text does not match the associated activity text. This means that it will not trigger the plagiarism feedback as intended. Please update the text above.
+    This plagiarism text does not match the associated activity text. This means that it may not trigger the plagiarism feedback as intended. Please update the text above.
   </p>
   <div
     className="button-wrapper"

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/__tests__/__snapshots__/rulePlagiarismAttributes.test.tsx.snap
@@ -8,12 +8,22 @@ exports[`RulePlagiarismAttributes component should render RulePlagiarismAttribut
     setPlagiarismText={[Function]}
     text="test plagiarism text"
   />
+  <p
+    className="all-errors-message"
+  >
+    This plagiarism text does not match the associated activity text. This means that it will not trigger the plagiarism feedback as intended. Please update the text above.
+  </p>
   <PlagiarismTextEditor
     index={1}
     key="1"
     setPlagiarismText={[Function]}
     text="test another plagiarism text"
   />
+  <p
+    className="all-errors-message"
+  >
+    This plagiarism text does not match the associated activity text. This means that it will not trigger the plagiarism feedback as intended. Please update the text above.
+  </p>
   <div
     className="button-wrapper"
   >

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/activityInvalidHighlights.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/activityInvalidHighlights.tsx
@@ -21,7 +21,7 @@ const ActivityInvalidHighlights = ({ activityId }) => {
 
   return (
     <Link to={`/activities/${activityId}`}>
-      {getCheckIcon(!(invalidHighlights.invalid_highlights && invalidHighlights.invalid_highlights.length))}
+      {getCheckIcon(!(invalidHighlights.invalid_related_texts && invalidHighlights.invalid_related_texts.length))}
     </Link>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -97,12 +97,15 @@ const RulePlagiarismAttributes = ({
     if (plagiarismText._destroy) { return <span /> }
 
     return (
-      <PlagiarismTextEditor
-        index={i}
-        key={i}
-        setPlagiarismText={onHandleSetPlagiarismText}
-        text={plagiarismText.text}
-      />
+      <React.Fragment>
+        <PlagiarismTextEditor
+          index={i}
+          key={i}
+          setPlagiarismText={onHandleSetPlagiarismText}
+          text={plagiarismText.text}
+        />
+        {!plagiarismText.valid_in_all_targets && <p className="all-errors-message">This plagiarism text does not match the associated activity text. This means that it will not trigger the plagiarism feedback as intended. Please update the text above.</p>}
+      </React.Fragment>
     )
   })
 

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureRules/rulePlagiarismAttributes.tsx
@@ -104,7 +104,7 @@ const RulePlagiarismAttributes = ({
           setPlagiarismText={onHandleSetPlagiarismText}
           text={plagiarismText.text}
         />
-        {!plagiarismText.valid_in_all_targets && <p className="all-errors-message">This plagiarism text does not match the associated activity text. This means that it will not trigger the plagiarism feedback as intended. Please update the text above.</p>}
+        {!plagiarismText.valid_in_all_targets && <p className="all-errors-message">This plagiarism text does not match the associated activity text. This means that it may not trigger the plagiarism feedback as intended. Please update the text above.</p>}
       </React.Fragment>
     )
   })

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/configureSettings/activityForm.tsx
@@ -20,7 +20,7 @@ interface ActivityFormProps {
 }
 
 const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormProps) => {
-  const { id, parent_activity_id, invalid_highlights, passages, prompts, title, notes, flag, } = activity;
+  const { id, parent_activity_id, invalid_related_texts, passages, prompts, title, notes, flag, } = activity;
   const formattedPassage = passages && passages.length ? passages : [{ text: '', highlight_prompt: DEFAULT_HIGHLIGHT_PROMPT, essential_knowledge_text: '' }];
   const formattedPrompts = promptsByConjunction(prompts);
   const becausePrompt = formattedPrompts && formattedPrompts[BECAUSE] ? formattedPrompts[BECAUSE] : buildBlankPrompt(BECAUSE);
@@ -114,7 +114,7 @@ const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormP
   const imageAttributionStyle = activityPassages[0].image_attribution  && activityPassages[0].image_attribution !== BREAK_TAG ? 'has-text' : '';
   const essentialKnowledgeStyle = activityPassages[0].essential_knowledge_text && activityPassages[0].essential_knowledge_text !== BREAK_TAG ? 'has-text' : '';
   const imageAttributionGuideLink = 'https://www.notion.so/quill/Activity-Images-9bc3993400da46a6af445a8a0d2d9d3f#11e9a01b071e41bc954e1182d56e93e8';
-  const invalidHighlightsPresent = (invalid_highlights && invalid_highlights.length > 0)
+  const invalidHighlightsPresent = (invalid_related_texts && invalid_related_texts.length > 0)
 
   function getMaxAttemptsFeedbackComponent(conjunction: string, prompt: PromptInterface) {
     return <MaxAttemptsEditor conjunction={conjunction} handleSetPrompt={handleSetPrompt} prompt={prompt} />
@@ -231,7 +231,7 @@ const ActivityForm = ({ activity, requestErrors, submitActivity }: ActivityFormP
         headers={dataTableFields}
         rows={formattedRows}
       />
-      {invalidHighlightsPresent && renderInvalidHighlightLinks(invalid_highlights, id)}
+      {invalidHighlightsPresent && renderInvalidHighlightLinks(invalid_related_texts, id)}
     </div>
   )
 }

--- a/services/QuillLMS/client/app/bundles/Staff/components/evidence/plagiarismRules/plagiarismRulesIndex.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/evidence/plagiarismRules/plagiarismRulesIndex.tsx
@@ -98,10 +98,11 @@ const PlagiarismRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = 
     }
 
     return plagiarismTexts.map((plagiarismText, i) => {
-      const { text } = plagiarismText;
+      const { text, valid_in_all_targets, } = plagiarismText;
+      const strippedText = stripHtml(text).result
       return {
         label: `Plagiarism Text - Text String ${i + 1}`,
-        value: stripHtml(text).result
+        value: valid_in_all_targets ? strippedText : <span className="all-errors-message">{strippedText}</span>
       }
     })
   }
@@ -183,7 +184,7 @@ const PlagiarismRulesIndex: React.FC<RouteComponentProps<ActivityRouteProps>> = 
   const becauseDisabled = getButtonClass(BECAUSE);
   const butDisabled = getButtonClass(BUT);
   const soDisabled = getButtonClass(SO);
-  const oneRuleWarning = 'There can only be one plagiarism rule per conjunction. Please click "View" below if you would like to update the plagiarized text.'
+  const oneRuleWarning = 'There can only be one plagiarism rule per conjunction. Please click "View" below if you would like to update the plagiarized text. Red text means that the plagiarism text does not match the associated passage.'
 
   return(
     <div className="rules-container">

--- a/services/QuillLMS/client/app/bundles/Staff/interfaces/evidenceInterfaces.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/interfaces/evidenceInterfaces.ts
@@ -23,7 +23,7 @@ export interface ActivityInterface {
   prompts?: PromptInterface[],
   passage_attributes?: PassagesInterface[],
   prompt_attributes?: PromptInterface[],
-  invalid_highlights?: InvalidHighlight[]
+  invalid_related_texts?: InvalidHighlight[]
 }
 
 export interface PromptInterface {

--- a/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
+++ b/services/QuillLMS/client/app/bundles/Staff/utils/evidence/activityAPIs.ts
@@ -166,11 +166,11 @@ export const fetchActivityVersions = async ({ queryKey, }) => {
 
 export const fetchInvalidHighlights = async ({ queryKey, }) => {
   const [key, activityId]: [string, string] = queryKey
-  const response = await apiFetch(`activities/${activityId}/invalid_highlights`);
-  const invalid_highlights = await response.json();
+  const response = await apiFetch(`activities/${activityId}/invalid_related_texts`);
+  const invalid_related_texts = await response.json();
 
   return {
-    invalid_highlights: invalid_highlights.invalid_highlights,
-    error: handleApiError('Failed to fetch invalid_highlights value, please refresh the page.', response)
+    invalid_related_texts: invalid_related_texts.invalid_related_texts,
+    error: handleApiError('Failed to fetch invalid_related_texts value, please refresh the page.', response)
   };
 }

--- a/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
+++ b/services/QuillLMS/engines/evidence/app/controllers/evidence/activities_controller.rb
@@ -2,7 +2,7 @@
 
 module Evidence
   class ActivitiesController < ApiController
-    before_action :set_activity, only: [:activity_versions, :create, :show, :update, :destroy, :seed_data, :change_logs, :labeled_synthetic_data, :topic_optimal_info, :invalid_highlights]
+    before_action :set_activity, only: [:activity_versions, :create, :show, :update, :destroy, :seed_data, :change_logs, :labeled_synthetic_data, :topic_optimal_info, :invalid_related_texts]
     before_action :set_lms_user_id, only: [:create, :destroy, :update]
 
     # GET /activities.json
@@ -152,9 +152,9 @@ module Evidence
     end
 
     # params [:id]
-    def invalid_highlights
+    def invalid_related_texts
       render json: {
-        invalid_highlights: @activity.invalid_highlights
+        invalid_related_texts: @activity.invalid_related_texts
       }
     end
 

--- a/services/QuillLMS/engines/evidence/app/helpers/text_formatter.rb
+++ b/services/QuillLMS/engines/evidence/app/helpers/text_formatter.rb
@@ -22,7 +22,7 @@ module TextFormatter
     CGI.unescapeHTML(html_string)
   end
 
-  def unscape_html_strip_tags_and_punctuation_and_downcase(str)
-    strip_punctuation_and_downcase(strip_tags_and_replace_with_spaces(unescape_html(str)))
+  def unescape_html_strip_tags_and_punctuation_and_downcase(str)
+    strip_punctuation_and_downcase(strip_tags_and_replace_with_spaces(unescape_html(str))).squeeze(' ')
   end
 end

--- a/services/QuillLMS/engines/evidence/app/helpers/text_formatter.rb
+++ b/services/QuillLMS/engines/evidence/app/helpers/text_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TextFormatter
   require 'cgi'
   require 'nokogiri'
@@ -11,7 +13,7 @@ module TextFormatter
   end
 
   def strip_tags_and_replace_with_spaces(input)
-    Nokogiri::HTML(input).xpath('//text()').map(&:text).join(' ').squeeze(' ')
+    Nokogiri::HTML(input).xpath('//text()').map(&:text).join(' ')
   end
 
   def strip_punctuation_and_downcase(str)

--- a/services/QuillLMS/engines/evidence/app/helpers/text_formatter.rb
+++ b/services/QuillLMS/engines/evidence/app/helpers/text_formatter.rb
@@ -1,0 +1,28 @@
+module TextFormatter
+  require 'cgi'
+  require 'nokogiri'
+
+  def strip_punctuation(str)
+    str.gsub(/[[:punct:]]/, '')
+  end
+
+  def strip_tags(input)
+    ::ActionController::Base.helpers.strip_tags(input)
+  end
+
+  def strip_tags_and_replace_with_spaces(input)
+    Nokogiri::HTML(input).xpath('//text()').map(&:text).join(' ').squeeze(' ')
+  end
+
+  def strip_punctuation_and_downcase(str)
+    strip_punctuation(str).downcase
+  end
+
+  def unescape_html(html_string)
+    CGI.unescapeHTML(html_string)
+  end
+
+  def unscape_html_strip_tags_and_punctuation_and_downcase(str)
+    strip_punctuation_and_downcase(strip_tags_and_replace_with_spaces(unescape_html(str)))
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -136,8 +136,7 @@ module Evidence
     end
 
     def invalid_highlights
-      invalid_feedback_highlights
-      invalid_plagiarism_texts
+      invalid_feedback_highlights.concat(invalid_plagiarism_texts)
     end
 
     def invalid_feedback_highlights

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -109,7 +109,7 @@ module Evidence
       super(options.reverse_merge(
         only: [:id, :parent_activity_id, :title, :version, :notes, :target_level, :scored_level],
         include: [:passages, :prompts],
-        methods: [:invalid_highlights, :flag]
+        methods: [:invalid_related_texts, :flag]
       ))
     end
 
@@ -135,13 +135,13 @@ module Evidence
       parent_activity.update(flag: flag)
     end
 
-    def invalid_highlights
+    def invalid_related_texts
       invalid_feedback_highlights.concat(invalid_plagiarism_texts)
     end
 
     def invalid_feedback_highlights
-      invalid_highlights = highlights.select { |h| h.invalid_activity_ids&.include?(id) }
-      invalid_highlights.map do |highlight|
+      invalid_related_texts = highlights.select { |h| h.invalid_activity_ids&.include?(id) }
+      invalid_related_texts.map do |highlight|
         {
           rule_id: highlight.feedback.rule_id,
           rule_type: highlight.feedback.rule.rule_type,

--- a/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/activity.rb
@@ -69,6 +69,7 @@ module Evidence
     has_many :rules, through: :prompts
     has_many :feedbacks, through: :rules
     has_many :highlights, through: :feedbacks
+    has_many :plagiarism_texts, through: :rules
 
     belongs_to :parent_activity, class_name: Evidence.parent_activity_classname
 
@@ -136,6 +137,7 @@ module Evidence
 
     def invalid_highlights
       invalid_feedback_highlights
+      invalid_plagiarism_texts
     end
 
     def invalid_feedback_highlights
@@ -145,6 +147,17 @@ module Evidence
           rule_id: highlight.feedback.rule_id,
           rule_type: highlight.feedback.rule.rule_type,
           prompt_id: highlight.feedback.rule.prompts.where(activity_id: id).first.id
+        }
+      end
+    end
+
+    def invalid_plagiarism_texts
+      invalid_plagiarism_texts = plagiarism_texts.select { |h| h.invalid_activity_ids&.include?(id) }
+      invalid_plagiarism_texts.map do |plagiarism_text|
+        {
+          rule_id: plagiarism_text.rule_id,
+          rule_type: plagiarism_text.rule.rule_type,
+          prompt_id: plagiarism_text.rule.prompts.where(activity_id: id).first.id
         }
       end
     end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
@@ -18,6 +18,8 @@
 #
 module Evidence
   class Highlight < ApplicationRecord
+    include TextFormatter
+    
     self.table_name = 'comprehension_highlights'
 
     include Evidence::ChangeLog
@@ -95,10 +97,6 @@ module Evidence
 
     private def second_order
       feedback.order == 1
-    end
-
-    private def strip_tags(input)
-      ::ActionController::Base.helpers.strip_tags(input)
     end
   end
 end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/highlight.rb
@@ -19,7 +19,7 @@
 module Evidence
   class Highlight < ApplicationRecord
     include TextFormatter
-    
+
     self.table_name = 'comprehension_highlights'
 
     include Evidence::ChangeLog

--- a/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
@@ -36,7 +36,8 @@ module Evidence
     def serializable_hash(options = nil)
       options ||= {}
       super(options.reverse_merge(
-        only: [:id, :rule_id, :text]
+        only: [:id, :rule_id, :text],
+        methods: [:valid_in_all_targets]
       ))
     end
 
@@ -54,6 +55,10 @@ module Evidence
 
     def conjunctions
       rule.prompts.map(&:conjunction)
+    end
+
+    def valid_in_all_targets
+      !invalid_activity_ids
     end
 
     def invalid_activity_ids

--- a/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
@@ -58,16 +58,7 @@ module Evidence
 
     def invalid_activity_ids
       related_passages = rule.prompts.map(&:activity).uniq.map(&:passages).flatten
-      invalid_ids = related_passages.reject do |p|
-        included = unscape_html_strip_tags_and_punctuation_and_downcase(p.text).include?(unscape_html_strip_tags_and_punctuation_and_downcase(text))
-        if !included
-          puts 'UNFORMATTED PASSAGE TEXT', p.text
-          puts 'UNFORMATTED TEXT', text
-          puts 'FORMATETTED PASSAGE TEXT', unscape_html_strip_tags_and_punctuation_and_downcase(p.text)
-          puts 'FORMATTED TEXT', unscape_html_strip_tags_and_punctuation_and_downcase(text)
-        end
-        included
-      end.map { |p| p.activity.id }
+      invalid_ids = related_passages.reject { |p| unescape_html_strip_tags_and_punctuation_and_downcase(p.text).include?(unescape_html_strip_tags_and_punctuation_and_downcase(text)) }.map { |p| p.activity.id }
       return if invalid_ids.empty?
 
       invalid_ids

--- a/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/plagiarism_text.rb
@@ -68,6 +68,5 @@ module Evidence
 
       invalid_ids
     end
-
   end
 end

--- a/services/QuillLMS/engines/evidence/config/routes.rb
+++ b/services/QuillLMS/engines/evidence/config/routes.rb
@@ -5,7 +5,7 @@ Evidence::Engine.routes.draw do
     member do
       get :activity_versions
       get :change_logs
-      get :invalid_highlights
+      get :invalid_related_texts
       put :increment_version
       get :rules
       get :topic_optimal_info

--- a/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
+++ b/services/QuillLMS/engines/evidence/lib/evidence/plagiarism_check.rb
@@ -4,6 +4,8 @@ require 'hotwater'
 
 module Evidence
   class PlagiarismCheck
+    include TextFormatter
+
     ALL_CORRECT_FEEDBACK = '<p>All plagiarism checks passed.</p>'
     PASSAGE_TYPE = 'passage'
     ENTRY_TYPE = 'response'
@@ -97,7 +99,7 @@ module Evidence
     end
 
     private def clean(str)
-      str.gsub(/[[:punct:]]/, '').downcase
+      strip_punctuation_and_downcase(str)
     end
 
     # split the entry into an array: ["i", "had", "a", "great", "time", "with", "you"]

--- a/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/controllers/evidence/activities_controller_spec.rb
@@ -593,26 +593,26 @@ module Evidence
       end
     end
 
-    context '#invalid_highlights' do
-      subject { get :invalid_highlights, params: { id: activity.id } }
+    context '#invalid_related_texts' do
+      subject { get :invalid_related_texts, params: { id: activity.id } }
       let(:parsed_response) { JSON.parse(response.body) }
 
       let(:because_rule) { create(:evidence_rule) }
       let(:because_prompt) { create(:evidence_prompt, rules: [because_rule]) }
       let(:activity) { create(:evidence_activity, prompts: [because_prompt]) }
-      let(:invalid_highlights) {
+      let(:invalid_related_texts) {
         [
           { rule_id: because_rule.id, rule_type: because_rule.rule_type, prompt_id: because_prompt.id }
         ]
       }
       let(:expected_response) {
         {
-          'invalid_highlights' => invalid_highlights.map(&:stringify_keys)
+          'invalid_related_texts' => invalid_related_texts.map(&:stringify_keys)
         }
       }
 
       before do
-        allow(activity).to receive(:invalid_highlights).and_return(invalid_highlights)
+        allow(activity).to receive(:invalid_related_texts).and_return(invalid_related_texts)
         allow(Activity).to receive(:find).and_return(activity)
       end
 

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/activity_spec.rb
@@ -222,25 +222,25 @@ module Evidence
       end
     end
 
-    context '#invalid_highlights' do
+    context '#invalid_related_texts' do
       let(:activity) { create(:evidence_activity, :with_prompt_and_passage) }
       let(:rule) { create(:evidence_rule, prompts: [activity.prompts.first]) }
       let(:feedback) { create(:evidence_feedback, rule: rule) }
       let(:highlight) { create(:evidence_highlight, feedback: feedback, highlight_type: 'passage', text: activity.passages.first.text) }
 
       it 'should return an empty array if there are no invalid highlights or plagiarism_texts at all' do
-        expect(activity.invalid_highlights).to eq([])
+        expect(activity.invalid_related_texts).to eq([])
       end
 
       it 'should return an empty array if all highlights and plagiarism_texts are valid' do
         expect(highlight.invalid_activity_ids).to be_nil
-        expect(activity.invalid_highlights).to eq([])
+        expect(activity.invalid_related_texts).to eq([])
       end
 
       it 'should return an array of rule_ids and rule_types for invalid highlights' do
         highlight.update(text: 'text that definitely is not in the passage')
-        expect(activity.invalid_highlights.length).to be(1)
-        expect(activity.invalid_highlights).to include({
+        expect(activity.invalid_related_texts.length).to be(1)
+        expect(activity.invalid_related_texts).to include({
           rule_id: rule.id,
           rule_type: rule.rule_type,
           prompt_id: rule.prompts.first.id

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/plagiarism_text_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/plagiarism_text_spec.rb
@@ -20,7 +20,6 @@ module Evidence
 
     context 'should validations' do
       it { should validate_presence_of(:rule) }
-
       it { should validate_presence_of(:text) }
     end
 
@@ -31,6 +30,43 @@ module Evidence
         json_hash = plagiarism_text.as_json
         expect(plagiarism_text.id).to(eq(json_hash['id']))
         expect(plagiarism_text.text).to(eq(json_hash['text']))
+      end
+    end
+
+    describe 'checks to make sure plagiarism text matches associated passages' do
+      let(:rule) { create(:evidence_rule) }
+      let!(:prompts) do
+        [
+          create(:evidence_prompt, activity: create(:evidence_activity, passages: [create(:evidence_passage, text: 'This is passage one it is at least fifty characters long and passes all validations.')])),
+          create(:evidence_prompt, activity: create(:evidence_activity, passages: [create(:evidence_passage, text: 'This is passage two it is at least fifty characters long and passes all validations.')]))
+        ]
+      end
+      let!(:prompts_rules) do
+        prompts.map { |prompt| create(:evidence_prompts_rule, prompt: prompt, rule: rule) }
+      end
+      let(:plagiarism_text) { create(:evidence_plagiarism_text, rule: rule, text: 'it is at least fifty characters long and passes all validations.') }
+
+      context 'invalid_activity_ids method' do
+        it 'returns nil when all related passages include the text' do
+          expect(plagiarism_text.invalid_activity_ids).to be_nil
+        end
+
+        it 'returns activity IDs when related passages do not include the text' do
+          plagiarism_text.update(text: 'This is passage two')
+          invalid_ids = [prompts.first.activity.id]
+          expect(plagiarism_text.invalid_activity_ids).to eq(invalid_ids)
+        end
+      end
+
+      context 'valid_in_all_targets method' do
+        it 'returns true when valid in all targets' do
+          expect(plagiarism_text.valid_in_all_targets).to be_truthy
+        end
+
+        it 'returns false when not valid in all targets' do
+          plagiarism_text.update(text: 'This is passage one')
+          expect(plagiarism_text.valid_in_all_targets).to be_falsey
+        end
       end
     end
   end


### PR DESCRIPTION
## WHAT
Handle invalid plagiarism texts similarly to how we handle invalid highlights.

## WHY
This was a request from the curriculum team.

## HOW
Update the backend to identify bad texts, and the frontend to display them. Also move some duplicated string formatting rules into a helper. Note: there's probably more deduplication we could do here, but since I'm going to be adding similar (but not identical) functionality for "relevant texts" as part of the AI project, I'm punting on that for now.

### Screenshots
<img width="1158" alt="Screenshot 2024-10-15 at 3 20 59 PM" src="https://github.com/user-attachments/assets/b3715ed3-2560-4651-bc79-c39dbeeadb23">
<img width="1026" alt="Screenshot 2024-10-15 at 3 21 06 PM" src="https://github.com/user-attachments/assets/2b1d6555-06b3-4557-8654-1f24effd4172">
<img width="1081" alt="Screenshot 2024-10-15 at 3 21 21 PM" src="https://github.com/user-attachments/assets/60fe5bfc-c11e-4581-b7d4-7663c4ffc713">

### Notion Card Links
https://www.notion.so/quill/The-CMS-is-not-showing-an-error-message-when-the-plagiarism-text-doesn-t-match-the-associated-text-i-3519ee8c595646cdb8accdf179a184a1?pvs=4

### What have you done to QA this feature?
Tested that a) the plagiarism check still functions, since I made a small change to that function, and that b) bad texts get highlighted on the activity settings page, the plagiarism rules index page, and the plagiarism rules show page.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
