### PR TITLE
Add Evidence Tutorial video to evidence tools page

### DIFF
--- a/services/QuillLMS/app/assets/stylesheets/pages/for_administrators.scss
+++ b/services/QuillLMS/app/assets/stylesheets/pages/for_administrators.scss
@@ -288,8 +288,9 @@
       position: relative;
       width: 100%;
       height: 100%;
-      background-color: $quill-black;
+      background-color: $quill-white;
       max-height: 675px;
+      margin-top: 80px;
     }
   }
 


### PR DESCRIPTION
## WHAT
Add this video to the tools page.

## WHY
To show teachers how evidence is typically used.

## HOW
Add the video html element and styling.

### Screenshots
![Screenshot 2024-11-18 at 9 46 41 AM](https://github.com/user-attachments/assets/4ecdcefd-8f46-473f-a30b-519e34df6236)

### Notion Card Links
https://www.notion.so/quill/Add-the-Evidence-Demo-Video-back-to-the-Evidence-Tool-Page-126d42e6f94180d0b490ee9ea19b9d57?pvs=4

### What have you done to QA this feature?
Deploy to staging and have Curriculum team verify the video is working as expected.

PR Checklist | Your Answer
------------ | -------------
Have you added and/or updated tests? |  No, small front-end change
Have you deployed to Staging? | yes
Self-Review: Have you done an initial self-review of the code below on Github? | yes
