### PR TITLE
add notes column to gen ai trials and stem vault id to relevant texts

### DIFF
--- a/services/QuillLMS/db/migrate/20241024133309_add_notes_to_trial.evidence.rb
+++ b/services/QuillLMS/db/migrate/20241024133309_add_notes_to_trial.evidence.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20241024133220)
+class AddNotesToTrial < ActiveRecord::Migration[7.1]
+  def change
+    add_column :evidence_research_gen_ai_trials, :notes, :text
+  end
+end

--- a/services/QuillLMS/db/migrate/20241024135021_add_stem_vault_id_to_relevant_texts.evidence.rb
+++ b/services/QuillLMS/db/migrate/20241024135021_add_stem_vault_id_to_relevant_texts.evidence.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20241024134904)
+class AddStemVaultIdToRelevantTexts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :evidence_research_gen_ai_relevant_texts, :stem_vault_id, :integer
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3602,7 +3602,8 @@ CREATE TABLE public.evidence_research_gen_ai_relevant_texts (
     text text NOT NULL,
     notes text DEFAULT ''::text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    stem_vault_id integer
 );
 
 
@@ -11874,6 +11875,7 @@ ALTER TABLE ONLY public.learn_worlds_account_course_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241024135021'),
 ('20241024133309'),
 ('20241022194332'),
 ('20241022194331'),

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -3156,8 +3156,8 @@ CREATE TABLE public.evidence_research_gen_ai_datasets (
     updated_at timestamp(6) without time zone NOT NULL,
     version integer NOT NULL,
     parent_id integer,
-    notes text,
-    task_type character varying
+    task_type character varying,
+    notes text
 );
 
 
@@ -3780,7 +3780,8 @@ CREATE TABLE public.evidence_research_gen_ai_trials (
     trial_duration double precision,
     evaluation_duration double precision,
     number integer NOT NULL,
-    temperature double precision NOT NULL
+    temperature double precision NOT NULL,
+    notes text
 );
 
 
@@ -11873,6 +11874,7 @@ ALTER TABLE ONLY public.learn_worlds_account_course_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241024133309'),
 ('20241022194332'),
 ('20241022194331'),
 ('20241022194330'),

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/relevant_text.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/relevant_text.rb
@@ -4,11 +4,12 @@
 #
 # Table name: evidence_research_gen_ai_relevant_texts
 #
-#  id         :bigint           not null, primary key
-#  notes      :text             default("")
-#  text       :text             not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  notes         :text             default("")
+#  text          :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  stem_vault_id :integer
 #
 module Evidence
   module Research

--- a/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/trial.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/research/gen_ai/trial.rb
@@ -6,6 +6,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  evaluation_duration :float
+#  notes               :text
 #  number              :integer          not null
 #  results             :jsonb
 #  status              :string           default("pending"), not null

--- a/services/QuillLMS/engines/evidence/db/migrate/20241024133220_add_notes_to_trial.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20241024133220_add_notes_to_trial.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotesToTrial < ActiveRecord::Migration[7.1]
+  def change
+    add_column :evidence_research_gen_ai_trials, :notes, :text
+  end
+end

--- a/services/QuillLMS/engines/evidence/db/migrate/20241024134904_add_stem_vault_id_to_relevant_texts.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20241024134904_add_stem_vault_id_to_relevant_texts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStemVaultIdToRelevantTexts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :evidence_research_gen_ai_relevant_texts, :stem_vault_id, :integer
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1493,7 +1493,8 @@ CREATE TABLE public.evidence_research_gen_ai_relevant_texts (
     text text NOT NULL,
     notes text DEFAULT ''::text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    stem_vault_id integer
 );
 
 
@@ -2720,6 +2721,7 @@ ALTER TABLE ONLY public.comprehension_regex_rules
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241024134904'),
 ('20241024133220'),
 ('20241022191816'),
 ('20241022191551'),

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -1047,8 +1047,8 @@ CREATE TABLE public.evidence_research_gen_ai_datasets (
     updated_at timestamp(6) without time zone NOT NULL,
     version integer NOT NULL,
     parent_id integer,
-    notes text,
-    task_type character varying
+    task_type character varying,
+    notes text
 );
 
 
@@ -1527,8 +1527,8 @@ CREATE TABLE public.evidence_research_gen_ai_stem_vaults (
     conjunction character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    prompt_id integer,
-    automl_data jsonb DEFAULT '{}'::jsonb NOT NULL
+    automl_data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    prompt_id integer
 );
 
 
@@ -1671,7 +1671,8 @@ CREATE TABLE public.evidence_research_gen_ai_trials (
     trial_duration double precision,
     evaluation_duration double precision,
     number integer NOT NULL,
-    temperature double precision NOT NULL
+    temperature double precision NOT NULL,
+    notes text
 );
 
 
@@ -2719,6 +2720,7 @@ ALTER TABLE ONLY public.comprehension_regex_rules
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241024133220'),
 ('20241022191816'),
 ('20241022191551'),
 ('20241022191503'),

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/relevant_texts.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/relevant_texts.rb
@@ -4,11 +4,12 @@
 #
 # Table name: evidence_research_gen_ai_relevant_texts
 #
-#  id         :bigint           not null, primary key
-#  notes      :text             default("")
-#  text       :text             not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  notes         :text             default("")
+#  text          :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  stem_vault_id :integer
 #
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/trials.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/research/gen_ai/trials.rb
@@ -6,6 +6,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  evaluation_duration :float
+#  notes               :text
 #  number              :integer          not null
 #  results             :jsonb
 #  status              :string           default("pending"), not null

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/relevant_text_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/relevant_text_spec.rb
@@ -4,13 +4,13 @@
 #
 # Table name: evidence_research_gen_ai_relevant_texts
 #
-#  id         :bigint           not null, primary key
-#  notes      :text             default("")
-#  text       :text             not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  notes         :text             default("")
+#  text          :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  stem_vault_id :integer
 #
-
 require 'rails_helper'
 
 module Evidence

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/research/gen_ai/trial_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  evaluation_duration :float
+#  notes               :text
 #  number              :integer          not null
 #  results             :jsonb
 #  status              :string           default("pending"), not null


### PR DESCRIPTION
## WHAT
Add `notes` column to `Evidence::Research::GenAI::Trials`, and `stem_vault_id` to `Evidence::Research::GenAI::RelevantTexts`.

## WHY
The notes on the trials are a requested piece of new functionality. The `stem_vault_id` on the `RelevantTexts` I realized that we'll need in order to populate requisite `RelevantText` records on `Dataset` creation, and show "hidden" `RelevantTexts` in the UI, because we're now "hiding" them by removing the association between the `Dataset` and the `RelevantText`. Otherwise, we'd have to just scrape all other `Datasets` for that `StemVault` for their associated `RelevantTexts`, which seems messy.

## HOW
Add and run the migrations.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Gen-AI-CMS-Project-2-Embed-Trial-Runner-in-CMS-61c994a106854512b449ccc82be573c2?pvs=4#11fd42e6f9418039bd06c05fda7a1654

### What have you done to QA this feature?
(Provide enough detail that a reviewer could assess whether additional QA should be done. For larger projects, additionally use the Engineer Feature Testing Notion template. Review Guidelines if needed: https://www.notion.so/quill/Github-PR-QA-Guidelines-49e99fc965654ceeb8c6249bd9d181d7)

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  NO -- just a migration
Have you deployed to Staging? | NO - tiny change
Self-Review: Have you done an initial self-review of the code below on Github? | YES
