### PR TITLE
Bug fix/ activities deleted from pack are reappearing

### DIFF
--- a/services/QuillLMS/app/controllers/teachers/units_controller.rb
+++ b/services/QuillLMS/app/controllers/teachers/units_controller.rb
@@ -49,7 +49,7 @@ class Teachers::UnitsController < ApplicationController
   end
 
   def update_classroom_unit_assigned_students
-    activities_data = UnitActivity.where(unit_id: params[:id]).order(:order_number).pluck(:activity_id).map { |id| { id: id } }
+    activities_data = UnitActivity.where(unit_id: params[:id]).where(visible: true).order(:order_number).pluck(:activity_id).map { |id| { id: id } }
 
     if activities_data.any?
       classroom_data = params[:unit][:classrooms].as_json.map(&:deep_symbolize_keys)


### PR DESCRIPTION
## WHAT
fix issue where activities deleted from a pack are reappearing when pack is assigned to previously unassigned students

## WHY
the activities should not be reappearing

## HOW
add a check in the controller for if the `UnitActivity` is visible before running unit updater

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)
https://www.notion.so/quill/Activities-that-a-teacher-has-deleted-from-an-activity-pack-reappear-when-the-activity-pack-is-assig-10ed42e6f9418017be3bc49eda4f3423

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)
verified on demo account that this behavior does not happen

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? | yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
