### PR TITLE
Backpack/ minimal banner

### DIFF
--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/__tests__/__snapshots__/postNavigationbanner.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/__tests__/__snapshots__/postNavigationbanner.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PostNavigationBanner it should render 1`] = `
 <DocumentFragment>
   <div
-    class="banner-container green"
+    class="banner-container green green"
   >
     <div
       class="left-side-container"
@@ -31,7 +31,7 @@ exports[`PostNavigationBanner it should render 1`] = `
         class="buttons-container"
       >
         <a
-          class="quill-button-archived fun primary contained focus-on-light"
+          class="quill-button green extra-small contained focus-on-light"
           href="www.test1.com"
           rel="noopener noreferrer"
           target="_blank"
@@ -39,12 +39,12 @@ exports[`PostNavigationBanner it should render 1`] = `
           Learn more 
         </a>
         <button
-          class="quill-button-archived fun primary contained focus-on-light"
+          class="quill-button green extra-small contained focus-on-light"
         >
           View activities
         </button>
         <a
-          class="nonstandard-banner-button focus-on-light"
+          class="nonstandard-banner-button extra-small contained focus-on-light"
           href="www.test2.com"
           rel="noopener noreferrer"
           target="_blank"
@@ -56,7 +56,7 @@ exports[`PostNavigationBanner it should render 1`] = `
           />
         </a>
         <a
-          class="nonstandard-banner-button focus-on-light"
+          class="nonstandard-banner-button extra-small contained focus-on-light"
           href="www.test3.com"
           rel="noopener noreferrer"
           target="_blank"
@@ -81,7 +81,7 @@ exports[`PostNavigationBanner it should render 1`] = `
 exports[`PostNavigationBanner should render the buttons as expected 1`] = `
 <DocumentFragment>
   <div
-    class="banner-container green"
+    class="banner-container green green"
   >
     <div
       class="left-side-container"
@@ -109,7 +109,7 @@ exports[`PostNavigationBanner should render the buttons as expected 1`] = `
         class="buttons-container"
       >
         <a
-          class="quill-button-archived fun primary contained focus-on-light"
+          class="quill-button green extra-small contained focus-on-light"
           href="www.test1.com"
           rel="noopener noreferrer"
           target="_blank"
@@ -117,12 +117,12 @@ exports[`PostNavigationBanner should render the buttons as expected 1`] = `
           Learn more 
         </a>
         <button
-          class="quill-button-archived fun primary contained focus-on-light"
+          class="quill-button green extra-small contained focus-on-light"
         >
           View activities
         </button>
         <a
-          class="nonstandard-banner-button focus-on-light"
+          class="nonstandard-banner-button extra-small contained focus-on-light"
           href="www.test2.com"
           rel="noopener noreferrer"
           target="_blank"
@@ -134,7 +134,7 @@ exports[`PostNavigationBanner should render the buttons as expected 1`] = `
           />
         </a>
         <a
-          class="nonstandard-banner-button focus-on-light"
+          class="nonstandard-banner-button extra-small contained focus-on-light"
           href="www.test3.com"
           rel="noopener noreferrer"
           target="_blank"

--- a/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
+++ b/services/QuillLMS/client/app/bundles/Shared/components/shared/postNavigationBanner.tsx
@@ -10,23 +10,53 @@ interface BannerProps {
   closeAria?: string,
   closeIconSrc?: string,
   handleCloseCard?: () => void,
-  icon: {
+  icon?: {
     alt: string,
     src: string
   },
   buttons: {
+    className?: string
     onClick?: () => void,
     href?: string,
     standardButtonStyle: boolean,
     text: string,
     target?: string
   }[],
-  bannerStyle: string
+  bannerStyle?: string
+  bannerColor?: string
 }
 
-export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHeaderText, bodyText, icon, buttons, bannerStyle, closeIconSrc, handleCloseCard, closeAria }: BannerProps) => {
+export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHeaderText, bodyText, icon, buttons, bannerStyle, bannerColor, closeIconSrc, handleCloseCard, closeAria }: BannerProps) => {
+  const color = bannerColor ? bannerColor : 'green'
+  if(bannerStyle && bannerStyle.includes('minimal')) {
+    return(
+      <div className={`banner-container ${bannerStyle} ${color}`}>
+        <div className="left-side-container">
+          {tagText && <p className="tag">{tagText}</p>}
+          <p className="primary-header">{primaryHeaderText}</p>
+          <p className="body">{bodyText}</p>
+        </div>
+        <div className="buttons-container">
+          {buttons.map((button, i) => {
+            const { className, onClick, href, standardButtonStyle, text, target } = button
+            let buttonClass = standardButtonStyle ? `quill-button ${color} ` : "nonstandard-banner-button "
+            if(className) {
+              buttonClass += className
+            } else {
+              buttonClass += "extra-small contained"
+            }
+            if (button.onClick) {
+              return <button className={`${buttonClass} focus-on-light`} key={`button-${i}`} onClick={onClick}>{text}</button>
+            } else {
+              return <a className={`${buttonClass} focus-on-light`} href={href} key={`button-${i}`} rel="noopener noreferrer" target={target}>{text} {!standardButtonStyle && <img alt={arrowPointingRightIcon.alt} src={arrowPointingRightIcon.src} />}</a>
+            }
+          })}
+        </div>
+      </div>
+    )
+  }
   return(
-    <div className={`banner-container ${bannerStyle}`}>
+    <div className={`banner-container ${bannerStyle} ${color}`}>
       <div className="left-side-container">
         {(tagText || secondaryHeaderText) && <div className="upper-section">
           {tagText && <p className="tag">{tagText}</p>}
@@ -36,8 +66,13 @@ export const PostNavigationBanner = ({ tagText, primaryHeaderText, secondaryHead
         <p className="body">{bodyText}</p>
         <div className="buttons-container">
           {buttons.map((button, i) => {
-            const { onClick, href, standardButtonStyle, text, target } = button
-            const buttonClass = standardButtonStyle ? "quill-button-archived fun primary contained" : "nonstandard-banner-button"
+            const { className, onClick, href, standardButtonStyle, text, target } = button
+            let buttonClass = standardButtonStyle ? `quill-button ${color} ` : "nonstandard-banner-button "
+            if (className) {
+              buttonClass += className
+            } else {
+              buttonClass += "extra-small contained"
+            }
             if(button.onClick) {
               return <button className={`${buttonClass} focus-on-light`} key={`button-${i}`} onClick={onClick}>{text}</button>
             } else {

--- a/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/banner.scss
@@ -43,8 +43,8 @@
     .buttons-container {
       display: flex;
       margin-top: 24px;
-      .quill-button-archived {
-        margin-right: 16px;
+      .quill-button {
+        margin-right: 8px;
       }
       .nonstandard-banner-button {
         display: flex;
@@ -78,14 +78,19 @@
     top: 20px;
     right: 20px;
   }
+  &.minimal {
+    align-items: center;
+    .buttons-container {
+      .quill-button {
+        margin-left: 8px;
+      }
+    }
+  }
   &.green {
     background-color: $quill-green-1;
     border: 1px solid $quill-green-20;
-    .tag, .quill-button-archived {
-      background-color: $quill-green !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-green-50 !important;
+    .tag {
+      background-color: $quill-green;
     }
     .secondary-header {
       color: $quill-green;
@@ -94,11 +99,8 @@
   &.gold {
     background-color: $quill-gold-1;
     border: 1px solid $quill-gold-dark-10;
-    .tag, .quill-button-archived {
-      background-color: $quill-gold-dark-50 !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-gold-dark-20 !important;
+    .tag {
+      background-color: $quill-gold-dark-50;
     }
     .secondary-header {
       color: $quill-gold-dark;
@@ -107,13 +109,10 @@
   &.gold-secondary {
     background-color: $quill-gold-1;
     border: 1px solid $quill-gold-dark-10;
-    .tag, .quill-button-archived {
+    .tag {
       background-color: $quill-white !important;
       color: $quill-gold-dark !important;
       border: 1px solid $quill-gold-dark-10;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-white !important;
     }
     .secondary-header {
       color: $quill-gold-dark;
@@ -123,11 +122,8 @@
     background-color: $quill-viridian-1;
     border: 1px solid $quill-viridian-20;
 
-    .tag, .quill-button-archived {
+    .tag {
       background-color: $quill-viridian !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-viridian-50 !important;
     }
     .secondary-header {
       color: $quill-viridian;
@@ -137,11 +133,8 @@
     background-color: $quill-teal-1;
     border: 1px solid $quill-teal-20;
 
-    .tag, .quill-button-archived {
+    .tag {
       background-color: $quill-teal !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-teal-50 !important;
     }
     .secondary-header {
       color: $quill-teal;
@@ -151,11 +144,8 @@
     background-color: $quill-blue-1;
     border: 1px solid $quill-blue-20;
 
-    .tag, .quill-button-archived {
+    .tag {
       background-color: $quill-blue !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-blue-50 !important;
     }
     .secondary-header {
       color: $quill-blue;
@@ -165,11 +155,8 @@
     background-color: $quill-purple-1;
     border: 1px solid $quill-purple-20;
 
-    .tag, .quill-button-archived {
+    .tag {
       background-color: $quill-purple !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-purple-50 !important;
     }
     .secondary-header {
       color: $quill-purple;
@@ -179,11 +166,8 @@
     background-color: $quill-violet-1;
     border: 1px solid $quill-violet-20;
 
-    .tag, .quill-button-archived {
+    .tag {
       background-color: $quill-violet !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-violet-50 !important;
     }
     .secondary-header {
       color: $quill-violet;
@@ -193,11 +177,8 @@
     background-color: $quill-red-1;
     border: 1px solid $quill-red-20;
 
-    .tag, .quill-button-archived {
+    .tag {
       background-color: $quill-red !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-red-50 !important;
     }
     .secondary-header {
       color: $quill-red;
@@ -207,11 +188,8 @@
     background-color: $quill-maroon-1;
     border: 1px solid $quill-maroon-20;
 
-    .tag, .quill-button-archived {
+    .tag {
       background-color: $quill-maroon !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-maroon-50 !important;
     }
     .secondary-header {
       color: $quill-maroon;
@@ -221,11 +199,8 @@
     background-color: $quill-grey-1;
     border: 1px solid $quill-grey-15;
 
-    .tag, .quill-button-archived {
+    .tag {
       background-color: $quill-grey-50 !important;
-    }
-    .quill-button-archived:hover {
-      background-color: $quill-grey-20 !important;
     }
     .secondary-header {
       color: $quill-grey-50;
@@ -236,11 +211,11 @@
     border: 1px solid $quill-gold-dark-10;
 
     .tag,
-    .quill-button-archived {
+    .quill-button {
       background-color: $quill-gold-dark-50 !important;
     }
 
-    .quill-button-archived:hover {
+    .quill-button:hover {
       background-color: $quill-gold-20 !important;
     }
 
@@ -253,11 +228,11 @@
     border: 1px solid $quill-maroon-20;
 
     .tag,
-    .quill-button-archived {
+    .quill-button {
       background-color: $quill-maroon !important;
     }
 
-    .quill-button-archived:hover {
+    .quill-button:hover {
       background-color: $quill-maroon-50 !important;
     }
 

--- a/services/QuillLMS/client/app/bundles/Shared/styles/button.scss
+++ b/services/QuillLMS/client/app/bundles/Shared/styles/button.scss
@@ -1,3 +1,6 @@
+a.quill-button {
+  text-decoration: none !important;
+}
 .quill-button {
   display: inline-flex;
   padding: 4px 16px;

--- a/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/postNavigationBanners.tsx
+++ b/services/QuillLMS/client/app/bundles/Staff/components/styleGuide/postNavigationBanners.tsx
@@ -36,10 +36,12 @@ const PostNavigationBanners = () => {
     <div id="post-navigation-banners">
       <h2 className="style-guide-h2">Banners</h2>
       <div className="element-container">
-        <h3>Standard Banner with one button</h3>
+        <h3>Primary (One Button)</h3>
         <pre>
           {
             `
+  // color will default to green if no bannerColor prop is passed
+
   <PostNavigationBanner
     bannerStyle="${colorOption.value}"
     bodyText="Quickly archive last year's classes."
@@ -83,12 +85,12 @@ const PostNavigationBanners = () => {
         />
       </div>
       <div className="element-container">
-        <h3>Standard Banner with multiple buttons</h3>
+        <h3>Primary (Multiple Buttons)</h3>
         <pre>
           {
             `
   <PostNavigationBanner
-    bannerStyle="${colorOption.value}"
+    bannerColor="${colorOption.value}"
     bodyText="Quickly archive last year's classes."
     buttons={[
       {
@@ -133,7 +135,7 @@ const PostNavigationBanners = () => {
           value={colorOption}
         />
         <PostNavigationBanner
-          bannerStyle={colorOption.value}
+          bannerColor={colorOption.value}
           bodyText="Quickly archive last year's classes."
           buttons={[
             {
@@ -168,7 +170,68 @@ const PostNavigationBanners = () => {
         />
       </div>
       <div className="element-container">
-        <h3>Premium Banner</h3>
+        <h3>Minimal</h3>
+        <pre>
+          {
+            `
+  <PostNavigationBanner
+    bannerColor={colorOption.value}
+    bannerStyle="minimal"
+    bodyText="Quickly archive last year's classes."
+    buttons={[
+      {
+        href: "",
+        className: "extra-small contained",
+        standardButtonStyle: true,
+        text: "Action",
+        target: "_blank"
+      },
+      {
+        href: "",
+        className: "extra-small outlined",
+        standardButtonStyle: true,
+        text: "Action",
+        target: "_blank"
+      }
+    ]}
+    primaryHeaderText="Start of a new school year?"
+  />
+            `
+          }
+        </pre>
+        <DropdownInput
+          className="color-options-dropdown"
+          handleChange={handleColorOptionChange}
+          isSearchable={true}
+          label="Banner color options"
+          options={COLOR_OPTIONS}
+          value={colorOption}
+        />
+        <PostNavigationBanner
+          bannerColor={colorOption.value}
+          bannerStyle="minimal"
+          bodyText="Quickly archive last year's classes"
+          buttons={[
+            {
+              href: "",
+              className: "extra-small contained",
+              standardButtonStyle: true,
+              text: "Action",
+              target: "_blank"
+            },
+            {
+              href: "",
+              className: "extra-small outlined",
+              standardButtonStyle: true,
+              text: "Action",
+              target: "_blank"
+            }
+          ]}
+          primaryHeaderText="Start of the new school year?"
+        />
+      </div>
+      <div className="element-container">
+        <h3>Premium</h3>
         <pre>
           {
             `

--- a/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/promotional_card.test.tsx.snap
+++ b/services/QuillLMS/client/app/bundles/Teacher/components/dashboard/__tests__/__snapshots__/promotional_card.test.tsx.snap
@@ -300,7 +300,7 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
       primaryHeaderText="Four Big Updates for the 2024-2025 School Year"
     >
       <div
-        className="banner-container gold-secondary school-year-updates-card"
+        className="banner-container gold-secondary school-year-updates-card green"
       >
         <div
           className="left-side-container"
@@ -332,7 +332,7 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
             className="buttons-container"
           >
             <a
-              className="quill-button-archived fun primary contained focus-on-light"
+              className="quill-button green extra-small contained focus-on-light"
               href="/teacher-center/quills-four-big-updates-for-the-20242025-school-year#diagnostics"
               key="button-0"
               rel="noopener noreferrer"
@@ -497,7 +497,7 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
       primaryHeaderText="Four Big Updates for the 2024-2025 School Year"
     >
       <div
-        className="banner-container gold-secondary school-year-updates-card"
+        className="banner-container gold-secondary school-year-updates-card green"
       >
         <div
           className="left-side-container"
@@ -529,7 +529,7 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
             className="buttons-container"
           >
             <a
-              className="quill-button-archived fun primary contained focus-on-light"
+              className="quill-button green extra-small contained focus-on-light"
               href="/teacher-center/quills-four-big-updates-for-the-20242025-school-year#diagnostics"
               key="button-0"
               rel="noopener noreferrer"
@@ -862,7 +862,7 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
       primaryHeaderText="Four Big Updates for the 2024-2025 School Year"
     >
       <div
-        className="banner-container gold-secondary school-year-updates-card"
+        className="banner-container gold-secondary school-year-updates-card green"
       >
         <div
           className="left-side-container"
@@ -894,7 +894,7 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
             className="buttons-container"
           >
             <a
-              className="quill-button-archived fun primary contained focus-on-light"
+              className="quill-button green extra-small contained focus-on-light"
               href="/teacher-center/quills-four-big-updates-for-the-20242025-school-year#diagnostics"
               key="button-0"
               rel="noopener noreferrer"
@@ -1059,7 +1059,7 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
       primaryHeaderText="Four Big Updates for the 2024-2025 School Year"
     >
       <div
-        className="banner-container gold-secondary school-year-updates-card"
+        className="banner-container gold-secondary school-year-updates-card green"
       >
         <div
           className="left-side-container"
@@ -1091,7 +1091,7 @@ exports[`PromotionalCard container BulkArchiveClassesCard rendering behavior whe
             className="buttons-container"
           >
             <a
-              className="quill-button-archived fun primary contained focus-on-light"
+              className="quill-button green extra-small contained focus-on-light"
               href="/teacher-center/quills-four-big-updates-for-the-20242025-school-year#diagnostics"
               key="button-0"
               rel="noopener noreferrer"
@@ -1424,7 +1424,7 @@ exports[`PromotionalCard container SchoolYearUpdatesCard rendering behavior when
       primaryHeaderText="Four Big Updates for the 2024-2025 School Year"
     >
       <div
-        className="banner-container gold-secondary school-year-updates-card"
+        className="banner-container gold-secondary school-year-updates-card green"
       >
         <div
           className="left-side-container"
@@ -1456,7 +1456,7 @@ exports[`PromotionalCard container SchoolYearUpdatesCard rendering behavior when
             className="buttons-container"
           >
             <a
-              className="quill-button-archived fun primary contained focus-on-light"
+              className="quill-button green extra-small contained focus-on-light"
               href="/teacher-center/quills-four-big-updates-for-the-20242025-school-year#diagnostics"
               key="button-0"
               rel="noopener noreferrer"


### PR DESCRIPTION
## WHAT
add minimal banner to Backpack

## WHY
we want this as a reusable component

## HOW
tweak `PostNavigationBanner` to accept `minimal` style (also tweak some of the CSS around button styling for existing banners)

### Screenshots
(If applicable. Also, please censor any sensitive data)
<img width="923" alt="Screen Shot 2024-10-16 at 7 13 35 PM" src="https://github.com/user-attachments/assets/a81cb7cf-6b93-496a-8a14-9791aa42462c">

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Quill-Backpack-Addition-of-New-Banner-Minimal-Component-6a241fd27f2644caa12263b729c2e7d7

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
tested on staging that banner renders as expected (also verified that existing banners render as expected)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
