### PR TITLE
Fix incorrect pathing bug on manifest.json

### DIFF
--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -38,7 +38,7 @@
   <meta name="og:description" content="<%= @description || @content %>">
   <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
   <link rel="canonical" href="https://www.quill.org<%= request.path %>">
-  <link rel="manifest" href="<%= ENV['DEFAULT_URL'] + "/manifest.json" %>" />
+  <link rel="manifest" href="/manifest.json" />
 
   <script defer src="<%= ENV['FONT_AWESOME_KIT_LINK'] %>" crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
   <!-- Inspectlet tracking -->

--- a/services/QuillLMS/app/views/application/_head.html.erb
+++ b/services/QuillLMS/app/views/application/_head.html.erb
@@ -38,7 +38,7 @@
   <meta name="og:description" content="<%= @description || @content %>">
   <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
   <link rel="canonical" href="https://www.quill.org<%= request.path %>">
-  <link rel="manifest" href="manifest.json" />
+  <link rel="manifest" href="<%= ENV['DEFAULT_URL'] + "/manifest.json" %>" />
 
   <script defer src="<%= ENV['FONT_AWESOME_KIT_LINK'] %>" crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
   <!-- Inspectlet tracking -->

--- a/services/QuillLMS/app/views/layouts/home.html.erb
+++ b/services/QuillLMS/app/views/layouts/home.html.erb
@@ -42,7 +42,7 @@
     <meta property="twitter:image"  content="https:<%= image_url('share/facebook.png') %>" />
     <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
     <link rel="canonical" href="https://www.quill.org<%= request.path %>">
-    <link rel="manifest" href="<%= ENV['DEFAULT_URL'] + "/manifest.json" %>" />
+    <link rel="manifest" href="/manifest.json" />
 
     <script defer src="<%= ENV['FONT_AWESOME_KIT_LINK'] %>" crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
     <%= render partial: 'typekit' unless Rails.env.test? %>

--- a/services/QuillLMS/app/views/layouts/home.html.erb
+++ b/services/QuillLMS/app/views/layouts/home.html.erb
@@ -42,7 +42,7 @@
     <meta property="twitter:image"  content="https:<%= image_url('share/facebook.png') %>" />
     <link rel="apple-touch-icon" href="<%= ENV['CDN_URL'].gsub(/[‘’]/, '') + "/images/logos/apple-touch-icon.png" %>">
     <link rel="canonical" href="https://www.quill.org<%= request.path %>">
-    <link rel="manifest" href="manifest.json" />
+    <link rel="manifest" href="<%= ENV['DEFAULT_URL'] + "/manifest.json" %>" />
 
     <script defer src="<%= ENV['FONT_AWESOME_KIT_LINK'] %>" crossorigin="anonymous" integrity="sha384-p7JrABPXxZLpj1XoHTzkPyVs8ekVssRFXc4B7XU6Z1c8XVDA7sVPem/lQ9UouxqE"></script>
     <%= render partial: 'typekit' unless Rails.env.test? %>


### PR DESCRIPTION
## WHAT
Fix a bug where the link to `manifest.json` file was 404ing on some pages.

## WHY
We don't want any 404 errors on the site and a missing manifest file prevents the user from downloading our PWA app.

## HOW
Use an absolute path here instead of relative path, because some of the relative paths such as login page and teacher home page are on a different root path, so the manifest file is not found.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
Deploy to staging and verify that the pages where this manifest is currently 404ing are not broken after the update.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no, tested manually
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
 