### PR TITLE
Resize and re-orient MIT logo

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/for_administrators.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/for_administrators.scss
@@ -288,8 +288,9 @@
       position: relative;
       width: 100%;
       height: 100%;
-      background-color: $quill-black;
+      background-color: $quill-white;
       max-height: 675px;
+      margin-top: 80px;
     }
   }
 


### PR DESCRIPTION
## WHAT
Resize and re-orient the MIT logo on about us page.

## WHY
The MIT program liaison requested making the logo slightly smaller so it conforms more to the sizing of the other logos on the page.

## HOW
CSS changes.

### Screenshots
![Screenshot 2024-11-01 at 1 04 43 PM](https://github.com/user-attachments/assets/0c87f74c-ce26-4d9a-9452-8a0a9801f05d)

### Notion Card Links
https://www.notion.so/quill/Add-logo-to-funder-list-on-website-4b6b4a5ba9b4440b9da5ba1a77bf80fd?d=69958d9b5e0041fc93a418157d00a2f0

### What have you done to QA this feature?
Check styling locally and on staging.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  no, tiny change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
