### PR TITLE
Change unique index on Evidence::LabeledEntry

### DIFF
--- a/services/QuillLMS/db/migrate/20241024165445_change_unique_index_on_evidence_labeled_entries.evidence.rb
+++ b/services/QuillLMS/db/migrate/20241024165445_change_unique_index_on_evidence_labeled_entries.evidence.rb
@@ -3,7 +3,7 @@
 # This migration comes from evidence (originally 20241024165314)
 class ChangeUniqueIndexOnEvidenceLabeledEntries < ActiveRecord::Migration[7.1]
   def change
-    remove_index :evidence_labeled_entries, [:prompt_id, :entry]
+    remove_index :evidence_labeled_entries, [:prompt_id, :entry], unique: true
     add_index :evidence_labeled_entries, [:prompt_id, :entry, :label], unique: true
   end
 end

--- a/services/QuillLMS/db/migrate/20241024165445_change_unique_index_on_evidence_labeled_entries.evidence.rb
+++ b/services/QuillLMS/db/migrate/20241024165445_change_unique_index_on_evidence_labeled_entries.evidence.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# This migration comes from evidence (originally 20241024165314)
+class ChangeUniqueIndexOnEvidenceLabeledEntries < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :evidence_labeled_entries, [:prompt_id, :entry]
+    add_index :evidence_labeled_entries, [:prompt_id, :entry, :label], unique: true
+  end
+end

--- a/services/QuillLMS/db/structure.sql
+++ b/services/QuillLMS/db/structure.sql
@@ -145,7 +145,7 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
           item timestamp;
         BEGIN
           SELECT created_at INTO as_created_at FROM activity_sessions WHERE id = act_sess;
-          
+
           -- backward compatibility block
           IF as_created_at IS NULL OR as_created_at < timestamp '2013-08-25 00:00:00.000000' THEN
             SELECT SUM(
@@ -160,11 +160,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
                       'epoch' FROM (activity_sessions.completed_at - activity_sessions.started_at)
                     )
                 END) INTO time_spent FROM activity_sessions WHERE id = act_sess AND state='finished';
-                
+
                 RETURN COALESCE(time_spent,0);
           END IF;
-          
-          
+
+
           first_item := NULL;
           last_item := NULL;
           max_item := NULL;
@@ -188,11 +188,11 @@ CREATE FUNCTION public.timespent_question(act_sess integer, question character v
 
             END IF;
           END LOOP;
-          
+
           IF max_item IS NOT NULL AND first_item IS NOT NULL THEN
             time_spent := time_spent + EXTRACT( EPOCH FROM max_item - first_item );
           END IF;
-          
+
           RETURN time_spent;
         END;
       $$;
@@ -207,7 +207,7 @@ CREATE FUNCTION public.timespent_student(student integer) RETURNS bigint
     AS $$
         SELECT COALESCE(SUM(time_spent),0) FROM (
           SELECT id,timespent_activity_session(id) AS time_spent FROM activity_sessions
-          WHERE activity_sessions.user_id = student 
+          WHERE activity_sessions.user_id = student
           GROUP BY id) as as_ids;
 
       $$;
@@ -9424,6 +9424,13 @@ CREATE INDEX idx_on_classroom_unit_id_activity_id_e74613431d ON public.student_l
 
 
 --
+-- Name: idx_on_prompt_id_entry_label_e61aa4cb93; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_on_prompt_id_entry_label_e61aa4cb93 ON public.evidence_labeled_entries USING btree (prompt_id, entry, label);
+
+
+--
 -- Name: idx_on_student_learning_sequence_id_63827699e9; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10128,13 +10135,6 @@ CREATE INDEX index_evidence_hints_on_rule_id ON public.evidence_hints USING btre
 --
 
 CREATE INDEX index_evidence_labeled_entries_on_prompt_id ON public.evidence_labeled_entries USING btree (prompt_id);
-
-
---
--- Name: index_evidence_labeled_entries_on_prompt_id_and_entry; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_evidence_labeled_entries_on_prompt_id_and_entry ON public.evidence_labeled_entries USING btree (prompt_id, entry);
 
 
 --
@@ -11877,6 +11877,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20241024135021'),
 ('20241024133309'),
+('20241024165445'),
 ('20241022194332'),
 ('20241022194331'),
 ('20241022194330'),

--- a/services/QuillLMS/engines/evidence/app/models/evidence/labeled_entry.rb
+++ b/services/QuillLMS/engines/evidence/app/models/evidence/labeled_entry.rb
@@ -17,8 +17,8 @@
 #
 # Indexes
 #
-#  index_evidence_labeled_entries_on_prompt_id            (prompt_id)
-#  index_evidence_labeled_entries_on_prompt_id_and_entry  (prompt_id,entry) UNIQUE
+#  idx_on_prompt_id_entry_label_e61aa4cb93      (prompt_id,entry,label) UNIQUE
+#  index_evidence_labeled_entries_on_prompt_id  (prompt_id)
 #
 
 require 'neighbor'

--- a/services/QuillLMS/engines/evidence/db/migrate/20241024165314_change_unique_index_on_evidence_labeled_entries.rb
+++ b/services/QuillLMS/engines/evidence/db/migrate/20241024165314_change_unique_index_on_evidence_labeled_entries.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeUniqueIndexOnEvidenceLabeledEntries < ActiveRecord::Migration[7.1]
+  def change
+    add_index :evidence_labeled_entries, [:prompt_id, :entry, :label], unique: true
+  end
+end

--- a/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
+++ b/services/QuillLMS/engines/evidence/spec/dummy/db/structure.sql
@@ -2533,6 +2533,13 @@ CREATE INDEX comprehension_turking_sessions_turking_id ON public.comprehension_t
 
 
 --
+-- Name: idx_on_prompt_id_entry_label_e61aa4cb93; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_on_prompt_id_entry_label_e61aa4cb93 ON public.evidence_labeled_entries USING btree (prompt_id, entry, label);
+
+
+--
 -- Name: index_change_logs_on_changed_record_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2723,6 +2730,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20241024134904'),
 ('20241024133220'),
+('20241024165314'),
 ('20241022191816'),
 ('20241022191551'),
 ('20241022191503'),

--- a/services/QuillLMS/engines/evidence/spec/factories/evidence/labeled_entries.rb
+++ b/services/QuillLMS/engines/evidence/spec/factories/evidence/labeled_entries.rb
@@ -17,8 +17,8 @@
 #
 # Indexes
 #
-#  index_evidence_labeled_entries_on_prompt_id            (prompt_id)
-#  index_evidence_labeled_entries_on_prompt_id_and_entry  (prompt_id,entry) UNIQUE
+#  idx_on_prompt_id_entry_label_e61aa4cb93      (prompt_id,entry,label) UNIQUE
+#  index_evidence_labeled_entries_on_prompt_id  (prompt_id)
 #
 
 FactoryBot.define do

--- a/services/QuillLMS/engines/evidence/spec/models/evidence/labeled_entry_spec.rb
+++ b/services/QuillLMS/engines/evidence/spec/models/evidence/labeled_entry_spec.rb
@@ -17,8 +17,8 @@
 #
 # Indexes
 #
-#  index_evidence_labeled_entries_on_prompt_id            (prompt_id)
-#  index_evidence_labeled_entries_on_prompt_id_and_entry  (prompt_id,entry) UNIQUE
+#  idx_on_prompt_id_entry_label_e61aa4cb93      (prompt_id,entry,label) UNIQUE
+#  index_evidence_labeled_entries_on_prompt_id  (prompt_id)
 #
 
 require 'rails_helper'


### PR DESCRIPTION
## WHAT
Change the unique index on the model `Evidence::LabeledEntry` from (prompt_id, entry) to (prompt_id, entry, label).

## WHY
Some of the testing/training data contains duplicate (prompt_id, entry) pairs with different labels.  This causes errors in the [.closest_text_prompt](https://github.com/empirical-org/Empirical-Core/blob/develop/services/QuillLMS/engines/evidence/app/models/evidence/labeled_entry.rb#L49) specifically in the `find_or_create_by!`  call

## HOW
Remove older index and add a new one in that includes the label.

### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
(Please provide links to any relevant Notion card(s) relevant to this PR.)

### What have you done to QA this feature?
I have checked that this migration goes through on staging and the `.closest_text_prompt` calls now work on the problematic cases.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  YES
Have you deployed to Staging? | YES
Self-Review: Have you done an initial self-review of the code below on Github? | YES
