### PR TITLE
Add pre-diagnostic and post-diagnostic stats to district Vitally data

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/for_administrators.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/for_administrators.scss
@@ -288,8 +288,9 @@
       position: relative;
       width: 100%;
       height: 100%;
-      background-color: $quill-black;
+      background-color: $quill-white;
       max-height: 675px;
+      margin-top: 80px;
     }
   }
 


### PR DESCRIPTION
## WHAT
Add stats on pre-diagnostic and post-diagnostics assigned and completed to District wrapup data in Vitally.

## WHY
Admin want these stats in order to stay better informed on school districts throughout the years.

## HOW
Add some methods for more fine-grained querying of activity data. 
Fix the bug where we were neglecting to include units that have been archived (visible: false) by using direct SQL instead of ActiveRecord in some of the queries.


### Screenshots
(If applicable. Also, please censor any sensitive data)

### Notion Card Links
https://www.notion.so/quill/Update-Vitally-Data-Sync-New-Diagnostic-Usage-Data-2fb92d4ba89847af9da661fc78710556?pvs=4

### What have you done to QA this feature?
Deploy to staging and test on a sample district.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  yes
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
