### PR TITLE
Fix stray calculation bugs in Vitally stats

### DIFF
--- a/services/QuillLMS/app/models/concerns/teacher.rb
+++ b/services/QuillLMS/app/models/concerns/teacher.rb
@@ -705,7 +705,7 @@ module Teacher
       .joins('JOIN classrooms_teachers ON classrooms.id=classrooms_teachers.classroom_id')
       .joins('JOIN users on users.id = classrooms_teachers.user_id')
       .where('users.id = ?', id)
-      .select('assigned_student_ids, activities.id, unit_activities.created_at')
+      .select('assigned_student_ids, activities.id, classroom_units.created_at')
   end
 
   private def base_sql_for_teacher_classrooms(only_visible_classrooms: true)

--- a/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
+++ b/services/QuillLMS/app/models/concerns/vitally_school_stats.rb
@@ -29,9 +29,12 @@ module VitallySchoolStats
   end
 
   def activities_assigned_query
-    @activities_assigned ||= ClassroomUnit.joins(classroom_unscoped: { teachers: :school }, unit: :activities)
+    @activities_assigned ||= ClassroomUnit.joins(classroom_unscoped: { teachers: :school })
+      .joins('JOIN units on classroom_units.unit_id = units.id')
+      .joins('JOIN unit_activities on unit_activities.unit_id = units.id')
+      .joins('JOIN activities ON unit_activities.activity_id = activities.id')
       .where('schools.id = ?', school.id)
       .where('classrooms_teachers.role = ?', ClassroomsTeacher::ROLE_TYPES[:owner])
-      .select('assigned_student_ids', 'activities.id', 'unit_activities.created_at')
+      .select('assigned_student_ids', 'activities.id', 'classroom_units.created_at')
   end
 end

--- a/services/QuillLMS/spec/services/vitally_integration/previous_year_school_datum_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/previous_year_school_datum_spec.rb
@@ -107,5 +107,34 @@ RSpec.describe VitallyIntegration::PreviousYearSchoolDatum, type: :model do
       teacher_data = described_class.new(school, year).calculate_data
       expect(teacher_data).to include(expected_data)
     end
+
+    it 'should include archived units' do
+      unit.update(visible: false)
+
+      create(:unit_activity, unit: unit, activity: post_diagnostic_activity, created_at: Date.new(year, 10, 1))
+      create(:unit_activity, unit: unit, activity: pre_diagnostic_activity, created_at: Date.new(year, 10, 1))
+      create(:activity_session,
+        user: student,
+        classroom_unit: classroom_unit1,
+        state: 'finished',
+        completed_at: Date.new(year, 10, 2),
+        updated_at: Date.new(year, 10, 2),
+        activity: pre_diagnostic_activity)
+      create(:activity_session,
+        user: student,
+        classroom_unit: classroom_unit1,
+        state: 'finished',
+        completed_at: Date.new(year, 10, 2),
+        updated_at: Date.new(year, 10, 2),
+        activity: post_diagnostic_activity)
+
+      expected_data = {
+        pre_diagnostics_assigned: 2,
+        pre_diagnostics_completed: 1,
+        post_diagnostics_assigned: 2,
+        post_diagnostics_completed: 1
+      }
+      expect(described_class.new(school, year).calculate_data).to include(expected_data)
+    end
   end
 end

--- a/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
+++ b/services/QuillLMS/spec/services/vitally_integration/serialize_vitally_sales_account_spec.rb
@@ -277,6 +277,25 @@ describe VitallyIntegration::SerializeVitallySalesAccount do
       it { expect(results[:traits][:active_students]).to eq(2) }
     end
 
+    context 'archived units' do
+      before do
+        Unit.update_all(visible: false)
+      end
+
+      it do
+        expect(results[:traits]).to include(
+          active_students: 2,
+          active_students_this_year: 1,
+          total_students: 3,
+          total_students_this_year: 1,
+          activities_finished: 3,
+          activities_finished_this_year: 2,
+          activities_per_student: 1.5,
+          activities_per_student_this_year: 2.0
+        )
+      end
+    end
+
     context 'when teachers are merely coteachers and not owners of the classroom' do
       let!(:classroom_teachers) { create_list(:classrooms_teacher, 2, classroom:, role: 'coteacher') }
 


### PR DESCRIPTION
## WHAT
Fix two small bugs that are still throwing off some of our Vitally numbers:
1. To find the date an activity was assigned, use the `created_at` date for ClassroomUnit instead of UnitActivity.
2. Use manual SQL statements to select for units and unit_activities because we are currently scoping `Units` so ActiveRecord selects will not pick up units that are `visible: false`. This is unintentionally omitting some units that have been archived by teachers.

## WHY
These bugs are causing slight inaccuracies in data reported for Vitally schools and teachers.

## HOW
See above.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-Vitally-Data-Sync-New-Diagnostic-Usage-Data-2fb92d4ba89847af9da661fc78710556?pvs=4

### What have you done to QA this feature?
I have manually run this new code in the production console for a school and teacher that had reported inaccuracies in their Vitally data. The new numbers using my new queries match expected numbers for that school.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  (The answer should mostly be 'YES'. If you answer 'NO', please justify.)
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
