### PR TITLE
Add prompt_id to Evidence::Research::GenAI::StemVault

### DIFF
--- a/services/QuillLMS/db/migrate/20241016130048_add_prompt_id_to_stem_vault.evidence.rb
+++ b/services/QuillLMS/db/migrate/20241016130048_add_prompt_id_to_stem_vault.evidence.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20241016125929)
+class AddPromptIdToStemVault < ActiveRecord::Migration[7.1]
+  def change
+    add_column :evidence_research_gen_ai_stem_vaults, :prompt_id, :integer
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3536,7 +3536,8 @@ CREATE TABLE public.evidence_research_gen_ai_stem_vaults (
     stem text NOT NULL,
     conjunction character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    prompt_id integer
 );
 
 
@@ -11727,6 +11728,7 @@ ALTER TABLE ONLY public.learn_worlds_account_course_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241016130048'),
 ('20241002164211'),
 ('20240925185730'),
 ('20240924151321'),

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
@@ -10,6 +10,7 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  activity_id :integer          not null
+#  prompt_id   :integer
 #
 module Evidence
   module Research
@@ -28,6 +29,7 @@ module Evidence
         }.freeze
 
         belongs_to :activity
+        belongs_to :prompt, class_name: 'Evidence::Prompt', optional: true
 
         has_many :guidelines, dependent: :destroy
         has_many :datasets, dependent: :destroy

--- a/services/QuillLMS/engines/evidence/db/migrate/20241016125929_add_prompt_id_to_stem_vault.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20241016125929_add_prompt_id_to_stem_vault.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPromptIdToStemVault < ActiveRecord::Migration[7.1]
+  def change
+    add_column :evidence_research_gen_ai_stem_vaults, :prompt_id, :integer
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1427,7 +1427,8 @@ CREATE TABLE public.evidence_research_gen_ai_stem_vaults (
     stem text NOT NULL,
     conjunction character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    prompt_id integer
 );
 
 
@@ -2573,6 +2574,7 @@ ALTER TABLE ONLY public.comprehension_regex_rules
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241016125929'),
 ('20241002153807'),
 ('20240925184213'),
 ('20240918144745'),

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/stem_vaults.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/stem_vaults.rb
@@ -10,6 +10,7 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  activity_id :integer          not null
+#  prompt_id   :integer
 #
 module Evidence
   module Research

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/stem_vault_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/stem_vault_spec.rb
@@ -10,6 +10,7 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  activity_id :integer          not null
+#  prompt_id   :integer
 #
 require 'rails_helper'
 
@@ -30,6 +31,7 @@ module Evidence
         it { should have_readonly_attribute(:activity_id) }
 
         it { should belong_to(:activity) }
+        it { should belong_to(:prompt).class_name('Evidence::Prompt').optional }
 
         it { have_many(:guidelines).dependent(:destroy) }
         it { have_many(:datasets).dependent(:destroy) }


### PR DESCRIPTION
## WHAT
Add `prompt_id` foreign_key to `Evidence::Research::GenAI::StemVault` model

## WHY
This will provide a link between `Evidence::Prompt` and  `Evidence::Research::GenAI::StemVault` which will facilitate integration of the TrialRunner into the CMS.

## HOW
Write a migration and then add a belongs_to relation.

### Screenshots

### Notion Card Links

### What have you done to QA this feature?
I have tested the staging console to see if I can add this piece of information on an existing ``Evidence::Research::GenAI::StemVault`

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
