### PR TITLE
Add Google Cloud storage default and fix db schema

### DIFF
--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -145,7 +145,7 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
           item timestamp;
         BEGIN
           SELECT created_at INTO as_created_at FROM activity_sessions WHERE id = act_sess;
-
+          
           -- backward compatibility block
           IF as_created_at IS NULL OR as_created_at < timestamp '2013-08-25 00:00:00.000000' THEN
             SELECT SUM(
@@ -160,11 +160,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
                       'epoch' FROM (activity_sessions.completed_at - activity_sessions.started_at)
                     )
                 END) INTO time_spent FROM activity_sessions WHERE id = act_sess AND state='finished';
-
+                
                 RETURN COALESCE(time_spent,0);
           END IF;
-
-
+          
+          
           first_item := NULL;
           last_item := NULL;
           max_item := NULL;
@@ -188,11 +188,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
 
             END IF;
           END LOOP;
-
+          
           IF max_item IS NOT NULL AND first_item IS NOT NULL THEN
             time_spent := time_spent + EXTRACT( EPOCH FROM max_item - first_item );
           END IF;
-
+          
           RETURN time_spent;
         END;
       $$;
@@ -207,7 +207,7 @@ CREATE FUNCTION public.timespent_student(student integer) RETURNS bigint
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (
           SELECT id,timespent_activity_session(id) AS time_spent FROM activity_sessions
-          WHERE activity_sessions.user_id = student
+          WHERE activity_sessions.user_id = student 
           GROUP BY id) as as_ids;
 
       $$;
@@ -3156,7 +3156,8 @@ CREATE TABLE public.evidence_research_gen_ai_datasets (
     updated_at timestamp(6) without time zone NOT NULL,
     version integer NOT NULL,
     parent_id integer,
-    notes text
+    notes text,
+    task_type character varying
 );
 
 
@@ -3635,7 +3636,8 @@ CREATE TABLE public.evidence_research_gen_ai_stem_vaults (
     conjunction character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    prompt_id integer
+    prompt_id integer,
+    automl_data jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 
@@ -11876,7 +11878,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241022194330'),
 ('20241022194329'),
 ('20241016130048'),
+('20241004133706'),
 ('20241002164211'),
+('20240926201615'),
 ('20240925185730'),
 ('20240924151321'),
 ('20240924151311'),

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/dataset.rb
@@ -9,6 +9,7 @@
 #  notes            :text
 #  optimal_count    :integer          default(0), not null
 #  suboptimal_count :integer          default(0), not null
+#  task_type        :string
 #  version          :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/stem_vault.rb
@@ -5,6 +5,7 @@
 # Table name: evidence_research_gen_ai_stem_vaults
 #
 #  id          :bigint           not null, primary key
+#  automl_data :jsonb            not null
 #  conjunction :string           not null
 #  stem        :text             not null
 #  created_at  :datetime         not null

--- a/services/QuillLMS/engines/evidence/config/initializers/google/cloud/storage.rb
+++ b/services/QuillLMS/engines/evidence/config/initializers/google/cloud/storage.rb
@@ -2,7 +2,7 @@
 
 require 'google/cloud/storage'
 
-GOOGLE_CLOUD_STORAGE_CSV_BUCKET = ENV.fetch('GOOGLE_CLOUD_STORAGE_CSV_BUCKET')
+GOOGLE_CLOUD_STORAGE_CSV_BUCKET = ENV.fetch('GOOGLE_CLOUD_STORAGE_CSV_BUCKET', '')
 
 Google::Cloud::Storage.configure do |config|
   config.credentials = JSON.parse(ENV.fetch('GOOGLE_CLOUD_STORAGE_CREDENTIALS', '{}'))

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1047,7 +1047,8 @@ CREATE TABLE public.evidence_research_gen_ai_datasets (
     updated_at timestamp(6) without time zone NOT NULL,
     version integer NOT NULL,
     parent_id integer,
-    notes text
+    notes text,
+    task_type character varying
 );
 
 
@@ -1526,7 +1527,8 @@ CREATE TABLE public.evidence_research_gen_ai_stem_vaults (
     conjunction character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    prompt_id integer
+    prompt_id integer,
+    automl_data jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 
@@ -2722,7 +2724,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241022191503'),
 ('20241022191325'),
 ('20241016125929'),
+('20241004133206'),
 ('20241002153807'),
+('20240926201306'),
 ('20240925184213'),
 ('20240918144745'),
 ('20240828221309'),


### PR DESCRIPTION
## WHAT
* Fix a bug with ENV setting on google cloud
* Fix structure.sql with missing lines

## WHY
* There was no default for ENV.fetch
* Migrations were split across different branches

## HOW
* Add a fallback to ENV.fetch
* Fix the missing fields.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No.
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
