### PR TITLE
Create RelevantText and related models

### DIFF
--- a/services/QuillLMS/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/config/initializers/zeitwerk.rb
@@ -25,6 +25,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_prompt_builder' => 'LLMPromptBuilder',
     'llm_prompt_guideline' => 'LLMPromptGuideline',
     'llm_prompt_prompt_example' => 'LLMPromptPromptExample',
+    'llm_prompt_relevant_text' => 'LLMPromptRelevantText',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',
     'llms' => 'LLMs',

--- a/services/QuillLMS/db/migrate/20241022194329_create_relevant_texts.evidence.rb
+++ b/services/QuillLMS/db/migrate/20241022194329_create_relevant_texts.evidence.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20241022191325)
+class CreateRelevantTexts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :evidence_research_gen_ai_relevant_texts do |t|
+      t.text :text, null: false
+      t.text :notes, default: ''
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20241022194330_create_dataset_relevant_text.evidence.rb
+++ b/services/QuillLMS/db/migrate/20241022194330_create_dataset_relevant_text.evidence.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20241022191503)
+class CreateDatasetRelevantText < ActiveRecord::Migration[7.1]
+  def change
+    create_table :evidence_research_gen_ai_dataset_relevant_texts do |t|
+      t.integer :dataset_id, null: false
+      t.integer :relevant_text_id, null: false
+      t.boolean :default, default: false
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20241022194331_create_llm_prompt_relevant_text.evidence.rb
+++ b/services/QuillLMS/db/migrate/20241022194331_create_llm_prompt_relevant_text.evidence.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20241022191551)
+class CreateLLMPromptRelevantText < ActiveRecord::Migration[7.1]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompt_relevant_texts do |t|
+      t.integer :llm_prompt_id, null: false
+      t.integer :relevant_text_id, null: false
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/db/migrate/20241022194332_add_notes_to_dataset.evidence.rb
+++ b/services/QuillLMS/db/migrate/20241022194332_add_notes_to_dataset.evidence.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20241022191816)
+class AddNotesToDataset < ActiveRecord::Migration[7.1]
+  def change
+    add_column :evidence_research_gen_ai_datasets, :notes, :text
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -145,7 +145,7 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
           item timestamp;
         BEGIN
           SELECT created_at INTO as_created_at FROM activity_sessions WHERE id = act_sess;
-          
+
           -- backward compatibility block
           IF as_created_at IS NULL OR as_created_at < timestamp '2013-08-25 00:00:00.000000' THEN
             SELECT SUM(
@@ -160,11 +160,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
                       'epoch' FROM (activity_sessions.completed_at - activity_sessions.started_at)
                     )
                 END) INTO time_spent FROM activity_sessions WHERE id = act_sess AND state='finished';
-                
+
                 RETURN COALESCE(time_spent,0);
           END IF;
-          
-          
+
+
           first_item := NULL;
           last_item := NULL;
           max_item := NULL;
@@ -188,11 +188,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
 
             END IF;
           END LOOP;
-          
+
           IF max_item IS NOT NULL AND first_item IS NOT NULL THEN
             time_spent := time_spent + EXTRACT( EPOCH FROM max_item - first_item );
           END IF;
-          
+
           RETURN time_spent;
         END;
       $$;
@@ -207,7 +207,7 @@ CREATE FUNCTION public.timespent_student(student integer) RETURNS bigint
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (
           SELECT id,timespent_activity_session(id) AS time_spent FROM activity_sessions
-          WHERE activity_sessions.user_id = student 
+          WHERE activity_sessions.user_id = student
           GROUP BY id) as as_ids;
 
       $$;
@@ -3110,6 +3110,39 @@ ALTER SEQUENCE public.evidence_research_gen_ai_comparisons_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_dataset_relevant_texts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_dataset_relevant_texts (
+    id bigint NOT NULL,
+    dataset_id integer NOT NULL,
+    relevant_text_id integer NOT NULL,
+    "default" boolean DEFAULT false,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_dataset_relevant_texts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_dataset_relevant_texts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_dataset_relevant_texts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_dataset_relevant_texts_id_seq OWNED BY public.evidence_research_gen_ai_dataset_relevant_texts.id;
+
+
+--
 -- Name: evidence_research_gen_ai_datasets; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3123,7 +3156,8 @@ CREATE TABLE public.evidence_research_gen_ai_datasets (
     updated_at timestamp(6) without time zone NOT NULL,
     version integer NOT NULL,
     parent_id integer,
-    task_type character varying
+    task_type character varying,
+    notes text
 );
 
 
@@ -3353,6 +3387,38 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompt_relevant_texts (
+    id bigint NOT NULL,
+    llm_prompt_id integer NOT NULL,
+    relevant_text_id integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompt_relevant_texts.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3525,6 +3591,38 @@ CREATE SEQUENCE public.evidence_research_gen_ai_prompt_template_variables_id_seq
 --
 
 ALTER SEQUENCE public.evidence_research_gen_ai_prompt_template_variables_id_seq OWNED BY public.evidence_research_gen_ai_prompt_template_variables.id;
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_relevant_texts (
+    id bigint NOT NULL,
+    text text NOT NULL,
+    notes text DEFAULT ''::text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_relevant_texts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_relevant_texts_id_seq OWNED BY public.evidence_research_gen_ai_relevant_texts.id;
 
 
 --
@@ -7096,6 +7194,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_comparisons ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_dataset_relevant_texts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_dataset_relevant_texts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_dataset_relevant_texts_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_datasets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7145,6 +7250,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_prompt_examples ALTE
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_relevant_texts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7177,6 +7289,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_examples ALTER COLUMN id
 --
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_template_variables ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_prompt_template_variables_id_seq'::regclass);
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_relevant_texts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_relevant_texts_id_seq'::regclass);
 
 
 --
@@ -8430,6 +8549,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_comparisons
 
 
 --
+-- Name: evidence_research_gen_ai_dataset_relevant_texts evidence_research_gen_ai_dataset_relevant_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_dataset_relevant_texts
+    ADD CONSTRAINT evidence_research_gen_ai_dataset_relevant_texts_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: evidence_research_gen_ai_datasets evidence_research_gen_ai_datasets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8486,6 +8613,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_prompt_examples
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts evidence_research_gen_ai_llm_prompt_relevant_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_relevant_texts
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_relevant_texts_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates evidence_research_gen_ai_llm_prompt_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8523,6 +8658,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_examples
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_template_variables
     ADD CONSTRAINT evidence_research_gen_ai_prompt_template_variables_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts evidence_research_gen_ai_relevant_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_relevant_texts
+    ADD CONSTRAINT evidence_research_gen_ai_relevant_texts_pkey PRIMARY KEY (id);
 
 
 --
@@ -11730,6 +11873,10 @@ ALTER TABLE ONLY public.learn_worlds_account_course_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241022194332'),
+('20241022194331'),
+('20241022194330'),
+('20241022194329'),
 ('20241016130048'),
 ('20241004133706'),
 ('20241002164211'),

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3636,7 +3636,6 @@ CREATE TABLE public.evidence_research_gen_ai_stem_vaults (
     conjunction character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    automl_data jsonb DEFAULT '{}'::jsonb NOT NULL,
     prompt_id integer
 );
 
@@ -11878,7 +11877,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241022194330'),
 ('20241022194329'),
 ('20241016130048'),
-('20241004133706'),
 ('20241002164211'),
 ('20240926201615'),
 ('20240925185730'),

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3156,7 +3156,6 @@ CREATE TABLE public.evidence_research_gen_ai_datasets (
     updated_at timestamp(6) without time zone NOT NULL,
     version integer NOT NULL,
     parent_id integer,
-    task_type character varying,
     notes text
 );
 
@@ -11878,7 +11877,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241022194329'),
 ('20241016130048'),
 ('20241002164211'),
-('20240926201615'),
 ('20240925185730'),
 ('20240924151321'),
 ('20240924151311'),

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
@@ -9,7 +9,6 @@
 #  notes            :text
 #  optimal_count    :integer          default(0), not null
 #  suboptimal_count :integer          default(0), not null
-#  task_type        :string
 #  version          :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
@@ -6,6 +6,7 @@
 #
 #  id               :bigint           not null, primary key
 #  locked           :boolean          default(FALSE), not null
+#  notes            :text
 #  optimal_count    :integer          default(0), not null
 #  suboptimal_count :integer          default(0), not null
 #  task_type        :string

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset_relevant_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset_relevant_text.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_dataset_relevant_texts
+#
+#  id               :bigint           not null, primary key
+#  default          :boolean          default(FALSE)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  dataset_id       :integer          not null
+#  relevant_text_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class DatasetRelevantText < ApplicationRecord
+        belongs_to :dataset
+        belongs_to :relevant_text
+
+        validates :dataset_id, presence: true
+        validates :relevant_text_id, presence: true
+
+        attr_readonly :dataset_id, :relevant_text_id
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_relevant_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/llm_prompt_relevant_text.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_relevant_texts
+#
+#  id               :bigint           not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  llm_prompt_id    :integer          not null
+#  relevant_text_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class LLMPromptRelevantText < ApplicationRecord
+        belongs_to :llm_prompt
+        belongs_to :relevant_text
+
+        validates :llm_prompt_id, presence: true
+        validates :relevant_text_id, presence: true
+
+        attr_readonly :llm_prompt_id, :relevant_text_id
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/relevant_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/relevant_text.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_relevant_texts
+#
+#  id         :bigint           not null, primary key
+#  notes      :text             default("")
+#  text       :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+module Evidence
+  module Research
+    module GenAI
+      class RelevantText < ApplicationRecord
+        validates :text, presence: true
+        attr_readonly :text
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
@@ -5,7 +5,6 @@
 # Table name: evidence_research_gen_ai_stem_vaults
 #
 #  id          :bigint           not null, primary key
-#  automl_data :jsonb            not null
 #  conjunction :string           not null
 #  stem        :text             not null
 #  created_at  :datetime         not null

--- a/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/zeitwerk.rb
@@ -20,6 +20,7 @@ Rails.autoloaders.each do |autoloader|
     'llm_prompt_builder' => 'LLMPromptBuilder',
     'llm_prompt_guideline' => 'LLMPromptGuideline',
     'llm_prompt_prompt_example' => 'LLMPromptPromptExample',
+    'llm_prompt_relevant_text' => 'LLMPromptRelevantText',
     'llm_prompt_template' => 'LLMPromptTemplate',
     'llm_prompt_templates_controller' => 'LLMPromptTemplatesController',
     'llms' => 'LLMs',

--- a/services/QuillLMS/engines/evidence/db/migrate/20241022191325_create_relevant_texts.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20241022191325_create_relevant_texts.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateRelevantTexts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :evidence_research_gen_ai_relevant_texts do |t|
+      t.text :text, null: false
+      t.text :notes, default: ''
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20241022191503_create_dataset_relevant_text.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20241022191503_create_dataset_relevant_text.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateDatasetRelevantText < ActiveRecord::Migration[7.1]
+  def change
+    create_table :evidence_research_gen_ai_dataset_relevant_texts do |t|
+      t.integer :dataset_id, null: false
+      t.integer :relevant_text_id, null: false
+      t.boolean :default, default: false
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20241022191551_create_llm_prompt_relevant_text.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20241022191551_create_llm_prompt_relevant_text.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateLLMPromptRelevantText < ActiveRecord::Migration[7.1]
+  def change
+    create_table :evidence_research_gen_ai_llm_prompt_relevant_texts do |t|
+      t.integer :llm_prompt_id, null: false
+      t.integer :relevant_text_id, null: false
+      t.timestamps
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20241022191816_add_notes_to_dataset.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20241022191816_add_notes_to_dataset.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotesToDataset < ActiveRecord::Migration[7.1]
+  def change
+    add_column :evidence_research_gen_ai_datasets, :notes, :text
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1047,7 +1047,6 @@ CREATE TABLE public.evidence_research_gen_ai_datasets (
     updated_at timestamp(6) without time zone NOT NULL,
     version integer NOT NULL,
     parent_id integer,
-    task_type character varying,
     notes text
 );
 
@@ -2724,7 +2723,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241022191325'),
 ('20241016125929'),
 ('20241002153807'),
-('20240926201306'),
 ('20240925184213'),
 ('20240918144745'),
 ('20240828221309'),

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1001,6 +1001,39 @@ ALTER SEQUENCE public.evidence_research_gen_ai_comparisons_id_seq OWNED BY publi
 
 
 --
+-- Name: evidence_research_gen_ai_dataset_relevant_texts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_dataset_relevant_texts (
+    id bigint NOT NULL,
+    dataset_id integer NOT NULL,
+    relevant_text_id integer NOT NULL,
+    "default" boolean DEFAULT false,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_dataset_relevant_texts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_dataset_relevant_texts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_dataset_relevant_texts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_dataset_relevant_texts_id_seq OWNED BY public.evidence_research_gen_ai_dataset_relevant_texts.id;
+
+
+--
 -- Name: evidence_research_gen_ai_datasets; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1014,7 +1047,8 @@ CREATE TABLE public.evidence_research_gen_ai_datasets (
     updated_at timestamp(6) without time zone NOT NULL,
     version integer NOT NULL,
     parent_id integer,
-    task_type character varying
+    task_type character varying,
+    notes text
 );
 
 
@@ -1244,6 +1278,38 @@ ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_prompt_examples_id_seq
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_llm_prompt_relevant_texts (
+    id bigint NOT NULL,
+    llm_prompt_id integer NOT NULL,
+    relevant_text_id integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq OWNED BY public.evidence_research_gen_ai_llm_prompt_relevant_texts.id;
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1416,6 +1482,38 @@ CREATE SEQUENCE public.evidence_research_gen_ai_prompt_template_variables_id_seq
 --
 
 ALTER SEQUENCE public.evidence_research_gen_ai_prompt_template_variables_id_seq OWNED BY public.evidence_research_gen_ai_prompt_template_variables.id;
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evidence_research_gen_ai_relevant_texts (
+    id bigint NOT NULL,
+    text text NOT NULL,
+    notes text DEFAULT ''::text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.evidence_research_gen_ai_relevant_texts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.evidence_research_gen_ai_relevant_texts_id_seq OWNED BY public.evidence_research_gen_ai_relevant_texts.id;
 
 
 --
@@ -1857,6 +1955,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_comparisons ALTER COLUMN id SET
 
 
 --
+-- Name: evidence_research_gen_ai_dataset_relevant_texts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_dataset_relevant_texts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_dataset_relevant_texts_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_datasets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1906,6 +2011,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_prompt_examples ALTE
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_relevant_texts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_llm_prompt_relevant_texts_id_seq'::regclass);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1938,6 +2050,13 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_examples ALTER COLUMN id
 --
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_template_variables ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_prompt_template_variables_id_seq'::regclass);
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_relevant_texts ALTER COLUMN id SET DEFAULT nextval('public.evidence_research_gen_ai_relevant_texts_id_seq'::regclass);
 
 
 --
@@ -2214,6 +2333,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_comparisons
 
 
 --
+-- Name: evidence_research_gen_ai_dataset_relevant_texts evidence_research_gen_ai_dataset_relevant_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_dataset_relevant_texts
+    ADD CONSTRAINT evidence_research_gen_ai_dataset_relevant_texts_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: evidence_research_gen_ai_datasets evidence_research_gen_ai_datasets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2270,6 +2397,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_prompt_examples
 
 
 --
+-- Name: evidence_research_gen_ai_llm_prompt_relevant_texts evidence_research_gen_ai_llm_prompt_relevant_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_llm_prompt_relevant_texts
+    ADD CONSTRAINT evidence_research_gen_ai_llm_prompt_relevant_texts_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: evidence_research_gen_ai_llm_prompt_templates evidence_research_gen_ai_llm_prompt_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2307,6 +2442,14 @@ ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_examples
 
 ALTER TABLE ONLY public.evidence_research_gen_ai_prompt_template_variables
     ADD CONSTRAINT evidence_research_gen_ai_prompt_template_variables_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evidence_research_gen_ai_relevant_texts evidence_research_gen_ai_relevant_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evidence_research_gen_ai_relevant_texts
+    ADD CONSTRAINT evidence_research_gen_ai_relevant_texts_pkey PRIMARY KEY (id);
 
 
 --
@@ -2576,6 +2719,10 @@ ALTER TABLE ONLY public.comprehension_regex_rules
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241022191816'),
+('20241022191551'),
+('20241022191503'),
+('20241022191325'),
 ('20241016125929'),
 ('20241004133206'),
 ('20241002153807'),

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1527,7 +1527,6 @@ CREATE TABLE public.evidence_research_gen_ai_stem_vaults (
     conjunction character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    automl_data jsonb DEFAULT '{}'::jsonb NOT NULL,
     prompt_id integer
 );
 
@@ -2724,7 +2723,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241022191503'),
 ('20241022191325'),
 ('20241016125929'),
-('20241004133206'),
 ('20241002153807'),
 ('20240926201306'),
 ('20240925184213'),

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/dataset_relevant_texts.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/dataset_relevant_texts.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_dataset_relevant_texts
+#
+#  id               :bigint           not null, primary key
+#  default          :boolean          default(FALSE)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  dataset_id       :integer          not null
+#  relevant_text_id :integer          not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_dataset_relevant_text, class: 'Evidence::Research::GenAI::DatasetRelevantText' do
+          text { 'This is the text' }
+          notes { 'These are the notes' }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/dataset_relevant_texts.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/dataset_relevant_texts.rb
@@ -17,8 +17,8 @@ module Evidence
     module GenAI
       FactoryBot.define do
         factory :evidence_research_gen_ai_dataset_relevant_text, class: 'Evidence::Research::GenAI::DatasetRelevantText' do
-          text { 'This is the text' }
-          notes { 'These are the notes' }
+          dataset { association :evidence_research_gen_ai_dataset }
+          relevant_text { association :evidence_research_gen_ai_relevant_text }
         end
       end
     end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/datasets.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/datasets.rb
@@ -9,7 +9,6 @@
 #  notes            :text
 #  optimal_count    :integer          default(0), not null
 #  suboptimal_count :integer          default(0), not null
-#  task_type        :string
 #  version          :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/datasets.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/datasets.rb
@@ -6,9 +6,10 @@
 #
 #  id               :bigint           not null, primary key
 #  locked           :boolean          default(FALSE), not null
+#  notes            :text
 #  optimal_count    :integer          default(0), not null
 #  suboptimal_count :integer          default(0), not null
-#  task_type        :string           not null
+#  task_type        :string
 #  version          :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_relevant_texts.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_relevant_texts.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_relevant_texts
+#
+#  id               :bigint           not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  llm_prompt_id    :integer          not null
+#  relevant_text_id :integer          not null
+#
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_llm_prompt_relevant_text, class: 'Evidence::LLMPromptResearch::GenAI::RelevantText' do
+          llm_prompt { association :evidence_research_gen_ai_llm_prompt }
+          relevant_text { association :evidence_research_gen_ai_relevant_text }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_relevant_texts.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/llm_prompt_relevant_texts.rb
@@ -14,7 +14,7 @@ module Evidence
   module Research
     module GenAI
       FactoryBot.define do
-        factory :evidence_research_gen_ai_llm_prompt_relevant_text, class: 'Evidence::LLMPromptResearch::GenAI::RelevantText' do
+        factory :evidence_research_gen_ai_llm_prompt_relevant_text, class: 'Evidence::Research::GenAI::LLMPromptRelevantText' do
           llm_prompt { association :evidence_research_gen_ai_llm_prompt }
           relevant_text { association :evidence_research_gen_ai_relevant_text }
         end

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/relevant_texts.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/relevant_texts.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_relevant_texts
+#
+#  id         :bigint           not null, primary key
+#  notes      :text             default("")
+#  text       :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+module Evidence
+  module Research
+    module GenAI
+      FactoryBot.define do
+        factory :evidence_research_gen_ai_relevant_text, class: 'Evidence::Research::GenAI::RelevantText' do
+          text { 'This is the text' }
+          notes { 'These are the notes' }
+        end
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_relevant_text_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_relevant_text_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_dataset_relevant_texts
+#
+#  id               :bigint           not null, primary key
+#  default          :boolean          default(FALSE)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  dataset_id       :integer          not null
+#  relevant_text_id :integer          not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe DatasetRelevantText, type: :model do
+        let(:factory) { described_class.model_name.singular.to_sym }
+
+        it { expect(build(factory)).to be_valid }
+
+        it { should belong_to(:dataset) }
+        it { should belong_to(:relevant_text) }
+
+        it { should validate_presence_of(:dataset_id) }
+        it { should validate_presence_of(:relevant_text_id) }
+
+        it { should have_readonly_attribute(:dataset_id) }
+        it { should have_readonly_attribute(:relevant_text_id) }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_spec.rb
@@ -9,7 +9,6 @@
 #  notes            :text
 #  optimal_count    :integer          default(0), not null
 #  suboptimal_count :integer          default(0), not null
-#  task_type        :string
 #  version          :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/dataset_spec.rb
@@ -6,9 +6,10 @@
 #
 #  id               :bigint           not null, primary key
 #  locked           :boolean          default(FALSE), not null
+#  notes            :text
 #  optimal_count    :integer          default(0), not null
 #  suboptimal_count :integer          default(0), not null
-#  task_type        :string           not null
+#  task_type        :string
 #  version          :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_relevant_text_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/llm_prompt_relevant_text_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_llm_prompt_relevant_texts
+#
+#  id               :bigint           not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  llm_prompt_id    :integer          not null
+#  relevant_text_id :integer          not null
+#
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe LLMPromptRelevantText, type: :model do
+        let(:factory) { described_class.model_name.singular.to_sym }
+
+        it { expect(build(factory)).to be_valid }
+
+        it { should belong_to(:llm_prompt) }
+        it { should belong_to(:relevant_text) }
+
+        it { should validate_presence_of(:llm_prompt_id) }
+        it { should validate_presence_of(:relevant_text_id) }
+
+        it { should have_readonly_attribute(:llm_prompt_id) }
+        it { should have_readonly_attribute(:relevant_text_id) }
+      end
+    end
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/relevant_text_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/relevant_text_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: evidence_research_gen_ai_relevant_texts
+#
+#  id         :bigint           not null, primary key
+#  notes      :text             default("")
+#  text       :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require 'rails_helper'
+
+module Evidence
+  module Research
+    module GenAI
+      RSpec.describe RelevantText, type: :model do
+        let(:factory) { described_class.model_name.singular.to_sym }
+
+        it { expect(build(factory)).to be_valid }
+
+        it { should validate_presence_of(:text) }
+
+        it { should have_readonly_attribute(:text) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
* Add `RelevantText` model
* Add `DatasetRelevantText` model
* Add `LLMPromptRelevantText` model
* Add notes to `Dataset` model

## WHY
* This resource persists text and notes be identified as a component of an LLMPrompt when using the Trial runner
* This resource connects a particular `RelevantText` record with a `Dataset` record.  This will allow for the ability to select a particular `RelevantText` for a given trial.
* This resource persists the choice of a particular `RelevantText` for a given trial.
* While we're in migration space, it's easy to add in a related migration.
 
## HOW
* Write a migration for the new resource and add a corresponding model file
* Write a migration for the new resource and add a corresponding model file
* Write a migration for the new resource and add a corresponding model file
* Write a migration for the new attribute

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links

### What have you done to QA this feature?
I have checked on staging that these migrations worked properly.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
